### PR TITLE
Translate Date formats to DateTime::createFromFormat 

### DIFF
--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -22,6 +22,15 @@ class Date extends AbstractRule
             return false !== strtotime($input);
         }
 
+        $exceptionalFormats = array(
+            'c'     =>  'Y-m-d\TH:i:sP',
+            'r'     =>  'D, d M Y H:i:s O',
+        );
+
+        if ( in_array($this->format, array_keys($exceptionalFormats)) ) {
+            $this->format = $exceptionalFormats[ $this->format ];
+        }
+
         $dateFromFormat = DateTime::createFromFormat($this->format, $input);
 
         return $dateFromFormat

--- a/tests/library/Respect/Validation/Rules/DateTest.php
+++ b/tests/library/Respect/Validation/Rules/DateTest.php
@@ -63,5 +63,14 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->dateValidator = new Date('y-m-d');
         $this->assertFalse($this->dateValidator->assert('2009-09-09'));
     }
+
+    public function testDateTimeExceptionalFormatsThatShouldBeValid()
+    {
+        $this->dateValidator = new Date('c');
+        $this->assertTrue($this->dateValidator->assert('2004-02-12T15:19:21+00:00'));
+
+        $this->dateValidator = new Date('r');
+        $this->assertTrue($this->dateValidator->assert('Thu, 29 Dec 2005 01:02:03 +0000'));
+    }
 }
 


### PR DESCRIPTION
Translate date formats to something DateTime::createFromFormat can understand. Should fix #152

I'm not sure if it's the right approach or if there's more formats that needs conversion.
