### PR TITLE
Make all rules optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ class HelloWorld extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) { // Handles optional inputs
+            return true;
+        }
+
         return $input === 'Hello World';
     }
 }

--- a/docs/Alnum.md
+++ b/docs/Alnum.md
@@ -23,10 +23,10 @@ v::alnum()->noWhitespace->validate('foo 123'); //false
 ```
 
 By default empty values are allowed, if you want
-to invalidate them, add `->notEmpty()` to the chain:
+to invalidate them, add `->notOptional()` to the chain:
 
 ```php
-v::alnum()->notEmpty()->validate(''); //false
+v::alnum()->notOptional()->validate(''); //false
 ```
 
 You can restrict case using the `->lowercase()` and

--- a/docs/NotOptional.md
+++ b/docs/NotOptional.md
@@ -1,0 +1,19 @@
+# NotOptional
+
+- `v::notOptional()`
+
+Validates if the given input is not optional or in other words is input mandatory
+and required.
+
+```php
+v::notOptional()->validate(''); //false
+```
+
+For more information, see the [Input optional](README.md#input-optional) section.
+
+***
+See also:
+
+  * [NotOptional](NotOptional.md)
+  * [NoWhitespace](NoWhitespace.md)
+  * [NullValue](NullValue.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,15 +55,24 @@ validated object as the first node in the chain.
 
 ## Input optional
 
-All validators treat input as optional and will accept empty string input as valid,
-unless otherwise stated in the documentation.
+All validators treat input as optional and will accept, by default, an empty
+string (`''`) input as valid, unless otherwise stated in the documentation.
 
-We use the `v:notEmpty()` validator prefixed to disallow empty input and effectively
+We use the `v:notOptional()` validator prefixed to disallow empty input and effectively
 define the field as mandatory as input will be required or validation will fail.
 
 ```php
