### PR TITLE
Fixed Exception class in "Informative Exceptions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ we use the `assert()` method instead of `validate()`:
 ```php
 try {
     $usernameValidator->assert('really messed up screen#name');
-} catch(\InvalidArgumentException $e) {
+} catch(DomainException $e) {
    echo $e->getFullMessage();
 }
 ```


### PR DESCRIPTION
The example in the "Informative Exceptions" section uses InvalidArgumentException, which is incorrect as that class does not have a getFullMessage() method. The class that defines getFullMessage() is AbstractNestedException, of which DomainException is a subclass, so I've replaced InvalidArgumentException with that to make the example accurate.
