### PR TITLE
Corrected a data set for valid prime number

### DIFF
--- a/tests/library/Respect/Validation/Rules/PrimeNumberTest.php
+++ b/tests/library/Respect/Validation/Rules/PrimeNumberTest.php
@@ -35,7 +35,7 @@ class PrimeNumberTest extends \PHPUnit_Framework_TestCase
     public function providerForPrimeNumber()
     {
         return array(
-            array(''),
+            array(2),
             array(3),
             array(5),
             array(7),


### PR DESCRIPTION
Previous empty input ('') is not a valid data set.
