### PR TITLE
Fix wrong behaviour on JSON rule

### DIFF
--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -5,6 +5,11 @@ class Json extends AbstractRule
 {
     public function validate($input)
     {
-        return (bool) (json_decode($input));
+        if (is_string($input)
+            && strtolower($input) == 'null') {
+            return true;
+        }
+
+        return (null !== json_decode($input));
     }
 }

--- a/tests/Rules/JsonTest.php
+++ b/tests/Rules/JsonTest.php
@@ -38,6 +38,10 @@ class JsonTest extends \PHPUnit_Framework_TestCase
             array('[1,2,3]'),
             array('["foo", "bar", "number", 1]'),
             array('{"foo": "bar", "number":1}'),
+            array('[]'),
+            array('{}'),
+            array('false'),
+            array('null'),
         );
     }
 


### PR DESCRIPTION
It was not considering values like `false`, `null`, `[]` or `{}`.

Fix #351