### PR TITLE
Update CI settings

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,11 +1,15 @@
 filter:
-        paths: [library/*]
+    excluded_paths:
+        - tests/*
+
+checks:
+    php:
+        code_rating: true
+
 tools:
-    external_code_coverage:
-        runs: 4
-    php_cpd:
-        excluded_dirs: [vendor]
-    php_pdepend:
-        excluded_dirs: [vendor]
-    sensiolabs_security_checker: true
+    php_analyzer: true
     php_changetracking: true
+    php_cpd: true
+    php_mess_detector: true
+    php_pdepend: true
+    sensiolabs_security_checker: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
-# a Courtesy of Respect/Foundation
-
-language: php
-
-env: FOUNDATION_NO_WAIT=1
+language:
+  php
 
 php:
   - 5.3
@@ -12,12 +9,11 @@ php:
   - hhvm
 
 before_script:
-  - make composer-install-dev
+  - composer install --dev --no-interaction --prefer-source
   - phpenv rehash
 
 script:
-  - make testdox
-  - make scrutinizer-coverage
+  - vendor/bin/phpunit --configuration tests/phpunit.xml --testdox tests/
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Since the last change of `.scrutinizer.yml` on Validation repository, Scrutinizer has been going through a lot of modifications, that's why the latest pull requests were not successful on it. Also, the latest builds on Travis got errors when running composer.

- Allow `code_rating` check on Scrutinizer
- Exclude tests/* and vendor/* from Scrutinizer paths
- Fix Travis error when running composer
- Run `php_analyzer` on Scrutinizer
- Run `php_mess_detector` on Scrutinizer
- Run PHPUnit on Travis without using Foundation
- Run tests coverage on Scrutinizer