### PR TITLE
Optimize PrimeNumber rule

### DIFF
--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -13,7 +13,7 @@ class PrimeNumber extends AbstractRule
             return false;
         }
 
-        for ($i = 2; $i < $input; $i++) {
+        for ($i = 3; $i <= ceil(sqrt($input)); $i+=2) {
             if (($input % $i) == 0) {
                 return false;
             }


### PR DESCRIPTION
Decrease the number of max required iterations from `$input - 2` to `ceil(sqrt($input) / 2))`