### PR TITLE
Method notEmpty - Issue 438

### DIFF
--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -17,6 +17,7 @@ class NotEmpty extends AbstractRule
     {
         if (is_string($input)) {
             $input = trim($input);
+            return isset($input[0]);
         }
 
         return !empty($input);

--- a/tests/unit/Rules/NotEmptyTest.php
+++ b/tests/unit/Rules/NotEmptyTest.php
@@ -47,6 +47,7 @@ class NotEmptyTest extends \PHPUnit_Framework_TestCase
         return array(
             array(1),
             array(' oi'),
+            array('0'),
             array(array(5)),
             array(array(0)),
             array(new \stdClass()),


### PR DESCRIPTION
modified:   library/Rules/NotEmpty.php
modified:   tests/unit/Rules/NotEmptyTest.php

- The test for empty strings was modified.
- A new value for "NotEmptyTest::providerForNotEmpty" was added.

fix #438