### PR TITLE
Fixed v::min documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ Reference
 
   * [v::between()](#vbetweenstart-end)
   * [v::equals()](#vequalsvalue)
-  * [v::max()](#vmax)
-  * [v::min()](#vmin)
+  * [v::max()](#vmaxmax)
+  * [v::min()](#vminmin)
 
 ### Numeric
 
@@ -541,8 +541,8 @@ Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
 See also:
 
   * [v::length()](#vlengthmin-max) - Validates the length of a input
-  * [v::min()](#vmin)
-  * [v::max()](#vmax)
+  * [v::min()](#vminmin)
+  * [v::max()](#vmaxmax)
 
 #### v::bool()
 
@@ -1278,6 +1278,8 @@ Validates if the input doesn't exceed the maximum value.
 
 ```php
 v::int()->max(15)->validate(20); //false
+v::int()->max(20)->validate(20); //false
+v::int()->max(20, true)->validate(20); //true
 ```
 
 Also accepts dates:
@@ -1293,7 +1295,7 @@ Message template for this validator includes `{{maxValue}}`.
 
 See also:
 
-  * [v::min()](#vmin)
+  * [v::min()](#vminmin)
   * [v::between()](#vbetweenstart-end)
 
 #### v::min($min)
@@ -1320,7 +1322,7 @@ Message template for this validator includes `{{minValue}}`.
 
 See also:
 
-  * [v::max()](#vmax)
+  * [v::max()](#vmaxmax)
   * [v::between()](#vbetweenstart-end)
 
 #### v::minimumAge($age)

--- a/README.md
+++ b/README.md
@@ -1271,8 +1271,8 @@ Validates a Mac Address.
 v::macAddress()->validate('00:11:22:33:44:55'); //true
 ```
 
-#### v::max()
-#### v::max(boolean $inclusive=false)
+#### v::max($max)
+#### v::max($max, boolean $inclusive=false)
 
 Validates if the input doesn't exceed the maximum value.
 
@@ -1296,13 +1296,15 @@ See also:
   * [v::min()](#vmin)
   * [v::between()](#vbetweenstart-end)
 
-#### v::min()
-#### v::min(boolean $inclusive=false)
+#### v::min($min)
+#### v::min($min, boolean $inclusive=false)
 
-Validates if the input doesn't exceed the minimum value.
+Validates if the input is greater than the minimum value.
 
 ```php
 v::int()->min(15)->validate(5); //false
+v::int()->min(5)->validate(5); //false
+v::int()->min(5, true)->validate(5); //true
 ```
 
 Also accepts dates:


### PR DESCRIPTION
Hi,

v::min had the incorrect description in the README.md.  I also added the parameters for v::min and v::max, as well as added some more examples for their usage.