### PR TITLE
Update conversion to strings on exceptions

### DIFF
--- a/library/Exceptions/AgeException.php
+++ b/library/Exceptions/AgeException.php
@@ -30,14 +30,6 @@ class AgeException extends AbstractNestedException
         ),
     );
 
-    public function configure($name, array $params = array())
-    {
-        $params['minAge'] = static::stringify($params['minAge']);
-        $params['maxAge'] = static::stringify($params['maxAge']);
-
-        return parent::configure($name, $params);
-    }
-
     public function chooseTemplate()
     {
         if (!$this->getParam('minAge')) {

--- a/library/Exceptions/AlnumException.php
+++ b/library/Exceptions/AlnumException.php
@@ -16,11 +16,11 @@ class AlnumException extends AlphaException
     public static $defaultTemplates = array(
         self::MODE_DEFAULT => array(
             self::STANDARD => '{{name}} must contain only letters (a-z) and digits (0-9)',
-            self::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and "{{additionalChars}}"',
+            self::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and {{additionalChars}}',
         ),
         self::MODE_NEGATIVE => array(
             self::STANDARD => '{{name}} must not contain letters (a-z) or digits (0-9)',
-            self::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or "{{additionalChars}}"',
+            self::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or {{additionalChars}}',
         ),
     );
 }

--- a/library/Exceptions/BetweenException.php
+++ b/library/Exceptions/BetweenException.php
@@ -30,14 +30,6 @@ class BetweenException extends AbstractNestedException
         ),
     );
 
-    public function configure($name, array $params = array())
-    {
-        $params['minValue'] = static::stringify($params['minValue']);
-        $params['maxValue'] = static::stringify($params['maxValue']);
-
-        return parent::configure($name, $params);
-    }
-
     public function chooseTemplate()
     {
         if (!$this->getParam('minValue')) {

--- a/library/Exceptions/ExtensionException.php
+++ b/library/Exceptions/ExtensionException.php
@@ -23,10 +23,10 @@ class ExtensionException extends ValidationException
      */
     public static $defaultTemplates = array(
         self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must have "{{extension}}" extension',
+            self::STANDARD => '{{name}} must have {{extension}} extension',
         ),
         self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not have "{{extension}}" extension',
+            self::STANDARD => '{{name}} must not have {{extension}} extension',
         ),
     );
 }

--- a/library/Exceptions/InException.php
+++ b/library/Exceptions/InException.php
@@ -15,10 +15,10 @@ class InException extends ValidationException
 {
     public static $defaultTemplates = array(
         self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must be in ({{haystack}})',
+            self::STANDARD => '{{name}} must be in {{haystack}}',
         ),
         self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not be in ({{haystack}})',
+            self::STANDARD => '{{name}} must not be in {{haystack}}',
         ),
     );
 }

--- a/library/Exceptions/KeySetException.php
+++ b/library/Exceptions/KeySetException.php
@@ -42,16 +42,4 @@ class KeySetException extends AbstractGroupedException
 
         return parent::chooseTemplate();
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setParam($name, $value)
-    {
-        if ($name === 'keys') {
-            $value = trim(json_encode($value), '[]');
-        }
-
-        return parent::setParam($name, $value);
-    }
 }

--- a/library/Exceptions/LengthException.php
+++ b/library/Exceptions/LengthException.php
@@ -30,14 +30,6 @@ class LengthException extends ValidationException
         ),
     );
 
-    public function configure($name, array $params = array())
-    {
-        $params['minValue'] = static::stringify($params['minValue']);
-        $params['maxValue'] = static::stringify($params['maxValue']);
-
-        return parent::configure($name, $params);
-    }
-
     public function chooseTemplate()
     {
         if (!$this->getParam('minValue')) {

--- a/library/Exceptions/MimetypeException.php
+++ b/library/Exceptions/MimetypeException.php
@@ -23,10 +23,10 @@ class MimetypeException extends ValidationException
      */
     public static $defaultTemplates = array(
         self::MODE_DEFAULT => array(
-            self::STANDARD => '{{name}} must have "{{mimetype}}" mimetype',
+            self::STANDARD => '{{name}} must have {{mimetype}} mimetype',
         ),
         self::MODE_NEGATIVE => array(
-            self::STANDARD => '{{name}} must not have "{{mimetype}}" mimetype',
+            self::STANDARD => '{{name}} must not have {{mimetype}} mimetype',
         ),
     );
 }

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -12,7 +12,9 @@
 namespace Respect\Validation\Exceptions;
 
 use DateTime;
+use Exception;
 use InvalidArgumentException;
+use Traversable;
 
 class ValidationException extends InvalidArgumentException implements ValidationExceptionInterface
 {
@@ -27,10 +29,22 @@ class ValidationException extends InvalidArgumentException implements Validation
             self::STANDARD => 'Data validation failed for %s',
         ),
     );
