### PR TITLE
Date-validation fails when system is set to non-UTC timezone

### DIFF
--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -34,6 +34,6 @@ class Date extends AbstractRule
         $dateFromFormat = DateTime::createFromFormat($this->format, $input);
 
         return $dateFromFormat
-               && $input === date($this->format, $dateFromFormat->getTimestamp());
+               && $input === $dateFromFormat->format($this->format);
     }
 }

--- a/tests/Rules/DateTest.php
+++ b/tests/Rules/DateTest.php
@@ -72,5 +72,22 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->dateValidator = new Date('r');
         $this->assertTrue($this->dateValidator->assert('Thu, 29 Dec 2005 01:02:03 +0000'));
     }
+
+    public function testDateTimeSystemTimezoneIndependent()
+    {
+        date_default_timezone_set('UTC');
+        $this->dateValidator = new Date('c');
+        $this->assertTrue($this->dateValidator->assert('2004-02-12T15:19:21+00:00'));
+
+        $this->dateValidator = new Date('c');
+        $this->assertTrue($this->dateValidator->assert('2004-02-12T16:19:21+01:00'));
+
+        date_default_timezone_set('Europe/Amsterdam');
+        $this->dateValidator = new Date('c');
+        $this->assertTrue($this->dateValidator->assert('2004-02-12T15:19:21+00:00'));
+
+        $this->dateValidator = new Date('c');
+        $this->assertTrue($this->dateValidator->assert('2004-02-12T16:19:21+01:00'));
+    }
 }
 


### PR DESCRIPTION
The validation of a string with timezone information failed on systems with a different timezone set then UTC. Changing the formatting to the DateTime-object keeps to original Timezone instead of adjusting to the system's Timezone information.

Found this issue when running the testsuite with php.ini setting "date.timezone = Europe/Amsterdam". Expanded the DateTest to simulate different timezone's on the system.