### PR TITLE
Create "IdentityCard" rule

### DIFF
--- a/docs/IdentityCard.md
+++ b/docs/IdentityCard.md
@@ -1,0 +1,21 @@
+# IdentityCard
+
+- `v::identityCard(string $countryCode)`
+
+Validates Identity Card numbers according to the defined country.
+
+```php
+v::identityCard('PL')->validate('AYW036733'); // true
+v::identityCard('PL')->validate('APH505567'); // true
+v::identityCard('PL')->validate('APH 505567'); // false
+v::identityCard('PL')->validate('AYW036731'); // false
+```
+
+For now this rule only accepts Polish Identity Card numbers (Dowód Osobisty).
+
+***
+See also:
+
+  * [Bank](Bank.md)
+  * [Pesel](Pesel.md)
+  * [SubdivisionCode](SubdivisionCode.md)

--- a/docs/VALIDATORS.md
+++ b/docs/VALIDATORS.md
@@ -139,6 +139,7 @@
 
   * [CountryCode](CountryCode.md)
   * [CurrencyCode](CurrencyCode.md)
+  * [IdentityCard](IdentityCard.md)
   * [LanguageCode](LanguageCode.md)
   * [PostalCode](PostalCode.md)
   * [SubdivisionCode](SubdivisionCode.md)
@@ -244,6 +245,7 @@
   * [FloatType](FloatType.md)
   * [Graph](Graph.md)
   * [HexRgbColor](HexRgbColor.md)
+  * [IdentityCard](IdentityCard.md)
   * [Image](Image.md)
   * [Imei](Imei.md)
   * [In](In.md)

--- a/library/Exceptions/IdentityCardException.php
+++ b/library/Exceptions/IdentityCardException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions;
+
+class IdentityCardException extends ValidationException
+{
+    /**
+     * @var array
+     */
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{name}} must be a valid Identity Card number for {{countryCode}}',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{name}} must not be a valid Identity Card number for {{countryCode}}',
+        ],
+    ];
+}

--- a/library/Exceptions/Locale/PlIdentityCardException.php
+++ b/library/Exceptions/Locale/PlIdentityCardException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions\Locale;
+
+use Respect\Validation\Exceptions\ValidationException;
+
+class PlIdentityCardException extends ValidationException
+{
+    /**
+     * @var array
+     */
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{name}} must be a valid Polish Identity Card number',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{name}} must not be a valid Polish Identity Card number',
+        ],
+    ];
+}

--- a/library/Rules/IdentityCard.php
+++ b/library/Rules/IdentityCard.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Exceptions\ComponentException;
+
+class IdentityCard extends AbstractWrapper
+{
+    public $countryCode;
+
+    public function __construct($countryCode)
+    {
+        $shortName = ucfirst(strtolower($countryCode)).'IdentityCard';
+        $className = __NAMESPACE__.'\\Locale\\'.$shortName;
+        if (!class_exists($className)) {
+            throw new ComponentException(sprintf('There is no support for identity cards from "%s"', $countryCode));
+        }
+
+        $this->countryCode = $countryCode;
+        $this->validatable = new $className();
+    }
+}

--- a/library/Rules/Locale/PlIdentityCard.php
+++ b/library/Rules/Locale/PlIdentityCard.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules\Locale;
+
+use Respect\Validation\Rules\AbstractRule;
+
+/**
+ * Validator for Polish identity card.
+ *
+ * @link https://en.wikipedia.org/wiki/Polish_identity_card
+ */
+class PlIdentityCard extends AbstractRule
+{
+    public function validate($input)
+    {
+        if (!preg_match('/^[A-Z0-9]{9}$/', $input)) {
+            return false;
+        }
+
+        $weights = [7, 3, 1, 0, 7, 3, 1, 7, 3];
+        $weightedSum = 0;
+        for ($i = 0; $i < 9; ++$i) {
+            $code = ord($input[$i]);
+            if ($i < 3 && $code <= 57) { // 57 is "9"
+                return false;
+            }
+
+            if ($i > 2 && $code >= 65) { // 65 is "A"
+                return false;
+            }
+
+            $difference = $code <= 57 ? 48 : 55; // 48 is "0"
+            $weightedSum += ($code - $difference) * $weights[$i];
+        }
+
+        return $weightedSum % 10 == $input[3];
+    }
+}

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -70,6 +70,7 @@ use Respect\Validation\Rules\Key;
  * @method static Validator floatType()
  * @method static Validator graph(string $additionalChars = null)
  * @method static Validator hexRgbColor()