+
     /**
-     * @var int Maximum depth when stringifying nested arrays
+     * @var int
      */
-    private static $maxDepthStringify = 3;
+    private static $maxDepthStringify = 5;
+
+    /**
+     * @var int
+     */
+    private static $maxCountStringify = 10;
+
+    /**
+     * @var string
+     */
+    private static $maxReplacementStringify = '...';
+
     protected $id = 'validation';
     protected $mode = self::MODE_DEFAULT;
     protected $name = '';
@@ -42,23 +56,61 @@ class ValidationException extends InvalidArgumentException implements Validation
         return preg_replace_callback(
             '/{{(\w+)}}/',
             function ($match) use ($vars) {
-                return isset($vars[$match[1]]) ? $vars[$match[1]] : $match[0];
+                if (!isset($vars[$match[1]])) {
+                    return $match[0];
+                }
+
+                $value = $vars[$match[1]];
+                if ('name' == $match[1]) {
+                    return $value;
+                }
+
+                return ValidationException::stringify($value);
             },
             $template
         );
     }
 
-    public static function stringify($value)
+    /**
+     * @param mixed $value
+     * @param int   $depth
+     *
+     * @return string
+     */
+    public static function stringify($value, $depth = 1)
     {
-        if (is_string($value)) {
-            return $value;
-        } elseif (is_array($value)) {
-            return self::stringifyArray($value);
-        } elseif (is_object($value)) {
-            return static::stringifyObject($value);
-        } else {
-            return (string) $value;
+        if ($depth >= self::$maxDepthStringify) {
+            return self::$maxReplacementStringify;
         }
+
+        if (is_array($value)) {
+            return static::stringifyArray($value, $depth);
+        }
+
+        if (is_object($value)) {
+            return static::stringifyObject($value, $depth);
+        }
+
+        if (is_resource($value)) {
+            return sprintf('`[resource] (%s)`', get_resource_type($value));
+        }
+
+        if (is_float($value)) {
+            if (is_infinite($value)) {
+                return ($value > 0 ? '' : '-').'INF';
+            }
+
+            if (is_nan($value)) {
+                return 'NaN';
+            }
+        }
+
+        $options = 0;
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $options = (JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+
+        return (@json_encode($value, $options) ?: $value);
     }
 
     /**
@@ -67,37 +119,77 @@ class ValidationException extends InvalidArgumentException implements Validation
      *
      * @return string
      */
-    private static function stringifyArray($value, $depth = 0)
+    public static function stringifyArray(array $value, $depth = 1)
     {
-        $items = array();
-        foreach ($value as $val) {
-            if (is_object($val)) {
-                $items[] = self::stringifyObject($val);
-            } elseif (is_array($val)) {
-                if ($depth >= self::$maxDepthStringify) {
-                    $items[] = '...';
-                } else {
-                    $items[] = '('.self::stringifyArray($val, $depth + 1).')';
-                }
-            } elseif (is_string($val)) {
-                $items[] = "'$val'";
-            } else {
-                $items[] = (string) $val;
+        $nextDepth = ($depth + 1);
+        if ($nextDepth >= self::$maxDepthStringify) {
+            return self::$maxReplacementStringify;
+        }
+
+        if (empty($value)) {
+            return '{ }';
+        }
+
+        $total = count($value);
+        $string = '';
+        $current = 0;
+        foreach ($value as $childKey => $childValue) {
+            if ($current++ >= self::$maxCountStringify) {
+                $string .= self::$maxReplacementStringify;
+                break;
+            }
+
+            if (!is_int($childKey)) {
+                $string .= sprintf('%s: ', static::stringify($childKey, $nextDepth));
+            }
+
+            $string .= static::stringify($childValue, $nextDepth);
+
+            if ($current !== $total) {
+                $string .= ', ';
             }
         }
 
-        return implode(', ', $items);
+        return sprintf('{ %s }', $string);
     }
 
-    public static function stringifyObject($value)
+    /**
+     * @param mixed $value
+     * @param int   $depth
+     *
+     * @return string
+     */
+    public static function stringifyObject($value, $depth = 2)
     {
-        if (method_exists($value, '__toString')) {
-            return (string) $value;
-        } elseif ($value instanceof DateTime) {
-            return $value->format('Y-m-d H:i:s');
-        } else {
-            return 'Object of class '.get_class($value);
+        $nextDepth = $depth + 1;
+
+        if ($value instanceof DateTime) {
+            return sprintf('"%s"', $value->format('Y-m-d H:i:s'));
         }
+
+        $class = get_class($value);
+
+        if ($value instanceof Traversable) {
+            return sprintf('`[traversable] (%s: %s)`', $class, static::stringify(iterator_to_array($value), $nextDepth));
+        }
+
+        if ($value instanceof Exception) {
+            $properties = array(
+                'message' => $value->getMessage(),
+                'code' => $value->getCode(),
+                'file' => $value->getFile().':'.$value->getLine(),
+            );
+
+            return sprintf('`[exception] (%s: %s)`', $class, static::stringify($properties, $nextDepth));
+        }
+
+        if (method_exists($value, '__toString')) {
+            return static::stringify($value->__toString(), $nextDepth);
+        }
+
+        $properties = static::stringify(get_object_vars($value), $nextDepth);
+
+        return sprintf('`[object] (%s: %s)`', $class, str_replace('`', '', $properties));
     }
 
     public function __toString()
@@ -175,7 +267,7 @@ class ValidationException extends InvalidArgumentException implements Validation
 
     public function setName($name)
     {
-        $this->name = static::stringify($name);
+        $this->name = $name;
 
         return $this;
     }
@@ -190,7 +282,7 @@ class ValidationException extends InvalidArgumentException implements Validation
 
     public function setParam($key, $value)
     {
-        $this->params[$key] = ($key == 'translator') ? $value : static::stringify($value);
+        $this->params[$key] = $value;
 
         return $this;
     }

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -61,8 +61,7 @@ abstract class AbstractRule implements Validatable
     public function reportError($input, array $extraParams = array())
     {
         $exception = $this->createException();
-        $input = ValidationException::stringify($input);
-        $name = $this->name ?: "\"$input\"";
+        $name = $this->name ?: ValidationException::stringify($input);
         $params = array_merge(
             get_class_vars(__CLASS__),
             get_object_vars($this),

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -208,28 +208,9 @@ class Validator extends AllOf
         return $this->addRule(static::buildRule($method, $arguments));
     }
 
-    /**
-     * @param mixed $input
-     * @param array $extraParams
-     *
-     * @return AllOfException
-     */
-    public function reportError($input, array $extraParams = array())
+    protected function createException()
     {
-        $exception = new AllOfException();
-        $input = AllOfException::stringify($input);
-        $name = $this->getName() ?: "\"$input\"";
-        $params = array_merge(
-            $extraParams,
-            get_object_vars($this),
-            get_class_vars(__CLASS__)
-        );
-        $exception->configure($name, $params);
-        if (!is_null($this->template)) {
-            $exception->setTemplate($this->template);
-        }
-
-        return $exception;
+        return new AllOfException();
     }
 
     /**

--- a/tests/integration/find_messages_should_apply_templates_to_flattened_messages.phpt
+++ b/tests/integration/find_messages_should_apply_templates_to_flattened_messages.phpt
@@ -47,5 +47,5 @@ try {
 Array
 (
     [allOf] => Invalid Validation Form
-    [first_name_length] => Invalid length for security_question fiif
+    [first_name_length] => Invalid length for security_question "fiif"
 )

--- a/tests/integration/find_messages_should_return_composite_validation_messages_flattened.phpt
+++ b/tests/integration/find_messages_should_return_composite_validation_messages_flattened.phpt
@@ -40,6 +40,6 @@ try {
 --EXPECTF--
 Array
 (
-    [allOf] => These rules must pass for Validation Form
+    [allOf] => All of the required rules must pass for Validation Form
     [first_name_length] => security_question must have a length between 5 and 256
 )

--- a/tests/integration/get_full_message_should_include_all_validation_messages_in_a_chain.phpt
+++ b/tests/integration/get_full_message_should_include_all_validation_messages_in_a_chain.phpt
@@ -14,6 +14,6 @@ try {
 }
 ?>
 --EXPECTF--
-\-These rules must pass for "0"
-  |-"0" must be a string
-  \-"0" must have a length between 2 and 15
+\-All of the required rules must pass for 0
+  |-0 must be a string
+  \-0 must have a length between 2 and 15

--- a/tests/integration/keys_as_validator_names.phpt
+++ b/tests/integration/keys_as_validator_names.phpt
@@ -20,7 +20,7 @@ try {
 }
 ?>
 --EXPECTF--
-\-These rules must pass for User Subscription Form
+\-All of the required rules must pass for User Subscription Form
   |-Key username must be valid
   | \-username must have a length between 2 and 32
   \-Key birthdate must be valid

--- a/tests/integration/not_with_recursion.phpt
+++ b/tests/integration/not_with_recursion.phpt
@@ -25,4 +25,4 @@ try {
 }
 ?>
 --EXPECTF--
-\-These rules must not pass for "2"
+\-These rules must not pass for 2

--- a/tests/integration/set_template_with_single_validator_should_use_template_as_main_message.phpt
+++ b/tests/integration/set_template_with_single_validator_should_use_template_as_main_message.phpt
@@ -6,6 +6,7 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Exceptions\NestedValidationExceptionInterface;
 use Respect\Validation\Validator;
+use Respect\Validation\Rules\Callback;
 
 try {
     Validator::callback('is_int')->setTemplate('{{name}} is not tasty')->assert('something');

--- a/tests/unit/Rules/FiniteTest.php
+++ b/tests/unit/Rules/FiniteTest.php
@@ -43,7 +43,7 @@ class FiniteTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\FiniteException
-     * @expectedExceptionMessage "INF" must be a finite number
+     * @expectedExceptionMessage INF must be a finite number
      */
     public function testShouldThrowFiniteExceptionWhenChecking()
     {

--- a/tests/unit/Rules/InTest.php
+++ b/tests/unit/Rules/InTest.php
@@ -42,7 +42,7 @@ class InTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\InException
-     * @expectedExceptionMessage "x" must be in ('foo', 'bar')
+     * @expectedExceptionMessage "x" must be in { "foo", "bar" }
      */
     public function testInCheckExceptionMessageWithArray()
     {

--- a/tests/unit/Rules/InfiniteTest.php
+++ b/tests/unit/Rules/InfiniteTest.php
@@ -43,7 +43,7 @@ class InfiniteTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\InfiniteException
-     * @expectedExceptionMessage "123456" must be an infinite number
+     * @expectedExceptionMessage 123456 must be an infinite number
      */
     public function testShouldThrowInfiniteExceptionWhenChecking()
     {
@@ -54,6 +54,7 @@ class InfiniteTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(INF),
+            array(INF * -1),
         );
     }
 

--- a/tests/unit/Rules/KeySetTest.php
+++ b/tests/unit/Rules/KeySetTest.php
@@ -145,7 +145,7 @@ class KeySetTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\KeySetException
-     * @expectedExceptionMessage Must have keys "foo","bar"
+     * @expectedExceptionMessage Must have keys { "foo", "bar" }
      */
     public function testShouldCheckKeys()
     {
@@ -160,7 +160,7 @@ class KeySetTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\KeySetException
-     * @expectedExceptionMessage Must have keys "foo","bar"
+     * @expectedExceptionMessage Must have keys { "foo", "bar" }
      */
     public function testShouldAssertKeys()
     {

--- a/tests/unit/Rules/MimetypeTest.php
+++ b/tests/unit/Rules/MimetypeTest.php
@@ -96,7 +96,7 @@ class MimetypeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\MimetypeException
-     * @expectedExceptionMessage MimetypeTest.php" must have "application/json" mimetype
+     * @expectedExceptionMessageRegExp #".+/MimetypeTest.php" must have "application.?/json" mimetype#
      */
     public function testShouldThowsMimetypeExceptionWhenCheckingValue()
     {

--- a/tests/unit/Rules/ScalarTest.php
+++ b/tests/unit/Rules/ScalarTest.php
@@ -43,7 +43,7 @@ class ScalarTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\ScalarException
-     * @expectedExceptionMessage "" must be a scalar value
+     * @expectedExceptionMessage null must be a scalar value
      */
     public function testShouldThrowScalarExceptionWhenChecking()
     {

--- a/tests/unit/Rules/SfTest.php
+++ b/tests/unit/Rules/SfTest.php
@@ -60,7 +60,7 @@ class SfTest extends \PHPUnit_Framework_TestCase
         } catch (\Respect\Validation\Exceptions\AllOfException $exception) {
             $fullValidationMessage = $exception->getFullMessage();
             $expectedValidationException = <<<EOF
-\-These rules must pass for "34:90:70"
+\-All of the required rules must pass for "34:90:70"
   \-Time
 EOF;
 

--- a/tests/unit/Rules/SizeTest.php
+++ b/tests/unit/Rules/SizeTest.php
@@ -112,7 +112,7 @@ class SizeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\SizeException
-     * @expectedExceptionMessage "vfs://root/1gb.txt" must be greater than 2pb
+     * @expectedExceptionMessageRegExp #"vfs:.?/.?/root.?/1gb.txt" must be greater than "2pb"#
      */
     public function testShouldThrowsSizeExceptionWhenAsserting()
     {

--- a/tests/unit/Rules/TypeTest.php
+++ b/tests/unit/Rules/TypeTest.php
@@ -66,7 +66,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\TypeException
-     * @expectedExceptionMessage "Something" must be integer
+     * @expectedExceptionMessage "Something" must be "integer"
      */
     public function testShouldThrowTypeExceptionWhenCheckingAnInvalidInput()
     {

--- a/tests/unit/Rules/WhenTest.php
+++ b/tests/unit/Rules/WhenTest.php
@@ -47,7 +47,7 @@ class WhenTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\AlwaysInvalidException
-     * @expectedExceptionMessage "15" is not valid
+     * @expectedExceptionMessage 15 is not valid
      */
     public function testWhenWithoutElseAssert()
     {


### PR DESCRIPTION
Update conversion to strings on exceptions

Many changes were made on `ValidationException::stringify`:
- Add support for instances of `Exception`;
- Add support for instances of `Traversable`;
- Add support for resources;
- Improve `Array` conversion;
- Improve `Object` conversion;
- Improve conversion of all values by using JSON.

Now, all the parameters of the exception classes are just converted to string when replacing parameters on exceptions, so the exception classes now keep the original value of all parameters.

Fix #395

***
Samples:

```plain
""
"foo"
INF
-INF
NaN
123
123.456
{ }
{ false }
{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,  ...  }
{ "foo": true, "bar": { "baz": 123, "qux": { 1, 2, 3 } } }
{ "foo": true, "bar": { "baz": 123, "qux": { "norf": ... } } }
{ { }, "foo" }
{ { 1 }, "foo" }
{ 1, { 2, { 3 } } }
{ 1, { 2, { 3, ... } } }
{ 1, { 2, { 3, ... } } }
{ "foo", "bar" }
{ "foo", -1 }
"stringify.phpt"
"1988-09-09T23:59:59+00:00"
`[object] (stdClass: { })`
`[object] (stdClass: { "foo": 1, "bar": false })`
`[object] (stdClass: { "name": [object] (stdClass: ...) })`
`[exception] (Exception: { "message": "My message", "code": 0, "file": "%s:%d" })`
`[traversable] (ArrayIterator: { 1, 2, 3 })`
`[traversable] (ArrayIterator: { "a": 1, "b": 2, "c": 3 })`
`[resource] (stream-context)`
`[resource] (stream)`
`[resource] (xml)`
{ `[object] (stdClass: { "foo": 1, "bar": false })`, { 42, 43 }, true, null, `[resource] (stream)` }
```