### PR TITLE
Add i18n support

### DIFF
--- a/library/Respect/Validation/Exceptions/ValidationException.php
+++ b/library/Respect/Validation/Exceptions/ValidationException.php
@@ -91,7 +91,10 @@ class ValidationException extends InvalidArgumentException
     {
         $vars = $this->getParams();
         $vars['name'] = $this->getName();
-        return static::format($this->getTemplate(), $vars);
+        $template = $this->getTemplate();
+        if(isset($vars['translator']) && is_callable($vars['translator']))
+            $template = call_user_func($vars['translator'], $template);
+        return static::format($template, $vars);
     }
 
     public function getParam($name)
@@ -138,7 +141,7 @@ class ValidationException extends InvalidArgumentException
 
     public function setParam($key, $value)
     {
-        $this->params[$key] = static::stringify($value);
+        $this->params[$key] = ($key == 'translator') ? $value : static::stringify($value);
         return $this;
     }
 

--- a/library/Respect/Validation/Rules/AbstractRule.php
+++ b/library/Respect/Validation/Rules/AbstractRule.php
@@ -11,6 +11,8 @@ abstract class AbstractRule implements Validatable
     protected $name;
     protected $template = null;
 
+    public static $translator = null;
+
     public function __construct()
     {
         //a constructor is required for ReflectionClass::newInstance()
@@ -50,7 +52,8 @@ abstract class AbstractRule implements Validatable
         $input = ValidationException::stringify($input);
         $name = $this->getName() ? : "\"$input\"";
         $params = array_merge(
-            $extraParams, get_object_vars($this), compact('input')
+            $extraParams, get_object_vars($this), get_class_vars(__CLASS__),
+            compact('input')
         );
         $exception->configure($name, $params);
         if (!is_null($this->template))

--- a/library/Respect/Validation/Validator.php
+++ b/library/Respect/Validation/Validator.php
@@ -96,7 +96,9 @@ class Validator extends AllOf
         $exception = new AllOfException;
         $input = AllOfException::stringify($input);
         $name = $this->getName() ? : "\"$input\"";
-        $params = array_merge($extraParams, get_object_vars($this));
+        $params = array_merge(
+            $extraParams, get_object_vars($this), get_class_vars(__CLASS__)
+        );
         $exception->configure($name, $params);
         if (!is_null($this->template))
             $exception->setTemplate($this->template);


### PR DESCRIPTION
**Before:**

``` php
try {
    v::int()->odd()->assert('jean pimentel');
} catch (\Respect\Validation\Exceptions\ValidationException $e) {
    echo $e->getFullMessage();
}
```

```
\-These 2 rules must pass for "jean pimentel"
  |-"jean pimentel" must be an integer number
  \-"jean pimentel" must be an odd number
```

**Now:**

``` php
// my translator class only to test
class MyTranslate {
     public function translate($text) {
         if($text == '{{name}} must be an integer number')
             return '{{name}} deve ser um número inteiro';
         if($text == '{{name}} must be an odd number')
             return '{{name}} deve ser um número ímpar';
         if($text == 'These {{failed}} rules must pass for {{name}}')
             return 'Essas {{failed}} regras devem ser seguidas para {{name}}';
         return $text;
     }
}
```

``` php
// setting the translator callback
v::$translator = array('MyTranslate', 'translate');

try {
    v::int()->odd()->assert('jean pimentel');
} catch (\Respect\Validation\Exceptions\ValidationException $e) {
    echo $e->getFullMessage();
}
```

```
\-Essas 2 regras devem ser seguidas para "jean pimentel"
  |-"jean pimentel" deve ser um número inteiro
  \-"jean pimentel" deve ser um número ímpar
```
