### PR TITLE
Added Minimum Age Validator

### DIFF
--- a/library/Respect/Validation/Exceptions/MinimumAgeException.php
+++ b/library/Respect/Validation/Exceptions/MinimumAgeException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Respect\Validation\Exceptions;
+
+class MinimumAgeException extends ValidationException
+{
+    
+    public static $defaultTemplates = array(
+        self::MODE_DEFAULT => array(
+            self::STANDARD => 'The age must be {{age}} years or more.',
+        ),
+        self::MODE_NEGATIVE => array(
+            self::STANDARD => 'The age must not be {{age}} years or more.',
+        )
+    );
+
+}
+
+/**
+ * LICENSE
+ *
+ * Copyright (c) 2011, Jean Pimentel.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright notice,
+ *       this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of Alexandre Gomes Gaigalas nor the names of its
+ *       contributors may be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */

--- a/library/Respect/Validation/Rules/MinimumAge.php
+++ b/library/Respect/Validation/Rules/MinimumAge.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Rules\Date;
+use DateTime;
+
+class MinimumAge extends AbstractRule
+{
+
+    public $age = null;
+    public $format = null;
+    
+    public function __construct($age, $format=null)
+    {
+        $this->age = $age;
+        $this->format = $format;
+    }
+
+    public function validate($input)
+    {
+        if(!is_int($this->age)) 
+            return false;
+        
+        $date = new Date($this->format);
+        $date->assert($input);
+        
+        if ($input instanceof DateTime) {
+            $birthday = new \DateTime('now - '.$this->age.' year');
+            return $birthday > $input;
+        }
+        else {
+            $age = ((date('Ymd') - date('Ymd', strtotime($input))) / 10000);
+            return $age >= $this->age;
+        }
+    }
+        
+}
+
+/**
+ * LICENSE
+ *
+ * Copyright (c) 2011, Jean Pimentel.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright notice,
+ *       this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of Alexandre Gomes Gaigalas nor the names of its
+ *       contributors may be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */

--- a/tests/library/Respect/Validation/Rules/MininumAgeTest.php
+++ b/tests/library/Respect/Validation/Rules/MininumAgeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+use DateTime;
+
+class MinimumAgeTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider providerForValidDateValidMinimumAge
+     *
+     */
+    public function testForValidDateValidMinimumAge($age, $format, $input)
+    {
+        $minimumAge = new MinimumAge($age, $format);
+        $this->assertTrue($minimumAge->assert($input));
+    }
+    
+    /**
+     * @dataProvider providerForValidDateInvalidMinimumAge
+     * @expectedException Respect\Validation\Exceptions\MinimumAgeException
+     */
+    public function testForValidDateInvalidMinimumAge($age, $format, $input)
+    {
+        $minimumAge = new MinimumAge($age, $format);
+        $this->assertTrue($minimumAge->assert($input));
+    }
+    
+    /**
+     * @dataProvider providerForInvalidDate
+     * @expectedException Respect\Validation\Exceptions\DateException
+     */
+    public function testInvalidDate($age, $format, $input)
+    {
+        $minimumAge = new MinimumAge($age, $format);
+        $this->assertTrue($minimumAge->assert($input));
+    }
+    
+    public function providerForValidDateValidMinimumAge()
+    {
+        return array(
+            array(18, 'Y-m-d', '1969-07-20'),
+            array(18, null, new \DateTime('1969-07-20')),
+            array(18, 'Y-m-d', new \DateTime('1969-07-20')),
+        );
+    }
+    
+    public function providerForValidDateInvalidMinimumAge()
+    {
+        return array(
+            array(18, 'Y-m-d', '2002-06-30'),
+            array(18, null, new \DateTime('2002-06-30')),
+            array(18, 'Y-m-d', new \DateTime('2002-06-30')),
+        );
+    }
+    
+    public function providerForInvalidDate()
+    {
+        return array(
+            array(18, null, 'invalid-input'),
+            array(18, null, new \stdClass),
+            array(18, 'y-m-d', '2002-06-30'),
+        );
+    }
+
+}


### PR DESCRIPTION
Like **Date Validator**, with format and _string_ input

``` php
try {
    v::minimumAge(18, 'Y-m-d')->assert('2002-06-30');
} catch(\InvalidArgumentException $e) {
   echo $e->getFullMessage(); // \-The age must be 18 years or more.
}
```

or with _DateTime_ input

``` php
try {
    v::minimumAge(18)->assert(new DateTime('2002-06-30'));
} catch(\InvalidArgumentException $e) {
   echo $e->getFullMessage(); // \-The age must be 18 years or more.
}
```

There's no need to call Date because MinimumAge uses Date internally.
