### PR TITLE
Some improvements including localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1380,10 +1380,10 @@ since length accepts many types:
 v::arr()->length(1, 5)->validate(array('foo', 'bar')); //true
 ```
 
-A third parameter may be passed to validate the passed values inclusive:
+A third parameter may be passed to validate the passed values exclusive:
 
 ```php
-v::string()->length(1, 5, true)->validate('a'); //true
+v::string()->length(1, 5, false)->validate('a'); //false
 ```
 
 Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.

--- a/README.md
+++ b/README.md
@@ -1414,14 +1414,14 @@ v::macAddress()->validate('af-AA-22-33-44-55'); //true
 ```
 
 #### v::max(mixed $maxValue)
-#### v::max(mixed $maxValue, boolean $inclusive = false)
+#### v::max(mixed $maxValue, boolean $inclusive = true)
 
 Validates if the input doesn't exceed the maximum value.
 
 ```php
 v::int()->max(15)->validate(20); //false
-v::int()->max(20)->validate(20); //false
-v::int()->max(20, true)->validate(20); //true
+v::int()->max(20)->validate(20); //true
+v::int()->max(20, false)->validate(20); //false
 ```
 
 Also accepts dates:
@@ -1437,8 +1437,8 @@ Also date intervals:
 v::date()->max('-18 years')->validate('1988-09-09'); //true
 ```
 
-`true` may be passed as a parameter to indicate that inclusive
-values must be used.
+`false` may be passed as a parameter to indicate that the max
+value is not inclusive.
 
 Message template for this validator includes `{{maxValue}}`.
 
@@ -1448,14 +1448,14 @@ See also:
   * [v::between()](#vbetweenmixed-start-mixed-end)
 
 #### v::min(mixed $minValue)
-#### v::min(mixed $minValue, boolean $inclusive = false)
+#### v::min(mixed $minValue, boolean $inclusive = true)
 
-Validates if the input is greater than the minimum value.
+Validates if the input is not less than the minimum value.
 
 ```php
 v::int()->min(15)->validate(5); //false
-v::int()->min(5)->validate(5); //false
-v::int()->min(5, true)->validate(5); //true
+v::int()->min(5)->validate(5); //true
+v::int()->min(5, false)->validate(5); //false
 ```
 
 Also accepts dates:
@@ -1464,8 +1464,8 @@ Also accepts dates:
 v::date()->min('2012-01-01')->validate('2015-01-01'); //true
 ```
 
-`true` may be passed as a parameter to indicate that inclusive
-values must be used.
+`false` may be passed as a parameter to indicate that the min
+value is not inclusive.
 
 Message template for this validator includes `{{minValue}}`.
 

--- a/README.md
+++ b/README.md
@@ -1406,6 +1406,13 @@ Also accepts dates:
 v::date()->max('2012-01-01')->validate('2010-01-01'); //true
 ```
 
+Also date intervals:
+
+```php
+// Same of minimum age validation
+v::date()->max('-18 years')->validate('1988-09-09'); //true
+```
+
 `true` may be passed as a parameter to indicate that inclusive
 values must be used.
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ try {
 
 `findMessages()` returns an array with messages from the requested validators.
 
+### Localized Messages
+
+You can define the locale of the validation library. Supported locales are under
+`Messages/` directory. Example usage:
+
+```php
+v::setLocale('en_US');
+
+try {
+    v::int()->check("hello");
+
+} catch ($exception) {
+    echo $exception->getMainMessage(); // automatically localized message
+}
+```
+
 ### Custom Messages
 
 Getting messages as an array is fine, but sometimes you need to customize them in order

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ See also
   * [v::bic()](#vbicstring-countrycode)
 
 #### v::between(mixed $start, mixed $end)
-#### v::between(mixed $start, mixed $end, boolean $inclusive = false)
+#### v::between(mixed $start, mixed $end, boolean $inclusive = true)
 
 Validates ranges. Most simple example:
 
@@ -620,10 +620,10 @@ Date ranges accept strtotime values:
 v::date()->between('yesterday', 'tomorrow')->validate('now'); //true
 ```
 
