### PR TITLE
Allow support for IDN with subdomains

### DIFF
--- a/library/Respect/Validation/Rules/Domain.php
+++ b/library/Respect/Validation/Rules/Domain.php
@@ -13,16 +13,16 @@ class Domain extends AbstractComposite
     {
         $this->checks[] = new NoWhitespace();
         $this->checks[] = new Contains('.');
-        $this->checks[] = new OneOf(new Not(new Contains('--')),
-                                    new AllOf(new StartsWith('xn--'),
-                                              new Callback(function ($str) {
-                                                  return substr_count($str, "--") == 1;
-                                              })));
         $this->checks[] = new Length(3, null);
         $this->TldCheck($tldCheck);
         $this->otherParts = new AllOf(
             new Alnum('-'),
-            new Not(new StartsWith('-'))
+            new Not(new StartsWith('-')),
+            new OneOf(new Not(new Contains('--')),
+                      new AllOf(new StartsWith('xn--'),
+                                new Callback(function ($str) {
+                                    return substr_count($str, "--") == 1;
+                                })))
         );
     }
 

--- a/tests/library/Respect/Validation/Rules/DomainTest.php
+++ b/tests/library/Respect/Validation/Rules/DomainTest.php
@@ -51,6 +51,7 @@ class DomainTest extends \PHPUnit_Framework_TestCase
             array('111111111111.domain.local', false),
             array('example.com'),
             array('xn--bcher-kva.ch'),
+            array('mail.xn--bcher-kva.ch'),
             array('example-hyphen.com'),
         );
     }


### PR DESCRIPTION
I just moved the IDN rulo from checks array to otherParts validation, because the old approach did not supported an IDN with subdomain