### PR TITLE
Replaced phpunit mocks of exceptions with concretions to fix hhvm issue

### DIFF
--- a/tests/Exceptions/AbstractNestedExceptionTest.php
+++ b/tests/Exceptions/AbstractNestedExceptionTest.php
@@ -3,11 +3,21 @@ namespace Respect\Validation\Exceptions;
 
 use Respect\Validation\Validator as v;
 
+/**
+ * Class PrivateAbstractNestedException
+ * @package Respect\Validation\Exceptions
+ * phpunit has an issue with mocking exceptions when in HHVM:
+ * https://github.com/sebastianbergmann/phpunit-mock-objects/issues/207
+ */
+class PrivateAbstractNestedException extends AbstractNestedException
+{
+}
+
 class AbstractNestedExceptionTest extends \PHPUnit_Framework_TestCase
 {
     public function testItImplementsNestedValidationExceptionInterface()
     {
-        $abstractNestedException = $this->getMock('Respect\Validation\Exceptions\AbstractNestedException');
+        $abstractNestedException = new PrivateAbstractNestedException();
         $this->assertInstanceOf('Respect\Validation\Exceptions\NestedValidationExceptionInterface',
             $abstractNestedException);
     }

--- a/tests/Exceptions/CheckExceptionsTest.php
+++ b/tests/Exceptions/CheckExceptionsTest.php
@@ -64,7 +64,7 @@ class CheckExceptionsTest extends \PHPUnit_Framework_TestCase
 
         foreach ($this->getAllRuleNames() as $ruleName) {
             $exceptionClass = $this->buildExceptionClass($ruleName);
-            $exceptionClassMock = $this->getMock($exceptionClass);
+            $exceptionClassMock = new $exceptionClass();
             if ($exceptionClassMock instanceof ValidationExceptionInterface) {
                 continue;
             }


### PR DESCRIPTION
It looks like phpunit has an issue with mocking exceptions while running in HHVM: https://github.com/sebastianbergmann/phpunit-mock-objects/issues/207

Added a class that extends `AbstractNestedException` inside of `AbstractNestedExceptionTest` so that `AbstractNestedException` doesn't have to be mocked.  