### PR TITLE
Date-validation fails when system is set to non-UTC timezone

### DIFF
--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -34,6 +34,6 @@ class Date extends AbstractRule
         $dateFromFormat = DateTime::createFromFormat($this->format, $input);
 
         return $dateFromFormat
-               && $input === date($this->format, $dateFromFormat->getTimestamp());
+               && $input === $dateFromFormat->format($this->format);
     }
 }

--- a/tests/library/Respect/Validation/Rules/DateTest.php
+++ b/tests/library/Respect/Validation/Rules/DateTest.php
@@ -72,5 +72,35 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->dateValidator = new Date('r');
         $this->assertTrue($this->dateValidator->assert('Thu, 29 Dec 2005 01:02:03 +0000'));
     }
+
+    /**
+     * Test that datetime strings with timezone information are valid independent on the system's timezone setting.
+     *
+     * @param string $systemTimezone
+     * @param string $input
+     * @dataProvider providerForDateTimeTimezoneStrings
+     */
+    public function testDateTimeSystemTimezoneIndependent($systemTimezone, $format, $input)
+    {
+        date_default_timezone_set($systemTimezone);
+        $this->dateValidator = new Date($format);
+        $this->assertTrue($this->dateValidator->assert($input));
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function providerForDateTimeTimezoneStrings(){
+        return array(
+                array('UTC', 'c', '2005-12-30T01:02:03+01:00',),
+                array('UTC', 'c', '2004-02-12T15:19:21+00:00',),
+                array('UTC', 'r', 'Thu, 29 Dec 2005 01:02:03 +0000',),
+                array('Europe/Amsterdam', 'c', '2005-12-30T01:02:03+01:00',),
+                array('Europe/Amsterdam', 'c', '2004-02-12T15:19:21+00:00',),
+                array('Europe/Amsterdam', 'r', 'Thu, 29 Dec 2005 01:02:03 +0000',),
+        );
+    }
+
 }
 


### PR DESCRIPTION
The creation of a DateTime-object from the input-string keeps the given timezone information. However, in the comparison the DateTime-object is
first output to a timestamp, which is then converted to a string with the
date()-function. But because a timestamp does not include timezone
information, date() will assume the system's timezone. So if the system
timezone set in the PHP settings is UTC, a string with another timezone,
e.g. 2015-04-24T21:11:00+02:00, will fail to be validated. The result from
the date()-function in this example is 2015-04-24T19:11:00+00:00, which is
a different string then the input.
The DateTime-class has also an option to create a string from a format,
DateTime->format(). So it is possible to skip the use of the
date()-function with the added benefit that using format() does have
access to the timezone information and thus produces the expected
2015-04-24T21:11:00+02:00 to compare with the given input.

This commit changes the Rule to accommodate this and expands the tests. If
these added tests are run before applying the fix to the Date-rule, the
tests will fail.