### PR TITLE
notEmpty fix

### DIFF
--- a/library/Respect/Validation/Rules/NotEmpty.php
+++ b/library/Respect/Validation/Rules/NotEmpty.php
@@ -6,7 +6,7 @@ class NotEmpty extends AbstractRule
     public function validate($input)
     {
         if (is_string($input)) {
-            $input = trim($input);
+            return trim($input) !== '';
         }
 
         return !empty($input);


### PR DESCRIPTION
For strings only: notEmpty now means "there was content supplied", rather than "the content was not empty according to the php empty function".

Effect: notEmpty no longer validates to false when string "0" is supplied.

This make more sense when validating HTML forms.

Related issue: https://github.com/Respect/Validation/issues/154

## Backward Compatibility Break

Currently the `notEmpty` rule works like:

```php
v::int()->notEmpty()->validate(0); //false
v::int()->notEmpty()->validate("0"); //false
```

If this PR is accepted:

```php
v::int()->notEmpty()->validate(0); //false
v::int()->notEmpty()->validate("0"); //true <-- BC Break
```

## Missing on this PR

If this PR gets accepted by other members, it still misses some stuff which I will point out just for the sake of not trusting my memory:

- [ ] Test to ensure current behavior.
- [ ] Test checking behavior using different types (string, int, float, boolean) to check for empty values.
- [ ] Change on README.
- [ ] Better short commit message (Ex: "NotEmpty returns true to 0 (zero) for strings.").