### PR TITLE
Create "AbstractSearcher" class

### DIFF
--- a/library/Rules/AbstractSearcher.php
+++ b/library/Rules/AbstractSearcher.php
@@ -1,0 +1,35 @@
+<?php
+namespace Respect\Validation\Rules;
+
+abstract class AbstractSearcher extends AbstractRule
+{
+    public $haystack;
+    public $compareIdentical;
+
+    protected function validateEquals($input)
+    {
+        if (is_array($this->haystack)) {
+            return in_array($input, $this->haystack);
+        }
+
+        return (false !== mb_stripos($this->haystack, $input, 0, mb_detect_encoding($input)));
+    }
+
+    protected function validateIdentical($input)
+    {
+        if (is_array($this->haystack)) {
+            return in_array($input, $this->haystack, true);
+        }
+
+        return (false !== mb_strpos($this->haystack, $input, 0, mb_detect_encoding($input)));
+    }
+
+    public function validate($input)
+    {
+        if ($this->compareIdentical) {
+            return $this->validateIdentical($input);
+        }
+
+        return $this->validateEquals($input);
+    }
+}

--- a/library/Rules/Country.php
+++ b/library/Rules/Country.php
@@ -7,7 +7,7 @@ use Respect\Validation\Exceptions\ComponentException;
 /**
  * Validates countries in ISO 3166-1.
  */
-class Country extends AbstractRule
+class Country extends AbstractSearcher
 {
     const ALPHA2  = 'alpha-2';
     const ALPHA3  = 'alpha-3';
@@ -284,8 +284,6 @@ class Country extends AbstractRule
 
     public $set;
 
-    private $index;
-
     public function __construct($set = self::ALPHA2)
     {
         $index = array_search($set, self::getAvailableSets(), true);
@@ -293,8 +291,9 @@ class Country extends AbstractRule
             throw new ComponentException(sprintf('"%s" is not a valid country set for ISO 3166-1', $set));
         }
 
-        $this->set   = $set;
-        $this->index = $index;
+        $this->set              = $set;
+        $this->haystack         = $this->getCountryList($index);
+        $this->compareIdentical = true;
     }
 
     public static function getAvailableSets()
@@ -314,10 +313,5 @@ class Country extends AbstractRule
         }
 
         return $countryList;
-    }
-
-    public function validate($input)
-    {
-        return in_array($input, $this->getCountryList($this->index), true);
     }
 }

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -1,38 +1,14 @@
 <?php
 namespace Respect\Validation\Rules;
 
-class In extends AbstractRule
+class In extends AbstractSearcher
 {
     public $haystack;
     public $compareIdentical;
 
     public function __construct($haystack, $compareIdentical = false)
     {
-        $this->haystack = $haystack;
+        $this->haystack         = $haystack;
         $this->compareIdentical = $compareIdentical;
-    }
-
-    public function reportError($input, array $extraParams = array())
-    {
-        return parent::reportError($input, $extraParams);
-    }
-
-    public function validate($input)
-    {
-        if (is_array($this->haystack)) {
-            return in_array($input, $this->haystack, $this->compareIdentical);
-        }
-
-        if (!is_string($this->haystack)) {
-            return false;
-        }
-
-        $enc = mb_detect_encoding($input);
-
-        if ($this->compareIdentical) {
-            return mb_strpos($this->haystack, $input, 0, $enc) !== false;
-        }
-
-        return mb_stripos($this->haystack, $input, 0, $enc) !== false;
     }
 }


### PR DESCRIPTION
There are some other rules which could extend this class too, like Tld and CountryCode, but was not changed in order to avoid code duplication or API breaks.