+ * @method static Validator identityCard(string $countryCode)
  * @method static Validator image(finfo $fileInfo = null)
  * @method static Validator imei()
  * @method static Validator in(mixed $haystack, bool $compareIdentical = false)

--- a/tests/integration/rules/identityCard_1.phpt
+++ b/tests/integration/rules/identityCard_1.phpt
@@ -1,0 +1,11 @@
+--FILE--
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+
+v::identityCard('PL')->check('AYE205410');
+v::identityCard('PL')->assert('AYE205410');
+?>
+--EXPECTF--

--- a/tests/integration/rules/identityCard_2.phpt
+++ b/tests/integration/rules/identityCard_2.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\Locale\PlIdentityCardException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::identityCard('PL')->check('AYE205411');
+} catch (PlIdentityCardException $e) {
+    echo $e->getMainMessage();
+}
+?>
+--EXPECTF--
+"AYE205411" must be a valid Polish Identity Card number

--- a/tests/integration/rules/identityCard_3.phpt
+++ b/tests/integration/rules/identityCard_3.phpt
@@ -1,0 +1,15 @@
+--FILE--
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+use Respect\Validation\Exceptions\AllOfException;
+
+try {
+	v::identityCard('PL')->assert('AYE205411');
+} catch (AllOfException $e) {
+	echo $e->getFullMessage();
+}
+--EXPECTF--
+- "AYE205411" must be a valid Polish Identity Card number

--- a/tests/integration/rules/identityCard_4.phpt
+++ b/tests/integration/rules/identityCard_4.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\IdentityCardException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::not(v::identityCard('PL'))->check('AYE205410');
+} catch (IdentityCardException $e) {
+    echo $e->getMainMessage();
+}
+?>
+--EXPECTF--
+"AYE205410" must not be a valid Identity Card number for "PL"

--- a/tests/integration/rules/identityCard_5.phpt
+++ b/tests/integration/rules/identityCard_5.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\AllOfException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::not(v::identityCard('PL'))->assert('AYE205410');
+} catch (AllOfException $e) {
+    echo $e->getFullMessage();
+}
+?>
+--EXPECTF--
+- "AYE205410" must not be a valid Identity Card number for "PL"

--- a/tests/unit/Rules/Locale/PlIdentityCardTest.php
+++ b/tests/unit/Rules/Locale/PlIdentityCardTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules\Locale;
+
+use Respect\Validation\Rules\RuleTestCase;
+
+/**
+ * @group  rule
+ * @covers Respect\Validation\Rules\Locale\PlIdentityCard
+ */
+class PlIdentityCardTest extends RuleTestCase
+{
+    public function providerForValidInput()
+    {
+        $rule = new PlIdentityCard();
+
+        return [
+            [$rule, 'APH505567'],
+            [$rule, 'AYE205410'],
+            [$rule, 'AYW036733'],
+        ];
+    }
+
+    public function providerForInvalidInput()
+    {
+        $rule = new PlIdentityCard();
+
+        return [
+            [$rule, 'AAAAAAAAA'],
+            [$rule, 'APH 505567'],
+            [$rule, 'AYE205411'],
+            [$rule, 'AYW036731'],
+        ];
+    }
+}


### PR DESCRIPTION
- `v::identityCard(string $countryCode)`

Validates Identity Card numbers according to the defined country.

```php
v::identityCard('PL')->validate('AYW036733'); // true
v::identityCard('PL')->validate('APH505567'); // true
v::identityCard('PL')->validate('APH 505567'); // false
v::identityCard('PL')->validate('AYW036731'); // false
```

For now this rule only accepts Polish Identity Card numbers (Dowód Osobisty).

***
Closes #623