### PR TITLE
Remove unnecessary checkings on unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ v::bank("de")->validate("12345"); //false
 
 These country codes are supported:
 
- * "de" (Germany) - This validator needs `malkusch/bav` as dependency.
+ * "de" (Germany) - You must add `"malkusch/bav": "~1.0"` to your `require` property on composer.json file.
 
 See also
 
@@ -528,7 +528,7 @@ v::bankAccount("de", "70169464")->validate("1234"); //false
 
 These country codes are supported:
 
- * "de" (Germany) - This validator needs `malkusch/bav` as dependency.
+ * "de" (Germany) - You must add `"malkusch/bav": "~1.0"` to your `require` property on composer.json file.
 
 See also
 
@@ -588,7 +588,7 @@ v::bic("de")->validate("VZVDDED1"); //true
 
 Theses country codes are supported:
 
- * "de" (Germany) - This validator needs `malkusch/bav` as dependency.
+ * "de" (Germany) - You must add `"malkusch/bav": "~1.0"` to your `require` property on composer.json file.
 
 See also
 
@@ -1783,7 +1783,9 @@ are preserved.
 v::sf('Time')->validate('15:00:00');
 ```
 
-You must add Symfony2 to your autoloading routines.
+
+You must add `"symfony/validator": "~2.6"` to your `require` property on composer.json file.
+
 
 See also:
 
@@ -2006,7 +2008,7 @@ are preserved.
 v::zend('Hostname')->validate('google.com');
 ```
 
-You need to put Zend Framework in your autoload routines.
+You must add `"zendframework/zend-validator": "~2.3"` to your `require` property on composer.json file.
 
 See also:
 

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,10 @@
     },
     "suggest": {
         "ext-bcmath": "Arbitrary Precision Mathematics",
+        "ext-mbstring": "Multibyte String Functions",
         "malkusch/bav": "German bank account validation",
-        "ext-mbstring": "Multibyte String Functions"
+        "symfony/validator": "Use Symfony validator through Respect\\Validation",
+        "zendframework/zend-validator": "Use Zend Framework validator through Respect\\Validation"
     },
     "autoload": {
         "psr-4": {

--- a/tests/library/Respect/Validation/Rules/BankAccountTest.php
+++ b/tests/library/Respect/Validation/Rules/BankAccountTest.php
@@ -6,13 +6,6 @@ namespace Respect\Validation\Rules;
  */
 class BankAccountTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (false === class_exists('malkusch\\bav\\BAV')) {
-            $this->markTestSkipped('"malkusch/bav" is not installed.');
-        }
-    }
-
     /**
      * @expectedException Respect\Validation\Exceptions\ComponentException
      * @expectedExceptionMessage Cannot validate bank account for country "xx"

--- a/tests/library/Respect/Validation/Rules/BankTest.php
+++ b/tests/library/Respect/Validation/Rules/BankTest.php
@@ -6,13 +6,6 @@ namespace Respect\Validation\Rules;
  */
 class BankTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (false === class_exists('malkusch\\bav\\BAV')) {
-            $this->markTestSkipped('"malkusch/bav" is not installed.');
-        }
-    }
-
     /**
      * @expectedException Respect\Validation\Exceptions\ComponentException
      * @expectedExceptionMessage Cannot validate bank for country "xx"

--- a/tests/library/Respect/Validation/Rules/BicTest.php
+++ b/tests/library/Respect/Validation/Rules/BicTest.php
@@ -10,24 +10,8 @@ use malkusch\bav\PDODataBackendContainer;
  */
 class BicTest extends \PHPUnit_Framework_TestCase
 {
-    protected static function isAvailable()
-    {
-        return class_exists('malkusch\\bav\\BAV');
-    }
-
-    protected function setUp()
-    {
-        if (false === self::isAvailable()) {
-            $this->markTestSkipped('"malkusch/bav" is not installed.');
-        }
-    }
-
     public static function setUpBeforeClass()
     {
-        if (false === self::isAvailable()) {
-            return;
-        }
-
         $configuration = new DefaultConfiguration();
 
         $pdo = new \PDO('sqlite::memory:');
@@ -38,10 +22,6 @@ class BicTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
-        if (false === self::isAvailable()) {
-            return;
-        }
-
         ConfigurationRegistry::setConfiguration(new DefaultConfiguration());
     }
 

--- a/tests/library/Respect/Validation/Rules/SfTest.php
+++ b/tests/library/Respect/Validation/Rules/SfTest.php
@@ -6,13 +6,6 @@ use Respect\Validation\Validator as v;
 
 class SfTest extends \PHPUnit_Framework_TestCase
 {
-    public function assertPreConditions()
-    {
-        if (false === class_exists('Symfony\Component\Validator\Constraints\Time')) {
-            $this->markTestSkipped('Expected Symfony\Validator installed.');
-        }
-    }
-
     public function testValidationWithAnExistingValidationConstraint()
     {
         $constraintName = 'Time';
@@ -38,7 +31,7 @@ class SfTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(
             v::sf($constraintName)->assert($validConstraintValue),
             sprintf('"%s" should be valid under "%s" constraint.', $validConstraintValue, $constraintName)
-        );        
+        );
     }
 
     /**

--- a/tests/library/Respect/Validation/Rules/ZendTest.php
+++ b/tests/library/Respect/Validation/Rules/ZendTest.php
@@ -5,16 +5,6 @@ use DateTime;
 
 class ZendTest extends \PHPUnit_Framework_TestCase
 {
-    public function testZendDependency()
-    {
-        if (false === class_exists('\Zend\Validator\Date')) {
-            $this->markTestSkipped('Zend Framework 2 Validator not installed.');
-        }
-    }
-
-    /**
-     * @depends testZendDependency
-     */
     public function testConstructorWithValidatorName()
     {
         $v = new Zend('Date');
@@ -38,9 +28,6 @@ class ZendTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @depends testZendDependency
-     */
     public function testConstructorWithZendValidatorInstance()
     {
         $zendInstance = new \Zend\Validator\Date;
@@ -53,7 +40,6 @@ class ZendTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @depends testZendDependency
      * @depends testConstructorWithZendValidatorInstance
      */
     public function testUserlandValidatorExtendingZendInterface()
@@ -66,9 +52,6 @@ class ZendTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @depends testZendDependency
-     */
     public function testConstructorWithZendValidatorPartialNamespace()
     {
         $v = new Zend('Sitemap\Lastmod');


### PR DESCRIPTION
Since we are using only Composer as autoloader and we have all
dependencies on `require-dev` there is no need to check if third-party
libraries are present or not.

Closes #251.