### PR TITLE
Make between inclusive by default

### DIFF
--- a/library/Respect/Validation/Rules/Between.php
+++ b/library/Respect/Validation/Rules/Between.php
@@ -8,7 +8,7 @@ class Between extends AllOf
     public $minValue;
     public $maxValue;
 
-    public function __construct($min=null, $max=null, $inclusive=false)
+    public function __construct($min=null, $max=null, $inclusive=true)
     {
         $this->minValue = $min;
         $this->maxValue = $max;


### PR DESCRIPTION
I think more developers expect between to be inclusive. Like [MySQL](https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_between).