### PR TITLE
Fixes MimeTypeTest Expected Exception Path

### DIFF
--- a/tests/unit/Rules/MimetypeTest.php
+++ b/tests/unit/Rules/MimetypeTest.php
@@ -95,9 +95,9 @@ class MimetypeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\MimetypeException
-     * @expectedExceptionMessageRegExp #".+/MimetypeTest.php" must have "application.?/json" mimetype#
+     * @expectedExceptionMessageRegExp #".+MimetypeTest.php" must have "application.?/json" mimetype#
      */
-    public function testShouldThowsMimetypeExceptionWhenCheckingValue()
+    public function testShouldThrowMimetypeExceptionWhenCheckingValue()
     {
         $rule = new Mimetype('application/json');
         $rule->check(__FILE__);


### PR DESCRIPTION
Previously, the MimeTypeTest was matching UNIX-style file slashes
in its PHPUnit Expected Exception. This change fixes it to
ignore the slash and match only the file name and pass on Windows
platforms as well.