### PR TITLE
Remove PHP 7 from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
   - hhvm
   - hhvm-nightly
 


### PR DESCRIPTION
We have the "Int" rule but "int" is reserved word in PHP 7, so, until we rename this rule - which will be just on our first major release -, we will have no support for this version of PHP.