### PR TITLE
add shorcuts not and addOr

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,12 +990,20 @@ See also:
 Negates any rule.
 
     v::not(v::ip())->validate('foo'); //true
+    
+using a shorcut 
+
+    v::ip()->not()->validate('foo'); //true
 
 In the sample above, validator returns true because 'foo' isn't an IP Address.
 
 You can negate complex, grouped or chained validators as well:
 
     v::not(v::int()->positive())->validate(-1.5); //true
+    
+using a shorcut 
+
+    v::int()->positive()->not()->validate(-1.5); //true
 
 Each other validation has custom messages for negated rules.
 
@@ -1091,6 +1099,10 @@ In the sample above, `v::int()` doesn't validates, but
 
 `v::oneOf` returns true if at least one inner validator
 passes.
+
+Using a shortcut
+
+    v::int()->addOr(v::float())->validate(15.5); //true
 
 See also:
 

--- a/library/Respect/Validation/Rules/AbstractRule.php
+++ b/library/Respect/Validation/Rules/AbstractRule.php
@@ -23,6 +23,16 @@ abstract class AbstractRule implements Validatable
         return $this->validate($input);
     }
 
+    public function not(){
+        return new Not($this);
+    }
+
+    public function addOr(){
+        $rules = func_get_args();
+        array_unshift($rules, $this);
+        return new OneOf($rules);
+    }
+
     public function assert($input)
     {
         if ($this->validate($input))
@@ -35,7 +45,7 @@ abstract class AbstractRule implements Validatable
     {
         return $this->assert($input);
     }
-    
+
     public function getName()
     {
         return $this->name;

--- a/tests/library/Respect/Validation/Rules/NotTest.php
+++ b/tests/library/Respect/Validation/Rules/NotTest.php
@@ -16,6 +16,15 @@ class NotTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerForValidNot
+     *
+     */
+    public function testShortcutNot($v, $input)
+    {
+        $this->assertTrue($v->not()->assert($input));
+    }
+
+    /**
      * @dataProvider providerForInvalidNot
      * @expectedException Respect\Validation\Exceptions\ValidationException
      */
@@ -23,6 +32,15 @@ class NotTest extends \PHPUnit_Framework_TestCase
     {
         $not = new Not($v);
         $this->assertFalse($not->assert($input));
+    }
+
+    /**
+     * @dataProvider providerForInvalidNot
+     * @expectedException Respect\Validation\Exceptions\ValidationException
+     */
+    public function testShortcutNotNotHaha($v, $input)
+    {
+        $this->assertFalse($v->not()->assert($input));
     }
 
     public function providerForValidNot()

--- a/tests/library/Respect/Validation/Rules/OneOfTest.php
+++ b/tests/library/Respect/Validation/Rules/OneOfTest.php
@@ -23,6 +23,25 @@ class OneOfTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($o->check('any'));
     }
 
+    public function testShorcutValid()
+    {
+        $valid1 = new Callback(function() {
+            return false;
+        });
+        $valid2 = new Callback(function() {
+            return true;
+        });
+        $valid3 = new Callback(function() {
+            return false;
+        });
+
+        $o = $valid1->addOr($valid2, $valid3);
+
+        $this->assertTrue($o->validate('any'));
+        $this->assertTrue($o->assert('any'));
+        $this->assertTrue($o->check('any'));
+    }
+
     /**
      * @expectedException Respect\Validation\Exceptions\OneOfException
      */
@@ -43,11 +62,41 @@ class OneOfTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Respect\Validation\Exceptions\OneOfException
+     */
+    public function testShorcutInvalid()
+    {
+        $valid1 = new Callback(function() {
+            return false;
+        });
+        $valid2 = new Callback(function() {
+            return false;
+        });
+        $valid3 = new Callback(function() {
+            return false;
+        });
+        $o = $valid1->addOr($valid2, $valid3);
+        $this->assertFalse($o->validate('any'));
+        $this->assertFalse($o->assert('any'));
+    }
+
+    /**
      * @expectedException Respect\Validation\Exceptions\HexaException
      */
     public function testInvalidCheck()
     {
         $o = new OneOf(new Hexa, new Alnum);
+        $this->assertFalse($o->validate(-10));
+        $this->assertFalse($o->check(-10));
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\HexaException
+     */
+    public function testShorcutInvalidCheck()
+    {
+        $hexa = new Hexa;
+        $o = $hexa->addOr(new Alnum);
         $this->assertFalse($o->validate(-10));
         $this->assertFalse($o->check(-10));
     }


### PR DESCRIPTION
this pull request add two methods to AbstractRule not and addOr

an example for this 

v::int()->addOr(
   v::float()->not()
)->validate(15.5);  // false 
