### PR TITLE
Exception messages using field name instead of value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,4 @@
 {
-    "name": "s-bhojani/Validation",
+    "name": "s-bhojani/validation",
     "description": "Fork of https://github.com/Respect/Validation"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,4 @@
 {
-    "name": "SBhojani/Validation",
+    "name": "s-bhojani/Validation",
     "description": "Fork of https://github.com/Respect/Validation"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,4 @@
 {
-    "name": "Respect/Validation",
-    "description": "The most awesome validation engine ever created for PHP",
-    "keywords": ["respect", "validation", "validator"],
-    "type": "library",
-    "homepage": "http://respect.li",
-    "license": "BSD Style",
-    "authors": [
-        {
-            "name": "Respect/Validation Contributors",
-            "homepage": "https://github.com/Respect/Validation/graphs/contributors"
-        }
-    ],
-    "repositories": [{
-        "type": "composer",
-        "url": "https://packages.zendframework.com/"
-    }],
-    "require-dev": {
-        "zendframework/zend-validator": "~2.0",
-        "symfony/validator": "~2.1",
-        "phpunit/phpunit": "~4.0"
-    },
-    "suggest": {
-        "ext-bcmath": "Arbitrary Precision Mathematics",
-        "ext-mbstring": "Multibyte String Functions"
-    },
-    "autoload": {
-        "psr-0": {
-            "Respect\\Validation": "library\/"
-        }
-    }
+    "name": "SBhojani/Validation",
+    "description": "Fork of https://github.com/Respect/Validation"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
     "name": "s-bhojani/validation",
-    "description": "Fork of https://github.com/Respect/Validation"
+    "description": "Fork of https://github.com/Respect/Validation",
+    "autoload": {
+        "psr-0": {
+            "Respect\\Validation": "library\/"
+        }
+    }
 }

--- a/library/RecursiveTreeIterator.php
+++ b/library/RecursiveTreeIterator.php
@@ -22,7 +22,7 @@
  * @version 1.1
  * @since   PHP 5.3
  */
-class RecursiveTreeIterator extends RecursiveIteratorIterator
+class NonSplRecursiveTreeIterator extends RecursiveIteratorIterator
 {
     const BYPASS_CURRENT = 0x00000004;
     const BYPASS_KEY     = 0x00000008;

--- a/library/Respect/Validation/ExceptionIterator.php
+++ b/library/Respect/Validation/ExceptionIterator.php
@@ -25,7 +25,9 @@ class ExceptionIterator extends RecursiveArrayIterator
 
     public function getChildren()
     {
-        return new static($this->current()->getRelated($this->fullRelated), $this->fullRelated);
+        if ($this->current()) {
+            return new static($this->current()->getRelated($this->fullRelated), $this->fullRelated);
+        }
     }
 }
 

--- a/library/Respect/Validation/Exceptions/AbstractNestedException.php
+++ b/library/Respect/Validation/Exceptions/AbstractNestedException.php
@@ -2,7 +2,7 @@
 namespace Respect\Validation\Exceptions;
 
 use RecursiveIteratorIterator;
-use RecursiveTreeIterator;
+use NonSplRecursiveTreeIterator;
 use Respect\Validation\ExceptionIterator;
 
 class AbstractNestedException extends ValidationException
@@ -59,7 +59,8 @@ class AbstractNestedException extends ValidationException
         if ($mode == self::ITERATE_ALL) {
             return new RecursiveIteratorIterator($exceptionIterator, 1);
         } else {
-            return new RecursiveTreeIterator($exceptionIterator);
+            require_once dirname(__FILE__).'/../../../RecursiveTreeIterator.php';
+            return new NonSplRecursiveTreeIterator($exceptionIterator);
         }
     }
 

--- a/library/Respect/Validation/Exceptions/SymbolicLinkException.php
+++ b/library/Respect/Validation/Exceptions/SymbolicLinkException.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace Respect\Validation\Exceptions;

--- a/library/Respect/Validation/Rules/AbstractRule.php
+++ b/library/Respect/Validation/Rules/AbstractRule.php
@@ -53,7 +53,7 @@ abstract class AbstractRule implements Validatable
     {
         $exception = $this->createException();
         $input = ValidationException::stringify($input);
-        $name = $this->name ?: "\"$input\"";
+        $name = ($this->name || $this->name === 0) ? $this->name : "\"$input\"";
         $params = array_merge(
             get_class_vars(__CLASS__), get_object_vars($this), $extraParams,
             compact('input')

--- a/library/Respect/Validation/Rules/Key.php
+++ b/library/Respect/Validation/Rules/Key.php
@@ -8,7 +8,7 @@ class Key extends AbstractRelated
 {
     public function __construct($reference, Validatable $referenceValidator=null, $mandatory=true)
     {
-        if (!is_string($reference) || empty($reference)) {
+        if (!is_string($reference) && !is_int($reference)) {
             throw new ComponentException('Invalid array key name');
         }
         parent::__construct($reference, $referenceValidator, $mandatory);

--- a/library/Respect/Validation/Validator.php
+++ b/library/Respect/Validation/Validator.php
@@ -127,15 +127,31 @@ class Validator extends AllOf
     public function __call($method, $arguments)
     {
         if ('not' === $method) {
-            return $arguments ? static::buildRule($method, $arguments) : new Rules\Not($this);
+            if ($arguments) {
+                $rule = static::buildRule($method, $arguments);
+                if ($this->getName() && !$rule->getName()) {
+                    $rule->setName($this->getName());
+                }
+                return $rule;
+            } else {
+                return new Rules\Not($this);
+            }
         }
 
         if (isset($method{4}) &&
             substr($method, 0, 4) == 'base' && preg_match('@^base([0-9]{1,2})$@', $method, $match)) {
-            return $this->addRule(static::buildRule('base', array($match[1])));
+            $rule = static::buildRule('base', array($match[1]));
+            if ($this->getName() && !$rule->getName()) {
+                $rule->setName($this->getName());
+            }
+            return $this->addRule($rule);
         }
 
-        return $this->addRule(static::buildRule($method, $arguments));
+        $rule = static::buildRule($method, $arguments);
+        if ($this->getName() && !$rule->getName()) {
+            $rule->setName($this->getName());
+        }
+        return $this->addRule($rule);
     }
 
     public function reportError($input, array $extraParams=array())


### PR DESCRIPTION
Fixing the issue discussed in https://github.com/Respect/Validation/issues/86 so atleast the following code gives the field names in the error messages:

    try{
        v::string()->setName('First Name')->notEmpty()->noWhitespace()->alpha()->assert($_POST['txt_first_name']);
    }catch (\Respect\Validation\Exceptions\ValidationException $e){
        echo $e->getFullMessage();
    }