### PR TITLE
Correct method from testInvalidFormattedCpf to testInvalidSlug

### DIFF
--- a/tests/library/Respect/Validation/Rules/SlugTest.php
+++ b/tests/library/Respect/Validation/Rules/SlugTest.php
@@ -25,7 +25,7 @@ class SlugTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider providerInvalidSlug
      * @expectedException Respect\Validation\Exceptions\SlugException
      */
-    public function testInvalidFormattedCpf($input) 
+    public function testInvalidSlug($input) 
     {
         $this->assertFalse($this->slug->validate($input));
         $this->assertFalse($this->slug->assert($input));


### PR DESCRIPTION
Correct method from testInvalidFormattedCpf to testInvalidSlug, because this method verifies a slug , not a CPF number.
