### PR TITLE
Replacing Numeric test to only validate against numeric (0-9) strings.

### DIFF
--- a/library/Respect/Validation/Rules/Number.php
+++ b/library/Respect/Validation/Rules/Number.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+class Number extends AbstractRule
+{
+
+    public function validate($input)
+    {
+        return is_numeric($input);
+    }
+
+}
+

--- a/library/Respect/Validation/Rules/Numeric.php
+++ b/library/Respect/Validation/Rules/Numeric.php
@@ -7,7 +7,7 @@ class Numeric extends AbstractRule
 
     public function validate($input)
     {
-        return is_numeric($input);
+        return (string)$input === preg_replace('/[^0-9]/','',(string)$input);
     }
 
 }


### PR DESCRIPTION
AlphaNumeric strings only contain characters a-z, A-Z and 0-9, and the AlNum test properly checks against that set.

The Alpha test properly only tests against a-z and A-Z.

The Numeric test, however, was using PHP's is_numeric(), which allows characters that are not strictly numeric:
- Plus (+)
- Minus (-)
- Exponent (e)
- Hexidecimal (x)
- Periods (.)

A new test named Number is added to perform the task previously filled by Numeric
