### PR TITLE
Declare php ext suggestions, fix #121

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,13 +84,13 @@
         "type": "composer",
         "url": "https://packages.zendframework.com/"
     }],
-    "require": {
-        "ext-bcmath": "*",
-        "ext-mbstring": "*"
-    },
     "require-dev": {
         "zendframework/zend-validator": "2.*",
         "symfony/validator": "2.*"
+    },
+    "suggest": {
+        "ext-bcmath": "*",
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Fix #121. Instead of putting extensions as "require" (what could make composer deny installing Respect/Validation), this PR declare them as "suggest".
