### PR TITLE
Create "composer test" command in order to run phpunit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,11 +187,23 @@ You can test the project using the commands:
 $ vendor/bin/phpunit
 ```
 
+or
+
+```sh
+$ composer test
+```
+
 ### Windows
 
 You can test the project using the commands:
 ```sh
 > vendor\bin\phpunit
+```
+
+or
+
+```sh
+> composer test
 ```
 
 No test should fail.

--- a/composer.json
+++ b/composer.json
@@ -45,5 +45,8 @@
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
     }
 }


### PR DESCRIPTION
As the project already is installed via composer, this command
could save a few keystrokes!

Besides that, is just one command for all OS, because will not be
needed to change slashes to backslashes in Windows.

*X      (21 keystrokes): `./vendor/bin/phpunit`
Windows (21 keystrokes): `.\vendor\bin\phpunit`
New (14 keystrokes):     `composer test`

https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands