### PR TITLE
Fixing CPF Validator

### DIFF
--- a/library/Respect/Validation/Exceptions/CpfException.php
+++ b/library/Respect/Validation/Exceptions/CpfException.php
@@ -2,7 +2,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class CPFException extends ValidationException
+class CpfException extends ValidationException
 {
 
     public static $defaultTemplates = array(

--- a/library/Respect/Validation/Rules/Cpf.php
+++ b/library/Respect/Validation/Rules/Cpf.php
@@ -4,7 +4,7 @@ namespace Respect\Validation\Rules;
 
 use Respect\Validation\Rules\Length;
 
-class CPF extends AbstractRule 
+class Cpf extends AbstractRule 
 {
 
     public function validate($input) 
@@ -26,9 +26,7 @@ class CPF extends AbstractRule
     
     private function processNumber($input)
     {
-        $verify = array('firstDigit' => 0,
-                        'secondDigit' => 0,
-        );
+        $verify = array('firstDigit' => 0, 'secondDigit' => 0);
 
         $multiple = 10;
 
@@ -65,7 +63,7 @@ class CPF extends AbstractRule
         return !$vl->assert($input);
     }
 
-    private function isSequenceOfNumber($input=null) 
+    private function isSequenceOfNumber($input) 
     {   
         for ($i = 0; $i <= 9; $i++)
             if (strcmp($input, str_pad('', strlen($input), $i)) === 0)
@@ -74,7 +72,7 @@ class CPF extends AbstractRule
         return false;
     }
 
-    private function clean($input=null) 
+    private function clean($input) 
     {
         return preg_replace("/\.|-/", "", $input);
     }

--- a/tests/library/Respect/Validation/Rules/CpfTest.php
+++ b/tests/library/Respect/Validation/Rules/CpfTest.php
@@ -2,60 +2,60 @@
 
 namespace Respect\Validation\Rules;
 
-class CPFTest extends \PHPUnit_Framework_TestCase {
+class CpfTest extends \PHPUnit_Framework_TestCase {
 
     protected $cpf;
 
     protected function setUp() 
     {
-        $this->cpf = new CPF;
+        $this->cpf = new Cpf;
     }
     
     /**
-     * @dataProvider providerValidFormattedCPF
+     * @dataProvider providerValidFormattedCpf
      */
-    public function testValidFormattedCPF($input) 
+    public function testValidFormattedCpf($input) 
     {
         $this->assertTrue($this->cpf->assert($input));
     }
 
     /**
-     * @dataProvider providerValidUnformattedCPF
+     * @dataProvider providerValidUnformattedCpf
      */
-    public function testValidUnformattedCPF($input) 
+    public function testValidUnformattedCpf($input) 
     {
         $this->assertTrue($this->cpf->assert($input));
     }
 
     /**
-     * @dataProvider providerInvalidFormattedCPF
-     * @expectedException Respect\Validation\Exceptions\CPFException
+     * @dataProvider providerInvalidFormattedCpf
+     * @expectedException Respect\Validation\Exceptions\CpfException
      */
-    public function testInvalidFormattedCPF($input) 
+    public function testInvalidFormattedCpf($input) 
     {
         $this->assertFalse($this->cpf->assert($input));
     }
 
     /**
-     * @dataProvider providerInvalidUnformattedCPF
-     * @expectedException Respect\Validation\Exceptions\CPFException
+     * @dataProvider providerInvalidUnformattedCpf
+     * @expectedException Respect\Validation\Exceptions\CpfException
      */
-    public function testInvalidUnformattedCPF($input) 
+    public function testInvalidUnformattedCpf($input) 
     {
         $this->assertFalse($this->cpf->assert($input));
     }
 
     
     /**
-     * @dataProvider providerInvalidFormattedAndUnformattedCPFLength
+     * @dataProvider providerInvalidFormattedAndUnformattedCpfLength
      * @expectedException Respect\Validation\Exceptions\LengthException
      */
-    public function testInvalidFormattedAndUnformattedCPFLength($input) 
+    public function testInvalidFormattedAndUnformattedCpfLength($input) 
     {
         $this->assertFalse($this->cpf->assert($input));
     }
     
-    public function providerValidFormattedCPF() 
+    public function providerValidFormattedCpf() 
     {
         return array(
             array('342.444.198-88'),
@@ -66,7 +66,7 @@ class CPFTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
-    public function providerValidUnformattedCPF() 
+    public function providerValidUnformattedCpf() 
     {
         return array(
             array('11598647644'),
@@ -77,7 +77,7 @@ class CPFTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
-    public function providerInvalidFormattedCPF() 
+    public function providerInvalidFormattedCpf() 
     {
         return array(
             array('000.000.000-00'),
@@ -89,7 +89,7 @@ class CPFTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
-    public function providerInvalidUnformattedCPF() 
+    public function providerInvalidUnformattedCpf() 
     {
         return array(
             array('11111111111'),
@@ -101,7 +101,7 @@ class CPFTest extends \PHPUnit_Framework_TestCase {
         );
     }
     
-    public function providerInvalidFormattedAndUnformattedCPFLength()
+    public function providerInvalidFormattedAndUnformattedCpfLength()
     {
         return array(
             array('1'),


### PR DESCRIPTION
Renaming class to CamelCase.
Before, CPF throws a  _Warning: require(Respect/Validation/Rules/__Cpf__.php)_

``` php
try {
    v::cpf()->assert('10125412940');
} catch(\InvalidArgumentException $e) {
   echo $e->getFullMessage();
}
```
