### PR TITLE
Fix wrong behavior on AbstractRelated class

### DIFF
--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -65,12 +65,15 @@ abstract class AbstractRelated extends AbstractRule
 
     public function validate($input)
     {
-        $hasReference = $this->hasReference($input);
+        if ($input === '') {
+            return true;
+        }
 
+        $hasReference = $this->hasReference($input);
         if ($this->mandatory && !$hasReference) {
             return false;
         }
 
-        return $this->decision('validate', $hasReference, $input) || $this->getReferenceValue($input) === '';
+        return $this->decision('validate', $hasReference, $input);
     }
 }

--- a/tests/library/Respect/Validation/Rules/KeyTest.php
+++ b/tests/library/Respect/Validation/Rules/KeyTest.php
@@ -13,14 +13,43 @@ class KeyTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->validate($obj));
     }
 
+    public function testEmptyInputMustReturnTrue()
+    {
+        $validator = new Key('someEmptyKey');
+        $input = '';
+
+        $this->assertTrue($validator->assert($input));
+        $this->assertTrue($validator->check($input));
+        $this->assertTrue($validator->validate($input));
+    }
+
     public function testArrayWithEmptyKeyShouldReturnTrue()
     {
         $validator = new Key('someEmptyKey');
-        $obj = array();
-        $obj['someEmptyKey'] = '';
-        $this->assertTrue($validator->assert($obj));
-        $this->assertTrue($validator->check($obj));
-        $this->assertTrue($validator->validate($obj));
+        $input = array();
+        $input['someEmptyKey'] = '';
+
+        $this->assertTrue($validator->assert($input));
+        $this->assertTrue($validator->check($input));
+        $this->assertTrue($validator->validate($input));
+    }
+
+    public function testShouldHaveTheSameReturnValueForAllValidators()
+    {
+        $rule   = new Key('key', new NotEmpty());
+        $input  = array('key' => '');
+
+        try {
+            $rule->assert($input);
+            $this->fail('`assert()` must throws exception');
+        } catch (\Exception $e) {}
+
+        try {
+            $rule->check($input);
+            $this->fail('`check()` must throws exception');
+        } catch (\Exception $e) {}
+
+        $this->assertFalse($rule->validate($input));
     }
 
     /**


### PR DESCRIPTION
The wrong behavior was that any key with `''` was considered as true even when the validator was/had NotEmpty rule.

Fix #306.