### PR TITLE
AbstractRelated should set names for child rule

### DIFF
--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -26,10 +26,22 @@ abstract class AbstractRelated extends AbstractRule
 
     public function __construct($reference, Validatable $validator = null, $mandatory = true)
     {
-        $this->setName($reference);
         $this->reference = $reference;
         $this->validator = $validator;
         $this->mandatory = $mandatory;
+
+        $this->setName($reference);
+    }
+
+    public function setName($name)
+    {
+        parent::setName($name);
+
+        if ($this->validator instanceof Validatable) {
+            $this->validator->setName($name);
+        }
+
+        return $this;
     }
 
     private function decision($type, $hasReference, $input)

--- a/tests/Exceptions/AbstractNestedExceptionTest.php
+++ b/tests/Exceptions/AbstractNestedExceptionTest.php
@@ -107,7 +107,7 @@ class AbstractNestedExceptionTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($messages['allOf'],
                 'These rules must pass for Validation Form');
             $this->assertEquals($messages['first_name_length'],
-                '"fiif" must have a length between 5 and 256');
+                'security_question must have a length between 5 and 256');
         }
     }
 
@@ -147,8 +147,7 @@ class AbstractNestedExceptionTest extends \PHPUnit_Framework_TestCase
                     )
             );
             $this->assertEquals($messages['allOf'], 'Invalid Validation Form');
-            $this->assertEquals($messages['first_name_length'],
-                'Invalid length for "fiif" fiif');
+            $this->assertEquals($messages['first_name_length'], 'Invalid length for security_question fiif');
         }
     }
 }


### PR DESCRIPTION
A code like this:
```php
try {
    v::key('username', v::alnum()->noWhitespace()->length(4,22))->check($_POST);
} catch (ValidationExceptionInterface $exception) {
    echo $exception->getMainMessage().PHP_EOL;
}
```

Should display messages like this:

```
username must not contain whitespace
```

Fix #86