### PR TITLE
Fixes #244, #154, #196, #173, #235 and #239

### DIFF
--- a/README.md
+++ b/README.md
@@ -1475,14 +1475,19 @@ See also:
 
   * [v::noneOf()](#vnoneofv1-v2-v3)
 
-#### v::notEmpty()
+#### v::notEmpty($jugglesTypes = true)
 
 Validates if the given input is not empty or in other words is input mandatory and
 required. This function also takes whitespace into account, use `noWhitespace()`
 if no spaces or linebreaks and other whitespace anywhere in the input is desired.
 
+
 ```php
 v::string()->notEmpty()->validate(''); //false
+v::string()->notEmpty()->validate('0'); //false
+
+// Disable type juggling
+v::string()->notEmpty(false)->validate('0'); //true
 ```
 
 Null values are empty:

--- a/README.md
+++ b/README.md
@@ -1475,7 +1475,8 @@ See also:
 
   * [v::noneOf()](#vnoneofv1-v2-v3)
 
-#### v::notEmpty($jugglesTypes = true)
+#### v::notEmpty()
+#### v::notEmpty($strict = false)
 
 Validates if the given input is not empty or in other words is input mandatory and
 required. This function also takes whitespace into account, use `noWhitespace()`
@@ -1486,8 +1487,8 @@ if no spaces or linebreaks and other whitespace anywhere in the input is desired
 v::string()->notEmpty()->validate(''); //false
 v::string()->notEmpty()->validate('0'); //false
 
-// Disable type juggling
-v::string()->notEmpty(false)->validate('0'); //true
+// Enable strict checking
+v::string()->notEmpty(true)->validate('0'); //true
 ```
 
 Null values are empty:

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -66,10 +66,12 @@ abstract class AbstractRelated extends AbstractRule
     public function validate($input)
     {
         $hasReference = $this->hasReference($input);
+
         if ($this->mandatory && !$hasReference) {
             return false;
         }
 
-        return $this->decision('validate', $hasReference, $input);
+        return $this->decision('validate', $hasReference, $input) ||
+        $this->getReferenceValue($input) === '';
     }
 }

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -18,8 +18,7 @@ abstract class AbstractRule implements Validatable
 
     public function __invoke($input)
     {
-        return !is_a($this, __NAMESPACE__.'\\NotEmpty')
-            && $input === '' || $this->validate($input);
+        return '' === $input || $this->validate($input);
     }
 
     public function addOr()

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -44,10 +44,6 @@ abstract class AbstractRule implements Validatable
 
     public function getName()
     {
-        if (empty($this->name)) {
-            preg_replace('/.*\\\/', '', get_class($this));
-        }
-
         return $this->name;
     }
 

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -3,12 +3,31 @@ namespace Respect\Validation\Rules;
 
 class NotEmpty extends AbstractRule
 {
+    /** Wheter to juggle PHP types **/
+    public $jugglesTypes = true;
+
+    public function __construct($jugglesTypes = true)
+    {
+        $this->jugglesTypes = $jugglesTypes;
+    }
+
     public function validate($input)
     {
-        if (is_string($input)) {
-            $input = trim($input);
+        if (!is_string($input)) {
+            return !empty($input);
         }
 
-        return !empty($input);
+        $input = trim($input);
+
+        if ($this->jugglesTypes) {
+            return !empty($input);
+        }
+
+        return '' !== $input;
+    }
+
+    public function __invoke($input)
+    {
+        return $this->validate($input);
     }
 }

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -4,11 +4,11 @@ namespace Respect\Validation\Rules;
 class NotEmpty extends AbstractRule
 {
     /** Wheter to juggle PHP types **/
-    public $jugglesTypes = true;
+    public $strict = false;
 
-    public function __construct($jugglesTypes = true)
+    public function __construct($strict = false)
     {
-        $this->jugglesTypes = $jugglesTypes;
+        $this->strict = $strict;
     }
 
     public function validate($input)
@@ -19,7 +19,7 @@ class NotEmpty extends AbstractRule
 
         $input = trim($input);
 
-        if ($this->jugglesTypes) {
+        if (!$this->strict) {
             return !empty($input);
         }
 

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -6,6 +6,7 @@ use ReflectionException;
 use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Rules\AllOf;
+use Respect\Validation\Rules\NotEmpty;
 
 /**
  * @method static Validator allOf()
@@ -113,6 +114,13 @@ class Validator extends AllOf
         $validator = new static();
 
         return $validator->__call($ruleName, $arguments);
+    }
+
+
+    public function __invoke($input)
+    {
+        return ( ! $this instanceof NotEmpty && $input === '' ) ||
+            $this->validate($input);
     }
 
     /**

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -6,7 +6,6 @@ use ReflectionException;
 use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Rules\AllOf;
-use Respect\Validation\Rules\NotEmpty;
 
 /**
  * @method static Validator allOf()
@@ -114,13 +113,6 @@ class Validator extends AllOf
         $validator = new static();
 
         return $validator->__call($ruleName, $arguments);
-    }
-
-
-    public function __invoke($input)
-    {
-        return ( ! $this instanceof NotEmpty && $input === '' ) ||
-            $this->validate($input);
     }
 
     /**

--- a/tests/library/Respect/Validation/MiscTest.php
+++ b/tests/library/Respect/Validation/MiscTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Respect\Validation;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class MiscTest extends \PHPUnit_Framework_TestCase
 {
     public function testStaticCreateShouldReturnNewValidator()
     {

--- a/tests/library/Respect/Validation/Rules/KeyTest.php
+++ b/tests/library/Respect/Validation/Rules/KeyTest.php
@@ -13,6 +13,16 @@ class KeyTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->validate($obj));
     }
 
+    public function testArrayWithEmptyKeyShouldReturnTrue()
+    {
+        $validator = new Key('someEmptyKey');
+        $obj = array();
+        $obj['someEmptyKey'] = '';
+        $this->assertTrue($validator->assert($obj));
+        $this->assertTrue($validator->check($obj));
+        $this->assertTrue($validator->validate($obj));
+    }
+
     /**
      * @expectedException Respect\Validation\Exceptions\KeyException
      */

--- a/tests/library/Respect/Validation/Rules/NotEmptyTest.php
+++ b/tests/library/Respect/Validation/Rules/NotEmptyTest.php
@@ -19,12 +19,44 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerForNotEmptyNoJuggle
+     */
+    public function testStringNotEmptyNoJuggle($input)
+    {
+        $this->object = new NotEmpty(false);
+        $this->assertTrue($this->object->assert($input));
+    }
+
+    /**
      * @dataProvider providerForEmpty
      * @expectedException Respect\Validation\Exceptions\NotEmptyException
      */
     public function testStringEmpty($input)
     {
         $this->assertFalse($this->object->assert($input));
+    }
+
+    /**
+     * @dataProvider providerForEmptyNoJuggle
+     * @expectedException Respect\Validation\Exceptions\NotEmptyException
+     */
+    public function testStringEmptyNoJuggle($input)
+    {
+        $this->object = new NotEmpty(false);
+        $this->assertFalse($this->object->assert($input));
+    }
+
+    public function providerForNotEmptyNoJuggle()
+    {
+        return array(
+            array(1),
+            array('0'),
+            array(' 0 '),
+            array(' oi'),
+            array(array(5)),
+            array(array(0)),
+            array(new \stdClass)
+        );
     }
 
     public function providerForNotEmpty()
@@ -39,6 +71,20 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
     }
 
     public function providerForEmpty()
+    {
+        return array(
+            array(''),
+            array('0'),
+            array(' 0 '),
+            array('    '),
+            array("\n"),
+            array(false),
+            array(null),
+            array(array())
+        );
+    }
+
+    public function providerForEmptyNoJuggle()
     {
         return array(
             array(''),

--- a/tests/library/Respect/Validation/Rules/NotEmptyTest.php
+++ b/tests/library/Respect/Validation/Rules/NotEmptyTest.php
@@ -23,7 +23,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringNotEmptyNoJuggle($input)
     {
-        $this->object = new NotEmpty(false);
+        $this->object = new NotEmpty(true);
         $this->assertTrue($this->object->assert($input));
     }
 
@@ -42,7 +42,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringEmptyNoJuggle($input)
     {
-        $this->object = new NotEmpty(false);
+        $this->object = new NotEmpty(true);
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/library/Respect/Validation/Rules/SfTest.php
+++ b/tests/library/Respect/Validation/Rules/SfTest.php
@@ -18,12 +18,13 @@ class SfTest extends \PHPUnit_Framework_TestCase
         $constraintName = 'Time';
         $validConstraintValue = '04:20:00';
         $invalidConstraintValue = 'yada';
+        $rule = new Sf($constraintName);
         $this->assertTrue(
-            v::sf($constraintName)->validate($validConstraintValue),
+            $rule->validate($validConstraintValue),
             sprintf('"%s" should be valid under "%s" constraint.', $validConstraintValue, $constraintName)
         );
         $this->assertFalse(
-            v::sf($constraintName)->validate($invalidConstraintValue),
+            $rule->validate($invalidConstraintValue),
             sprintf('"%s" should be invalid under "%s" constraint.', $invalidConstraintValue, $constraintName)
         );
     }
@@ -35,10 +36,11 @@ class SfTest extends \PHPUnit_Framework_TestCase
     {
         $constraintName = 'Time';
         $validConstraintValue = '04:20:00';
+        $rule = new Sf($constraintName);
         $this->assertTrue(
-            v::sf($constraintName)->assert($validConstraintValue),
+            $rule->assert($validConstraintValue),
             sprintf('"%s" should be valid under "%s" constraint.', $validConstraintValue, $constraintName)
-        );        
+        );
     }
 
     /**
@@ -48,8 +50,9 @@ class SfTest extends \PHPUnit_Framework_TestCase
     {
         $constraintName = 'Time';
         $invalidConstraintValue = '34:90:70';
+        $rule = new AllOf(new Sf($constraintName));
         try {
-            v::sf($constraintName)->assert($invalidConstraintValue);
+            $rule->assert($invalidConstraintValue);
         } catch (\Respect\Validation\Exceptions\AllOfException $exception) {
             $fullValidationMessage = $exception->getFullMessage();
             $expectedValidationException = <<<EOF
@@ -72,7 +75,8 @@ EOF;
     public function testValidationWithNonExistingConstraint()
     {
         $fantasyConstraintName = 'FluxCapacitor';
+        $rule = new Sf($fantasyConstraintName);
         $fantasyValue = '8GW';
-        v::sf($fantasyConstraintName)->validate($fantasyValue);
+        $rule->validate($fantasyValue);
     }
 }


### PR DESCRIPTION
  - Moves code from  __invoke on AbstractRule into NotEmpty.
  - Moves foreign type check to the chain.
  - Fixes tests using the chain instead of concrete instances.
  - Adds a parameter for strict type checking on NotEmpty. (no BC break)
  - Adds new tests for the BC behavior and new parameter.
  - Fixes AbstractRelated to allow empty referenced values.
  - Removes dead code found in #239 

Fixes #154, #196, #173 and #235.