-v::string()->notEmpty()->validate(''); //false input required
+v::string()->notOptional()->validate(''); //false input required
 ```
+
+We know there are cases when you want to consider other values as optional, for
+that reason we allow you to overwrite what is considered as optional.
+
+```php
+v::setOptionalValues(array(null, ''));
+```
+
+With the code above `null` and an empty string (`''`) are considered optional values.
 
 ## Negating Rules
 
@@ -147,7 +156,7 @@ It will return all messages from the rules that did not pass the validation.
 try {
     Validator::key('username', Validator::length(2, 32))
              ->key('birthdate', Validator::date())
-             ->key('password', Validator::notEmpty())
+             ->key('password', Validator::notOptional())
              ->key('email', Validator::email())
              ->assert($input);
 } catch (NestedValidationExceptionInterface $e) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,6 +195,10 @@ class MyRule extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) { // Handles optional inputs
+            return true;
+        }
+
         // Do something here with the $input and return a boolean value
     }
 }

--- a/docs/VALIDATORS.md
+++ b/docs/VALIDATORS.md
@@ -245,6 +245,7 @@
   * [NoneOf](NoneOf.md)
   * [Not](Not.md)
   * [NotEmpty](NotEmpty.md)
+  * [NotOptional](NotOptional.md)
   * [NullValue](NullValue.md)
   * [Numeric](Numeric.md)
   * [Object](Object.md)

--- a/library/Exceptions/NotOptionalException.php
+++ b/library/Exceptions/NotOptionalException.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions;
+
+class NotOptionalException extends ValidationException
+{
+    const STANDARD = 0;
+    const NAMED = 1;
+    public static $defaultTemplates = array(
+        self::MODE_DEFAULT => array(
+            self::STANDARD => 'The value cannot be optional',
+            self::NAMED => '{{name}} cannot be optional',
+        ),
+        self::MODE_NEGATIVE => array(
+            self::STANDARD => 'The value must be optional',
+            self::NAMED => '{{name}} must be optional',
+        ),
+    );
+
+    public function chooseTemplate()
+    {
+        return $this->getName() == '' ? static::STANDARD : static::NAMED;
+    }
+}

--- a/library/Rules/AbstractCountryInfo.php
+++ b/library/Rules/AbstractCountryInfo.php
@@ -44,6 +44,10 @@ abstract class AbstractCountryInfo extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return in_array(strtolower($input), $this->tldList);
     }
 }

--- a/library/Rules/AbstractFilterRule.php
+++ b/library/Rules/AbstractFilterRule.php
@@ -35,12 +35,16 @@ abstract class AbstractFilterRule extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (!is_scalar($input)) {
             return false;
         }
 
         $cleanInput = $this->filter((string) $input);
 
-        return $cleanInput === '' || $this->validateClean($cleanInput);
+        return $this->isOptional($cleanInput) || $this->validateClean($cleanInput);
     }
 }

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -53,7 +53,7 @@ abstract class AbstractRelated extends AbstractRule
 
     public function assert($input)
     {
-        if ($input === '') {
+        if ($this->isOptional($input)) {
             return true;
         }
 
@@ -73,7 +73,7 @@ abstract class AbstractRelated extends AbstractRule
 
     public function check($input)
     {
-        if ($input === '') {
+        if ($this->isOptional($input)) {
             return true;
         }
 
@@ -87,7 +87,7 @@ abstract class AbstractRelated extends AbstractRule
 
     public function validate($input)
     {
-        if ($input === '') {
+        if ($this->isOptional($input)) {
             return true;
         }
 

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -11,9 +11,9 @@
 
 namespace Respect\Validation\Rules;
 
-use Respect\Validation\Validatable;
 use Respect\Validation\Exceptions\ValidationException;
-use Respect\Validation\Validator as v;
+use Respect\Validation\Validatable;
+use Respect\Validation\Validator;
 
 abstract class AbstractRule implements Validatable
 {
@@ -29,7 +29,7 @@ abstract class AbstractRule implements Validatable
 
     protected function isOptional($input)
     {
-        return ($input === '');
+        return in_array($input, Validator::getOptionalValues(), true);
     }
 
     public function __invoke($input)

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Rules;
 
 use Respect\Validation\Validatable;
 use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validator as v;
 
 abstract class AbstractRule implements Validatable
 {
@@ -26,10 +27,14 @@ abstract class AbstractRule implements Validatable
         //a constructor is required for ReflectionClass::newInstance()
     }
 
+    protected function isOptional($input)
+    {
+        return ($input === '');
+    }
+
     public function __invoke($input)
     {
-        return !is_a($this, __NAMESPACE__.'\\NotEmpty')
-            && $input === '' || $this->validate($input);
+        return $this->validate($input);
     }
 
     public function addOr()
@@ -42,9 +47,10 @@ abstract class AbstractRule implements Validatable
 
     public function assert($input)
     {
-        if ($this->__invoke($input)) {
+        if ($this->validate($input)) {
             return true;
         }
+
         throw $this->reportError($input);
     }
 

--- a/library/Rules/AbstractSearcher.php
+++ b/library/Rules/AbstractSearcher.php
@@ -36,6 +36,10 @@ abstract class AbstractSearcher extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->compareIdentical) {
             return $this->validateIdentical($input);
         }

--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -13,11 +13,6 @@ namespace Respect\Validation\Rules;
 
 class AlwaysInvalid extends AbstractRule
 {
-    public function __invoke($input)
-    {
-        return $this->validate($input);
-    }
-
     public function validate($input)
     {
         return false;

--- a/library/Rules/Arr.php
+++ b/library/Rules/Arr.php
@@ -19,6 +19,10 @@ class Arr extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_array($input) || ($input instanceof ArrayAccess
             && $input instanceof Traversable
             && $input instanceof Countable);

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -33,6 +33,10 @@ class Base extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $valid = substr($this->chars, 0, $this->base);
 
         return (boolean) preg_match("@^[$valid]+$@", (string) $input);

--- a/library/Rules/Bool.php
+++ b/library/Rules/Bool.php
@@ -15,6 +15,10 @@ class Bool extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_bool($input);
     }
 }

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -21,6 +21,10 @@ class CallableType extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_callable($input);
     }
 }

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -33,6 +33,10 @@ class Callback extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $params = $this->arguments;
         array_unshift($params, $input);
 

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -35,6 +35,10 @@ class Charset extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $detectedEncoding = mb_detect_encoding($input, $this->charset, true);
 
         return in_array($detectedEncoding, $this->charset, true);

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -15,6 +15,10 @@ class Cnh extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $ret = false;
 
         if ((strlen($input = preg_replace('/[^\d]/', '', $input)) == 11)

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -15,6 +15,10 @@ class Cnpj extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         //Code ported from jsfromhell.com
         $c = preg_replace('/\D/', '', $input);
         $b = array(6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2);

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -24,6 +24,10 @@ class Contains extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->identical) {
             return $this->validateIdentical($input);
         }

--- a/library/Rules/CountryCode.php
+++ b/library/Rules/CountryCode.php
@@ -36,6 +36,10 @@ class CountryCode extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return in_array(strtoupper($input), $this->countryCodeList);
     }
 }

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -15,6 +15,10 @@ class Cpf extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         // Code ported from jsfromhell.com
         $c = preg_replace('/\D/', '', $input);
 

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -15,6 +15,10 @@ class CreditCard extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $input = preg_replace('([^0-9])', '', $input);
         if (!empty($input)) {
             return $this->verifyMod10($input);

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -24,6 +24,10 @@ class Date extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof DateTime) {
             return true;
         } elseif (!is_string($input)) {

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -15,6 +15,10 @@ class Directory extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             return $input->isDir();
         }

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -61,6 +61,10 @@ class Domain extends AbstractComposite
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         foreach ($this->checks as $chk) {
             if (!$chk->validate($input)) {
                 return false;
@@ -83,6 +87,10 @@ class Domain extends AbstractComposite
 
     public function assert($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $e = array();
         foreach ($this->checks as $chk) {
             $this->collectAssertException($e, $chk, $input);
@@ -114,6 +122,10 @@ class Domain extends AbstractComposite
 
     public function check($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         foreach ($this->checks as $chk) {
             $chk->check($input);
         }

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -28,6 +28,10 @@ class Each extends AbstractRule
 
     public function assert($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $exceptions = array();
 
         if (!is_array($input) || $input instanceof Traversable) {
@@ -65,6 +69,10 @@ class Each extends AbstractRule
 
     public function check($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (empty($input)) {
             return true;
         }
@@ -88,6 +96,10 @@ class Each extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (!is_array($input) || $input instanceof Traversable) {
             return false;
         }

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -32,6 +32,10 @@ class Email extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $emailValidator = $this->getEmailValidator();
         if (null !== $emailValidator) {
             return $emailValidator->isValid($input);

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -24,6 +24,10 @@ class EndsWith extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->identical) {
             return $this->validateIdentical($input);
         }

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -29,6 +29,10 @@ class Equals extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->compareIdentical) {
             return $input === $this->compareTo;
         }

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -15,6 +15,10 @@ class Even extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return ((int) $input % 2 === 0);
     }
 }

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -15,6 +15,10 @@ class Executable extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             return $input->isExecutable();
         }

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -15,6 +15,10 @@ class Exists extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             $input = $input->getPathname();
         }

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -38,6 +38,10 @@ class Extension extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof SplFileInfo) {
             return ($input->getExtension() == $this->extension);
         }

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -33,6 +33,10 @@ class Factor extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         // Every integer is a factor of zero, and zero is the only integer that
         // has zero for a factor.
         if ($this->dividend === 0) {

--- a/library/Rules/False.php
+++ b/library/Rules/False.php
@@ -15,6 +15,10 @@ class False extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (false === $input) { // PHP 5.3 workaround
             return true;
         }

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -15,6 +15,10 @@ class File extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             return $input->isFile();
         }

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -21,6 +21,10 @@ class Finite extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_numeric($input) && is_finite($input);
     }
 }

--- a/library/Rules/Float.php
+++ b/library/Rules/Float.php
@@ -15,6 +15,10 @@ class Float extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_float(filter_var($input, FILTER_VALIDATE_FLOAT));
     }
 }

--- a/library/Rules/HexRgbColor.php
+++ b/library/Rules/HexRgbColor.php
@@ -15,6 +15,10 @@ class HexRgbColor extends Xdigit
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (!is_string($input)) {
             return false;
         }

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -21,6 +21,10 @@ class Infinite extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_numeric($input) && is_infinite($input);
     }
 }

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -27,6 +27,10 @@ class Instance extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $input instanceof $this->instanceName;
     }
 }

--- a/library/Rules/Int.php
+++ b/library/Rules/Int.php
@@ -15,6 +15,10 @@ class Int extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_numeric($input) && (int) $input == $input;
     }
 }

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -98,6 +98,10 @@ class Ip extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $this->verifyAddress($input) && $this->verifyNetwork($input);
     }
 

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -15,6 +15,10 @@ class Json extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (is_string($input)
             && strtolower($input) == 'null') {
             return true;

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -136,6 +136,10 @@ class KeySet extends AllOf
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (!$this->hasValidStructure($input)) {
             return false;
         }

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -24,6 +24,10 @@ class LeapDate extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (is_string($input)) {
             $date = DateTime::createFromFormat($this->format, $input);
         } elseif ($input instanceof DateTime) {

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -17,6 +17,10 @@ class LeapYear extends AbstractRule
 {
     public function validate($year)
     {
+        if ($this->isOptional($year)) {
+            return true;
+        }
+
         if (is_numeric($year)) {
             $year = (int) $year;
         } elseif (is_string($year)) {

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -47,6 +47,10 @@ class Length extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $length = $this->extractLength($input);
 
         return $this->validateMin($length) && $this->validateMax($length);

--- a/library/Rules/Locale/GermanBank.php
+++ b/library/Rules/Locale/GermanBank.php
@@ -46,6 +46,10 @@ class GermanBank extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $this->bav->isValidBank($input);
     }
 }

--- a/library/Rules/Locale/GermanBankAccount.php
+++ b/library/Rules/Locale/GermanBankAccount.php
@@ -52,6 +52,10 @@ class GermanBankAccount extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $this->bav->isValidBankAccount($this->bank, $input);
     }
 }

--- a/library/Rules/Locale/GermanBic.php
+++ b/library/Rules/Locale/GermanBic.php
@@ -53,6 +53,10 @@ class GermanBic extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $this->bav->isValidBIC($input);
     }
 }

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -15,6 +15,10 @@ class Lowercase extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $input === mb_strtolower($input, mb_detect_encoding($input));
     }
 }

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -15,6 +15,10 @@ class MacAddress extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return !empty($input) && preg_match('/^(([0-9a-fA-F]{2}-){5}|([0-9a-fA-F]{2}:){5})[0-9a-fA-F]{2}$/', $input);
     }
 }

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -15,6 +15,10 @@ class Max extends AbstractInterval
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->inclusive) {
             return $this->filterInterval($input) <= $this->filterInterval($this->interval);
         }

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -46,6 +46,10 @@ class Mimetype extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof SplFileInfo) {
             $input = $input->getPathname();
         }

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -15,6 +15,10 @@ class Min extends AbstractInterval
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->inclusive) {
             return $this->filterInterval($input) >= $this->filterInterval($this->interval);
         }

--- a/library/Rules/MinimumAge.php
+++ b/library/Rules/MinimumAge.php
@@ -26,6 +26,10 @@ class MinimumAge extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (!is_int($this->age)) {
             return false;
         }

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -22,6 +22,10 @@ class Multiple extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->multipleOf == 0) {
             return ($input == 0);
         }

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -15,6 +15,10 @@ class Negative extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $input < 0;
     }
 }

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -28,6 +28,10 @@ class NfeAccessKey extends AbstractRule
      */
     public function validate($aK)
     {
+        if ($this->isOptional($aK)) {
+            return true;
+        }
+
         if (strlen($aK) !== 44) {
             return false;
         }

--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -15,6 +15,10 @@ class NoWhitespace extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (is_null($input)) {
             return true;
         }

--- a/library/Rules/NotOptional.php
+++ b/library/Rules/NotOptional.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Validator;
+
+class NotOptional extends AbstractRule
+{
+    public function validate($input)
+    {
+        return !in_array($input, Validator::getOptionalValues(), true);
+    }
+}

--- a/library/Rules/NullValue.php
+++ b/library/Rules/NullValue.php
@@ -15,6 +15,10 @@ class NullValue extends NotEmpty
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_null($input);
     }
 }

--- a/library/Rules/Numeric.php
+++ b/library/Rules/Numeric.php
@@ -15,6 +15,10 @@ class Numeric extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_numeric($input);
     }
 }

--- a/library/Rules/Object.php
+++ b/library/Rules/Object.php
@@ -15,6 +15,10 @@ class Object extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_object($input);
     }
 }

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -15,6 +15,10 @@ class Odd extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return ((int) $input % 2 !== 0);
     }
 }

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -15,6 +15,10 @@ class PerfectSquare extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_numeric($input) && sqrt($input) * sqrt($input) == $input;
     }
 }

--- a/library/Rules/Phone.php
+++ b/library/Rules/Phone.php
@@ -15,6 +15,10 @@ class Phone extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return !empty($input) && preg_match('/^[+]?([\d]{0,3})?[\(\.\-\s]?(([\d]{1,3})[\)\.\-\s]*)?(([\d]{3,5})[\.\-\s]?([\d]{4})|([\d]{2}[\.\-\s]?){4})$/', $input);
     }
 }

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -15,6 +15,10 @@ class Positive extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $input > 0;
     }
 }

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -15,6 +15,10 @@ class PrimeNumber extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (!is_numeric($input) || $input <= 1) {
             return false;
         }

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -15,6 +15,10 @@ class Readable extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             return $input->isReadable();
         }

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -22,6 +22,10 @@ class Regex extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return (bool) preg_match($this->regex, $input);
     }
 }

--- a/library/Rules/Resource.php
+++ b/library/Rules/Resource.php
@@ -21,6 +21,10 @@ class Resource extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_resource($input);
     }
 }

--- a/library/Rules/Scalar.php
+++ b/library/Rules/Scalar.php
@@ -21,6 +21,10 @@ class Scalar extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_scalar($input);
     }
 }

--- a/library/Rules/Sf.php
+++ b/library/Rules/Sf.php
@@ -65,6 +65,10 @@ class Sf extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $violations = $this->returnViolationsForConstraint($input, $this->constraint);
         if (count($violations)) {
             return false;

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -102,6 +102,10 @@ class Size extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof SplFileInfo) {
             return $this->isValidSize($input->getSize());
         }

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -15,6 +15,10 @@ class Slug extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (strstr($input, '--')) {
             return false;
         }

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -24,6 +24,10 @@ class StartsWith extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($this->identical) {
             return $this->validateIdentical($input);
         }

--- a/library/Rules/String.php
+++ b/library/Rules/String.php
@@ -15,6 +15,10 @@ class String extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return is_string($input);
     }
 }

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -15,6 +15,10 @@ class SymbolicLink extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             return $input->isLink();
         }

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -121,6 +121,10 @@ class Tld extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return in_array(strtolower($input), $this->tldList);
     }
 }

--- a/library/Rules/True.php
+++ b/library/Rules/True.php
@@ -15,6 +15,10 @@ class True extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return (true === filter_var($input, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
     }
 }

--- a/library/Rules/Type.php
+++ b/library/Rules/Type.php
@@ -43,6 +43,10 @@ class Type extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $lowerType = strtolower($this->type);
         if ('callable' === $lowerType) {
             return is_callable($input);

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -15,6 +15,10 @@ class Uploaded extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             $input = $input->getPathname();
         }

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -15,6 +15,10 @@ class Uppercase extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         return $input === mb_strtoupper($input, mb_detect_encoding($input));
     }
 }

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -18,6 +18,10 @@ class Version extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $pattern = '/^[0-9]+\.[0-9]+\.[0-9]+([+-][^+-][0-9A-Za-z-.]*)?$/';
 
         return (bool) preg_match($pattern, $input);

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -54,6 +54,10 @@ class VideoUrl extends AbstractRule
      */
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if (isset($this->services[$this->serviceKey])) {
             return (preg_match($this->services[$this->serviceKey], $input) > 0);
         }

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -15,6 +15,10 @@ class Writable extends AbstractRule
 {
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         if ($input instanceof \SplFileInfo) {
             return $input->isWritable();
         }

--- a/library/Rules/Zend.php
+++ b/library/Rules/Zend.php
@@ -62,6 +62,10 @@ class Zend extends AbstractRule
 
     public function validate($input)
     {
+        if ($this->isOptional($input)) {
+            return true;
+        }
+
         $validator = clone $this->zendValidator;
 
         return $validator->isValid($input);

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -86,6 +86,7 @@ use Respect\Validation\Rules\Key;
  * @method static Validator noneOf()
  * @method static Validator not(Validatable $rule)
  * @method static Validator notEmpty()
+ * @method static Validator notOptional()
  * @method static Validator noWhitespace()
  * @method static Validator nullValue()
  * @method static Validator numeric()
@@ -130,6 +131,23 @@ use Respect\Validation\Rules\Key;
 class Validator extends AllOf
 {
     protected static $factory;
+    protected static $optionalValues = array('');
+
+    /**
+     * @return array
+     */
+    public static function getOptionalValues()
+    {
+        return static::$optionalValues;
+    }
+
+    /**
+     * @param array $optionalValues
+     */
+    public static function setOptionalValues(array $optionalValues)
+    {
+        static::$optionalValues = $optionalValues;
+    }
 
     /**
      * @return Factory

--- a/tests/integration/not_optional.phpt
+++ b/tests/integration/not_optional.phpt
@@ -1,0 +1,12 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+
+var_dump(v::int()->validate(''));
+var_dump(v::notOptional()->int()->validate(''));
+?>
+--EXPECTF--
+bool(true)
+bool(false)

--- a/tests/integration/not_optional_customized.phpt
+++ b/tests/integration/not_optional_customized.phpt
@@ -1,0 +1,19 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+
+var_dump(v::int()->validate(''));
+var_dump(v::int()->validate(null));
+
+v::setOptionalValues(array('', null));
+
+var_dump(v::int()->validate(''));
+var_dump(v::int()->validate(null));
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)
+bool(true)

--- a/tests/unit/Rules/AgeTest.php
+++ b/tests/unit/Rules/AgeTest.php
@@ -137,4 +137,11 @@ class AgeTest extends \PHPUnit_Framework_TestCase
         $rule = new Age(18, 50);
         $rule->assert('today');
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Age(18, 50);
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/AllOfTest.php
+++ b/tests/unit/Rules/AllOfTest.php
@@ -56,10 +56,10 @@ class AllOfTest extends \PHPUnit_Framework_TestCase
                     return true;
                 });
         $o = new AllOf($valid1, $valid2, $valid3);
-        $this->assertTrue($o->__invoke('any'));
+        $this->assertTrue($o->validate('any'));
         $this->assertTrue($o->check('any'));
         $this->assertTrue($o->assert('any'));
-        $this->assertTrue($o->__invoke(''));
+        $this->assertTrue($o->validate(''));
         $this->assertTrue($o->check(''));
         $this->assertTrue($o->assert(''));
     }
@@ -71,7 +71,7 @@ class AllOfTest extends \PHPUnit_Framework_TestCase
     public function testValidationAssertShouldFailIfAnyRuleFailsAndReturnAllExceptionsFailed($v1, $v2, $v3)
     {
         $o = new AllOf($v1, $v2, $v3);
-        $this->assertFalse($o->__invoke('any'));
+        $this->assertFalse($o->validate('any'));
         $this->assertFalse($o->assert('any'));
     }
 
@@ -82,7 +82,7 @@ class AllOfTest extends \PHPUnit_Framework_TestCase
     public function testValidationCheckShouldFailIfAnyRuleFailsAndThrowTheFirstExceptionOnly($v1, $v2, $v3)
     {
         $o = new AllOf($v1, $v2, $v3);
-        $this->assertFalse($o->__invoke('any'));
+        $this->assertFalse($o->validate('any'));
         $this->assertFalse($o->check('any'));
     }
 
@@ -92,7 +92,7 @@ class AllOfTest extends \PHPUnit_Framework_TestCase
     public function testValidationCheckShouldNotFailOnEmptyInput($v1, $v2, $v3)
     {
         $o = new AllOf($v1, $v2, $v3);
-        $this->assertTrue($o->__invoke(''));
+        $this->assertTrue($o->validate(''));
         $this->assertTrue($o->check(''));
         $this->assertTrue($o->assert(''));
     }
@@ -103,7 +103,7 @@ class AllOfTest extends \PHPUnit_Framework_TestCase
     public function testValidationShouldFailIfAnyRuleFails($v1, $v2, $v3)
     {
         $o = new AllOf($v1, $v2, $v3);
-        $this->assertFalse($o->__invoke('any'));
+        $this->assertFalse($o->validate('any'));
     }
 
     public function providerStaticDummyRules()

--- a/tests/unit/Rules/ArrTest.php
+++ b/tests/unit/Rules/ArrTest.php
@@ -34,7 +34,7 @@ class ArrTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidArrayOrArrayObjectShouldReturnTrue($input)
     {
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->assert($input));
         $this->assertTrue($this->object->check($input));
     }
@@ -45,7 +45,7 @@ class ArrTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotArraysShouldThrowArrException($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/AttributeTest.php
+++ b/tests/unit/Rules/AttributeTest.php
@@ -29,7 +29,7 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $obj = new \stdClass();
         $obj->bar = 'foo';
         $this->assertTrue($validator->check($obj));
-        $this->assertTrue($validator->__invoke($obj));
+        $this->assertTrue($validator->validate($obj));
         $this->assertTrue($validator->assert($obj));
     }
 
@@ -41,7 +41,7 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $validator = new Attribute('bar');
         $obj = new \stdClass();
         $obj->baraaaaa = 'foo';
-        $this->assertFalse($validator->__invoke($obj));
+        $this->assertFalse($validator->validate($obj));
         $this->assertFalse($validator->assert($obj));
     }
     /**
@@ -52,7 +52,7 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $validator = new Attribute('bar');
         $obj = new \stdClass();
         $obj->baraaaaa = 'foo';
-        $this->assertFalse($validator->__invoke($obj));
+        $this->assertFalse($validator->validate($obj));
         $this->assertFalse($validator->check($obj));
     }
 
@@ -80,10 +80,10 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $validator = new Attribute('bar', $subValidator);
         $obj = new \stdClass();
         $obj->bar = 'foo';
-        $this->assertTrue($validator->__invoke($obj));
+        $this->assertTrue($validator->validate($obj));
         $this->assertTrue($validator->assert($obj));
         $this->assertTrue($validator->check($obj));
-        $this->assertTrue($validator->__invoke(''));
+        $this->assertTrue($validator->validate(''));
         $this->assertTrue($validator->assert(''));
         $this->assertTrue($validator->check(''));
     }
@@ -94,7 +94,7 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $validator = new Attribute('bar', $subValidator);
         $obj = new \stdClass();
         $obj->bar = 'foo hey this has more than 3 chars';
-        $this->assertFalse($validator->__invoke($obj));
+        $this->assertFalse($validator->validate($obj));
     }
 
     /**
@@ -124,7 +124,7 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Attribute('bar', null, false);
         $obj = new \stdClass();
-        $this->assertTrue($validator->__invoke($obj));
+        $this->assertTrue($validator->validate($obj));
     }
 
     public function testNotMandatoryAttributeShouldNotFailWhenAttributeIsAbsent_with_extra_validator()
@@ -132,7 +132,7 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $subValidator = new Length(1, 3);
         $validator = new Attribute('bar', $subValidator, false);
         $obj = new \stdClass();
-        $this->assertTrue($validator->__invoke($obj));
+        $this->assertTrue($validator->validate($obj));
     }
 
     public function testPrivateAttributeShouldAlsoBeChecked()
@@ -148,6 +148,6 @@ class AttributeTest extends \PHPUnit_Framework_TestCase
         $subValidator = new Length(33333, 888888);
         $validator = new Attribute('bar', $subValidator);
         $obj = new PrivClass();
-        $this->assertFalse($validator->__invoke($obj));
+        $this->assertFalse($validator->validate($obj));
     }
 }

--- a/tests/unit/Rules/BankAccountTest.php
+++ b/tests/unit/Rules/BankAccountTest.php
@@ -46,4 +46,13 @@ class BankAccountTest extends LocaleTestCase
 
         $this->assertInstanceOf('Respect\Validation\Rules\Locale\GermanBankAccount', $rule->getValidatable());
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $countryCode = 'DE';
+        $bank = '123456';
+        $rule = new BankAccount($countryCode, $bank);
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/BankTest.php
+++ b/tests/unit/Rules/BankTest.php
@@ -44,4 +44,12 @@ class BankTest extends LocaleTestCase
 
         $this->assertInstanceOf('Respect\Validation\Rules\Locale\GermanBank', $rule->getValidatable());
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $countryCode = 'DE';
+        $rule = new Bank($countryCode);
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/BaseTest.php
+++ b/tests/unit/Rules/BaseTest.php
@@ -26,7 +26,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     public function testBase($base, $input)
     {
         $object = new Base($base);
-        $this->assertTrue($object->__invoke($input));
+        $this->assertTrue($object->validate($input));
         $this->assertTrue($object->check($input));
         $this->assertTrue($object->assert($input));
     }
@@ -37,7 +37,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     public function testInvalidBase($base, $input)
     {
         $object = new Base($base);
-        $this->assertFalse($object->__invoke($input));
+        $this->assertFalse($object->validate($input));
     }
 
     /**
@@ -47,7 +47,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     public function testExceptionBase($base, $input)
     {
         $object = new Base($base);
-        $this->assertTrue($object->__invoke($input));
+        $this->assertTrue($object->validate($input));
         $this->assertTrue($object->assert($input));
     }
 
@@ -57,7 +57,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     public function testCustomBase($base, $custom, $input)
     {
         $object = new Base($base, $custom);
-        $this->assertTrue($object->__invoke($input));
+        $this->assertTrue($object->validate($input));
         $this->assertTrue($object->check($input));
         $this->assertTrue($object->assert($input));
     }

--- a/tests/unit/Rules/BetweenTest.php
+++ b/tests/unit/Rules/BetweenTest.php
@@ -67,7 +67,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testValuesBetweenBoundsShouldPass($min, $max, $inclusive, $input)
     {
         $o = new Between($min, $max, $inclusive);
-        $this->assertTrue($o->__invoke($input));
+        $this->assertTrue($o->validate($input));
         $this->assertTrue($o->assert($input));
         $this->assertTrue($o->check($input));
     }
@@ -79,7 +79,7 @@ class BetweenTest extends \PHPUnit_Framework_TestCase
     public function testValuesOutBoundsShouldRaiseException($min, $max, $inclusive, $input)
     {
         $o = new Between($min, $max, $inclusive);
-        $this->assertFalse($o->__invoke($input));
+        $this->assertFalse($o->validate($input));
         $this->assertFalse($o->assert($input));
     }
 

--- a/tests/unit/Rules/BicTest.php
+++ b/tests/unit/Rules/BicTest.php
@@ -44,4 +44,12 @@ class BicTest extends LocaleTestCase
 
         $this->assertInstanceOf('Respect\Validation\Rules\Locale\GermanBic', $rule->getValidatable());
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $countryCode = 'DE';
+        $rule = new Bic($countryCode);
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/BoolTest.php
+++ b/tests/unit/Rules/BoolTest.php
@@ -21,9 +21,9 @@ class BoolTest extends \PHPUnit_Framework_TestCase
     public function testBooleanValuesONLYShouldReturnTrue()
     {
         $validator = new Bool();
-        $this->assertTrue($validator->__invoke(''));
-        $this->assertTrue($validator->__invoke(true));
-        $this->assertTrue($validator->__invoke(false));
+        $this->assertTrue($validator->validate(''));
+        $this->assertTrue($validator->validate(true));
+        $this->assertTrue($validator->validate(false));
         $this->assertTrue($validator->assert(true));
         $this->assertTrue($validator->assert(false));
         $this->assertTrue($validator->check(true));
@@ -42,12 +42,12 @@ class BoolTest extends \PHPUnit_Framework_TestCase
     public function testInvalidBooleanValuesShouldReturnFalse()
     {
         $validator = new Bool();
-        $this->assertFalse($validator->__invoke('foo'));
-        $this->assertFalse($validator->__invoke(123123));
-        $this->assertFalse($validator->__invoke(new \stdClass()));
-        $this->assertFalse($validator->__invoke(array()));
-        $this->assertFalse($validator->__invoke(1));
-        $this->assertFalse($validator->__invoke(0));
-        $this->assertFalse($validator->__invoke(null));
+        $this->assertFalse($validator->validate('foo'));
+        $this->assertFalse($validator->validate(123123));
+        $this->assertFalse($validator->validate(new \stdClass()));
+        $this->assertFalse($validator->validate(array()));
+        $this->assertFalse($validator->validate(1));
+        $this->assertFalse($validator->validate(0));
+        $this->assertFalse($validator->validate(null));
     }
 }

--- a/tests/unit/Rules/CallTest.php
+++ b/tests/unit/Rules/CallTest.php
@@ -58,4 +58,16 @@ class CallTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($v->validate('test'));
         $this->assertFalse($v->assert('test'));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Call(
+            function () {
+                return array();
+            },
+            new String()
+        );
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/CallableTypeTest.php
+++ b/tests/unit/Rules/CallableTypeTest.php
@@ -50,6 +50,13 @@ class CallableTypeTest extends \PHPUnit_Framework_TestCase
         $this->rule->check(__FUNCTION__);
     }
 
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new CallableType();
+
+        $this->assertTrue($rule->validate(''));
+    }
+
     public function providerForCallable()
     {
         return array(

--- a/tests/unit/Rules/CallbackTest.php
+++ b/tests/unit/Rules/CallbackTest.php
@@ -81,4 +81,11 @@ class CallbackTest extends \PHPUnit_Framework_TestCase
         $v = new Callback(new \stdClass());
         $this->assertTrue($v->assert('w poiur'));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Callback(function() { return false; });
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/CharsetTest.php
+++ b/tests/unit/Rules/CharsetTest.php
@@ -24,7 +24,7 @@ class CharsetTest extends \PHPUnit_Framework_TestCase
     public function testValidDataWithCharsetShouldReturnTrue($charset, $input)
     {
         $validator = new Charset($charset);
-        $this->assertTrue($validator->__invoke($input));
+        $this->assertTrue($validator->validate($input));
     }
 
     /**
@@ -34,7 +34,7 @@ class CharsetTest extends \PHPUnit_Framework_TestCase
     public function testInvalidCharsetShouldFailAndThrowCharsetException($charset, $input)
     {
         $validator = new Charset($charset);
-        $this->assertFalse($validator->__invoke($input));
+        $this->assertFalse($validator->validate($input));
         $this->assertFalse($validator->assert($input));
     }
 

--- a/tests/unit/Rules/CnhTest.php
+++ b/tests/unit/Rules/CnhTest.php
@@ -31,7 +31,7 @@ class CnhTest extends \PHPUnit_Framework_TestCase
     public function testValidCnh($cnh)
     {
         $this->assertTrue($this->cnhValidator->assert($cnh));
-        $this->assertTrue($this->cnhValidator->__invoke($cnh));
+        $this->assertTrue($this->cnhValidator->validate($cnh));
         $this->assertTrue($this->cnhValidator->check($cnh));
     }
 

--- a/tests/unit/Rules/CnpjTest.php
+++ b/tests/unit/Rules/CnpjTest.php
@@ -78,6 +78,7 @@ class CnpjTest extends \PHPUnit_Framework_TestCase
     public function providerValidFormattedCnpj()
     {
         return array(
+            array(''),
             array('32.063.364/0001-07'),
             array('24.663.454/0001-00'),
             array('57.535.083/0001-30'),
@@ -90,6 +91,7 @@ class CnpjTest extends \PHPUnit_Framework_TestCase
     public function providerValidUnformattedCnpj()
     {
         return array(
+            array(''),
             array('38175021000110'),
             array('37550610000179'),
             array('12774546000189'),

--- a/tests/unit/Rules/ContainsTest.php
+++ b/tests/unit/Rules/ContainsTest.php
@@ -24,7 +24,7 @@ class ContainsTest extends \PHPUnit_Framework_TestCase
     public function testStringsContainingExpectedValueShouldPass($start, $input)
     {
         $v = new Contains($start);
-        $this->assertTrue($v->__invoke($input));
+        $this->assertTrue($v->validate($input));
         $this->assertTrue($v->check($input));
         $this->assertTrue($v->assert($input));
     }
@@ -36,7 +36,7 @@ class ContainsTest extends \PHPUnit_Framework_TestCase
     public function testStringsNotContainsExpectedValueShouldNotPass($start, $input, $identical = false)
     {
         $v = new Contains($start, $identical);
-        $this->assertFalse($v->__invoke($input));
+        $this->assertFalse($v->validate($input));
         $this->assertFalse($v->assert($input));
     }
 

--- a/tests/unit/Rules/CpfTest.php
+++ b/tests/unit/Rules/CpfTest.php
@@ -68,6 +68,11 @@ class CpfTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->cpfValidator->assert($input));
     }
 
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $this->assertTrue($this->cpfValidator->validate(''));
+    }
+
     public function providerValidFormattedCpf()
     {
         return array(

--- a/tests/unit/Rules/CreditCardTest.php
+++ b/tests/unit/Rules/CreditCardTest.php
@@ -30,7 +30,7 @@ class CreditCardTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidCreditCardsShouldReturnTrue($input)
     {
-        $this->assertTrue($this->creditCardValidator->__invoke($input));
+        $this->assertTrue($this->creditCardValidator->validate($input));
         $this->assertTrue($this->creditCardValidator->assert($input));
         $this->assertTrue($this->creditCardValidator->check($input));
     }
@@ -41,8 +41,13 @@ class CreditCardTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidCreditCardsShouldThrowCreditCardException($input)
     {
-        $this->assertFalse($this->creditCardValidator->__invoke($input));
+        $this->assertFalse($this->creditCardValidator->validate($input));
         $this->assertFalse($this->creditCardValidator->assert($input));
+    }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $this->assertTrue($this->creditCardValidator->validate(''));
     }
 
     public function providerForCreditCard()

--- a/tests/unit/Rules/DateTest.php
+++ b/tests/unit/Rules/DateTest.php
@@ -29,34 +29,34 @@ class DateTest extends \PHPUnit_Framework_TestCase
 
     public function testDateEmptyShouldValidate()
     {
-        $this->assertTrue($this->dateValidator->__invoke(''));
+        $this->assertTrue($this->dateValidator->validate(''));
         $this->assertTrue($this->dateValidator->check(''));
         $this->assertTrue($this->dateValidator->assert(''));
     }
 
     public function testDateWithoutFormatShouldValidate()
     {
-        $this->assertTrue($this->dateValidator->__invoke('today'));
+        $this->assertTrue($this->dateValidator->validate('today'));
     }
 
     public function testDateTimeInstancesShouldAlwaysValidate()
     {
-        $this->assertTrue($this->dateValidator->__invoke(new DateTime('today')));
+        $this->assertTrue($this->dateValidator->validate(new DateTime('today')));
     }
 
     public function testInvalidDateShouldFail()
     {
-        $this->assertFalse($this->dateValidator->__invoke('aids'));
+        $this->assertFalse($this->dateValidator->validate('aids'));
     }
     public function testInvalidDateShouldFail_on_invalid_conversions()
     {
         $this->dateValidator->format = 'Y-m-d';
-        $this->assertFalse($this->dateValidator->__invoke('2009-12-00'));
+        $this->assertFalse($this->dateValidator->validate('2009-12-00'));
     }
 
     public function testAnyObjectExceptDateTimeInstancesShouldFail()
     {
-        $this->assertFalse($this->dateValidator->__invoke(new \stdClass()));
+        $this->assertFalse($this->dateValidator->validate(new \stdClass()));
     }
 
     public function testFormatsShouldValidateDateStrings()
@@ -108,6 +108,7 @@ class DateTest extends \PHPUnit_Framework_TestCase
     public function providerForDateTimeTimezoneStrings()
     {
         return array(
+                array('UTC', 'c', ''),
                 array('UTC', 'c', '2005-12-30T01:02:03+01:00'),
                 array('UTC', 'c', '2004-02-12T15:19:21+00:00'),
                 array('UTC', 'r', 'Thu, 29 Dec 2005 01:02:03 +0000'),

--- a/tests/unit/Rules/DirectoryTest.php
+++ b/tests/unit/Rules/DirectoryTest.php
@@ -24,7 +24,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
     public function testValidDirectoryShouldReturnTrue($input)
     {
         $rule = new Directory();
-        $this->assertTrue($rule->__invoke($input));
+        $this->assertTrue($rule->validate($input));
         $this->assertTrue($rule->assert($input));
         $this->assertTrue($rule->check($input));
     }
@@ -36,7 +36,7 @@ class DirectoryTest extends \PHPUnit_Framework_TestCase
     public function testInvalidDirectoryShouldThrowException($input)
     {
         $rule = new Directory();
-        $this->assertFalse($rule->__invoke($input));
+        $this->assertFalse($rule->validate($input));
         $this->assertFalse($rule->assert($input));
         $this->assertFalse($rule->check($input));
     }

--- a/tests/unit/Rules/DomainTest.php
+++ b/tests/unit/Rules/DomainTest.php
@@ -33,7 +33,7 @@ class DomainTest extends \PHPUnit_Framework_TestCase
     public function testValidDomainsShouldReturnTrue($input, $tldcheck = true)
     {
         $this->object->tldCheck($tldcheck);
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->assert($input));
         $this->assertTrue($this->object->check($input));
     }
@@ -61,6 +61,7 @@ class DomainTest extends \PHPUnit_Framework_TestCase
     public function providerForDomain()
     {
         return array(
+            array('', false),
             array('111111111111domain.local', false),
             array('111111111111.domain.local', false),
             array('example.com'),
@@ -74,7 +75,6 @@ class DomainTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(null),
-            array(''),
             array('2222222domain.local'),
             array('example--invalid.com'),
             array('-example-invalid.com'),

--- a/tests/unit/Rules/EachTest.php
+++ b/tests/unit/Rules/EachTest.php
@@ -94,4 +94,13 @@ class EachTest extends \PHPUnit_Framework_TestCase
         $result = $v->assert(123);
         $this->assertFalse($result);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Each(new Int());
+
+        $this->assertTrue($rule->validate(''));
+        $this->assertTrue($rule->assert(''));
+        $this->assertTrue($rule->check(''));
+    }
 }

--- a/tests/unit/Rules/EmailTest.php
+++ b/tests/unit/Rules/EmailTest.php
@@ -101,7 +101,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
     public function testValidEmailShouldPass($validEmail)
     {
         $validator = new Email();
-        $this->assertTrue($validator->__invoke($validEmail));
+        $this->assertTrue($validator->validate($validEmail));
         $this->assertTrue($validator->check($validEmail));
         $this->assertTrue($validator->assert($validEmail));
     }
@@ -113,7 +113,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
     public function testInvalidEmailsShouldFailValidation($invalidEmail)
     {
         $validator = new Email();
-        $this->assertFalse($validator->__invoke($invalidEmail));
+        $this->assertFalse($validator->validate($invalidEmail));
         $this->assertFalse($validator->assert($invalidEmail));
     }
 

--- a/tests/unit/Rules/EndsWithTest.php
+++ b/tests/unit/Rules/EndsWithTest.php
@@ -24,7 +24,7 @@ class EndsWithTest extends \PHPUnit_Framework_TestCase
     public function testStringsEndingWithExpectedValueShouldPass($start, $input)
     {
         $v = new EndsWith($start);
-        $this->assertTrue($v->__invoke($input));
+        $this->assertTrue($v->validate($input));
         $this->assertTrue($v->check($input));
         $this->assertTrue($v->assert($input));
     }
@@ -36,7 +36,7 @@ class EndsWithTest extends \PHPUnit_Framework_TestCase
     public function testStringsNotEndingWithExpectedValueShouldNotPass($start, $input, $caseSensitive = false)
     {
         $v = new EndsWith($start, $caseSensitive);
-        $this->assertFalse($v->__invoke($input));
+        $this->assertFalse($v->validate($input));
         $this->assertFalse($v->assert($input));
     }
 

--- a/tests/unit/Rules/EqualsTest.php
+++ b/tests/unit/Rules/EqualsTest.php
@@ -24,7 +24,7 @@ class EqualsTest extends \PHPUnit_Framework_TestCase
     public function testStringsContainingExpectedValueShouldPass($start, $input)
     {
         $v = new Equals($start);
-        $this->assertTrue($v->__invoke($input));
+        $this->assertTrue($v->validate($input));
         $this->assertTrue($v->check($input));
         $this->assertTrue($v->assert($input));
     }
@@ -36,7 +36,7 @@ class EqualsTest extends \PHPUnit_Framework_TestCase
     public function testStringsNotEqualsExpectedValueShouldNotPass($start, $input, $identical = false)
     {
         $v = new Equals($start, $identical);
-        $this->assertFalse($v->__invoke($input));
+        $this->assertFalse($v->validate($input));
         $this->assertFalse($v->assert($input));
     }
 

--- a/tests/unit/Rules/ExecutableTest.php
+++ b/tests/unit/Rules/ExecutableTest.php
@@ -59,4 +59,11 @@ class ExecutableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Executable();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/ExistsTest.php
+++ b/tests/unit/Rules/ExistsTest.php
@@ -67,4 +67,11 @@ class ExistsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Exists();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/ExtensionTest.php
+++ b/tests/unit/Rules/ExtensionTest.php
@@ -25,6 +25,7 @@ class ExtensionTest extends PHPUnit_Framework_TestCase
     public function providerValidExtension()
     {
         return array(
+            array('', 'whatever'),
             array('filename.txt', 'txt'),
             array('filename.jpg', 'jpg'),
             array('filename.inc.php', 'php'),

--- a/tests/unit/Rules/FactorTest.php
+++ b/tests/unit/Rules/FactorTest.php
@@ -28,7 +28,7 @@ class FactorTest extends \PHPUnit_Framework_TestCase
     public function testValidFactorShouldReturnTrue($dividend, $input)
     {
         $min = new Factor($dividend);
-        $this->assertTrue($min->__invoke($input));
+        $this->assertTrue($min->validate($input));
         $this->assertTrue($min->check($input));
         $this->assertTrue($min->assert($input));
     }
@@ -44,7 +44,7 @@ class FactorTest extends \PHPUnit_Framework_TestCase
         );
 
         $min = new Factor($dividend);
-        $this->assertFalse($min->__invoke($input));
+        $this->assertFalse($min->validate($input));
         $this->assertFalse($min->assert($input));
     }
 
@@ -61,6 +61,13 @@ class FactorTest extends \PHPUnit_Framework_TestCase
         // It is enough to simply create a new Factor to trigger the dividend
         // exceptions in __construct.
         new Factor($dividend);
+    }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Factor(3);
+
+        $this->assertTrue($rule->validate(''));
     }
 
     public function providerForValidFactor()

--- a/tests/unit/Rules/FalseTest.php
+++ b/tests/unit/Rules/FalseTest.php
@@ -31,6 +31,7 @@ class FalseTest extends \PHPUnit_Framework_TestCase
     public function validFalseProvider()
     {
         return array(
+            array(''),
             array(false),
             array(0),
             array('0'),

--- a/tests/unit/Rules/FileTest.php
+++ b/tests/unit/Rules/FileTest.php
@@ -68,4 +68,11 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new File();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/FiniteTest.php
+++ b/tests/unit/Rules/FiniteTest.php
@@ -53,6 +53,7 @@ class FiniteTest extends \PHPUnit_Framework_TestCase
     public function providerForFinite()
     {
         return array(
+            array(''),
             array('123456'),
             array(-9),
             array(0),

--- a/tests/unit/Rules/FloatTest.php
+++ b/tests/unit/Rules/FloatTest.php
@@ -31,7 +31,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
     public function testFloatNumbersShouldPass($input)
     {
         $this->assertTrue($this->floatValidator->assert($input));
-        $this->assertTrue($this->floatValidator->__invoke($input));
+        $this->assertTrue($this->floatValidator->validate($input));
         $this->assertTrue($this->floatValidator->check($input));
     }
 
@@ -41,7 +41,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotFloatNumbersShouldFail($input)
     {
-        $this->assertFalse($this->floatValidator->__invoke($input));
+        $this->assertFalse($this->floatValidator->validate($input));
         $this->assertFalse($this->floatValidator->assert($input));
     }
 

--- a/tests/unit/Rules/HexRgbColorTest.php
+++ b/tests/unit/Rules/HexRgbColorTest.php
@@ -41,6 +41,7 @@ class HexRgbColorTest extends \PHPUnit_Framework_TestCase
     public function providerForValidHexRgbColor()
     {
         return array(
+            array(''),
             array('#000'),
             array('#00000F'),
             array('#123'),

--- a/tests/unit/Rules/InTest.php
+++ b/tests/unit/Rules/InTest.php
@@ -24,7 +24,7 @@ class InTest extends \PHPUnit_Framework_TestCase
     public function testSuccessInValidatorCases($input, $options = null)
     {
         $v = new In($options);
-        $this->assertTrue($v->__invoke($input));
+        $this->assertTrue($v->validate($input));
         $this->assertTrue($v->check($input));
         $this->assertTrue($v->assert($input));
     }
@@ -36,7 +36,7 @@ class InTest extends \PHPUnit_Framework_TestCase
     public function testInvalidInChecksShouldThrowInException($input, $options, $strict = false)
     {
         $v = new In($options, $strict);
-        $this->assertFalse($v->__invoke($input));
+        $this->assertFalse($v->validate($input));
         $this->assertFalse($v->assert($input));
     }
 

--- a/tests/unit/Rules/InfiniteTest.php
+++ b/tests/unit/Rules/InfiniteTest.php
@@ -53,6 +53,7 @@ class InfiniteTest extends \PHPUnit_Framework_TestCase
     public function providerForInfinite()
     {
         return array(
+            array(''),
             array(INF),
             array(INF * -1),
         );

--- a/tests/unit/Rules/InstanceTest.php
+++ b/tests/unit/Rules/InstanceTest.php
@@ -27,10 +27,10 @@ class InstanceTest extends \PHPUnit_Framework_TestCase
 
     public function testInstanceValidationShouldReturnTrueForValidInstances()
     {
-        $this->assertTrue($this->instanceValidator->__invoke(''));
+        $this->assertTrue($this->instanceValidator->validate(''));
         $this->assertTrue($this->instanceValidator->assert(''));
         $this->assertTrue($this->instanceValidator->check(''));
-        $this->assertTrue($this->instanceValidator->__invoke(new \ArrayObject()));
+        $this->assertTrue($this->instanceValidator->validate(new \ArrayObject()));
         $this->assertTrue($this->instanceValidator->assert(new \ArrayObject()));
         $this->assertTrue($this->instanceValidator->check(new \ArrayObject()));
     }

--- a/tests/unit/Rules/IntTest.php
+++ b/tests/unit/Rules/IntTest.php
@@ -30,7 +30,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIntegersShouldReturnTrue($input)
     {
-        $this->assertTrue($this->intValidator->__invoke($input));
+        $this->assertTrue($this->intValidator->validate($input));
         $this->assertTrue($this->intValidator->check($input));
         $this->assertTrue($this->intValidator->assert($input));
     }
@@ -41,7 +41,7 @@ class IntTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIntegersShouldThrowIntException($input)
     {
-        $this->assertFalse($this->intValidator->__invoke($input));
+        $this->assertFalse($this->intValidator->validate($input));
         $this->assertFalse($this->intValidator->assert($input));
     }
 

--- a/tests/unit/Rules/IpTest.php
+++ b/tests/unit/Rules/IpTest.php
@@ -24,7 +24,7 @@ class IpTest extends \PHPUnit_Framework_TestCase
     public function testValidIpsShouldReturnTrue($input, $options = null)
     {
         $ipValidator = new Ip($options);
-        $this->assertTrue($ipValidator->__invoke($input));
+        $this->assertTrue($ipValidator->validate($input));
         $this->assertTrue($ipValidator->assert($input));
         $this->assertTrue($ipValidator->check($input));
     }
@@ -35,7 +35,7 @@ class IpTest extends \PHPUnit_Framework_TestCase
     public function testIpsBetweenRangeShouldReturnTrue($input, $networkRange)
     {
         $ipValidator = new Ip($networkRange);
-        $this->assertTrue($ipValidator->__invoke($input));
+        $this->assertTrue($ipValidator->validate($input));
         $this->assertTrue($ipValidator->assert($input));
         $this->assertTrue($ipValidator->check($input));
     }
@@ -47,7 +47,7 @@ class IpTest extends \PHPUnit_Framework_TestCase
     public function testInvalidIpsShouldThrowIpException($input, $options = null)
     {
         $ipValidator = new Ip($options);
-        $this->assertFalse($ipValidator->__invoke($input));
+        $this->assertFalse($ipValidator->validate($input));
         $this->assertFalse($ipValidator->assert($input));
     }
 
@@ -58,7 +58,7 @@ class IpTest extends \PHPUnit_Framework_TestCase
     public function testIpsOutsideRangeShouldReturnFalse($input, $networkRange)
     {
         $ipValidator = new Ip($networkRange);
-        $this->assertFalse($ipValidator->__invoke($input));
+        $this->assertFalse($ipValidator->validate($input));
         $this->assertFalse($ipValidator->assert($input));
     }
 

--- a/tests/unit/Rules/JsonTest.php
+++ b/tests/unit/Rules/JsonTest.php
@@ -30,7 +30,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidJsonsShouldReturnTrue($input)
     {
-        $this->assertTrue($this->json->__invoke($input));
+        $this->assertTrue($this->json->validate($input));
         $this->assertTrue($this->json->check($input));
         $this->assertTrue($this->json->assert($input));
     }
@@ -40,7 +40,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidJsonsShouldThrowJsonException()
     {
-        $this->assertFalse($this->json->__invoke('{foo:bar}'));
+        $this->assertFalse($this->json->validate('{foo:bar}'));
         $this->assertFalse($this->json->assert('{foo:bar}'));
     }
 

--- a/tests/unit/Rules/KeySetTest.php
+++ b/tests/unit/Rules/KeySetTest.php
@@ -172,4 +172,13 @@ class KeySetTest extends PHPUnit_Framework_TestCase
         $keySet = new KeySet($key1, $key2);
         $keySet->assert($input);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $key1 = new Key('foo', new AlwaysInvalid(), true);
+
+        $rule = new KeySet($key1);
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/LeapDateTest.php
+++ b/tests/unit/Rules/LeapDateTest.php
@@ -52,4 +52,9 @@ class LeapDateTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->leapDateValidator->validate(array()));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $this->assertTrue($this->leapDateValidator->validate(''));
+    }
 }

--- a/tests/unit/Rules/LeapYearTest.php
+++ b/tests/unit/Rules/LeapYearTest.php
@@ -27,23 +27,21 @@ class LeapYearTest extends \PHPUnit_Framework_TestCase
         $this->leapYearValidator = new LeapYear();
     }
 
-    public function testValidLeapDate()
+    public function testValidLeapYear()
     {
-        $this->assertTrue($this->leapYearValidator->__invoke(''));
-        $this->assertTrue($this->leapYearValidator->__invoke('2008'));
-        $this->assertTrue($this->leapYearValidator->__invoke('2008-02-29'));
-        $this->assertTrue($this->leapYearValidator->__invoke(2008));
-        $this->assertTrue($this->leapYearValidator->__invoke(
-            new DateTime('2008-02-29')));
+        $this->assertTrue($this->leapYearValidator->validate(''));
+        $this->assertTrue($this->leapYearValidator->validate('2008'));
+        $this->assertTrue($this->leapYearValidator->validate('2008-02-29'));
+        $this->assertTrue($this->leapYearValidator->validate(2008));
+        $this->assertTrue($this->leapYearValidator->validate(new DateTime('2008-02-29')));
     }
 
-    public function testInvalidLeapDate()
+    public function testInvalidLeapYear()
     {
-        $this->assertFalse($this->leapYearValidator->__invoke('2009'));
-        $this->assertFalse($this->leapYearValidator->__invoke('2009-02-29'));
-        $this->assertFalse($this->leapYearValidator->__invoke(2009));
-        $this->assertFalse($this->leapYearValidator->__invoke(
-            new DateTime('2009-02-29')));
-        $this->assertFalse($this->leapYearValidator->__invoke(array()));
+        $this->assertFalse($this->leapYearValidator->validate('2009'));
+        $this->assertFalse($this->leapYearValidator->validate('2009-02-29'));
+        $this->assertFalse($this->leapYearValidator->validate(2009));
+        $this->assertFalse($this->leapYearValidator->validate(new DateTime('2009-02-29')));
+        $this->assertFalse($this->leapYearValidator->validate(array()));
     }
 }

--- a/tests/unit/Rules/LengthTest.php
+++ b/tests/unit/Rules/LengthTest.php
@@ -24,7 +24,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     public function testLengthInsideBoundsShouldReturnTrue($string, $min, $max)
     {
         $validator = new Length($min, $max);
-        $this->assertTrue($validator->__invoke($string));
+        $this->assertTrue($validator->validate($string));
         $this->assertTrue($validator->check($string));
         $this->assertTrue($validator->assert($string));
     }
@@ -36,7 +36,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     public function testLengthOutsideBoundsShouldThrowLengthException($string, $min, $max)
     {
         $validator = new Length($min, $max, false);
-        $this->assertfalse($validator->__invoke($string));
+        $this->assertfalse($validator->validate($string));
         $this->assertfalse($validator->assert($string));
     }
 
@@ -47,7 +47,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     public function testLengthOutsideValidBoundsShouldThrowLengthException($string, $min, $max)
     {
         $validator = new Length($min, $max);
-        $this->assertFalse($validator->__invoke($string));
+        $this->assertFalse($validator->validate($string));
         $this->assertFalse($validator->assert($string));
     }
 
@@ -58,7 +58,7 @@ class LengthTest extends \PHPUnit_Framework_TestCase
     public function testInvalidConstructorParametersShouldThrowComponentExceptionUponInstantiation($string, $min, $max)
     {
         $validator = new Length($min, $max);
-        $this->assertFalse($validator->__invoke($string));
+        $this->assertFalse($validator->validate($string));
         $this->assertFalse($validator->assert($string));
     }
 

--- a/tests/unit/Rules/Locale/GermanBankAccountTest.php
+++ b/tests/unit/Rules/Locale/GermanBankAccountTest.php
@@ -93,4 +93,16 @@ class GermanBankAccountTest extends LocaleTestCase
 
         $rule->check($input);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $bank = '10000000';
+        $bav = $this->getBavMock();
+        $rule = new GermanBankAccount($bank, $bav);
+
+        $bav->expects($this->never())
+            ->method('isValidBankAccount');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/Locale/GermanBankTest.php
+++ b/tests/unit/Rules/Locale/GermanBankTest.php
@@ -80,4 +80,15 @@ class GermanBankTest extends LocaleTestCase
 
         $rule->check($input);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $bav = $this->getBavMock();
+        $rule = new GermanBank($bav);
+
+        $bav->expects($this->never())
+            ->method('isValidBank');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/Locale/GermanBicTest.php
+++ b/tests/unit/Rules/Locale/GermanBicTest.php
@@ -80,4 +80,15 @@ class GermanBicTest extends LocaleTestCase
 
         $rule->check($input);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $bav = $this->getBavMock();
+        $rule = new GermanBic($bav);
+
+        $bav->expects($this->never())
+            ->method('isValidBIC');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/LowercaseTest.php
+++ b/tests/unit/Rules/LowercaseTest.php
@@ -24,7 +24,7 @@ class LowercaseTest extends \PHPUnit_Framework_TestCase
     public function testValidLowercaseShouldReturnTrue($input)
     {
         $lowercase = new Lowercase();
-        $this->assertTrue($lowercase->__invoke($input));
+        $this->assertTrue($lowercase->validate($input));
         $this->assertTrue($lowercase->assert($input));
         $this->assertTrue($lowercase->check($input));
     }
@@ -36,7 +36,7 @@ class LowercaseTest extends \PHPUnit_Framework_TestCase
     public function testInvalidLowercaseShouldThrowException($input)
     {
         $lowercase = new Lowercase();
-        $this->assertFalse($lowercase->__invoke($input));
+        $this->assertFalse($lowercase->validate($input));
         $this->assertFalse($lowercase->assert($input));
     }
 

--- a/tests/unit/Rules/MacAddressTest.php
+++ b/tests/unit/Rules/MacAddressTest.php
@@ -30,7 +30,7 @@ class MacAddressTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidMacaddressesShouldReturnTrue($input)
     {
-        $this->assertTrue($this->macaddressValidator->__invoke($input));
+        $this->assertTrue($this->macaddressValidator->validate($input));
         $this->assertTrue($this->macaddressValidator->assert($input));
         $this->assertTrue($this->macaddressValidator->check($input));
     }
@@ -41,7 +41,7 @@ class MacAddressTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMacaddressShouldThrowMacAddressException($input)
     {
-        $this->assertFalse($this->macaddressValidator->__invoke($input));
+        $this->assertFalse($this->macaddressValidator->validate($input));
         $this->assertFalse($this->macaddressValidator->assert($input));
     }
 

--- a/tests/unit/Rules/MimetypeTest.php
+++ b/tests/unit/Rules/MimetypeTest.php
@@ -102,4 +102,11 @@ class MimetypeTest extends PHPUnit_Framework_TestCase
         $rule = new Mimetype('application/json');
         $rule->check(__FILE__);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Mimetype('application/octet-stream');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/MinTest.php
+++ b/tests/unit/Rules/MinTest.php
@@ -26,7 +26,7 @@ class MinTest extends \PHPUnit_Framework_TestCase
     public function testValidMinShouldReturnTrue($minValue, $inclusive, $input)
     {
         $min = new Min($minValue, $inclusive);
-        $this->assertTrue($min->__invoke($input));
+        $this->assertTrue($min->validate($input));
         $this->assertTrue($min->check($input));
         $this->assertTrue($min->assert($input));
     }
@@ -38,7 +38,7 @@ class MinTest extends \PHPUnit_Framework_TestCase
     public function testInvalidMinShouldThrowMinException($minValue, $inclusive, $input)
     {
         $min = new Min($minValue, $inclusive);
-        $this->assertFalse($min->__invoke($input));
+        $this->assertFalse($min->validate($input));
         $this->assertFalse($min->assert($input));
     }
 

--- a/tests/unit/Rules/MininumAgeTest.php
+++ b/tests/unit/Rules/MininumAgeTest.php
@@ -24,7 +24,7 @@ class MininumAgeTest extends \PHPUnit_Framework_TestCase
     public function testValidMinimumAgeInsideBoundsShouldPass($age, $format, $input)
     {
         $minimumAge = new MinimumAge($age, $format);
-        $this->assertTrue($minimumAge->__invoke($input));
+        $this->assertTrue($minimumAge->validate($input));
         $this->assertTrue($minimumAge->assert($input));
         $this->assertTrue($minimumAge->check($input));
     }
@@ -36,7 +36,7 @@ class MininumAgeTest extends \PHPUnit_Framework_TestCase
     public function testInvalidMinimumAgeShouldThrowException($age, $format, $input)
     {
         $minimumAge = new MinimumAge($age, $format);
-        $this->assertFalse($minimumAge->__invoke($input));
+        $this->assertFalse($minimumAge->validate($input));
         $this->assertFalse($minimumAge->assert($input));
     }
 
@@ -47,7 +47,7 @@ class MininumAgeTest extends \PHPUnit_Framework_TestCase
     public function testInvalidDateShouldNotPass($age, $format, $input)
     {
         $minimumAge = new MinimumAge($age, $format);
-        $this->assertFalse($minimumAge->__invoke($input));
+        $this->assertFalse($minimumAge->validate($input));
         $this->assertFalse($minimumAge->assert($input));
     }
 

--- a/tests/unit/Rules/NegativeTest.php
+++ b/tests/unit/Rules/NegativeTest.php
@@ -31,7 +31,7 @@ class NegativeTest extends \PHPUnit_Framework_TestCase
     public function testNegativeShouldPass($input)
     {
         $this->assertTrue($this->negativeValidator->assert($input));
-        $this->assertTrue($this->negativeValidator->__invoke($input));
+        $this->assertTrue($this->negativeValidator->validate($input));
         $this->assertTrue($this->negativeValidator->check($input));
     }
 
@@ -41,7 +41,7 @@ class NegativeTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotNegativeNumbersShouldThrowNegativeException($input)
     {
-        $this->assertFalse($this->negativeValidator->__invoke($input));
+        $this->assertFalse($this->negativeValidator->validate($input));
         $this->assertFalse($this->negativeValidator->assert($input));
     }
 

--- a/tests/unit/Rules/NfeAccessKeyTest.php
+++ b/tests/unit/Rules/NfeAccessKeyTest.php
@@ -31,7 +31,7 @@ class NfeAccessKeyTest extends \PHPUnit_Framework_TestCase
     public function testValidAccessKey($aK)
     {
         $this->assertTrue($this->nfeValidator->assert($aK));
-        $this->assertTrue($this->nfeValidator->__invoke($aK));
+        $this->assertTrue($this->nfeValidator->validate($aK));
         $this->assertTrue($this->nfeValidator->check($aK));
     }
 
@@ -56,6 +56,7 @@ class NfeAccessKeyTest extends \PHPUnit_Framework_TestCase
     public function validAccessKeyProvider()
     {
         return array(
+            array(''),
             array('52060433009911002506550120000007800267301615'),
         );
     }

--- a/tests/unit/Rules/NoWhitespaceTest.php
+++ b/tests/unit/Rules/NoWhitespaceTest.php
@@ -30,7 +30,7 @@ class NoWhitespaceTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringWithNoWhitespaceShouldPass($input)
     {
-        $this->assertTrue($this->noWhitespaceValidator->__invoke($input));
+        $this->assertTrue($this->noWhitespaceValidator->validate($input));
         $this->assertTrue($this->noWhitespaceValidator->check($input));
         $this->assertTrue($this->noWhitespaceValidator->assert($input));
     }
@@ -41,7 +41,7 @@ class NoWhitespaceTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringWithWhitespaceShouldFail($input)
     {
-        $this->assertFalse($this->noWhitespaceValidator->__invoke($input));
+        $this->assertFalse($this->noWhitespaceValidator->validate($input));
         $this->assertFalse($this->noWhitespaceValidator->assert($input));
     }
     /**
@@ -49,7 +49,7 @@ class NoWhitespaceTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringWithLineBreaksShouldFail()
     {
-        $this->assertFalse($this->noWhitespaceValidator->__invoke("w\npoiur"));
+        $this->assertFalse($this->noWhitespaceValidator->validate("w\npoiur"));
         $this->assertFalse($this->noWhitespaceValidator->assert("w\npoiur"));
     }
 

--- a/tests/unit/Rules/NotOptionalTest.php
+++ b/tests/unit/Rules/NotOptionalTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+/**
+ * @group  rule
+ * @covers Respect\Validation\Rules\NotOptional
+ * @covers Respect\Validation\Exceptions\NotOptionalException
+ */
+class NotOptionalTest extends \PHPUnit_Framework_TestCase
+{
+    protected $rule;
+
+    protected function setUp()
+    {
+        $this->rule = new NotOptional();
+    }
+
+    /**
+     * @dataProvider providerNotOptional
+     */
+    public function testStringNotOptional($input)
+    {
+        $this->assertTrue($this->rule->validate($input));
+    }
+
+    /**
+     * @dataProvider providerForOptional
+     */
+    public function testStringOptional($input)
+    {
+        $this->assertFalse($this->rule->validate($input));
+    }
+
+    public function providerNotOptional()
+    {
+        return array(
+            array(' '),
+            array(null),
+            array(array(5)),
+            array(array(0)),
+            array(new \stdClass()),
+        );
+    }
+
+    public function providerForOptional()
+    {
+        return array(
+            array(''),
+        );
+    }
+}

--- a/tests/unit/Rules/NullValueTest.php
+++ b/tests/unit/Rules/NullValueTest.php
@@ -28,8 +28,13 @@ class NullValueTest extends \PHPUnit_Framework_TestCase
     public function testNullValue()
     {
         $this->assertTrue($this->object->assert(null));
-        $this->assertTrue($this->object->__invoke(null));
+        $this->assertTrue($this->object->validate(null));
         $this->assertTrue($this->object->check(null));
+    }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $this->assertTrue($this->object->validate(''));
     }
 
     /**
@@ -38,14 +43,13 @@ class NullValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotNull($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 
     public function providerForNotNull()
     {
         return array(
-            array(''),
             array(0),
             array('w poiur'),
             array(' '),

--- a/tests/unit/Rules/NumericTest.php
+++ b/tests/unit/Rules/NumericTest.php
@@ -30,7 +30,7 @@ class NumericTest extends \PHPUnit_Framework_TestCase
      */
     public function testNumeric($input)
     {
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->check($input));
         $this->assertTrue($this->object->assert($input));
     }
@@ -41,7 +41,7 @@ class NumericTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotNumeric($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/ObjectTest.php
+++ b/tests/unit/Rules/ObjectTest.php
@@ -30,7 +30,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
      */
     public function testObject($input)
     {
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->assert($input));
         $this->assertTrue($this->object->check($input));
     }
@@ -41,7 +41,7 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotObject($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/OddTest.php
+++ b/tests/unit/Rules/OddTest.php
@@ -31,7 +31,7 @@ class OddTest extends \PHPUnit_Framework_TestCase
     public function testOdd($input)
     {
         $this->assertTrue($this->object->assert($input));
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->check($input));
     }
 
@@ -41,7 +41,7 @@ class OddTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotOdd($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/PerfectSquareTest.php
+++ b/tests/unit/Rules/PerfectSquareTest.php
@@ -30,7 +30,7 @@ class PerfectSquareTest extends \PHPUnit_Framework_TestCase
      */
     public function testPerfectSquare($input)
     {
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->check($input));
         $this->assertTrue($this->object->assert($input));
     }
@@ -41,7 +41,7 @@ class PerfectSquareTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotPerfectSquare($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/PhoneTest.php
+++ b/tests/unit/Rules/PhoneTest.php
@@ -30,7 +30,7 @@ class PhoneTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidPhoneShouldReturnTrue($input)
     {
-        $this->assertTrue($this->phoneValidator->__invoke($input));
+        $this->assertTrue($this->phoneValidator->validate($input));
         $this->assertTrue($this->phoneValidator->assert($input));
         $this->assertTrue($this->phoneValidator->check($input));
     }
@@ -41,7 +41,7 @@ class PhoneTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPhoneShouldThrowPhoneException($input)
     {
-        $this->assertFalse($this->phoneValidator->__invoke($input));
+        $this->assertFalse($this->phoneValidator->validate($input));
         $this->assertFalse($this->phoneValidator->assert($input));
     }
 

--- a/tests/unit/Rules/PositiveTest.php
+++ b/tests/unit/Rules/PositiveTest.php
@@ -30,7 +30,7 @@ class PositiveTest extends \PHPUnit_Framework_TestCase
      */
     public function testPositive($input)
     {
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->check($input));
         $this->assertTrue($this->object->assert($input));
     }
@@ -41,7 +41,7 @@ class PositiveTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotPositive($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/PrimeNumberTest.php
+++ b/tests/unit/Rules/PrimeNumberTest.php
@@ -30,7 +30,7 @@ class PrimeNumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testPrimeNumber($input)
     {
-        $this->assertTrue($this->object->__invoke($input));
+        $this->assertTrue($this->object->validate($input));
         $this->assertTrue($this->object->check($input));
         $this->assertTrue($this->object->assert($input));
     }
@@ -41,7 +41,7 @@ class PrimeNumberTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotPrimeNumber($input)
     {
-        $this->assertFalse($this->object->__invoke($input));
+        $this->assertFalse($this->object->validate($input));
         $this->assertFalse($this->object->assert($input));
     }
 

--- a/tests/unit/Rules/ReadableTest.php
+++ b/tests/unit/Rules/ReadableTest.php
@@ -68,4 +68,11 @@ class ReadableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Readable();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/RegexTest.php
+++ b/tests/unit/Rules/RegexTest.php
@@ -39,4 +39,11 @@ class RegexTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($v->validate('w poiur'));
         $this->assertFalse($v->assert('w poiur'));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Regex('/^.$/');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/ResourceTest.php
+++ b/tests/unit/Rules/ResourceTest.php
@@ -53,6 +53,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
     public function providerForResource()
     {
         return array(
+            array(''),
             array(stream_context_create()),
             array(tmpfile()),
             array(xml_parser_create()),

--- a/tests/unit/Rules/RomanTest.php
+++ b/tests/unit/Rules/RomanTest.php
@@ -30,7 +30,7 @@ class RomanTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidRomansShouldReturnTrue($input)
     {
-        $this->assertTrue($this->romanValidator->__invoke($input));
+        $this->assertTrue($this->romanValidator->validate($input));
         $this->assertTrue($this->romanValidator->assert($input));
         $this->assertTrue($this->romanValidator->check($input));
     }
@@ -41,7 +41,7 @@ class RomanTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidRomansShouldThrowRomanException($input)
     {
-        $this->assertFalse($this->romanValidator->__invoke($input));
+        $this->assertFalse($this->romanValidator->validate($input));
         $this->assertFalse($this->romanValidator->assert($input));
     }
 

--- a/tests/unit/Rules/ScalarTest.php
+++ b/tests/unit/Rules/ScalarTest.php
@@ -53,6 +53,7 @@ class ScalarTest extends \PHPUnit_Framework_TestCase
     public function providerForScalar()
     {
         return array(
+            array(''),
             array('6'),
             array('String'),
             array(1.0),

--- a/tests/unit/Rules/SfTest.php
+++ b/tests/unit/Rules/SfTest.php
@@ -82,4 +82,11 @@ EOF;
         $fantasyValue = '8GW';
         v::sf($fantasyConstraintName)->validate($fantasyValue);
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Sf('Time');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/SizeTest.php
+++ b/tests/unit/Rules/SizeTest.php
@@ -122,4 +122,11 @@ class SizeTest extends PHPUnit_Framework_TestCase
         $rule = new Size('2pb');
         $rule->assert($file1Gb->url());
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Size('2pb');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/SlugTest.php
+++ b/tests/unit/Rules/SlugTest.php
@@ -30,7 +30,7 @@ class SlugTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidSlug($input)
     {
-        $this->assertTrue($this->slug->__invoke($input));
+        $this->assertTrue($this->slug->validate($input));
         $this->assertTrue($this->slug->check($input));
         $this->assertTrue($this->slug->assert($input));
     }
@@ -41,7 +41,7 @@ class SlugTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidSlug($input)
     {
-        $this->assertFalse($this->slug->__invoke($input));
+        $this->assertFalse($this->slug->validate($input));
         $this->assertFalse($this->slug->assert($input));
     }
 

--- a/tests/unit/Rules/StartsWithTest.php
+++ b/tests/unit/Rules/StartsWithTest.php
@@ -24,7 +24,7 @@ class StartsWithTest extends \PHPUnit_Framework_TestCase
     public function testStartsWith($start, $input)
     {
         $v = new StartsWith($start);
-        $this->assertTrue($v->__invoke($input));
+        $this->assertTrue($v->validate($input));
         $this->assertTrue($v->check($input));
         $this->assertTrue($v->assert($input));
     }
@@ -36,7 +36,7 @@ class StartsWithTest extends \PHPUnit_Framework_TestCase
     public function testNotStartsWith($start, $input, $caseSensitive = false)
     {
         $v = new StartsWith($start, $caseSensitive);
-        $this->assertFalse($v->__invoke($input));
+        $this->assertFalse($v->validate($input));
         $this->assertFalse($v->assert($input));
     }
 

--- a/tests/unit/Rules/SymbolicLinkTest.php
+++ b/tests/unit/Rules/SymbolicLinkTest.php
@@ -68,4 +68,11 @@ class SymbolicLinkTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new SymbolicLink();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/TrueTest.php
+++ b/tests/unit/Rules/TrueTest.php
@@ -31,6 +31,7 @@ class TrueTest extends \PHPUnit_Framework_TestCase
     public function validTrueProvider()
     {
         return array(
+            array(''),
             array(true),
             array(1),
             array('1'),

--- a/tests/unit/Rules/TypeTest.php
+++ b/tests/unit/Rules/TypeTest.php
@@ -77,6 +77,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
     public function providerForValidType()
     {
         return array(
+            array('array', ''),
             array('array', array()),
             array('bool', true),
             array('boolean', false),

--- a/tests/unit/Rules/UploadedTest.php
+++ b/tests/unit/Rules/UploadedTest.php
@@ -67,4 +67,11 @@ class UploadedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Uploaded();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/VersionTest.php
+++ b/tests/unit/Rules/VersionTest.php
@@ -24,7 +24,7 @@ class VersionTest extends \PHPUnit_Framework_TestCase
     public function testValidVersionShouldReturnTrue($input)
     {
         $rule = new Version();
-        $this->assertTrue($rule->__invoke($input));
+        $this->assertTrue($rule->validate($input));
         $this->assertTrue($rule->assert($input));
         $this->assertTrue($rule->check($input));
     }
@@ -36,7 +36,7 @@ class VersionTest extends \PHPUnit_Framework_TestCase
     public function testInvalidVersionShouldThrowException($input)
     {
         $rule = new Version();
-        $this->assertFalse($rule->__invoke($input));
+        $this->assertFalse($rule->validate($input));
         $this->assertFalse($rule->assert($input));
     }
 

--- a/tests/unit/Rules/VideoUrlTest.php
+++ b/tests/unit/Rules/VideoUrlTest.php
@@ -30,6 +30,9 @@ class VideoUrlTest extends \PHPUnit_Framework_TestCase
     public function validVideoUrlProvider()
     {
         return array(
+            array('vimeo', ''),
+            array('youtube', ''),
+            array(null, ''),
             array('vimeo', 'https://player.vimeo.com/video/71787467'),
             array('vimeo', 'https://vimeo.com/71787467'),
             array('youtube', 'https://www.youtube.com/embed/netHLn9TScY'),

--- a/tests/unit/Rules/WhenTest.php
+++ b/tests/unit/Rules/WhenTest.php
@@ -65,12 +65,12 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Respect\Validation\Exceptions\NotEmptyException
+     * @expectedException Respect\Validation\Exceptions\DigitException
      */
     public function testWhenException_on_else()
     {
-        $v = new When(new Int(), new Between(1, 5), new NotEmpty());
-        $this->assertFalse($v->assert(''));
+        $v = new When(new Int(), new Between(1, 5), new Digit());
+        $this->assertFalse($v->assert('String'));
     }
 
     /**
@@ -83,11 +83,11 @@ class WhenTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Respect\Validation\Exceptions\NotEmptyException
+     * @expectedException Respect\Validation\Exceptions\DigitException
      */
     public function testWhenException_on_else_failfast()
     {
-        $v = new When(new Int(), new Between(1, 5), new NotEmpty());
-        $this->assertFalse($v->check(''));
+        $v = new When(new Int(), new Between(1, 5), new Digit());
+        $this->assertFalse($v->check('String'));
     }
 }

--- a/tests/unit/Rules/WritableTest.php
+++ b/tests/unit/Rules/WritableTest.php
@@ -68,4 +68,11 @@ class WritableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($rule->validate($object));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Writable();
+
+        $this->assertTrue($rule->validate(''));
+    }
 }

--- a/tests/unit/Rules/ZendTest.php
+++ b/tests/unit/Rules/ZendTest.php
@@ -132,6 +132,13 @@ class ZendTest extends \PHPUnit_Framework_TestCase
         $v = new Zend('StringLength', array('min' => 10, 'max' => 25));
         $this->assertFalse($v->assert('aw'));
     }
+
+    public function testShouldAcceptEmptyStringAsOptionalInput()
+    {
+        $rule = new Zend('Date');
+
+        $this->assertTrue($rule->validate(''));
+    }
 }
 
 // Stubs


### PR DESCRIPTION
This is the hard-coded solution I was avoiding but seems the best thing to do, due the created issues related to the _optional input_ feature.

All rules should accept optional values (`''`) and that behaviour must be the same for `assert()`, `check()` and `validate()` methods.

Create `notOptional()` rule to handle optional values. This rule uses the defined optional values for the library by using the method `Validator::getOptionalValues()`. This commit also allows the user to customize optional values by `Validator::setOptionalValues()`.

Fix #235, Closes #422