### PR TITLE
Update Composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache:
 
 before_script:
   - composer install --dev --no-interaction --prefer-source
+  - composer require --dev --no-interaction --prefer-source malkusch/bav=~1.0
+  - composer require --dev --no-interaction --prefer-source symfony/validator=~2.6
+  - composer require --dev --no-interaction --prefer-source zendframework/zend-validator=~2.3
 
 script:
   - vendor/bin/phpunit --configuration phpunit.xml.dist --colors --coverage-clover=coverage.clover

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ v::bank("de")->validate("12345"); //false
 
 These country codes are supported:
 
- * "de" (Germany) - This validator needs `malkusch/bav` as dependency.
+ * "de" (Germany) - You must add `"malkusch/bav": "~1.0"` to your `require` property on composer.json file.
 
 See also
 
@@ -528,7 +528,7 @@ v::bankAccount("de", "70169464")->validate("1234"); //false
 
 These country codes are supported:
 
- * "de" (Germany) - This validator needs `malkusch/bav` as dependency.
+ * "de" (Germany) - You must add `"malkusch/bav": "~1.0"` to your `require` property on composer.json file.
 
 See also
 
@@ -588,7 +588,7 @@ v::bic("de")->validate("VZVDDED1"); //true
 
 Theses country codes are supported:
 
- * "de" (Germany) - This validator needs `malkusch/bav` as dependency.
+ * "de" (Germany) - You must add `"malkusch/bav": "~1.0"` to your `require` property on composer.json file.
 
 See also
 
@@ -1783,7 +1783,9 @@ are preserved.
 v::sf('Time')->validate('15:00:00');
 ```
 
-You must add Symfony2 to your autoloading routines.
+
+You must add `"symfony/validator": "~2.6"` to your `require` property on composer.json file.
+
 
 See also:
 
@@ -2006,7 +2008,7 @@ are preserved.
 v::zend('Hostname')->validate('google.com');
 ```
 
-You need to put Zend Framework in your autoload routines.
+You must add `"zendframework/zend-validator": "~2.3"` to your `require` property on composer.json file.
 
 See also:
 

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,14 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "symfony/validator": "~2.6",
-        "malkusch/bav": "~1.0",
-        "zendframework/zend-validator": "~2.3"
+        "phpunit/phpunit": "~4.0"
     },
     "suggest": {
         "ext-bcmath": "Arbitrary Precision Mathematics",
+        "ext-mbstring": "Multibyte String Functions",
         "malkusch/bav": "German bank account validation",
-        "ext-mbstring": "Multibyte String Functions"
+        "symfony/validator": "Use Symfony validator through Respect\\Validation",
+        "zendframework/zend-validator": "Use Zend Framework validator through Respect\\Validation"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Does not require third-party packages to run Respect\Validation test suite.

Closes #252