### PR TITLE
Make exception messages simpler

### DIFF
--- a/library/ExceptionIterator.php
+++ b/library/ExceptionIterator.php
@@ -24,6 +24,23 @@ class ExceptionIterator extends RecursiveArrayIterator
         parent::__construct(is_array($target) ? $target : array($target));
     }
 
+    public function current()
+    {
+        $current = parent::current();
+        if ($this->fullRelated
+            || $current->hasCustomTemplate()
+            || !$current instanceof AbstractNestedException) {
+            return $current;
+        }
+
+        $currentRelated = $current->getRelated(false);
+        if (count($currentRelated) == 1) {
+            return current($currentRelated);
+        }
+
+        return $current;
+    }
+
     public function hasChildren()
     {
         if (!$this->current() instanceof AbstractNestedException) {

--- a/library/Exceptions/AbstractNestedException.php
+++ b/library/Exceptions/AbstractNestedException.php
@@ -77,8 +77,7 @@ class AbstractNestedException extends ValidationException implements NestedValid
     {
         $messages = array();
         foreach ($this->getIterator() as $key => $exception) {
-            if ($exception instanceof AbstractNestedException
-                && count($exception->getRelated()) > 0) {
+            if ($key === 0) {
                 continue;
             }
 

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -50,6 +50,7 @@ class ValidationException extends InvalidArgumentException implements Validation
     protected $name = '';
     protected $template = '';
     protected $params = array();
+    private $customTemplate = false;
 
     public static function format($template, array $vars = array())
     {
@@ -296,8 +297,14 @@ class ValidationException extends InvalidArgumentException implements Validation
         return $this;
     }
 
+    public function hasCustomTemplate()
+    {
+        return (true === $this->customTemplate);
+    }
+
     public function setTemplate($template)
     {
+        $this->customTemplate = true;
         $this->template = $template;
 
         return $this;

--- a/tests/integration/assert-with-keys.phpt
+++ b/tests/integration/assert-with-keys.phpt
@@ -1,0 +1,52 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+use Respect\Validation\Exceptions\NestedValidationExceptionInterface;
+use Respect\Validation\Validator as v;
+try {
+    v::create()
+        ->key(
+            'mysql',
+            v::create()
+                ->key('host', v::string(), true)
+                ->key('user', v::string(), true)
+                ->key('password', v::string(), true)
+                ->key('schema', v::string(), true),
+            true
+        )
+        ->key(
+            'postgresql',
+            v::create()
+                ->key('host', v::string(), true)
+                ->key('user', v::string(), true)
+                ->key('password', v::string(), true)
+                ->key('schema', v::string(), true),
+            true
+        )
+        ->setName('the given data')
+        ->assert(array(
+            'mysql' => array(
+                'host' => 42,
+                'schema' => 42,
+            ),
+            'postgresql' => array(
+                'user' => 42,
+                'password' => 42,
+            ),
+        ));
+} catch (NestedValidationExceptionInterface $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+\-All of the required rules must pass for the given data
+  |-Key mysql must be valid
+  | |-host must be a string
+  | |-Key user must be present
+  | |-Key password must be present
+  | \-schema must be a string
+  \-Key postgresql must be valid
+    |-Key host must be present
+    |-user must be a string
+    |-password must be a string
+    \-Key schema must be present

--- a/tests/integration/keys_as_validator_names.phpt
+++ b/tests/integration/keys_as_validator_names.phpt
@@ -21,7 +21,5 @@ try {
 ?>
 --EXPECTF--
 \-All of the required rules must pass for User Subscription Form
-  |-Key username must be valid
-  | \-username must have a length between 2 and 32
-  \-Key birthdate must be valid
-    \-birthdate must be a valid date
+  |-username must have a length between 2 and 32
+  \-birthdate must be a valid date

--- a/tests/unit/Rules/SfTest.php
+++ b/tests/unit/Rules/SfTest.php
@@ -60,8 +60,7 @@ class SfTest extends \PHPUnit_Framework_TestCase
         } catch (\Respect\Validation\Exceptions\AllOfException $exception) {
             $fullValidationMessage = $exception->getFullMessage();
             $expectedValidationException = <<<EOF
-\-All of the required rules must pass for "34:90:70"
-  \-Time
+\-Time
 EOF;
 
             return $this->assertEquals(


### PR DESCRIPTION
When the exception has only one related exception, there is no need to
display it's messages unless it has an user-defined template.