### PR TITLE
Shortened first validation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Respect\Validation [![Build Status](https://secure.travis-ci.org/Respect/Validat
 
 The most awesome validation engine ever created for PHP.
 
-- Fluent/Chained builders like `v::numeric()->positive()->between(1, 256)->validate($myNumber)` (more samples below)
+- Fluent/Chained builders like `v::numeric()->between(1, 256)->validate($myNumber)` (more samples below)
 - Informative, awesome exceptions
 - More than 30 fully tested validators
 


### PR DESCRIPTION
The configured `Between` instance implies positive numbers. To be precise, the instance only allows numbers greater than one (and less than 256), as it is configured non-inclusive (`$inclusive` defaults to `false`). Returning the error message of `PositiveException` (`{{name}} must be positive) on invalid numbers`) is contradictory in this case.
