### PR TITLE
Prevents noWithespace from failing validating arrays

### DIFF
--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -5,6 +5,14 @@ class NoWhitespace extends AbstractRule
 {
     public function validate($input)
     {
-        return is_null($input) || !preg_match('#\s#', $input);
+        if (is_null($input)) {
+            return true;
+        }
+
+        if (false === is_scalar($input)) {
+            return false;
+        }
+
+        return !preg_match('#\s#', $input);
     }
 }

--- a/tests/Rules/NoWhitespaceTest.php
+++ b/tests/Rules/NoWhitespaceTest.php
@@ -42,6 +42,7 @@ class NoWhitespaceTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(''),
+            array(null),
             array(0),
             array('wpoiur'),
             array('Foo'),
@@ -57,5 +58,14 @@ class NoWhitespaceTest extends \PHPUnit_Framework_TestCase
             array("Foo\nBar"),
             array("Foo\tBar"),
         );
+    }
+
+    /**
+     * @issue 346
+     * @expectedException Respect\Validation\Exceptions\NoWhitespaceException
+     */
+    public function testArrayDoesNotThrowAWarning()
+    {
+        $this->noWhitespaceValidator->assert(array());
     }
 }


### PR DESCRIPTION
A warning was thrown because of the preg_match call, as not every input
is a string we prevent calls from arrays going further into checking.

Issue #346