### PR TITLE
Required improvements on "PostalCode" rule

### DIFF
--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -6,6 +6,8 @@ use Respect\Validation\Exceptions\ComponentException;
 
 class PostalCode extends Regex
 {
+    const DEFAULT_PATTERN = '/^$/';
+
     /**
      * @link http://download.geonames.org/export/dump/countryInfo.txt
      */
@@ -32,6 +34,7 @@ class PostalCode extends Regex
         "CL" => "/^(\d{7})$/",
         "CN" => "/^(\d{6})$/",
         "CR" => "/^(\d{4})$/",
+        "CS" => "/^(\d{5})$/",
         "CU" => "/^(?:CP)*(\d{5})$/",
         "CV" => "/^(\d{4})$/",
         "CX" => "/^(\d{4})$/",
@@ -160,15 +163,21 @@ class PostalCode extends Regex
         "YT" => "/^(\d{5})$/",
         "ZA" => "/^(\d{4})$/",
         "ZM" => "/^(\d{5})$/",
-        "CS" => "/^(\d{5})$/",
     );
 
-    public function __construct($countryCode)
+    public function __construct($countryCode, CountryCode $countryCodeRule = null)
     {
-        if (!isset($this->postalCodes[$countryCode])) {
+        $countryCodeRule = $countryCodeRule ?: new CountryCode();
+        if (! $countryCodeRule->validate($countryCode)) {
             throw new ComponentException(sprintf('Cannot validate postal code from "%s" country', $countryCode));
         }
 
-        parent::__construct($this->postalCodes[$countryCode]);
+        $regex = self::DEFAULT_PATTERN;
+        $upperCountryCode = strtoupper($countryCode);
+        if (isset($this->postalCodes[$upperCountryCode])) {
+            $regex = $this->postalCodes[$upperCountryCode];
+        }
+
+        parent::__construct($regex);
     }
 }

--- a/tests/library/Respect/Validation/Rules/PostalCodeTest.php
+++ b/tests/library/Respect/Validation/Rules/PostalCodeTest.php
@@ -1,25 +1,60 @@
 <?php
 namespace Respect\Validation\Rules;
 
+/**
+ * @covers Respect\Validation\Rules\PostalCode
+ */
 class PostalCodeTest extends \PHPUnit_Framework_TestCase
 {
-    public function testShouldUsePatternAccordingToLocale()
+    public function testShouldUsePatternAccordingToCountryCode()
     {
-        $locale = 'BR';
+        $countryCode = 'BR';
 
-        $rule = new PostalCode($locale);
+        $rule = new PostalCode($countryCode);
 
         $actualPattern = $rule->regex;
-        $expectedPattern = $rule->postalCodes[$locale];
+        $expectedPattern = $rule->postalCodes[$countryCode];
 
         $this->assertEquals($expectedPattern, $actualPattern);
+    }
+
+    public function testShouldNotBeCaseSensitiveWhenChoosingPatternAccordingToCountryCode()
+    {
+        $rule1 = new PostalCode('BR');
+        $rule2 = new PostalCode('br');
+
+        $this->assertEquals($rule1->regex, $rule2->regex);
+    }
+
+    public function testShouldUseDefaultPatternWhenCountryCodeDoesNotHavePostalCode()
+    {
+        $rule = new PostalCode('ZW');
+
+        $actualPattern = $rule->regex;
+        $expectedPattern = PostalCode::DEFAULT_PATTERN;
+
+        $this->assertEquals($expectedPattern, $actualPattern);
+    }
+
+    public function testShouldValidateEmptyStringsWhenUsingDefaultPattern()
+    {
+        $rule = new PostalCode('ZW');
+
+        $this->assertTrue($rule->validate(''));
+    }
+
+    public function testShouldNotValidateNonEmptyStringsWhenUsingDefaultPattern()
+    {
+        $rule = new PostalCode('ZW');
+
+        $this->assertFalse($rule->validate(' '));
     }
 
     /**
      * @expectedException Respect\Validation\Exceptions\ComponentException
      * @expectedExceptionMessage Cannot validate postal code from "Whatever" country
      */
-    public function testShouldThrowsExceptionWhenCannotFindLocalePattern()
+    public function testShouldThrowsExceptionWhenCountryCodeIsNotValid()
     {
         new PostalCode('Whatever');
     }
@@ -27,9 +62,9 @@ class PostalCodeTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider validPostalCodesProvider
      */
-    public function testShouldValidatePatternAccordingToTheDefinedLocale($locale, $postalCode)
+    public function testShouldValidatePatternAccordingToTheDefinedCountryCode($countryCode, $postalCode)
     {
-        $rule = new PostalCode($locale);
+        $rule = new PostalCode($countryCode);
 
         $this->assertTrue($rule->validate($postalCode));
     }
@@ -37,18 +72,19 @@ class PostalCodeTest extends \PHPUnit_Framework_TestCase
     public function validPostalCodesProvider()
     {
         return array(
-            array('BR', '02179000'),
             array('BR', '02179-000'),
+            array('BR', '02179000'),
             array('US', '02179'),
+            array('YE', ''),
         );
     }
 
     /**
      * @dataProvider invalidPostalCodesProvider
      */
-    public function testShouldNotValidatePatternAccordingToTheDefinedLocale($locale, $postalCode)
+    public function testShouldNotValidatePatternAccordingToTheDefinedCountryCode($countryCode, $postalCode)
     {
-        $rule = new PostalCode($locale);
+        $rule = new PostalCode($countryCode);
 
         $this->assertFalse($rule->validate($postalCode));
     }
@@ -59,6 +95,7 @@ class PostalCodeTest extends \PHPUnit_Framework_TestCase
             array('BR', '02179'),
             array('BR', '02179.000'),
             array('US', '021 79'),
+            array('YE', '02179'),
         );
     }
 }


### PR DESCRIPTION
- Turn rule case insensitive
- Use default pattern for countries who doesn't have postal code

Fix #285.