### PR TITLE
Use standard phrasing for max/min exception messages

### DIFF
--- a/library/Exceptions/MaxException.php
+++ b/library/Exceptions/MaxException.php
@@ -17,12 +17,12 @@ class MaxException extends ValidationException
 
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be lower than {{interval}}',
-            self::INCLUSIVE => '{{name}} must be lower than or equals {{interval}}',
+            self::STANDARD => '{{name}} must be less than {{interval}}',
+            self::INCLUSIVE => '{{name}} must be less than or equal to {{interval}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be lower than {{interval}}',
-            self::INCLUSIVE => '{{name}} must not be lower than or equals {{interval}}',
+            self::STANDARD => '{{name}} must not be less than {{interval}}',
+            self::INCLUSIVE => '{{name}} must not be less than or equal to {{interval}}',
         ],
     ];
 

--- a/library/Exceptions/MinException.php
+++ b/library/Exceptions/MinException.php
@@ -18,11 +18,11 @@ class MinException extends ValidationException
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
             self::STANDARD => '{{name}} must be greater than {{interval}}',
-            self::INCLUSIVE => '{{name}} must be greater than or equals {{interval}}',
+            self::INCLUSIVE => '{{name}} must be greater than or equal to {{interval}}',
         ],
         self::MODE_NEGATIVE => [
             self::STANDARD => '{{name}} must not be greater than {{interval}}',
-            self::INCLUSIVE => '{{name}} must not be greater than or equals {{interval}}',
+            self::INCLUSIVE => '{{name}} must not be greater than or equal to {{interval}}',
         ],
     ];
 

--- a/tests/integration/rules/beetwen_2.phpt
+++ b/tests/integration/rules/beetwen_2.phpt
@@ -11,4 +11,4 @@ try {
     echo $e->getMainMessage().PHP_EOL;
 }
 --EXPECTF--
-42 must be lower than or equals 2
+42 must be less than or equal to 2

--- a/tests/integration/rules/beetwen_3.phpt
+++ b/tests/integration/rules/beetwen_3.phpt
@@ -11,4 +11,4 @@ try {
     echo $e->getMainMessage().PHP_EOL;
 }
 --EXPECTF--
--42 must be greater than or equals 1
+-42 must be greater than or equal to 1

--- a/tests/integration/rules/beetwen_4.phpt
+++ b/tests/integration/rules/beetwen_4.phpt
@@ -11,4 +11,4 @@ try {
     echo $e->getFullMessage();
 }
 --EXPECTF--
-- "c" must be lower than or equals "b"
+- "c" must be less than or equal to "b"

--- a/tests/integration/rules/beetwen_5.phpt
+++ b/tests/integration/rules/beetwen_5.phpt
@@ -11,4 +11,4 @@ try {
     echo $e->getFullMessage();
 }
 --EXPECTF--
-- "a" must not be lower than or equals "b"
+- "a" must not be less than or equal to "b"

--- a/tests/integration/rules/beetwen_6.phpt
+++ b/tests/integration/rules/beetwen_6.phpt
@@ -11,4 +11,4 @@ try {
     echo $e->getFullMessage();
 }
 --EXPECTF--
-- 41 must not be lower than or equals 42
+- 41 must not be less than or equal to 42

--- a/tests/integration/set_template_with_multiple_validators_should_use_template_as_full_message.phpt
+++ b/tests/integration/set_template_with_multiple_validators_should_use_template_as_full_message.phpt
@@ -15,4 +15,4 @@ try {
 ?>
 --EXPECTF--
 - "something" is not tasty
-  - "something" must be greater than or equals 1
+  - "something" must be greater than or equal to 1


### PR DESCRIPTION
Existing exception messages for max/min validators are:

**Max:**
```
must be greater than [or equals]
```
**Min:**
```
must be lower than [or equals]
```

This PR updates those messages to use more standard comparison phrasing:

**Max:**
```
must be greater than [or equal to]
```

**Min:**
```
must be less than [or equal to]
```