-A third parameter may be passed to validate the passed values inclusive:
+A third parameter may be passed to validate the passed values exclusive:
 
 ```php
-v::date()->between(10, 20, true)->validate(20); //true
+v::int()->between(10, 20, false)->validate(20); //false
 ```
 
 Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ $errors = $exception->findMessages(array(
 
 For all messages, the `{{name}}` and `{{input}}` variable is available for templates.
 
+### Custom Rules
+
+You also can use your own rules:
+
+```php
+v::with('My\\Validation\\Rules\\');
+v::myRule(); // Try to load "My\Validation\Rules\MyRule" if any
+```
+
+By default `with()` appends the given prefix, but you can change this behavior
+in order to overwrite default rules:
+
+```php
+v::with('My\\Validation\\Rules\\', true);
+v::alnum(); // Try to use "My\Validation\Rules\Alnum" if any
+```
+
 ### Validator Name
 
 On `v::attribute()` and `v::key()`, `{{name}}` is the attribute/key name. For others,

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ v::numeric()->validate($number); //true
 ### Chained Validation
 
 It is possible to use validators in a chain. Sample below validates a string
-containing numbers and letters, no whitespace and length between 1 and 15.
+containing numbers and letters and length between 1 and 15.
 
 ```php
-$usernameValidator = v::alnum()->noWhitespace()->length(1,15);
+$usernameValidator = v::alnum()->length(1,15);
 $usernameValidator->validate('alganet'); //true
 ```
 
@@ -438,23 +438,16 @@ See also:
 #### v::alnum()
 #### v::alnum(string $additionalChars)
 
-Validates alphanumeric characters from a-Z and 0-9.
+Validates alphanumeric characters from a-z and 0-9.
 
 ```php
-v::alnum()->validate('foo 123'); //true
+v::alnum()->validate('foo123'); //true
 ```
 
 A parameter for extra characters can be used:
 
 ```php
-v::alnum('-')->validate('foo - 123'); //true
-```
-
-This validator allows whitespace, if you want to
-remove them add `->noWhitespace()` to the chain:
-
-```php
-v::alnum()->noWhitespace->validate('foo 123'); //false
+v::alnum('-')->validate('foo-123'); //true
 ```
 
 By default empty values are allowed, if you want
@@ -476,8 +469,8 @@ the string of extra chars passed as the parameter.
 
 See also:
 
-  * [v::alpha()](#valpha)  - a-Z, empty or whitespace only
-  * [v::digit()](#vdigit) - 0-9, empty or whitespace only
+  * [v::alpha()](#valpha)  - a-z or empty
+  * [v::digit()](#vdigit) - 0-9 or empty
   * [v::consonant()](#vconsonant)
   * [v::vowel()](#vvowel)
 
@@ -485,13 +478,12 @@ See also:
 #### v::alpha(string $additionalChars)
 
 This is similar to v::alnum(), but it doesn't allow numbers. It also
-accepts empty values and whitespace, so use `v::notEmpty()` and
-`v::noWhitespace()` when appropriate.
+accepts empty values, so use `v::notEmpty()` when appropriate.
 
 See also:
 
-  * [v::alnum()](#valnum)  - a-z0-9, empty or whitespace only
-  * [v::digit()](#vdigit) - 0-9, empty or whitespace only
+  * [v::alnum()](#valnum)  - a-z0-9 or empty
+  * [v::digit()](#vdigit) - 0-9 or empty
   * [v::consonant()](#vconsonant)
   * [v::vowel()](#vvowel)
 
@@ -777,9 +769,9 @@ v::consonant()->validate('xkcd'); //true
 
 See also:
 
-  * [v::alnum()](#valnum)  - a-z0-9, empty or whitespace only
-  * [v::digit()](#vdigit) - 0-9, empty or whitespace only
-  * [v::alpha()](#valpha)  - a-Z, empty or whitespace only
+  * [v::alnum()](#valnum)  - a-z0-9 or empty
+  * [v::digit()](#vdigit) - 0-9 or empty
+  * [v::alpha()](#valpha)  - a-z or empty
   * [v::vowel()](#vvowel)
 
 #### v::contains(mixed $value)
@@ -819,9 +811,9 @@ v::cntrl()->validate("\n\r\t"); //true
 
 See also:
 
-  * [v::alnum()](#valnum)     - a-z0-9, empty or whitespace only
+  * [v::alnum()](#valnum)    - a-z0-9 or empty
   * [v::prnt()](#vprnt)      - all printable characters
-  * [v::space()](#vspace)     - empty or whitespace only
+  * [v::space()](#vspace)    - empty or whitespace only
 
 #### v::countryCode()
 
@@ -928,14 +920,13 @@ See also:
 
 #### v::digit()
 
-This is similar to v::alnum(), but it doesn't allow a-Z. It also
-accepts empty values and whitespace, so use `v::notEmpty()` and
-`v::noWhitespace()` when appropriate.
+This is similar to v::alnum(), but it doesn't allow a-z. It also
+accepts empty values, so use `v::notEmpty()` when appropriate.
 
 See also:
 
-  * [v::alnum()](#valnum)  - a-z0-9, empty or whitespace only
-  * [v::alpha()](#valpha)  - a-Z, empty or whitespace only
+  * [v::alnum()](#valnum)  - a-z0-9 or empty
+  * [v::alpha()](#valpha)  - a-z or empty
   * [v::vowel()](#vvowel)
   * [v::consonant()](#vconsonant)
 
@@ -1563,8 +1554,6 @@ v::string()->noWhitespace()->validate('');  //true
 v::string()->noWhitespace()->validate(' '); //false
 ```
 
-This is most useful when chaining with other validators such as `v::alnum()`
-
 #### v::noneOf(v $v1, v $v2, v $v3...)
 
 Validates if NONE of the given validators validate:
@@ -2054,9 +2043,9 @@ v::vowel()->validate('aei'); //true
 
 See also:
 
-  * [v::alnum()](#valnum)  - a-z0-9, empty or whitespace only
-  * [v::digit()](#vdigit) - 0-9, empty or whitespace only
-  * [v::alpha()](#valpha)  - a-Z, empty or whitespace only
+  * [v::alnum()](#valnum)  - a-z0-9 or empty
+  * [v::digit()](#vdigit) - 0-9 or empty
+  * [v::alpha()](#valpha)  - a-z or empty
   * [v::consonant()](#vconsonant)
 
 #### v::when(v $if, v $then, v $else)

--- a/library/Exceptions/AbstractGroupedException.php
+++ b/library/Exceptions/AbstractGroupedException.php
@@ -5,16 +5,6 @@ class AbstractGroupedException extends AbstractNestedException
 {
     const NONE = 0;
     const SOME = 1;
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::NONE => 'All of the required rules must pass for {{name}}',
-            self::SOME => 'These rules must pass for {{name}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::NONE => 'None of there rules must pass for {{name}}',
-            self::SOME => 'These rules must not pass for {{name}}',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/AllOfException.php
+++ b/library/Exceptions/AllOfException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class AllOfException extends AbstractGroupedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::NONE => 'All of the required rules must pass for {{name}}',
-            self::SOME => 'These rules must pass for {{name}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::NONE => 'None of these rules must pass for {{name}}',
-            self::SOME => 'These rules must not pass for {{name}}',
-        ),
-    );
 }

--- a/library/Exceptions/AlnumException.php
+++ b/library/Exceptions/AlnumException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class AlnumException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only letters (a-z) and digits (0-9)',
-            self::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain letters (a-z) or digits (0-9)',
-            self::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/AlphaException.php
+++ b/library/Exceptions/AlphaException.php
@@ -5,16 +5,6 @@ class AlphaException extends ValidationException
 {
     const EXTRA = 1;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only letters (a-z)',
-            self::EXTRA => '{{name}} must contain only letters (a-z) and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain letters (a-z)',
-            self::EXTRA => '{{name}} must not contain letters (a-z) or "{{additionalChars}}"',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/AlwaysInvalidException.php
+++ b/library/Exceptions/AlwaysInvalidException.php
@@ -5,14 +5,4 @@ class AlwaysInvalidException extends ValidationException
 {
     const SIMPLE = 0;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} is always invalid',
-            self::SIMPLE   => '{{name}} is not valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} is always valid',
-            self::SIMPLE   => '{{name}} is valid',
-        ),
-    );
 }

--- a/library/Exceptions/AlwaysValidException.php
+++ b/library/Exceptions/AlwaysValidException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class AlwaysValidException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} is always valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} is always invalid',
-        ),
-    );
 }

--- a/library/Exceptions/ArrException.php
+++ b/library/Exceptions/ArrException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class ArrException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an array',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an array',
-        ),
-    );
 }

--- a/library/Exceptions/AtLeastException.php
+++ b/library/Exceptions/AtLeastException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class AtLeastException extends AbstractGroupedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::NONE => 'At least {{howMany}} of the {{failed}} required rules must pass for {{name}}',
-            self::SOME => 'At least {{howMany}} of the {{failed}} required rules must pass for {{name}}, only {{passed}} passed.',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::NONE => 'At least {{howMany}} of the {{failed}} required rules must not pass for {{name}}',
-            self::SOME => 'At least {{howMany}} of the {{failed}} required rules must not pass for {{name}}, only {{passed}} passed.',
-        ),
-    );
 }

--- a/library/Exceptions/AttributeException.php
+++ b/library/Exceptions/AttributeException.php
@@ -5,16 +5,6 @@ class AttributeException extends AbstractNestedException
 {
     const NOT_PRESENT = 0;
     const INVALID = 1;
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::NOT_PRESENT => 'Attribute {{name}} must be present',
-            self::INVALID => 'Attribute {{name}} must be valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::NOT_PRESENT => 'Attribute {{name}} must not be present',
-            self::INVALID => 'Attribute {{name}} must not validate',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/BankAccountException.php
+++ b/library/Exceptions/BankAccountException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class BankAccountException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a bank account',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a bank account',
-        )
-    );
 }

--- a/library/Exceptions/BankException.php
+++ b/library/Exceptions/BankException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class BankException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a bank',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a bank',
-        )
-    );
 }

--- a/library/Exceptions/BetweenException.php
+++ b/library/Exceptions/BetweenException.php
@@ -7,18 +7,6 @@ class BetweenException extends AbstractNestedException
     const LOWER = 1;
     const GREATER = 2;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::BOTH => '{{name}} must be between {{minValue}} and {{maxValue}}',
-            self::LOWER => '{{name}}  must be greater than {{minValue}}',
-            self::GREATER => '{{name}} must be lower than {{maxValue}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::BOTH => '{{name}} must not be between {{minValue}} and {{maxValue}}',
-            self::LOWER => '{{name}}  must not be greater than {{minValue}}',
-            self::GREATER => '{{name}} must not be lower than {{maxValue}}',
-        ),
-    );
 
     public function configure($name, array $params = array())
     {

--- a/library/Exceptions/BicException.php
+++ b/library/Exceptions/BicException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class BicException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a BIC',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a BIC',
-        )
-    );
 }

--- a/library/Exceptions/BoolException.php
+++ b/library/Exceptions/BoolException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class BoolException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a boolean',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a boolean',
-        ),
-    );
 }

--- a/library/Exceptions/CallbackException.php
+++ b/library/Exceptions/CallbackException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CallbackException extends AbstractNestedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be valid',
-        ),
-    );
 }

--- a/library/Exceptions/CharsetException.php
+++ b/library/Exceptions/CharsetException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CharsetException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be in the {{charset}} charset',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be in the {{charset}} charset',
-        ),
-    );
 }

--- a/library/Exceptions/CnhException.php
+++ b/library/Exceptions/CnhException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CnhException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid CNH number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid CNH number',
-        ),
-    );
 }

--- a/library/Exceptions/CnpjException.php
+++ b/library/Exceptions/CnpjException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class CnpjException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid CNPJ number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid CNPJ number',
-        ),
-    );
 }

--- a/library/Exceptions/CntrlException.php
+++ b/library/Exceptions/CntrlException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CntrlException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only control characters',
-            self::EXTRA => '{{name}} must contain only control characters and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain control characters',
-            self::EXTRA => '{{name}} must not contain control characters or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/ConsonantException.php
+++ b/library/Exceptions/ConsonantException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class ConsonantException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only consonants',
-            self::EXTRA => '{{name}} must contain only consonants and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain consonants',
-            self::EXTRA => '{{name}} must not contain consonants or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/ContainsException.php
+++ b/library/Exceptions/ContainsException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class ContainsException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain the value "{{containsValue}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain the value "{{containsValue}}"',
-        ),
-    );
 }

--- a/library/Exceptions/CountryCodeException.php
+++ b/library/Exceptions/CountryCodeException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CountryCodeException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid country',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid country',
-        ),
-    );
 }

--- a/library/Exceptions/CpfException.php
+++ b/library/Exceptions/CpfException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CpfException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid CPF number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid CPF number',
-        ),
-    );
 }

--- a/library/Exceptions/CreditCardException.php
+++ b/library/Exceptions/CreditCardException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class CreditCardException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid Credit Card number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid Credit Card number',
-        ),
-    );
 }

--- a/library/Exceptions/DateException.php
+++ b/library/Exceptions/DateException.php
@@ -5,16 +5,6 @@ class DateException extends ValidationException
 {
     const FORMAT = 1;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid date',
-            self::FORMAT => '{{name}} must be a valid date. Sample format: {{format}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid date',
-            self::FORMAT => '{{name}} must not be a valid date in the format {{format}}',
-        ),
-    );
 
     public function configure($name, array $params = array())
     {

--- a/library/Exceptions/DigitException.php
+++ b/library/Exceptions/DigitException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class DigitException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only digits (0-9)',
-            self::EXTRA => '{{name}} must contain only digits (0-9) and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain digits (0-9)',
-            self::EXTRA => '{{name}} must not contain digits (0-9) or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/DirectoryException.php
+++ b/library/Exceptions/DirectoryException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class DirectoryException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a directory',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a directory',
-        ),
-    );
 }

--- a/library/Exceptions/DomainException.php
+++ b/library/Exceptions/DomainException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class DomainException extends AbstractNestedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid domain',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid domain',
-        ),
-    );
 }

--- a/library/Exceptions/EachException.php
+++ b/library/Exceptions/EachException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class EachException extends AbstractNestedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => 'Each item in {{name}} must be valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => 'Each item in {{name}} must not validate',
-        ),
-    );
 }

--- a/library/Exceptions/EmailException.php
+++ b/library/Exceptions/EmailException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class EmailException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be valid email',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an email',
-        ),
-    );
 }

--- a/library/Exceptions/EndsWithException.php
+++ b/library/Exceptions/EndsWithException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class EndsWithException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must end with ({{endValue}})',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not end with ({{endValue}})',
-        ),
-    );
 }

--- a/library/Exceptions/EqualsException.php
+++ b/library/Exceptions/EqualsException.php
@@ -6,16 +6,6 @@ class EqualsException extends ValidationException
     const EQUALS = 0;
     const IDENTICAL = 1;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::EQUALS => '{{name}} must be equals {{compareTo}}',
-            self::IDENTICAL => '{{name}} must be identical as {{compareTo}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::EQUALS => '{{name}} must not be equals {{compareTo}}',
-            self::IDENTICAL => '{{name}} must not be identical as {{compareTo}}',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/EvenException.php
+++ b/library/Exceptions/EvenException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class EvenException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an even number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an even number',
-        ),
-    );
 }

--- a/library/Exceptions/ExecutableException.php
+++ b/library/Exceptions/ExecutableException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class ExecutableException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an executable file',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an executable file',
-        ),
-    );
 }

--- a/library/Exceptions/ExistsException.php
+++ b/library/Exceptions/ExistsException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class ExistsException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must exists',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not exists',
-        ),
-    );
 }

--- a/library/Exceptions/FalseException.php
+++ b/library/Exceptions/FalseException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class FalseException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} is not considered as "False"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} is considered as "False"',
-        ),
-    );
 }

--- a/library/Exceptions/FileException.php
+++ b/library/Exceptions/FileException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class FileException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a file',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a file',
-        ),
-    );
 }

--- a/library/Exceptions/FilterVarException.php
+++ b/library/Exceptions/FilterVarException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class FilterVarException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be valid',
-        ),
-    );
 }

--- a/library/Exceptions/FloatException.php
+++ b/library/Exceptions/FloatException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class FloatException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a float number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a float number',
-        ),
-    );
 }

--- a/library/Exceptions/GraphException.php
+++ b/library/Exceptions/GraphException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class GraphException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only graphical characters',
-            self::EXTRA => '{{name}} must contain only graphical characters and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain graphical characters',
-            self::EXTRA => '{{name}} must not contain graphical characters or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/HexRgbColorException.php
+++ b/library/Exceptions/HexRgbColorException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class HexRgbColorException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a hex RGB color',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a hex RGB color',
-        ),
-    );
 }

--- a/library/Exceptions/HexaException.php
+++ b/library/Exceptions/HexaException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class HexaException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a hexadecimal number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a hexadecimal number',
-        ),
-    );
 }

--- a/library/Exceptions/InException.php
+++ b/library/Exceptions/InException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class InException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be in ({{haystack}})',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be in ({{haystack}})',
-        ),
-    );
 }

--- a/library/Exceptions/InstanceException.php
+++ b/library/Exceptions/InstanceException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class InstanceException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an instance of {{instanceName}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an instance of {{instanceName}}',
-        ),
-    );
 }

--- a/library/Exceptions/IntException.php
+++ b/library/Exceptions/IntException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class IntException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an integer number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an integer number',
-        ),
-    );
 }

--- a/library/Exceptions/IpException.php
+++ b/library/Exceptions/IpException.php
@@ -6,16 +6,6 @@ class IpException extends ValidationException
     const STANDARD = 0;
     const NETWORK_RANGE = 1;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an IP address',
-            self::NETWORK_RANGE => '{{name}} must be an IP address in the {{range}} range',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an IP address',
-            self::NETWORK_RANGE => '{{name}} must not be an IP address in the {{range}} range',
-        ),
-    );
 
     public function configure($name, array $params = array())
     {

--- a/library/Exceptions/JsonException.php
+++ b/library/Exceptions/JsonException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class JsonException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid JSON string',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid JSON string',
-        ),
-    );
 }

--- a/library/Exceptions/KeyException.php
+++ b/library/Exceptions/KeyException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class KeyException extends AttributeException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::NOT_PRESENT => 'Key {{name}} must be present',
-            self::INVALID => 'Key {{name}} must be valid',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::NOT_PRESENT => 'Key {{name}} must not be present',
-            self::INVALID => 'Key {{name}} must not be valid',
-        ),
-    );
 }

--- a/library/Exceptions/LengthException.php
+++ b/library/Exceptions/LengthException.php
@@ -7,18 +7,6 @@ class LengthException extends ValidationException
     const LOWER = 1;
     const GREATER = 2;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::BOTH => '{{name}} must have a length between {{minValue}} and {{maxValue}}',
-            self::LOWER => '{{name}} must have a length greater than {{minValue}}',
-            self::GREATER => '{{name}} must have a length lower than {{maxValue}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::BOTH => '{{name}} must not have a length between {{minValue}} and {{maxValue}}',
-            self::LOWER => '{{name}} must not have a length greater than {{minValue}}',
-            self::GREATER => '{{name}} must not have a length lower than {{maxValue}}',
-        ),
-    );
 
     public function configure($name, array $params = array())
     {

--- a/library/Exceptions/Locale/GermanBankAccountException.php
+++ b/library/Exceptions/Locale/GermanBankAccountException.php
@@ -5,12 +5,4 @@ use Respect\Validation\Exceptions\BankAccountException;
 
 class GermanBankAccountException extends BankAccountException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a german bank account',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a german bank account',
-        )
-    );
 }

--- a/library/Exceptions/Locale/GermanBankException.php
+++ b/library/Exceptions/Locale/GermanBankException.php
@@ -5,12 +5,4 @@ use Respect\Validation\Exceptions\BankException;
 
 class GermanBankException extends BankException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a german bank',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a german bank',
-        )
-    );
 }

--- a/library/Exceptions/Locale/GermanBicException.php
+++ b/library/Exceptions/Locale/GermanBicException.php
@@ -5,12 +5,4 @@ use Respect\Validation\Exceptions\BicException;
 
 class GermanBicException extends BicException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a german BIC',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a german BIC',
-        )
-    );
 }

--- a/library/Exceptions/LowercaseException.php
+++ b/library/Exceptions/LowercaseException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class LowercaseException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be lowercase',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be lowercase',
-        ),
-    );
 }

--- a/library/Exceptions/MacAddressException.php
+++ b/library/Exceptions/MacAddressException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class MacAddressException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid mac address',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid mac address',
-        ),
-    );
 }

--- a/library/Exceptions/MaxException.php
+++ b/library/Exceptions/MaxException.php
@@ -7,12 +7,12 @@ class MaxException extends ValidationException
 
     public static $defaultTemplates = array(
         self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be lower than {{maxValue}}',
-            self::INCLUSIVE => '{{name}} must be lower than or equals {{maxValue}}',
+            self::STANDARD => '{{name}} must be lower than {{interval}}',
+            self::INCLUSIVE => '{{name}} must be lower than or equals {{interval}}',
         ),
         self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be lower than {{maxValue}}',
-            self::INCLUSIVE => '{{name}} must not be lower than or equals {{maxValue}}',
+            self::STANDARD => '{{name}} must not be lower than {{interval}}',
+            self::INCLUSIVE => '{{name}} must not be lower than or equals {{interval}}',
         ),
     );
 

--- a/library/Exceptions/MaxException.php
+++ b/library/Exceptions/MaxException.php
@@ -5,16 +5,6 @@ class MaxException extends ValidationException
 {
     const INCLUSIVE = 1;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be lower than {{interval}}',
-            self::INCLUSIVE => '{{name}} must be lower than or equals {{interval}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be lower than {{interval}}',
-            self::INCLUSIVE => '{{name}} must not be lower than or equals {{interval}}',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/MinException.php
+++ b/library/Exceptions/MinException.php
@@ -5,16 +5,6 @@ class MinException extends ValidationException
 {
     const INCLUSIVE = 1;
 
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be greater than {{interval}}',
-            self::INCLUSIVE => '{{name}} must be greater than or equals {{interval}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be greater than {{interval}}',
-            self::INCLUSIVE => '{{name}} must not be greater than or equals {{interval}}',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/MinException.php
+++ b/library/Exceptions/MinException.php
@@ -7,12 +7,12 @@ class MinException extends ValidationException
 
     public static $defaultTemplates = array(
         self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be greater than {{minValue}}',
-            self::INCLUSIVE => '{{name}} must be greater than or equals {{minValue}}',
+            self::STANDARD => '{{name}} must be greater than {{interval}}',
+            self::INCLUSIVE => '{{name}} must be greater than or equals {{interval}}',
         ),
         self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be greater than {{minValue}}',
-            self::INCLUSIVE => '{{name}} must not be greater than or equals {{minValue}}',
+            self::STANDARD => '{{name}} must not be greater than {{interval}}',
+            self::INCLUSIVE => '{{name}} must not be greater than or equals {{interval}}',
         ),
     );
 

--- a/library/Exceptions/MinimumAgeException.php
+++ b/library/Exceptions/MinimumAgeException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class MinimumAgeException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => 'The age must be {{age}} years or more.',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => 'The age must not be {{age}} years or more.',
-        ),
-    );
 }

--- a/library/Exceptions/MultipleException.php
+++ b/library/Exceptions/MultipleException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class MultipleException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be multiple of {{multipleOf}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be multiple of {{multipleOf}}',
-        ),
-    );
 }

--- a/library/Exceptions/NegativeException.php
+++ b/library/Exceptions/NegativeException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NegativeException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be negative',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be negative',
-        ),
-    );
 }

--- a/library/Exceptions/NfeAccessKeyException.php
+++ b/library/Exceptions/NfeAccessKeyException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NfeAccessKeyException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid NFe access key',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid NFe access key',
-        ),
-    );
 }

--- a/library/Exceptions/NoException.php
+++ b/library/Exceptions/NoException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NoException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} is not considered as "No"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} is considered as "No"',
-        ),
-    );
 }

--- a/library/Exceptions/NoWhitespaceException.php
+++ b/library/Exceptions/NoWhitespaceException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NoWhitespaceException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must not contain whitespace',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not not contain whitespace',
-        ),
-    );
 }

--- a/library/Exceptions/NoneOfException.php
+++ b/library/Exceptions/NoneOfException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NoneOfException extends AbstractNestedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => 'None of these rules must pass for {{name}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => 'All of these rules must pass for {{name}}',
-        ),
-    );
 }

--- a/library/Exceptions/NotEmptyException.php
+++ b/library/Exceptions/NotEmptyException.php
@@ -5,16 +5,6 @@ class NotEmptyException extends ValidationException
 {
     const STANDARD = 0;
     const NAMED = 1;
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => 'The value must not be empty',
-            self::NAMED => '{{name}} must not be empty',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => 'The value must be empty',
-            self::NAMED => '{{name}} must be empty',
-        ),
-    );
 
     public function chooseTemplate()
     {

--- a/library/Exceptions/NullValueException.php
+++ b/library/Exceptions/NullValueException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NullValueException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be null',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be null',
-        ),
-    );
 }

--- a/library/Exceptions/NumericException.php
+++ b/library/Exceptions/NumericException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class NumericException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be numeric',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be numeric',
-        ),
-    );
 }

--- a/library/Exceptions/ObjectException.php
+++ b/library/Exceptions/ObjectException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class ObjectException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an object',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an object',
-        ),
-    );
 }

--- a/library/Exceptions/OddException.php
+++ b/library/Exceptions/OddException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class OddException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an odd number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an odd number',
-        ),
-    );
 }

--- a/library/Exceptions/OneOfException.php
+++ b/library/Exceptions/OneOfException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class OneOfException extends AbstractNestedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => 'At least one of these rules must pass for {{name}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => 'At least one of these rules must not pass for {{name}}',
-        ),
-    );
 }

--- a/library/Exceptions/PerfectSquareException.php
+++ b/library/Exceptions/PerfectSquareException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PerfectSquareException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid perfect square',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid perfect square',
-        ),
-    );
 }

--- a/library/Exceptions/PhoneException.php
+++ b/library/Exceptions/PhoneException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PhoneException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid telephone number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid telephone number',
-        ),
-    );
 }

--- a/library/Exceptions/PositiveException.php
+++ b/library/Exceptions/PositiveException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PositiveException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be positive',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be positive',
-        ),
-    );
 }

--- a/library/Exceptions/PostalCodeException.php
+++ b/library/Exceptions/PostalCodeException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PostalCodeException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid postal code',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid postal code',
-        ),
-    );
 }

--- a/library/Exceptions/PrimeNumberException.php
+++ b/library/Exceptions/PrimeNumberException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PrimeNumberException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid prime number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid prime number',
-        ),
-    );
 }

--- a/library/Exceptions/PrntException.php
+++ b/library/Exceptions/PrntException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PrntException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only printable characters',
-            self::EXTRA => '{{name}} must contain only printable characters and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain printable characters',
-            self::EXTRA => '{{name}} must not contain printable characters or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/PunctException.php
+++ b/library/Exceptions/PunctException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class PunctException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only punctuation characters',
-            self::EXTRA => '{{name}} must contain only punctuation characters and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain punctuation characters',
-            self::EXTRA => '{{name}} must not contain punctuation characters or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/ReadableException.php
+++ b/library/Exceptions/ReadableException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class ReadableException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be readable',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be readable',
-        ),
-    );
 }

--- a/library/Exceptions/RegexException.php
+++ b/library/Exceptions/RegexException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class RegexException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must validate against {{regex}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not validate against {{regex}}',
-        ),
-    );
 }

--- a/library/Exceptions/RomanException.php
+++ b/library/Exceptions/RomanException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class RomanException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid roman number',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid roman number',
-        ),
-    );
 }

--- a/library/Exceptions/SfException.php
+++ b/library/Exceptions/SfException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class SfException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}}',
-        ),
-    );
 }

--- a/library/Exceptions/SlugException.php
+++ b/library/Exceptions/SlugException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class SlugException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid slug',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid slug',
-        ),
-    );
 }

--- a/library/Exceptions/SpaceException.php
+++ b/library/Exceptions/SpaceException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class SpaceException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only space characters',
-            self::EXTRA => '{{name}} must contain only space characters and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain space characters',
-            self::EXTRA => '{{name}} must not contain space characters or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/StartsWithException.php
+++ b/library/Exceptions/StartsWithException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class StartsWithException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must start with ({{startValue}})',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not start with ({{startValue}})',
-        ),
-    );
 }

--- a/library/Exceptions/StringException.php
+++ b/library/Exceptions/StringException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class StringException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a string',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be string',
-        ),
-    );
 }

--- a/library/Exceptions/SymbolicLinkException.php
+++ b/library/Exceptions/SymbolicLinkException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class SymbolicLinkException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a symbolic link',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a symbolic link',
-        ),
-    );
 }

--- a/library/Exceptions/TldException.php
+++ b/library/Exceptions/TldException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class TldException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a valid top-level domain name',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a valid top-level domain name',
-        ),
-    );
 }

--- a/library/Exceptions/TrueException.php
+++ b/library/Exceptions/TrueException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class TrueException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} is not considered as "True"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} is considered as "True"',
-        ),
-    );
 }

--- a/library/Exceptions/TypeException.php
+++ b/library/Exceptions/TypeException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class TypeException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be {{type}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be {{type}}',
-        ),
-    );
 }

--- a/library/Exceptions/UploadedException.php
+++ b/library/Exceptions/UploadedException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class UploadedException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an uploaded file',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an uploaded file',
-        ),
-    );
 }

--- a/library/Exceptions/UppercaseException.php
+++ b/library/Exceptions/UppercaseException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class UppercaseException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be uppercase',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be uppercase',
-        ),
-    );
 }

--- a/library/Exceptions/UrlException.php
+++ b/library/Exceptions/UrlException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class UrlException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be an URL',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be an URL',
-        ),
-    );
 }

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -64,7 +64,7 @@ class ValidationException extends InvalidArgumentException implements Validation
             Validator::setLocale(Validator::$locale);
         }
 
-        return key(Validator::$messages[basename(get_called_class())][$this->mode]);
+        return key(@ Validator::$messages[basename(get_called_class())][$this->mode]);
     }
 
     public function configure($name, array $params = array())
@@ -172,7 +172,7 @@ class ValidationException extends InvalidArgumentException implements Validation
     {
         $templateKey = $this->chooseTemplate();
 
-        return Validator::$messages[basename(get_called_class())][$this->mode][$templateKey];
+        return @ Validator::$messages[basename(get_called_class())][$this->mode][$templateKey];
     }
 
     protected function guessId()

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -3,20 +3,14 @@ namespace Respect\Validation\Exceptions;
 
 use DateTime;
 use InvalidArgumentException;
+use Respect\Validation\Validator;
 
 class ValidationException extends InvalidArgumentException implements ValidationExceptionInterface
 {
     const MODE_DEFAULT = 1;
     const MODE_NEGATIVE = 2;
     const STANDARD = 0;
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => 'Data validation failed for %s',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => 'Data validation failed for %s',
-        ),
-    );
+
     protected $id = 'validation';
     protected $mode = self::MODE_DEFAULT;
     protected $name = '';
@@ -65,7 +59,7 @@ class ValidationException extends InvalidArgumentException implements Validation
 
     public function chooseTemplate()
     {
-        return key(static::$defaultTemplates[$this->mode]);
+        return key(Validator::$messages[basename(get_called_class())][$this->mode]);
     }
 
     public function configure($name, array $params = array())
@@ -173,7 +167,7 @@ class ValidationException extends InvalidArgumentException implements Validation
     {
         $templateKey = $this->chooseTemplate();
 
-        return static::$defaultTemplates[$this->mode][$templateKey];
+        return Validator::$messages[basename(get_called_class())][$this->mode][$templateKey];
     }
 
     protected function guessId()

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -59,6 +59,11 @@ class ValidationException extends InvalidArgumentException implements Validation
 
     public function chooseTemplate()
     {
+        // If no locale is loaded, load the default one
+        if (! Validator::$messages) {
+            Validator::setLocale(Validator::$locale);
+        }
+
         return key(Validator::$messages[basename(get_called_class())][$this->mode]);
     }
 

--- a/library/Exceptions/VersionException.php
+++ b/library/Exceptions/VersionException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class VersionException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be a version',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be a version',
-        ),
-    );
 }

--- a/library/Exceptions/VowelException.php
+++ b/library/Exceptions/VowelException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class VowelException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must contain only vowels',
-            self::EXTRA => '{{name}} must contain only vowels and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain vowels',
-            self::EXTRA => '{{name}} must not contain vowels or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/WritableException.php
+++ b/library/Exceptions/WritableException.php
@@ -4,12 +4,4 @@ namespace Respect\Validation\Exceptions;
 
 class WritableException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be writable',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be writable',
-        ),
-    );
 }

--- a/library/Exceptions/XdigitException.php
+++ b/library/Exceptions/XdigitException.php
@@ -3,14 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class XdigitException extends AlphaException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} contain only hexadecimal digits',
-            self::EXTRA => '{{name}} contain only hexadecimal digits and "{{additionalChars}}"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not contain hexadecimal digits',
-            self::EXTRA => '{{name}} must not contain hexadecimal digits or "{{additionalChars}}"',
-        ),
-    );
 }

--- a/library/Exceptions/YesException.php
+++ b/library/Exceptions/YesException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class YesException extends ValidationException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} is not considered as "Yes"',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} is considered as "Yes"',
-        ),
-    );
 }

--- a/library/Exceptions/ZendException.php
+++ b/library/Exceptions/ZendException.php
@@ -3,12 +3,4 @@ namespace Respect\Validation\Exceptions;
 
 class ZendException extends AbstractNestedException
 {
-    public static $defaultTemplates = array(
-        self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}}',
-        ),
-        self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}}',
-        ),
-    );
 }

--- a/library/Factory.php
+++ b/library/Factory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Respect\Validation;
+
+use ReflectionClass;
+use Respect\Validation\Exceptions\ComponentException;
+
+class Factory
+{
+    protected $rulePrefixes = array('Respect\\Validation\\Rules\\');
+
+    public function getRulePrefixes()
+    {
+        return $this->rulePrefixes;
+    }
+
+    public function appendRulePrefix($rulePrefix)
+    {
+        array_push($this->rulePrefixes, $rulePrefix);
+    }
+
+    public function prependRulePrefix($rulePrefix)
+    {
+        array_unshift($this->rulePrefixes, $rulePrefix);
+    }
+
+    public function rule($ruleName, array $arguments = array())
+    {
+        if ($ruleName instanceof Validatable) {
+            return $ruleName;
+        }
+
+        foreach ($this->getRulePrefixes() as $prefix) {
+            $className = $prefix.ucfirst($ruleName);
+            if (! class_exists($className)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+            if (! $reflection->isSubclassOf('Respect\\Validation\\Validatable')) {
+                throw new ComponentException(sprintf('"%s" is not a valid respect rule', $className));
+            }
+
+            return $reflection->newInstanceArgs($arguments);
+        }
+
+        throw new ComponentException(sprintf('"%s" is not a valid rule name', $ruleName));
+    }
+}

--- a/library/Messages/en_US.php
+++ b/library/Messages/en_US.php
@@ -1,0 +1,954 @@
+<?php
+namespace Respect\Validation;
+
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Exceptions\AbstractGroupedException;
+use Respect\Validation\Exceptions\AlphaException;
+use Respect\Validation\Exceptions\AlwaysInvalidException;
+use Respect\Validation\Exceptions\AttributeException;
+use Respect\Validation\Exceptions\BetweenException;
+use Respect\Validation\Exceptions\DateException;
+use Respect\Validation\Exceptions\EqualsException;
+use Respect\Validation\Exceptions\IpException;
+use Respect\Validation\Exceptions\LengthException;
+use Respect\Validation\Exceptions\MaxException;
+use Respect\Validation\Exceptions\MinException;
+use Respect\Validation\Exceptions\NotEmptyException;
+
+$messages = array(
+    'AbstractGroupedException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AbstractGroupedException::NONE => 'All of the required rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AbstractGroupedException::NONE => 'None of there rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must not pass for {{name}}',
+        ),
+    ),
+
+    'AllOfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AbstractGroupedException::NONE => 'All of the required rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AbstractGroupedException::NONE => 'None of these rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must not pass for {{name}}',
+        ),
+    ),
+
+    'AlnumException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only letters (a-z) and digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain letters (a-z) or digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or "{{additionalChars}}"',
+        ),
+    ),
+
+    'AlphaException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only letters (a-z)',
+            AlphaException::EXTRA => '{{name}} must contain only letters (a-z) and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain letters (a-z)',
+            AlphaException::EXTRA => '{{name}} must not contain letters (a-z) or "{{additionalChars}}"',
+        ),
+    ),
+
+    'AlwaysInvalidException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is always invalid',
+            AlwaysInvalidException::SIMPLE   => '{{name}} is not valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is always valid',
+            AlwaysInvalidException::SIMPLE   => '{{name}} is valid',
+        ),
+    ),
+
+    'AlwaysValidException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is always valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is always invalid',
+        ),
+    ),
+
+    'ArrException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an array',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an array',
+        ),
+    ),
+
+    'AtLeastException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AbstractGroupedException::NONE => 'At least {{howMany}} of the {{failed}} required rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'At least {{howMany}} of the {{failed}} required rules must pass for {{name}}, only {{passed}} passed.',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AbstractGroupedException::NONE => 'At least {{howMany}} of the {{failed}} required rules must not pass for {{name}}',
+            AbstractGroupedException::SOME => 'At least {{howMany}} of the {{failed}} required rules must not pass for {{name}}, only {{passed}} passed.',
+        ),
+    ),
+
+    'AttributeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AttributeException::NOT_PRESENT => 'Attribute {{name}} must be present',
+            AttributeException::INVALID => 'Attribute {{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AttributeException::NOT_PRESENT => 'Attribute {{name}} must not be present',
+            AttributeException::INVALID => 'Attribute {{name}} must not validate',
+        ),
+    ),
+
+    'BankAccountException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a bank account',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a bank account',
+        ),
+    ),
+
+    'BankException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a bank',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a bank',
+        ),
+    ),
+
+    'BetweenException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            BetweenException::BOTH      => '{{name}} must be between {{minValue}} and {{maxValue}}',
+            BetweenException::LOWER     => '{{name}}  must be greater than {{minValue}}',
+            BetweenException::GREATER   => '{{name}} must be lower than {{maxValue}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            BetweenException::BOTH      => '{{name}} must not be between {{minValue}} and {{maxValue}}',
+            BetweenException::LOWER     => '{{name}}  must not be greater than {{minValue}}',
+            BetweenException::GREATER   => '{{name}} must not be lower than {{maxValue}}',
+        ),
+    ),
+
+    'BicException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a BIC',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a BIC',
+        ),
+    ),
+
+    'BoolException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a boolean',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a boolean',
+        ),
+    ),
+
+    'CallbackException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be valid',
+        ),
+    ),
+
+    'CharsetException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be in the {{charset}} charset',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be in the {{charset}} charset',
+        ),
+    ),
+
+    'CnhException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid CNH number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid CNH number',
+        ),
+    ),
+
+    'CnpjException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid CNPJ number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid CNPJ number',
+        ),
+    ),
+
+    'CntrlException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only control characters',
+            AlphaException::EXTRA => '{{name}} must contain only control characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain control characters',
+            AlphaException::EXTRA => '{{name}} must not contain control characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'ConsonantException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only consonants',
+            AlphaException::EXTRA => '{{name}} must contain only consonants and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain consonants',
+            AlphaException::EXTRA => '{{name}} must not contain consonants or "{{additionalChars}}"',
+        ),
+    ),
+
+    'ContainsException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain the value "{{containsValue}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain the value "{{containsValue}}"',
+        ),
+    ),
+
+    'CountryCodeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid country',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid country',
+        ),
+    ),
+
+    'CpfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid CPF number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid CPF number',
+        ),
+    ),
+
+    'CreditCardException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid Credit Card number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid Credit Card number',
+        ),
+    ),
+
+    'DateException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid date',
+            DateException::FORMAT => '{{name}} must be a valid date. Sample format: {{format}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid date',
+            DateException::FORMAT => '{{name}} must not be a valid date in the format {{format}}',
+        ),
+    ),
+
+    'DigitException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must contain only digits (0-9) and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must not contain digits (0-9) or "{{additionalChars}}"',
+        ),
+    ),
+
+    'DirectoryException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a directory',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a directory',
+        ),
+    ),
+
+    'DomainException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid domain',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid domain',
+        ),
+    ),
+
+    'EachException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'Each item in {{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'Each item in {{name}} must not validate',
+        ),
+    ),
+
+    'EmailException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be valid email',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an email',
+        ),
+    ),
+
+    'EndsWithException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must end with ({{endValue}})',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not end with ({{endValue}})',
+        ),
+    ),
+
+    'EqualsException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            EqualsException::EQUALS => '{{name}} must be equals {{compareTo}}',
+            EqualsException::IDENTICAL => '{{name}} must be identical as {{compareTo}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            EqualsException::EQUALS => '{{name}} must not be equals {{compareTo}}',
+            EqualsException::IDENTICAL => '{{name}} must not be identical as {{compareTo}}',
+        ),
+    ),
+
+    'EvenException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an even number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an even number',
+        ),
+    ),
+
+    'ExecutableException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an executable file',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an executable file',
+        ),
+    ),
+
+    'ExistsException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must exists',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not exists',
+        ),
+    ),
+
+    'FalseException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "False"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "False"',
+        ),
+    ),
+
+    'FileException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a file',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a file',
+        ),
+    ),
+
+    'FilterVarException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be valid',
+        ),
+    ),
+
+    'FloatException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a float number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a float number',
+        ),
+    ),
+
+    'GraphException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only graphical characters',
+            AlphaException::EXTRA => '{{name}} must contain only graphical characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain graphical characters',
+            AlphaException::EXTRA => '{{name}} must not contain graphical characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'HexaException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a hexadecimal number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a hexadecimal number',
+        ),
+    ),
+
+    'HexRgbColorException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a hex RGB color',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a hex RGB color',
+        ),
+    ),
+
+    'InException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be in ({{haystack}})',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be in ({{haystack}})',
+        ),
+    ),
+
+    'InstanceException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an instance of {{instanceName}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an instance of {{instanceName}}',
+        ),
+    ),
+
+    'IntException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an integer number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an integer number',
+        ),
+    ),
+
+    'IpException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an IP address',
+            IpException::NETWORK_RANGE => '{{name}} must be an IP address in the {{range}} range',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an IP address',
+            IpException::NETWORK_RANGE => '{{name}} must not be an IP address in the {{range}} range',
+        ),
+    ),
+
+    'JsonException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid JSON string',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid JSON string',
+        ),
+    ),
+
+    'KeyException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AttributeException::NOT_PRESENT => 'Key {{name}} must be present',
+            AttributeException::INVALID => 'Key {{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AttributeException::NOT_PRESENT => 'Key {{name}} must not be present',
+            AttributeException::INVALID => 'Key {{name}} must not be valid',
+        ),
+    ),
+
+    'LengthException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            LengthException::BOTH       => '{{name}} must have a length between {{minValue}} and {{maxValue}}',
+            LengthException::LOWER      => '{{name}} must have a length greater than {{minValue}}',
+            LengthException::GREATER    => '{{name}} must have a length lower than {{maxValue}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            LengthException::BOTH       => '{{name}} must not have a length between {{minValue}} and {{maxValue}}',
+            LengthException::LOWER      => '{{name}} must not have a length greater than {{minValue}}',
+            LengthException::GREATER    => '{{name}} must not have a length lower than {{maxValue}}',
+        ),
+    ),
+
+    'LowercaseException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be lowercase',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be lowercase',
+        ),
+    ),
+
+    'MacAddressException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid mac address',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid mac address',
+        ),
+    ),
+
+    'MaxException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be lower than {{interval}}',
+            MaxException::INCLUSIVE => '{{name}} must be lower than or equals {{interval}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be lower than {{interval}}',
+            MaxException::INCLUSIVE => '{{name}} must not be lower than or equals {{interval}}',
+        ),
+    ),
+
+    'MinException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be greater than {{interval}}',
+            MinException::INCLUSIVE => '{{name}} must be greater than or equals {{interval}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be greater than {{interval}}',
+            MinException::INCLUSIVE => '{{name}} must not be greater than or equals {{interval}}',
+        ),
+    ),
+
+    'MinimumAgeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'The age must be {{age}} years or more.',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'The age must not be {{age}} years or more.',
+        ),
+    ),
+
+    'MultipleException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be multiple of {{multipleOf}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be multiple of {{multipleOf}}',
+        ),
+    ),
+
+    'NegativeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be negative',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be negative',
+        ),
+    ),
+
+    'NfeAccessKeyException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid NFe access key',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid NFe access key',
+        ),
+    ),
+
+    'NoException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "No"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "No"',
+        ),
+    ),
+
+    'NoneOfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'None of these rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'All of these rules must pass for {{name}}',
+        ),
+    ),
+
+    'NotEmptyException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'The value must not be empty',
+            NotEmptyException::NAMED => '{{name}} must not be empty',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'The value must be empty',
+            NotEmptyException::NAMED => '{{name}} must be empty',
+        ),
+    ),
+
+    'NoWhitespaceException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must not contain whitespace',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not not contain whitespace',
+        ),
+    ),
+
+    'NullValueException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be null',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be null',
+        ),
+    ),
+
+    'NumericException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be numeric',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be numeric',
+        ),
+    ),
+
+    'ObjectException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an object',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an object',
+        ),
+    ),
+
+    'OddException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an odd number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an odd number',
+        ),
+    ),
+
+    'OneOfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'At least one of these rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'At least one of these rules must not pass for {{name}}',
+        ),
+    ),
+
+    'PerfectSquareException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid perfect square',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid perfect square',
+        ),
+    ),
+
+    'PhoneException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid telephone number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid telephone number',
+        ),
+    ),
+
+    'PositiveException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be positive',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be positive',
+        ),
+    ),
+
+    'PostalCodeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid postal code',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid postal code',
+        ),
+    ),
+
+    'PrimeNumberException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid prime number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid prime number',
+        ),
+    ),
+
+    'PrntException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only printable characters',
+            AlphaException::EXTRA => '{{name}} must contain only printable characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain printable characters',
+            AlphaException::EXTRA => '{{name}} must not contain printable characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'PunctException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only punctuation characters',
+            AlphaException::EXTRA => '{{name}} must contain only punctuation characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain punctuation characters',
+            AlphaException::EXTRA => '{{name}} must not contain punctuation characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'ReadableException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be readable',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be readable',
+        ),
+    ),
+
+    'RegexException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must validate against {{regex}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not validate against {{regex}}',
+        ),
+    ),
+
+    'RomanException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid roman number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid roman number',
+        ),
+    ),
+
+    'SfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+    ),
+
+    'SlugException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid slug',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid slug',
+        ),
+    ),
+
+    'SpaceException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only space characters',
+            AlphaException::EXTRA => '{{name}} must contain only space characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain space characters',
+            AlphaException::EXTRA => '{{name}} must not contain space characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'StartsWithException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must start with ({{startValue}})',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not start with ({{startValue}})',
+        ),
+    ),
+
+    'StringException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a string',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be string',
+        ),
+    ),
+
+    'SymbolicLinkException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a symbolic link',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a symbolic link',
+        ),
+    ),
+
+    'TldException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid top-level domain name',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid top-level domain name',
+        ),
+    ),
+
+    'TrueException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "True"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "True"',
+        ),
+    ),
+
+    'TypeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be {{type}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be {{type}}',
+        ),
+    ),
+
+    'UploadedException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an uploaded file',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an uploaded file',
+        ),
+    ),
+
+    'UppercaseException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be uppercase',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be uppercase',
+        ),
+    ),
+
+    'UrlException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an URL',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an URL',
+        ),
+    ),
+
+    'ValidationException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'Data validation failed for %s',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'Data validation failed for %s',
+        ),
+    ),
+
+    'VersionException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a version',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a version',
+        ),
+    ),
+
+    'VowelException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only vowels',
+            AlphaException::EXTRA => '{{name}} must contain only vowels and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain vowels',
+            AlphaException::EXTRA => '{{name}} must not contain vowels or "{{additionalChars}}"',
+        ),
+    ),
+
+    'WritableException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be writable',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be writable',
+        ),
+    ),
+
+    'XdigitException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} contain only hexadecimal digits',
+            AlphaException::EXTRA => '{{name}} contain only hexadecimal digits and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain hexadecimal digits',
+            AlphaException::EXTRA => '{{name}} must not contain hexadecimal digits or "{{additionalChars}}"',
+        ),
+    ),
+
+    'YesException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "Yes"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "Yes"',
+        ),
+    ),
+
+    'ZendException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+    ),
+
+    'GermanBankAccountException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a german bank account',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a german bank account',
+        ),
+    ),
+
+    'GermanBankException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a german bank',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a german bank',
+        ),
+    ),
+
+    'GermanBicException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a german BIC',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a german BIC',
+        ),
+    ),
+);

--- a/library/Messages/en_US.php
+++ b/library/Messages/en_US.php
@@ -132,13 +132,13 @@ $messages = array(
     'BetweenException' => array(
         ValidationException::MODE_DEFAULT => array(
             BetweenException::BOTH      => '{{name}} must be between {{minValue}} and {{maxValue}}',
-            BetweenException::LOWER     => '{{name}}  must be greater than {{minValue}}',
-            BetweenException::GREATER   => '{{name}} must be lower than {{maxValue}}',
+            BetweenException::LOWER     => '{{name}} must be greater than or equal to {{minValue}}',
+            BetweenException::GREATER   => '{{name}} must be lower than or equal to {{maxValue}}',
         ),
         ValidationException::MODE_NEGATIVE => array(
             BetweenException::BOTH      => '{{name}} must not be between {{minValue}} and {{maxValue}}',
-            BetweenException::LOWER     => '{{name}}  must not be greater than {{minValue}}',
-            BetweenException::GREATER   => '{{name}} must not be lower than {{maxValue}}',
+            BetweenException::LOWER     => '{{name}} must be lower than {{minValue}}',
+            BetweenException::GREATER   => '{{name}} must be greater than {{maxValue}}',
         ),
     ),
 

--- a/library/Messages/tr_TR.php
+++ b/library/Messages/tr_TR.php
@@ -1,0 +1,954 @@
+<?php
+namespace Respect\Validation;
+
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Exceptions\AbstractGroupedException;
+use Respect\Validation\Exceptions\AlphaException;
+use Respect\Validation\Exceptions\AlwaysInvalidException;
+use Respect\Validation\Exceptions\AttributeException;
+use Respect\Validation\Exceptions\BetweenException;
+use Respect\Validation\Exceptions\DateException;
+use Respect\Validation\Exceptions\EqualsException;
+use Respect\Validation\Exceptions\IpException;
+use Respect\Validation\Exceptions\LengthException;
+use Respect\Validation\Exceptions\MaxException;
+use Respect\Validation\Exceptions\MinException;
+use Respect\Validation\Exceptions\NotEmptyException;
+
+$messages = array(
+    'AbstractGroupedException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AbstractGroupedException::NONE => 'All of the required rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AbstractGroupedException::NONE => 'None of there rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must not pass for {{name}}',
+        ),
+    ),
+
+    'AllOfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AbstractGroupedException::NONE => 'All of the required rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AbstractGroupedException::NONE => 'None of these rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'These rules must not pass for {{name}}',
+        ),
+    ),
+
+    'AlnumException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only letters (a-z) and digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain letters (a-z) or digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or "{{additionalChars}}"',
+        ),
+    ),
+
+    'AlphaException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only letters (a-z)',
+            AlphaException::EXTRA => '{{name}} must contain only letters (a-z) and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain letters (a-z)',
+            AlphaException::EXTRA => '{{name}} must not contain letters (a-z) or "{{additionalChars}}"',
+        ),
+    ),
+
+    'AlwaysInvalidException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is always invalid',
+            AlwaysInvalidException::SIMPLE   => '{{name}} is not valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is always valid',
+            AlwaysInvalidException::SIMPLE   => '{{name}} is valid',
+        ),
+    ),
+
+    'AlwaysValidException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is always valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is always invalid',
+        ),
+    ),
+
+    'ArrException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an array',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an array',
+        ),
+    ),
+
+    'AtLeastException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AbstractGroupedException::NONE => 'At least {{howMany}} of the {{failed}} required rules must pass for {{name}}',
+            AbstractGroupedException::SOME => 'At least {{howMany}} of the {{failed}} required rules must pass for {{name}}, only {{passed}} passed.',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AbstractGroupedException::NONE => 'At least {{howMany}} of the {{failed}} required rules must not pass for {{name}}',
+            AbstractGroupedException::SOME => 'At least {{howMany}} of the {{failed}} required rules must not pass for {{name}}, only {{passed}} passed.',
+        ),
+    ),
+
+    'AttributeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AttributeException::NOT_PRESENT => 'Attribute {{name}} must be present',
+            AttributeException::INVALID => 'Attribute {{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AttributeException::NOT_PRESENT => 'Attribute {{name}} must not be present',
+            AttributeException::INVALID => 'Attribute {{name}} must not validate',
+        ),
+    ),
+
+    'BankAccountException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a bank account',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a bank account',
+        ),
+    ),
+
+    'BankException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a bank',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a bank',
+        ),
+    ),
+
+    'BetweenException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            BetweenException::BOTH      => '{{name}} must be between {{minValue}} and {{maxValue}}',
+            BetweenException::LOWER     => '{{name}}  must be greater than {{minValue}}',
+            BetweenException::GREATER   => '{{name}} must be lower than {{maxValue}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            BetweenException::BOTH      => '{{name}} must not be between {{minValue}} and {{maxValue}}',
+            BetweenException::LOWER     => '{{name}}  must not be greater than {{minValue}}',
+            BetweenException::GREATER   => '{{name}} must not be lower than {{maxValue}}',
+        ),
+    ),
+
+    'BicException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a BIC',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a BIC',
+        ),
+    ),
+
+    'BoolException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a boolean',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a boolean',
+        ),
+    ),
+
+    'CallbackException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be valid',
+        ),
+    ),
+
+    'CharsetException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be in the {{charset}} charset',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be in the {{charset}} charset',
+        ),
+    ),
+
+    'CnhException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid CNH number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid CNH number',
+        ),
+    ),
+
+    'CnpjException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid CNPJ number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid CNPJ number',
+        ),
+    ),
+
+    'CntrlException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only control characters',
+            AlphaException::EXTRA => '{{name}} must contain only control characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain control characters',
+            AlphaException::EXTRA => '{{name}} must not contain control characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'ConsonantException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only consonants',
+            AlphaException::EXTRA => '{{name}} must contain only consonants and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain consonants',
+            AlphaException::EXTRA => '{{name}} must not contain consonants or "{{additionalChars}}"',
+        ),
+    ),
+
+    'ContainsException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain the value "{{containsValue}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain the value "{{containsValue}}"',
+        ),
+    ),
+
+    'CountryCodeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid country',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid country',
+        ),
+    ),
+
+    'CpfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid CPF number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid CPF number',
+        ),
+    ),
+
+    'CreditCardException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid Credit Card number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid Credit Card number',
+        ),
+    ),
+
+    'DateException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid date',
+            DateException::FORMAT => '{{name}} must be a valid date. Sample format: {{format}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid date',
+            DateException::FORMAT => '{{name}} must not be a valid date in the format {{format}}',
+        ),
+    ),
+
+    'DigitException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must contain only digits (0-9) and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain digits (0-9)',
+            AlphaException::EXTRA => '{{name}} must not contain digits (0-9) or "{{additionalChars}}"',
+        ),
+    ),
+
+    'DirectoryException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a directory',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a directory',
+        ),
+    ),
+
+    'DomainException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid domain',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid domain',
+        ),
+    ),
+
+    'EachException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'Each item in {{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'Each item in {{name}} must not validate',
+        ),
+    ),
+
+    'EmailException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be valid email',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an email',
+        ),
+    ),
+
+    'EndsWithException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must end with ({{endValue}})',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not end with ({{endValue}})',
+        ),
+    ),
+
+    'EqualsException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            EqualsException::EQUALS => '{{name}} must be equals {{compareTo}}',
+            EqualsException::IDENTICAL => '{{name}} must be identical as {{compareTo}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            EqualsException::EQUALS => '{{name}} must not be equals {{compareTo}}',
+            EqualsException::IDENTICAL => '{{name}} must not be identical as {{compareTo}}',
+        ),
+    ),
+
+    'EvenException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an even number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an even number',
+        ),
+    ),
+
+    'ExecutableException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an executable file',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an executable file',
+        ),
+    ),
+
+    'ExistsException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must exists',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not exists',
+        ),
+    ),
+
+    'FalseException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "False"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "False"',
+        ),
+    ),
+
+    'FileException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a file',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a file',
+        ),
+    ),
+
+    'FilterVarException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be valid',
+        ),
+    ),
+
+    'FloatException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a float number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a float number',
+        ),
+    ),
+
+    'GraphException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only graphical characters',
+            AlphaException::EXTRA => '{{name}} must contain only graphical characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain graphical characters',
+            AlphaException::EXTRA => '{{name}} must not contain graphical characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'HexaException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a hexadecimal number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a hexadecimal number',
+        ),
+    ),
+
+    'HexRgbColorException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a hex RGB color',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a hex RGB color',
+        ),
+    ),
+
+    'InException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be in ({{haystack}})',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be in ({{haystack}})',
+        ),
+    ),
+
+    'InstanceException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an instance of {{instanceName}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an instance of {{instanceName}}',
+        ),
+    ),
+
+    'IntException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an integer number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an integer number',
+        ),
+    ),
+
+    'IpException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an IP address',
+            IpException::NETWORK_RANGE => '{{name}} must be an IP address in the {{range}} range',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an IP address',
+            IpException::NETWORK_RANGE => '{{name}} must not be an IP address in the {{range}} range',
+        ),
+    ),
+
+    'JsonException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid JSON string',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid JSON string',
+        ),
+    ),
+
+    'KeyException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            AttributeException::NOT_PRESENT => 'Key {{name}} must be present',
+            AttributeException::INVALID => 'Key {{name}} must be valid',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            AttributeException::NOT_PRESENT => 'Key {{name}} must not be present',
+            AttributeException::INVALID => 'Key {{name}} must not be valid',
+        ),
+    ),
+
+    'LengthException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            LengthException::BOTH       => '{{name}} must have a length between {{minValue}} and {{maxValue}}',
+            LengthException::LOWER      => '{{name}} must have a length greater than {{minValue}}',
+            LengthException::GREATER    => '{{name}} must have a length lower than {{maxValue}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            LengthException::BOTH       => '{{name}} must not have a length between {{minValue}} and {{maxValue}}',
+            LengthException::LOWER      => '{{name}} must not have a length greater than {{minValue}}',
+            LengthException::GREATER    => '{{name}} must not have a length lower than {{maxValue}}',
+        ),
+    ),
+
+    'LowercaseException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be lowercase',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be lowercase',
+        ),
+    ),
+
+    'MacAddressException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid mac address',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid mac address',
+        ),
+    ),
+
+    'MaxException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be lower than {{interval}}',
+            MaxException::INCLUSIVE => '{{name}} must be lower than or equals {{interval}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be lower than {{interval}}',
+            MaxException::INCLUSIVE => '{{name}} must not be lower than or equals {{interval}}',
+        ),
+    ),
+
+    'MinException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be greater than {{interval}}',
+            MinException::INCLUSIVE => '{{name}} must be greater than or equals {{interval}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be greater than {{interval}}',
+            MinException::INCLUSIVE => '{{name}} must not be greater than or equals {{interval}}',
+        ),
+    ),
+
+    'MinimumAgeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'The age must be {{age}} years or more.',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'The age must not be {{age}} years or more.',
+        ),
+    ),
+
+    'MultipleException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be multiple of {{multipleOf}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be multiple of {{multipleOf}}',
+        ),
+    ),
+
+    'NegativeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be negative',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be negative',
+        ),
+    ),
+
+    'NfeAccessKeyException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid NFe access key',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid NFe access key',
+        ),
+    ),
+
+    'NoException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "No"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "No"',
+        ),
+    ),
+
+    'NoneOfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'None of these rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'All of these rules must pass for {{name}}',
+        ),
+    ),
+
+    'NotEmptyException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'The value must not be empty',
+            NotEmptyException::NAMED => '{{name}} must not be empty',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'The value must be empty',
+            NotEmptyException::NAMED => '{{name}} must be empty',
+        ),
+    ),
+
+    'NoWhitespaceException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must not contain whitespace',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not not contain whitespace',
+        ),
+    ),
+
+    'NullValueException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be null',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be null',
+        ),
+    ),
+
+    'NumericException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be numeric',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be numeric',
+        ),
+    ),
+
+    'ObjectException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an object',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an object',
+        ),
+    ),
+
+    'OddException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an odd number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an odd number',
+        ),
+    ),
+
+    'OneOfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'At least one of these rules must pass for {{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'At least one of these rules must not pass for {{name}}',
+        ),
+    ),
+
+    'PerfectSquareException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid perfect square',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid perfect square',
+        ),
+    ),
+
+    'PhoneException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid telephone number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid telephone number',
+        ),
+    ),
+
+    'PositiveException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be positive',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be positive',
+        ),
+    ),
+
+    'PostalCodeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid postal code',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid postal code',
+        ),
+    ),
+
+    'PrimeNumberException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid prime number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid prime number',
+        ),
+    ),
+
+    'PrntException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only printable characters',
+            AlphaException::EXTRA => '{{name}} must contain only printable characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain printable characters',
+            AlphaException::EXTRA => '{{name}} must not contain printable characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'PunctException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only punctuation characters',
+            AlphaException::EXTRA => '{{name}} must contain only punctuation characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain punctuation characters',
+            AlphaException::EXTRA => '{{name}} must not contain punctuation characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'ReadableException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be readable',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be readable',
+        ),
+    ),
+
+    'RegexException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must validate against {{regex}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not validate against {{regex}}',
+        ),
+    ),
+
+    'RomanException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid roman number',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid roman number',
+        ),
+    ),
+
+    'SfException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+    ),
+
+    'SlugException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid slug',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid slug',
+        ),
+    ),
+
+    'SpaceException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only space characters',
+            AlphaException::EXTRA => '{{name}} must contain only space characters and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain space characters',
+            AlphaException::EXTRA => '{{name}} must not contain space characters or "{{additionalChars}}"',
+        ),
+    ),
+
+    'StartsWithException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must start with ({{startValue}})',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not start with ({{startValue}})',
+        ),
+    ),
+
+    'StringException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a string',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be string',
+        ),
+    ),
+
+    'SymbolicLinkException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a symbolic link',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a symbolic link',
+        ),
+    ),
+
+    'TldException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a valid top-level domain name',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a valid top-level domain name',
+        ),
+    ),
+
+    'TrueException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "True"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "True"',
+        ),
+    ),
+
+    'TypeException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be {{type}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be {{type}}',
+        ),
+    ),
+
+    'UploadedException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an uploaded file',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an uploaded file',
+        ),
+    ),
+
+    'UppercaseException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be uppercase',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be uppercase',
+        ),
+    ),
+
+    'UrlException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be an URL',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be an URL',
+        ),
+    ),
+
+    'ValidationException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => 'Data validation failed for %s',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => 'Data validation failed for %s',
+        ),
+    ),
+
+    'VersionException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a version',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a version',
+        ),
+    ),
+
+    'VowelException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must contain only vowels',
+            AlphaException::EXTRA => '{{name}} must contain only vowels and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain vowels',
+            AlphaException::EXTRA => '{{name}} must not contain vowels or "{{additionalChars}}"',
+        ),
+    ),
+
+    'WritableException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be writable',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be writable',
+        ),
+    ),
+
+    'XdigitException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} contain only hexadecimal digits',
+            AlphaException::EXTRA => '{{name}} contain only hexadecimal digits and "{{additionalChars}}"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not contain hexadecimal digits',
+            AlphaException::EXTRA => '{{name}} must not contain hexadecimal digits or "{{additionalChars}}"',
+        ),
+    ),
+
+    'YesException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} is not considered as "Yes"',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} is considered as "Yes"',
+        ),
+    ),
+
+    'ZendException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}}',
+        ),
+    ),
+
+    'GermanBankAccountException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a german bank account',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a german bank account',
+        ),
+    ),
+
+    'GermanBankException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a german bank',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a german bank',
+        ),
+    ),
+
+    'GermanBicException' => array(
+        ValidationException::MODE_DEFAULT => array(
+            ValidationException::STANDARD => '{{name}} must be a german BIC',
+        ),
+        ValidationException::MODE_NEGATIVE => array(
+            ValidationException::STANDARD => '{{name}} must not be a german BIC',
+        ),
+    ),
+);

--- a/library/Messages/tr_TR.php
+++ b/library/Messages/tr_TR.php
@@ -131,14 +131,14 @@ $messages = array(
 
     'BetweenException' => array(
         ValidationException::MODE_DEFAULT => array(
-            BetweenException::BOTH      => '{{name}} must be between {{minValue}} and {{maxValue}}',
-            BetweenException::LOWER     => '{{name}}  must be greater than {{minValue}}',
-            BetweenException::GREATER   => '{{name}} must be lower than {{maxValue}}',
+            BetweenException::BOTH      => '{{name}} şu aralıkta olmalı: {{minValue}} - {{maxValue}}',
+            BetweenException::LOWER     => '{{name}} en az {{minValue}} olabilir',
+            BetweenException::GREATER   => '{{name}} en fazla {{maxValue}} olabilir',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            BetweenException::BOTH      => '{{name}} must not be between {{minValue}} and {{maxValue}}',
-            BetweenException::LOWER     => '{{name}}  must not be greater than {{minValue}}',
-            BetweenException::GREATER   => '{{name}} must not be lower than {{maxValue}}',
+            BetweenException::BOTH      => '{{name}} şu aralıkta olmamalı: {{minValue}} - {{maxValue}}',
+            BetweenException::LOWER     => '{{name}} şundan küçük olmalı: {{minValue}}',
+            BetweenException::GREATER   => '{{name}} şundan büyük olmalı: {{maxValue}}',
         ),
     ),
 
@@ -484,14 +484,14 @@ $messages = array(
 
     'LengthException' => array(
         ValidationException::MODE_DEFAULT => array(
-            LengthException::BOTH       => '{{name}} must have a length between {{minValue}} and {{maxValue}}',
-            LengthException::LOWER      => '{{name}} must have a length greater than {{minValue}}',
-            LengthException::GREATER    => '{{name}} must have a length lower than {{maxValue}}',
+            LengthException::BOTH       => '{{name}} şu aralıkta bir uzunluğa sahip olmalı: {{minValue}} - {{maxValue}}',
+            LengthException::LOWER      => '{{name}} en az şu uzunlukta olmalı: {{minValue}}',
+            LengthException::GREATER    => '{{name}} en fazla şu uzunlukta olmalı: {{maxValue}}',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            LengthException::BOTH       => '{{name}} must not have a length between {{minValue}} and {{maxValue}}',
-            LengthException::LOWER      => '{{name}} must not have a length greater than {{minValue}}',
-            LengthException::GREATER    => '{{name}} must not have a length lower than {{maxValue}}',
+            LengthException::BOTH       => '{{name}} şu aralıkta bir uzunluğa sahip olmamalı: {{minValue}} - {{maxValue}}',
+            LengthException::LOWER      => '{{name}} şundan daha kısa olmalı: {{minValue}}',
+            LengthException::GREATER    => '{{name}} şundan daha uzun olmalı: {{maxValue}}',
         ),
     ),
 
@@ -515,23 +515,23 @@ $messages = array(
 
     'MaxException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be lower than {{interval}}',
-            MaxException::INCLUSIVE => '{{name}} must be lower than or equals {{interval}}',
+            ValidationException::STANDARD => '{{name}} şundan küçük olmalı: {{interval}}',
+            MaxException::INCLUSIVE => '{{name}} en fazla {{interval}} olabilir',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be lower than {{interval}}',
-            MaxException::INCLUSIVE => '{{name}} must not be lower than or equals {{interval}}',
+            ValidationException::STANDARD => '{{name}} şundan küçük olmamalı: {{interval}}',
+            MaxException::INCLUSIVE => '{{name}} şundan büyük olmalı: {{interval}}',
         ),
     ),
 
     'MinException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be greater than {{interval}}',
-            MinException::INCLUSIVE => '{{name}} must be greater than or equals {{interval}}',
+            ValidationException::STANDARD => '{{name}} şundan büyük olmalı: {{interval}}',
+            MinException::INCLUSIVE => '{{name}} en az {{interval}} olabilir',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be greater than {{interval}}',
-            MinException::INCLUSIVE => '{{name}} must not be greater than or equals {{interval}}',
+            ValidationException::STANDARD => '{{name}} şundan büyük olmamalı: {{interval}}',
+            MinException::INCLUSIVE => '{{name}} şundan küçük olmalı: {{interval}}',
         ),
     ),
 

--- a/library/Messages/tr_TR.php
+++ b/library/Messages/tr_TR.php
@@ -29,34 +29,34 @@ $messages = array(
 
     'AllOfException' => array(
         ValidationException::MODE_DEFAULT => array(
-            AbstractGroupedException::NONE => 'All of the required rules must pass for {{name}}',
-            AbstractGroupedException::SOME => 'These rules must pass for {{name}}',
+            AbstractGroupedException::NONE => '{{name}} tüm zorunlu kurallara uymalıdır',
+            AbstractGroupedException::SOME => '{{name}} şu kurallara uymalıdır',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            AbstractGroupedException::NONE => 'None of these rules must pass for {{name}}',
-            AbstractGroupedException::SOME => 'These rules must not pass for {{name}}',
+            AbstractGroupedException::NONE => '{{name}} bu kuralların hiçbirine uymamalıdır',
+            AbstractGroupedException::SOME => '{{name}} şu kurallara uymamalıdır',
         ),
     ),
 
     'AlnumException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must contain only letters (a-z) and digits (0-9)',
-            AlphaException::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} sadece harf (a-z) ve rakamlardan (0-9) oluşmalı',
+            AlphaException::EXTRA => '{{name}} sadece harflerden (a-z), rakamlardan (0-9) ve şunlardan oluşmalı: "{{additionalChars}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not contain letters (a-z) or digits (0-9)',
-            AlphaException::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} tamamen harf (a-z) ve rakamlardan (0-9) oluşmamalı',
+            AlphaException::EXTRA => '{{name}} tamamen harflerden (a-z), rakamlardan (0-9) ve şunlardan oluşmamalı: "{{additionalChars}}"',
         ),
     ),
 
     'AlphaException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must contain only letters (a-z)',
-            AlphaException::EXTRA => '{{name}} must contain only letters (a-z) and "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} sadece harflerden oluşmalı (a-z)',
+            AlphaException::EXTRA => '{{name}} sadece harflerden (a-z) ve şunlardan oluşmalı: "{{additionalChars}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not contain letters (a-z)',
-            AlphaException::EXTRA => '{{name}} must not contain letters (a-z) or "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} tamamen harflerden oluşmamalı (a-z)',
+            AlphaException::EXTRA => '{{name}} tamamen harflerden (a-z) ve şunlardan oluşmamalı: "{{additionalChars}}"',
         ),
     ),
 
@@ -82,10 +82,10 @@ $messages = array(
 
     'ArrException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an array',
+            ValidationException::STANDARD => '{{name}} bir dizi olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an array',
+            ValidationException::STANDARD => '{{name}} dizi olmamalı',
         ),
     ),
 
@@ -153,10 +153,10 @@ $messages = array(
 
     'BoolException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a boolean',
+            ValidationException::STANDARD => '{{name}} bir boolean olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be a boolean',
+            ValidationException::STANDARD => '{{name}} boolean olmamalı',
         ),
     ),
 
@@ -220,10 +220,10 @@ $messages = array(
 
     'ContainsException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must contain the value "{{containsValue}}"',
+            ValidationException::STANDARD => '{{name}} şunu içermeli: "{{containsValue}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not contain the value "{{containsValue}}"',
+            ValidationException::STANDARD => '{{name}} şunu içermemeli: "{{containsValue}}"',
         ),
     ),
 
@@ -247,41 +247,41 @@ $messages = array(
 
     'CreditCardException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a valid Credit Card number',
+            ValidationException::STANDARD => '{{name}} geçersiz',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be a valid Credit Card number',
+            ValidationException::STANDARD => '{{name}} geçerli bir numara olmamalı',
         ),
     ),
 
     'DateException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a valid date',
-            DateException::FORMAT => '{{name}} must be a valid date. Sample format: {{format}}',
+            ValidationException::STANDARD => '{{name}} geçerli bir tarih olmalı',
+            DateException::FORMAT => '{{name}} geçerli bir tarih olmalı. Örnek format: {{format}}',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be a valid date',
-            DateException::FORMAT => '{{name}} must not be a valid date in the format {{format}}',
+            ValidationException::STANDARD => '{{name}} geçerli bir tarih olmamalı',
+            DateException::FORMAT => '{{name}} şu tarih formatında olmamalı: {{format}}',
         ),
     ),
 
     'DigitException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must contain only digits (0-9)',
-            AlphaException::EXTRA => '{{name}} must contain only digits (0-9) and "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} sadece rakamlardan oluşmalı (0-9)',
+            AlphaException::EXTRA => '{{name}} sadece rakamlardan (0-9) ve şunlardan oluşmalı: "{{additionalChars}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not contain digits (0-9)',
-            AlphaException::EXTRA => '{{name}} must not contain digits (0-9) or "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} tamamen rakamlardan (0-9) oluşmamalı',
+            AlphaException::EXTRA => '{{name}} tamamen rakamlardan (0-9) ve şunlardan oluşmamalı: "{{additionalChars}}"',
         ),
     ),
 
     'DirectoryException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a directory',
+            ValidationException::STANDARD => '{{name}} var olan bir klasör olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be a directory',
+            ValidationException::STANDARD => '{{name}} var olan bir klasör olmamalı',
         ),
     ),
 
@@ -305,19 +305,19 @@ $messages = array(
 
     'EmailException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be valid email',
+            ValidationException::STANDARD => '{{name}} geçerli bir eposta olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an email',
+            ValidationException::STANDARD => '{{name}} geçerli bir eposta olmamalı',
         ),
     ),
 
     'EndsWithException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must end with ({{endValue}})',
+            ValidationException::STANDARD => '{{name}} şununla bitmeli: "{{endValue}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not end with ({{endValue}})',
+            ValidationException::STANDARD => '{{name}} şununla bitmemeli: "{{endValue}}"',
         ),
     ),
 
@@ -334,10 +334,10 @@ $messages = array(
 
     'EvenException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an even number',
+            ValidationException::STANDARD => '{{name}} çift sayı olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an even number',
+            ValidationException::STANDARD => '{{name}} çift sayı olmamalı',
         ),
     ),
 
@@ -370,10 +370,10 @@ $messages = array(
 
     'FileException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a file',
+            ValidationException::STANDARD => '{{name}} var olan bir dosya olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be a file',
+            ValidationException::STANDARD => '{{name}} var olan bir dosya olmamalı',
         ),
     ),
 
@@ -388,10 +388,10 @@ $messages = array(
 
     'FloatException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a float number',
+            ValidationException::STANDARD => '{{name}} bir float olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be a float number',
+            ValidationException::STANDARD => '{{name}} float olmamalı',
         ),
     ),
 
@@ -444,10 +444,10 @@ $messages = array(
 
     'IntException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an integer number',
+            ValidationException::STANDARD => '{{name}} bir sayı olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an integer number',
+            ValidationException::STANDARD => '{{name}} bir sayı olmamalı',
         ),
     ),
 
@@ -497,10 +497,10 @@ $messages = array(
 
     'LowercaseException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be lowercase',
+            ValidationException::STANDARD => '{{name}} yalnızca küçük harflerden oluşmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be lowercase',
+            ValidationException::STANDARD => '{{name}} tamamen küçük harflerden oluşmamalı',
         ),
     ),
 
@@ -555,10 +555,10 @@ $messages = array(
 
     'NegativeException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be negative',
+            ValidationException::STANDARD => '{{name}} sıfırdan küçük olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be negative',
+            ValidationException::STANDARD => '{{name}} sıfırdan küçük olmamalı',
         ),
     ),
 
@@ -591,57 +591,57 @@ $messages = array(
 
     'NotEmptyException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => 'The value must not be empty',
-            NotEmptyException::NAMED => '{{name}} must not be empty',
+            ValidationException::STANDARD => 'Değer boş bırakılamaz',
+            NotEmptyException::NAMED => '{{name}} boş bırakılamaz',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => 'The value must be empty',
-            NotEmptyException::NAMED => '{{name}} must be empty',
+            ValidationException::STANDARD => 'Değer boş olmalı',
+            NotEmptyException::NAMED => '{{name}} boş olmalı',
         ),
     ),
 
     'NoWhitespaceException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must not contain whitespace',
+            ValidationException::STANDARD => '{{name}} boşluk karakterleri içermemeli',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not not contain whitespace',
+            ValidationException::STANDARD => '{{name}} boşluk karakterleri içermeli',
         ),
     ),
 
     'NullValueException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be null',
+            ValidationException::STANDARD => '{{name}} null olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be null',
+            ValidationException::STANDARD => '{{name}} null olmamalı',
         ),
     ),
 
     'NumericException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be numeric',
+            ValidationException::STANDARD => '{{name}} sayısal bir ifade olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be numeric',
+            ValidationException::STANDARD => '{{name}} sayısal bir ifade olmamalı',
         ),
     ),
 
     'ObjectException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an object',
+            ValidationException::STANDARD => '{{name}} bir nesne olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an object',
+            ValidationException::STANDARD => '{{name}} bir nesne olmamalı',
         ),
     ),
 
     'OddException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an odd number',
+            ValidationException::STANDARD => '{{name}} tek sayı olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an odd number',
+            ValidationException::STANDARD => '{{name}} tek sayı olmamalı',
         ),
     ),
 
@@ -674,10 +674,10 @@ $messages = array(
 
     'PositiveException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be positive',
+            ValidationException::STANDARD => '{{name}} sıfırdan büyük olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be positive',
+            ValidationException::STANDARD => '{{name}} sıfırdan büyük olmamalı',
         ),
     ),
 
@@ -732,10 +732,10 @@ $messages = array(
 
     'RegexException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must validate against {{regex}}',
+            ValidationException::STANDARD => '{{name}} şu düzenli ifadeyle eşleşmeli: {{regex}}',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not validate against {{regex}}',
+            ValidationException::STANDARD => '{{name}} şu düzenli ifadeyle eşleşmemeli: {{regex}}',
         ),
     ),
 
@@ -768,30 +768,30 @@ $messages = array(
 
     'SpaceException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must contain only space characters',
-            AlphaException::EXTRA => '{{name}} must contain only space characters and "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} sadece boşluk karakterleri içermeli',
+            AlphaException::EXTRA => '{{name}} sadece boşluk karakterleri ve şunları içermeli: "{{additionalChars}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not contain space characters',
-            AlphaException::EXTRA => '{{name}} must not contain space characters or "{{additionalChars}}"',
+            ValidationException::STANDARD => '{{name}} tamamen boşluk karakterlerinden oluşmamalı',
+            AlphaException::EXTRA => '{{name}} tamamen boşluk karakterlerinden ve şunlardan oluşmamalı: "{{additionalChars}}"',
         ),
     ),
 
     'StartsWithException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must start with ({{startValue}})',
+            ValidationException::STANDARD => '{{name}} şununla başlamalı: "{{startValue}}"',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not start with ({{startValue}})',
+            ValidationException::STANDARD => '{{name}} şununla başlamamalı: "{{startValue}}"',
         ),
     ),
 
     'StringException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be a string',
+            ValidationException::STANDARD => '{{name}} bir metin olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be string',
+            ValidationException::STANDARD => '{{name}} bir metin olmamalı',
         ),
     ),
 
@@ -833,28 +833,28 @@ $messages = array(
 
     'UploadedException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an uploaded file',
+            ValidationException::STANDARD => '{{name}}, yüklenmiş bir dosya olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an uploaded file',
+            ValidationException::STANDARD => '{{name}}, yüklenmiş bir dosya olmamalı',
         ),
     ),
 
     'UppercaseException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be uppercase',
+            ValidationException::STANDARD => '{{name}} yalnızca büyük harflerden oluşmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be uppercase',
+            ValidationException::STANDARD => '{{name}} tamamen büyük harflerden oluşmamalı',
         ),
     ),
 
     'UrlException' => array(
         ValidationException::MODE_DEFAULT => array(
-            ValidationException::STANDARD => '{{name}} must be an URL',
+            ValidationException::STANDARD => '{{name}} geçerli bir URL olmalı',
         ),
         ValidationException::MODE_NEGATIVE => array(
-            ValidationException::STANDARD => '{{name}} must not be an URL',
+            ValidationException::STANDARD => '{{name}} geçerli bir URL olmamalı',
         ),
     ),
 

--- a/library/Rules/AbstractCtypeRule.php
+++ b/library/Rules/AbstractCtypeRule.php
@@ -5,15 +5,6 @@ abstract class AbstractCtypeRule extends AbstractFilterRule
 {
     abstract protected function ctypeFunction($input);
 
-    protected function filterWhiteSpaceOption($input)
-    {
-        if (!empty($this->additionalChars)) {
-            $input = str_replace(str_split($this->additionalChars), '', $input);
-        }
-
-        return preg_replace('/\s/', '', $input);
-    }
-
     public function validateClean($input)
     {
         return $this->ctypeFunction($input);

--- a/library/Rules/AbstractInterval.php
+++ b/library/Rules/AbstractInterval.php
@@ -1,0 +1,36 @@
+<?php
+namespace Respect\Validation\Rules;
+
+use Exception;
+use DateTime;
+
+abstract class AbstractInterval extends AbstractRule
+{
+    public $interval;
+    public $inclusive;
+
+    public function __construct($interval, $inclusive = false)
+    {
+        $this->interval  = $interval;
+        $this->inclusive = $inclusive;
+    }
+
+    protected function filterInterval($value)
+    {
+        if (!is_string($value) || is_numeric($value) || empty($value)) {
+            return $value;
+        }
+
+        if (strlen($value) == 1) {
+            return $value;
+        }
+
+        try {
+            return new DateTime($value);
+        } catch (Exception $e) {
+            // Pokémon Exception Handling
+        }
+
+        return $value;
+    }
+}

--- a/library/Rules/AbstractInterval.php
+++ b/library/Rules/AbstractInterval.php
@@ -9,7 +9,7 @@ abstract class AbstractInterval extends AbstractRule
     public $interval;
     public $inclusive;
 
-    public function __construct($interval, $inclusive = false)
+    public function __construct($interval, $inclusive = true)
     {
         $this->interval  = $interval;
         $this->inclusive = $inclusive;

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -66,10 +66,11 @@ abstract class AbstractRelated extends AbstractRule
     public function validate($input)
     {
         $hasReference = $this->hasReference($input);
+
         if ($this->mandatory && !$hasReference) {
             return false;
         }
 
-        return $this->decision('validate', $hasReference, $input);
+        return $this->decision('validate', $hasReference, $input) || $this->getReferenceValue($input) === '';
     }
 }

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -65,12 +65,15 @@ abstract class AbstractRelated extends AbstractRule
 
     public function validate($input)
     {
-        $hasReference = $this->hasReference($input);
+        if ($input === '') {
+            return true;
+        }
 
+        $hasReference = $this->hasReference($input);
         if ($this->mandatory && !$hasReference) {
             return false;
         }
 
-        return $this->decision('validate', $hasReference, $input) || $this->getReferenceValue($input) === '';
+        return $this->decision('validate', $hasReference, $input);
     }
 }

--- a/library/Rules/Alnum.php
+++ b/library/Rules/Alnum.php
@@ -3,11 +3,6 @@ namespace Respect\Validation\Rules;
 
 class Alnum extends AbstractCtypeRule
 {
-    protected function filter($input)
-    {
-        return $this->filterWhiteSpaceOption($input);
-    }
-
     protected function ctypeFunction($input)
     {
         return ctype_alnum($input);

--- a/library/Rules/Alpha.php
+++ b/library/Rules/Alpha.php
@@ -3,11 +3,6 @@ namespace Respect\Validation\Rules;
 
 class Alpha extends AbstractCtypeRule
 {
-    protected function filter($input)
-    {
-        return $this->filterWhiteSpaceOption($input);
-    }
-
     protected function ctypeFunction($input)
     {
         return ctype_alpha($input);

--- a/library/Rules/Between.php
+++ b/library/Rules/Between.php
@@ -8,7 +8,7 @@ class Between extends AllOf
     public $minValue;
     public $maxValue;
 
-    public function __construct($min = null, $max = null, $inclusive = false)
+    public function __construct($min = null, $max = null, $inclusive = true)
     {
         $this->minValue = $min;
         $this->maxValue = $max;

--- a/library/Rules/Digit.php
+++ b/library/Rules/Digit.php
@@ -3,11 +3,6 @@ namespace Respect\Validation\Rules;
 
 class Digit extends AbstractCtypeRule
 {
-    protected function filter($input)
-    {
-        return $this->filterWhiteSpaceOption($input);
-    }
-
     protected function ctypeFunction($input)
     {
         return ctype_digit($input);

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -1,23 +1,14 @@
 <?php
 namespace Respect\Validation\Rules;
 
-class Max extends AbstractRule
+class Max extends AbstractInterval
 {
-    public $maxValue;
-    public $inclusive;
-
-    public function __construct($maxValue, $inclusive = false)
-    {
-        $this->maxValue = $maxValue;
-        $this->inclusive = $inclusive;
-    }
-
     public function validate($input)
     {
         if ($this->inclusive) {
-            return $input <= $this->maxValue;
-        } else {
-            return $input < $this->maxValue;
+            return $this->filterInterval($input) <= $this->filterInterval($this->interval);
         }
+
+        return $this->filterInterval($input) < $this->filterInterval($this->interval);
     }
 }

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -1,23 +1,14 @@
 <?php
 namespace Respect\Validation\Rules;
 
-class Min extends AbstractRule
+class Min extends AbstractInterval
 {
-    public $inclusive;
-    public $minValue;
-
-    public function __construct($minValue, $inclusive = false)
-    {
-        $this->minValue = $minValue;
-        $this->inclusive = $inclusive;
-    }
-
     public function validate($input)
     {
         if ($this->inclusive) {
-            return $input >= $this->minValue;
-        } else {
-            return $input > $this->minValue;
+            return $this->filterInterval($input) >= $this->filterInterval($this->interval);
         }
+
+        return $this->filterInterval($input) > $this->filterInterval($this->interval);
     }
 }

--- a/library/Rules/Roman.php
+++ b/library/Rules/Roman.php
@@ -1,10 +1,11 @@
 <?php
 namespace Respect\Validation\Rules;
 
-class Roman extends AbstractRule
+class Roman extends Regex
 {
-    public function validate($input)
+    public function __construct()
     {
-        return (boolean) preg_match('/^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$/', $input);
+        $pattern = '^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$';
+        parent::__construct('/'.$pattern.'/');
     }
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -106,6 +106,45 @@ use Respect\Validation\Rules\AllOf;
  */
 class Validator extends AllOf
 {
+    protected static $factory;
+
+    /**
+     * @return Factory
+     */
+    protected static function getFactory()
+    {
+        if (! static::$factory instanceof Factory) {
+            static::$factory = new Factory();
+        }
+
+        return static::$factory;
+    }
+
+    /**
+     * @param Factory $factory
+     *
+     * @return null
+     */
+    public static function setFactory($factory)
+    {
+        static::$factory = $factory;
+    }
+
+    /**
+     * @param string $rulePrefix
+     * @param bool   $prepend
+     *
+     * @return null
+     */
+    public static function with($rulePrefix, $prepend = false)
+    {
+        if (false === $prepend) {
+            self::getFactory()->appendRulePrefix($rulePrefix);
+        } else {
+            self::getFactory()->prependRulePrefix($rulePrefix);
+        }
+    }
+
     /**
      * @param string $ruleName
      * @param array  $arguments
@@ -131,18 +170,10 @@ class Validator extends AllOf
      */
     public static function buildRule($ruleSpec, $arguments = array())
     {
-        if ($ruleSpec instanceof Validatable) {
-            return $ruleSpec;
-        }
-
         try {
-            $validatorFqn = 'Respect\\Validation\\Rules\\'.ucfirst($ruleSpec);
-            $validatorClass = new ReflectionClass($validatorFqn);
-            $validatorInstance = $validatorClass->newInstanceArgs($arguments);
-
-            return $validatorInstance;
-        } catch (ReflectionException $e) {
-            throw new ComponentException($e->getMessage());
+            return static::getFactory()->rule($ruleSpec, $arguments);
+        } catch (\Exception $exception) {
+            throw new ComponentException($exception->getMessage(), $exception->getCode(), $exception);
         }
     }
 

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -108,6 +108,9 @@ class Validator extends AllOf
 {
     protected static $factory;
 
+    protected static $locale = 'en_US';
+    public static $messages = array();
+
     /**
      * @return Factory
      */
@@ -227,5 +230,29 @@ class Validator extends AllOf
         $ref = new ReflectionClass(__CLASS__);
 
         return $ref->newInstanceArgs(func_get_args());
+    }
+
+    /**
+     * Set locale for error messages.
+     *
+     * @return null
+     */
+    public static function setLocale($locale)
+    {
+        if (self::$locale == $locale && self::$messages) {
+            return;
+        }
+
+        // sanitize
+        $locale = preg_replace('%\W%', '', $locale);
+
+        $localeFile = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Messages' . DIRECTORY_SEPARATOR . $locale . '.php';
+
+        if (file_exists($localeFile)) {
+            require $localeFile;
+
+            self::$messages = $messages;
+            self::$locale = $locale;
+        }
     }
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -108,7 +108,7 @@ class Validator extends AllOf
 {
     protected static $factory;
 
-    protected static $locale = 'en_US';
+    public static $locale = 'en_US';
     public static $messages = array();
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Respect\Validation;
+
+/**
+ * @covers Respect\Validation\Factory
+ */
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldHaveRulePrefixesByDefault()
+    {
+        $factory = new Factory();
+
+        $this->assertEquals(array('Respect\\Validation\\Rules\\'), $factory->getRulePrefixes());
+    }
+
+    public function testShouldBeAbleToAppendANewPrefix()
+    {
+        $factory = new Factory();
+        $factory->appendRulePrefix('My\\Validation\\Rules\\');
+
+        $this->assertEquals(array('Respect\\Validation\\Rules\\', 'My\\Validation\\Rules\\'), $factory->getRulePrefixes());
+    }
+
+    public function testShouldBeAbleToPrependANewRulePrefix()
+    {
+        $factory = new Factory();
+        $factory->prependRulePrefix('My\\Validation\\Rules\\');
+
+        $this->assertEquals(array('My\\Validation\\Rules\\', 'Respect\\Validation\\Rules\\'), $factory->getRulePrefixes());
+    }
+
+    public function testShouldCreateARuleByName()
+    {
+        $factory = new Factory();
+
+        $this->assertInstanceOf('Respect\\Validation\\Rules\\Uppercase', $factory->rule('uppercase'));
+    }
+
+    public function testShouldDefineConstructorArgumentsWhenCreatingARule()
+    {
+        $factory = new Factory();
+        $rule = $factory->rule('date', array('Y-m-d'));
+
+        $this->assertEquals('Y-m-d', $rule->format);
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\ComponentException
+     * @expectedExceptionMessage "uterere" is not a valid rule name
+     */
+    public function testShouldThrowsAnExceptionWhenRuleNameIsNotValid()
+    {
+        $factory = new Factory();
+        $factory->rule('uterere');
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\ComponentException
+     * @expectedExceptionMessage "Respect\Validation\TestNonRule" is not a valid respect rule
+     */
+    public function testShouldThrowsAnExceptionWhenRuleIsNotInstanceOfRuleInterface()
+    {
+        $factory = new Factory();
+        $factory->appendRulePrefix('Respect\\Validation\\Test');
+        $factory->rule('nonRule');
+    }
+}
+
+class TestNonRule
+{
+}

--- a/tests/Rules/KeyTest.php
+++ b/tests/Rules/KeyTest.php
@@ -13,14 +13,43 @@ class KeyTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->validate($obj));
     }
 
+    public function testEmptyInputMustReturnTrue()
+    {
+        $validator = new Key('someEmptyKey');
+        $input = '';
+
+        $this->assertTrue($validator->assert($input));
+        $this->assertTrue($validator->check($input));
+        $this->assertTrue($validator->validate($input));
+    }
+
     public function testArrayWithEmptyKeyShouldReturnTrue()
     {
         $validator = new Key('someEmptyKey');
-        $obj = array();
-        $obj['someEmptyKey'] = '';
-        $this->assertTrue($validator->assert($obj));
-        $this->assertTrue($validator->check($obj));
-        $this->assertTrue($validator->validate($obj));
+        $input = array();
+        $input['someEmptyKey'] = '';
+
+        $this->assertTrue($validator->assert($input));
+        $this->assertTrue($validator->check($input));
+        $this->assertTrue($validator->validate($input));
+    }
+
+    public function testShouldHaveTheSameReturnValueForAllValidators()
+    {
+        $rule   = new Key('key', new NotEmpty());
+        $input  = array('key' => '');
+
+        try {
+            $rule->assert($input);
+            $this->fail('`assert()` must throws exception');
+        } catch (\Exception $e) {}
+
+        try {
+            $rule->check($input);
+            $this->fail('`check()` must throws exception');
+        } catch (\Exception $e) {}
+
+        $this->assertFalse($rule->validate($input));
     }
 
     /**

--- a/tests/Rules/KeyTest.php
+++ b/tests/Rules/KeyTest.php
@@ -13,6 +13,16 @@ class KeyTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->validate($obj));
     }
 
+    public function testArrayWithEmptyKeyShouldReturnTrue()
+    {
+        $validator = new Key('someEmptyKey');
+        $obj = array();
+        $obj['someEmptyKey'] = '';
+        $this->assertTrue($validator->assert($obj));
+        $this->assertTrue($validator->check($obj));
+        $this->assertTrue($validator->validate($obj));
+    }
+
     /**
      * @expectedException Respect\Validation\Exceptions\KeyException
      */

--- a/tests/Rules/MaxTest.php
+++ b/tests/Rules/MaxTest.php
@@ -33,6 +33,10 @@ class MaxTest extends \PHPUnit_Framework_TestCase
             array(200, false, -200),
             array(200, true, 200),
             array(200, false, 0),
+            array('-18 years', true, '1988-09-09'),
+            array('z', true, 'z'),
+            array('z', false, 'y'),
+            array('tomorrow', true, 'now'),
         );
     }
 

--- a/tests/Rules/MinTest.php
+++ b/tests/Rules/MinTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Respect\Validation\Rules;
 
+use DateTime;
+
 class MinTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -35,6 +37,15 @@ class MinTest extends \PHPUnit_Framework_TestCase
             array(-100, false, 200),
             array(200, true, 200),
             array(200, false, 300),
+            array('a', true, 'a'),
+            array('a', true, 'c'),
+            array('yesterday', true, 'now'),
+
+            // Samples from issue #178
+            array('13-05-2014 03:16', true, '20-05-2014 03:16'),
+            array(new DateTime('13-05-2014 03:16'), true, new DateTime('20-05-2014 03:16')),
+            array('13-05-2014 03:16', true, new DateTime('20-05-2014 03:16')),
+            array(new DateTime('13-05-2014 03:16'), true, '20-05-2014 03:16'),
         );
     }
 


### PR DESCRIPTION
I've implemented below:

1. Quick and a little dirty localization. Definitely it can be improved, but works fine in current state.
2. Make `between()`, `max()` and `min()` inclusive by default
3. Do not allow whitespace in `alnum()`, `alpha()` and `digit()`
4. Update README for above changes
5. Added Turkish translation (not all the messages are translated).

Localization example:

```php
v::setLocale('en_US');

try {
    v::int()->check("hello");

} catch ($exception) {
    echo $exception->getMainMessage(); // automatically localized message
}
```

If no locale is set, English is the default. So it won't break existing code.

\# 2 and # 3 however will break existing code. It would be good to get feedback from users if they agree with those changes.

Notes:

* I'm not able to update tests at the moment.
* I've based my changes onto 0.8 tag. This PR is through master and it seems it gonna give conflicts.

/cc #119, #28 