### PR TITLE
Allow `null` to pass nullable rules

### DIFF
--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -29,7 +29,7 @@ abstract class AbstractRule implements Validatable
     public function __invoke($input)
     {
         return !is_a($this, __NAMESPACE__.'\\NotEmpty')
-            && $input === '' || $this->validate($input);
+            && ($input === '' || $input === null) || $this->validate($input);
     }
 
     public function addOr()


### PR DESCRIPTION
I think the following is an inconsistency:

    v::someRule()->validate(''); // passes
    v::someRule()->validate(null); // doesn't pass

This commit fixes this.