### PR TITLE
Create Factory rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Message:
   * [v::cpf()](#vcpf)
   * [v::domain()](#vdomain)
   * [v::email()](#vemail)
+  * [v::factory()](#vfactoryrulename-array-constructorargs--null)
   * [v::hexRgbColor()](#vhexrgbcolor)
   * [v::ip()](#vip)
   * [v::json()](#vjson)
@@ -1067,6 +1068,22 @@ See also
 
   * [v::odd()](#vodd)
   * [v::multiple()](#vmultiplemultipleof)
+
+#### v::factory($ruleName, array $constructorArgs = null)
+
+Create rules by its name.
+
+```php
+v::factory('int')->validate(42); //true
+```
+
+The best think on this rule if that you also can append or prepend custom prefixes
+to use your own rules:
+
+```php
+Respect\Validation\Rules\Factory::prependPrefix('My\\Priority\\Rules\\');
+Respect\Validation\Rules\Factory::appendPrefix('My\\Other\\Rules\\');
+```
 
 #### v::file()
 

--- a/library/Rules/Factory.php
+++ b/library/Rules/Factory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+use ReflectionClass;
+use Respect\Validation\Exceptions\ComponentException;
+use Respect\Validation\Validatable;
+
+class Factory extends AbstractRule
+{
+    public $rule;
+
+    public static $prefixes = array('Respect\\Validation\\Rules\\');
+
+    public function __construct($ruleName, array $constructorArgs = array())
+    {
+        $this->rule = $this->rule($ruleName, $constructorArgs);
+    }
+
+    public function rule($ruleName, array $constructorArgs = array())
+    {
+        foreach (self::$prefixes as $prefix) {
+            $className = $prefix.ucfirst($ruleName);
+
+            if (! class_exists($className)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+            if (! $reflection->isSubclassOf('Respect\\Validation\\Validatable')) {
+                throw new ComponentException(sprintf('"%s" is not a valid respect rule', $className));
+            }
+
+            return $reflection->newInstanceArgs($constructorArgs);
+        }
+
+        throw new ComponentException(sprintf('"%s" is not a valid rule name', $ruleName));
+    }
+
+    public static function appendPrefix($rulePrefix)
+    {
+        array_push(self::$prefixes, $rulePrefix);
+    }
+
+    public static function prependPrefix($rulePrefix)
+    {
+        array_unshift(self::$prefixes, $rulePrefix);
+    }
+
+    public function assert($input)
+    {
+        return $this->rule->assert($input);
+    }
+
+    public function check($input)
+    {
+        return $this->rule->check($input);
+    }
+
+    public function validate($input)
+    {
+        return $this->rule->validate($input);
+    }
+}

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -102,6 +102,7 @@ use Respect\Validation\Rules\AllOf;
  * @method static Validator xdigit(string $additionalChars = null)
  * @method static Validator yes($useLocale = false)
  * @method static Validator zend(mixed $validator, array $params = null)
+ * @method static Validator factory($ruleName, array $constructorArgs = null)
  */
 class Validator extends AllOf
 {

--- a/tests/Exceptions/CheckExceptionsTest.php
+++ b/tests/Exceptions/CheckExceptionsTest.php
@@ -7,9 +7,10 @@ use DirectoryIterator;
 
 class CheckExceptionsTest extends \PHPUnit_Framework_TestCase
 {
-    protected $deprecateds = array(
+    protected $blacklist = array(
         'Consonants',
         'Digits',
+        'Factory',
         'Vowels',
     );
 
@@ -23,7 +24,7 @@ class CheckExceptionsTest extends \PHPUnit_Framework_TestCase
                 continue;
             }
             $ruleName = substr($fileInfo->getBasename(), 0, -4);
-            if (in_array($ruleName, $this->deprecateds)) {
+            if (in_array($ruleName, $this->blacklist)) {
                 continue;
             }
 

--- a/tests/Rules/FactoryTest.php
+++ b/tests/Rules/FactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Respect\Validation\Rules;
+
+/**
+ * @covers Respect\Validation\Rules\Factory
+ */
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $prefixes;
+
+    protected function setUp()
+    {
+        $this->prefixes = Factory::$prefixes;
+    }
+
+    protected function tearDown()
+    {
+        Factory::$prefixes = $this->prefixes;
+    }
+
+    public function testShouldBeAbleToAppendANewPrefix()
+    {
+        Factory::appendPrefix('My\\Validation\\Rules\\');
+
+        $this->assertEquals(array('Respect\\Validation\\Rules\\', 'My\\Validation\\Rules\\'), Factory::$prefixes);
+    }
+
+    public function testShouldBeAbleToPrependANewPrefix()
+    {
+        Factory::prependPrefix('My\\Validation\\Rules\\');
+
+        $this->assertEquals(array('My\\Validation\\Rules\\', 'Respect\\Validation\\Rules\\'), Factory::$prefixes);
+    }
+
+    public function testShouldCreateARuleByName()
+    {
+        $rule = new Factory('Uppercase');
+
+        $this->assertInstanceOf('Respect\\Validation\\Rules\\Uppercase', $rule->rule);
+    }
+
+    public function testShouldDefineConstructorArgumentsWhenCreatingARule()
+    {
+        $rule = new Factory('date', array('Y-m-d'));
+
+        $this->assertEquals('Y-m-d', $rule->rule->format);
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\ComponentException
+     * @expectedExceptionMessage "uterere" is not a valid rule name
+     */
+    public function testShouldThrowsAnExceptionWhenFactoryIsNotValid()
+    {
+        new Factory('uterere');
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\ComponentException
+     * @expectedExceptionMessage "Respect\Validation\Rules\NonRule" is not a valid respect rule
+     */
+    public function testShouldThrowsAnExceptionWhenRuleIsNotInstanceOfRuleInterface()
+    {
+        new Factory('nonRule');
+    }
+
+    public function testShouldUseRuleToValidate()
+    {
+        $rule = new Factory('Int');
+
+        $this->assertTrue($rule->validate(123));
+    }
+}
+
+class NonRule
+{
+}


### PR DESCRIPTION
Create rules by its name.

```php
v::factory('int')->validate(42); //true
```

The best think on this rule if that you also can append or prepend custom prefixes
to use your own rules:

```php
Respect\Validation\Rules\Factory::prependPrefix('My\\Priority\\Rules\\');
Respect\Validation\Rules\Factory::appendPrefix('My\\Other\\Rules\\');
```

Closes #176.