### PR TITLE
Fix 139: Broken `sf` (Symfony) rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }],
     "require-dev": {
         "zendframework/zend-validator": "2.*",
-        "symfony/validator": "2.*",
+        "symfony/validator": ">=2.1.0",
         "phpunit/phpunit": "3.7.*"
     },
     "suggest": {

--- a/tests/library/Respect/Validation/Rules/SfTest.php
+++ b/tests/library/Respect/Validation/Rules/SfTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Validator as v;
+
+class SfTest extends \PHPUnit_Framework_TestCase
+{
+    public function assertPreConditions()
+    {
+        if (false === class_exists('Symfony\Component\Validator\Constraints\Time')) {
+            $this->markTestSkipped('Expected Symfony\Validator installed.');
+        }
+    }
+
+    public function testValidationWithAnExistingValidationConstraint()
+    {
+        $constraintName = 'Time';
+        $validConstraintValue = '04:20:00';
+        $invalidConstraintValue = 'yada';
+        $this->assertTrue(
+            v::sf($constraintName)->validate($validConstraintValue),
+            sprintf('"%s" should be valid under "%s" constraint.', $validConstraintValue, $constraintName)
+        );
+        $this->assertFalse(
+            v::sf($constraintName)->validate($invalidConstraintValue),
+            sprintf('"%s" should be invalid under "%s" constraint.', $invalidConstraintValue, $constraintName)
+        );
+    }
+
+    /**
+     * @depends testValidationWithAnExistingValidationConstraint
+     */
+    public function testAssertionWithAnExistingValidationConstraint()
+    {
+        $constraintName = 'Time';
+        $validConstraintValue = '04:20:00';
+        $this->assertTrue(
+            v::sf($constraintName)->assert($validConstraintValue),
+            sprintf('"%s" should be valid under "%s" constraint.', $validConstraintValue, $constraintName)
+        );        
+    }
+
+    /**
+     * @depends testAssertionWithAnExistingValidationConstraint
+     */
+    public function testAssertionMessageWithAnExistingValidationConstraint()
+    {
+        $constraintName = 'Time';
+        $invalidConstraintValue = '34:90:70';
+        try {
+            v::sf($constraintName)->assert($invalidConstraintValue);
+        } catch (\Respect\Validation\Exceptions\AllOfException $exception) {
+            $fullValidationMessage = $exception->getFullMessage();
+            $expectedValidationException = <<<EOF
+\-These rules must pass for "34:90:70"
+  \-Time
+EOF;
+            return $this->assertEquals(
+                $expectedValidationException,
+                $fullValidationMessage,
+                'Exception message is different from the one expected.'
+            );
+        }
+        $this->fail('Validation exception expected to compare message.');
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\ComponentException
+     * @expectedExceptionMessage Symfony/Validator constraint "FluxCapacitor" does not exist.
+     */
+    public function testValidationWithNonExistingConstraint()
+    {
+        $fantasyConstraintName = 'FluxCapacitor';
+        $fantasyValue = '8GW';
+        v::sf($fantasyConstraintName)->validate($fantasyValue);
+    }
+}


### PR DESCRIPTION
This **breaks compatibility** in my opinion, since people who are currently using this rule (compatible with `Symfony\Validator` < 2.1) will start to have problems; even though for _stable_ versions of the `Symfony\Validator` this rule is not working at all (as noted on #139).
