### PR TITLE
A rule without name must resturn NULL in getName()

### DIFF
--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -46,7 +46,7 @@ abstract class AbstractRule implements Validatable
     public function getName()
     {
         if (empty($this->name)) {
-            preg_replace('/.*\\\/', '', get_class($this));
+            return null;
         }
 
         return $this->name;


### PR DESCRIPTION
I fixed this little bug #208 