### PR TITLE
Base validator

### DIFF
--- a/library/Respect/Validation/Exceptions/BaseException.php
+++ b/library/Respect/Validation/Exceptions/BaseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Respect\Validation\Exceptions;
+
+class BaseException extends ValidationException
+{
+ 
+}
+

--- a/library/Respect/Validation/Rules/Base.php
+++ b/library/Respect/Validation/Rules/Base.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Exceptions\BaseException;
+
+class Base extends AbstractRule
+{
+
+    public $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    public $base;
+
+    public function __construct($base=null, $chars=null)
+    {
+        if (!is_null($chars)) $this->chars = $chars;
+
+        $max = strlen($this->chars);
+        if (!is_numeric($base) || $base > $max)
+            throw new BaseException(
+                sprintf(
+                    'a base between 1 and %s is required', $max
+                )
+            );
+        $this->base = $base;
+    }
+
+    public function validate($input)
+    {
+        $valid = substr($this->chars, 0, $this->base);
+        return (boolean)preg_match("@^[$valid]+$@", (string)$input);
+    }
+
+}
+

--- a/library/Respect/Validation/Validator.php
+++ b/library/Respect/Validation/Validator.php
@@ -90,9 +90,13 @@ class Validator extends AllOf
     {
         if ('not' === $method)
             return $arguments ? static::buildRule($method, $arguments) : new Rules\Not($this);
-
-        $this->addRule(static::buildRule($method, $arguments));
-        return $this;
+            
+        if (isset($method{4}) && 
+            substr($method, 0, 4) == 'base' && preg_match('@^base([0-9]{1,2})$@', $method, $match))
+            return $this->addRule(static::buildRule('base', array($match[1])));
+        
+                
+        return $this->addRule(static::buildRule($method, $arguments));
     }
 
     public function reportError($input, array $extraParams=array())

--- a/tests/library/Respect/Validation/Rules/BaseTest.php
+++ b/tests/library/Respect/Validation/Rules/BaseTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+use \Respect\Validation\Validator as v;
+
+class BaseTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $object;
+
+    protected function setUp()
+    {
+
+    }
+
+    /**
+     * @dataProvider providerForBase
+     *
+     */
+    public function testBase($base, $input)
+    {
+        $object = new Base($base);
+        $this->assertTrue($object->validate($input));
+        $this->assertTrue($object->check($input));
+        $this->assertTrue($object->assert($input));
+    }
+
+    /**
+     * @dataProvider providerForBase
+     *
+     */
+    public function testBaseShortcut($base, $input)
+    {
+        $method = 'base' . $base;
+        $object = v::$method();
+
+        $this->assertTrue($object->validate($input));
+        $this->assertTrue($object->check($input));
+        $this->assertTrue($object->assert($input));
+    }
+
+    /**
+     * @dataProvider providerForInvalidBase
+     *
+     */
+    public function testInvalidBase($base, $input)
+    {
+        $object = new Base($base);
+        $this->assertFalse($object->validate($input));
+    }
+
+    /**
+     * @dataProvider providerForInvalidBase
+     *
+     */
+    public function testInvalidBaseShortcut($base, $input)
+    {
+        $method = 'base' . $base;
+        $object = v::$method();
+        $this->assertFalse($object->validate($input));
+    }
+
+    /**
+     * @dataProvider providerForExceptionBase
+     * @expectedException Respect\Validation\Exceptions\BaseException
+     */
+    public function testExceptionBase($base, $input)
+    {
+        $object = new Base($base);
+        $this->assertTrue($object->validate($input));
+        $this->assertTrue($object->assert($input));
+    }
+
+    /**
+     * @dataProvider providerForCustomBase
+     *
+     */
+    public function testCustomBase($base, $custom, $input)
+    {
+        $object = new Base($base, $custom);
+        $this->assertTrue($object->validate($input));
+        $this->assertTrue($object->check($input));
+        $this->assertTrue($object->assert($input));
+    }
+
+    public function providerForBase()
+    {
+        return array(
+            array(2, '011010001'),
+            array(3, '0120122001'),
+            array(8, '01234567520'),
+            array(16, '012a34f5675c20d'),
+            array(20, '012ah34f5675hic20dj'),
+            array(50, '012ah34f56A75FGhic20dj'),
+            array(62, 'Z01xSsg5675hic20dj')
+        );
+    }
+
+    public function providerForInvalidBase()
+    {
+        return array(
+            array(2, '01210103001'),
+            array(3, '0120125f2001'),
+            array(8, '01234dfZ567520'),
+            array(16, '012aXS34f5675c20d'),
+            array(20, '012ahZX34f5675hic20dj'),
+            array(50, '012ahGZ34f56A75FGhic20dj'),
+            array(61, 'Z01xSsg5675hic20dj')
+        );
+    }
+
+    public function providerForCustomBase()
+    {
+        return array(
+            array(2, 'xy', 'xyyxyxxy'),
+            array(3, 'pfg', 'gfpffp')
+        );
+    }
+
+    public function providerForExceptionBase()
+    {
+        return array(
+            array(63, '01210103001'),
+            array(125, '0120125f2001')
+        );
+    }
+
+}


### PR DESCRIPTION
New numeric validator for any base. Samples:

v::base(2)->assert('010101');
v::base(4)->assert('01233210');

with a shortcut:
v::base2()->assert('010101');
v::base4()->assert('01233210');

and custom numeric sequences:
v::base(2, 'xyzw')->assert('xxyxx');
