### PR TITLE
Do not lock up travis-ci.org workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ php:
   - 5.3
 
 before_script: 
-  - "sudo apt-get install php-pear"
+  - "sudo apt-get install -y php-pear"
   - make dev
 script: make test


### PR DESCRIPTION
If you don't use the -y switch, apt will wait for keyboard input. Please make sure to always use -y in your scripts used on travis-ci.org.
