### PR TITLE
Ensure namespace separator on appended prefixes

### DIFF
--- a/library/Factory.php
+++ b/library/Factory.php
@@ -25,7 +25,12 @@ class Factory
 
     public function appendRulePrefix($rulePrefix)
     {
-        array_push($this->rulePrefixes, $rulePrefix);
+        $namespaceSeparator = '\\';
+        $rulePrefix = rtrim($rulePrefix, $namespaceSeparator);
+        array_push(
+            $this->rulePrefixes,
+            $rulePrefix . $namespaceSeparator
+        );
     }
 
     public function prependRulePrefix($rulePrefix)

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -23,12 +23,45 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['Respect\\Validation\\Rules\\'], $factory->getRulePrefixes());
     }
 
-    public function testShouldBeAbleToAppendANewPrefix()
+    /**
+     * @dataProvider provideRulePrefixes
+     */
+    public function testShouldBeAbleToAppendANewPrefix($namespace, $expectedNamespace)
     {
         $factory = new Factory();
-        $factory->appendRulePrefix('My\\Validation\\Rules\\');
+        $factory->appendRulePrefix($namespace);
 
-        $this->assertEquals(['Respect\\Validation\\Rules\\', 'My\\Validation\\Rules\\'], $factory->getRulePrefixes());
+        $currentRulePrefixes = $factory->getRulePrefixes();
+        $this->assertContains(
+            'Respect\\Validation\\Rules\\',
+            $currentRulePrefixes,
+            "Respect validation namespace with rules is always to be expected when " .
+            "appending new prefixes to the rule factory."
+        );
+        $this->assertContains(
+            $expectedNamespace,
+            $currentRulePrefixes,
+            'Appended namespace rule was not found as expected into the prefix list.' . PHP_EOL .
+            sprintf(
+                'Appended "%s", current list is ' . PHP_EOL . '%s',
+                $namespace,
+                implode(PHP_EOL, $currentRulePrefixes)
+            )
+        );
+    }
+
+    public function provideRulePrefixes()
+    {
+        return [
+            "Namespace with trailing separator" => [
+                "namespace" => "My\\Validation\\Rules\\",
+                "expected" => "My\\Validation\\Rules\\"
+            ],
+            "Namespace without trailing separator" => [
+                "namespace" => "My\\Validation\\Rules",
+                "expected" => "My\\Validation\\Rules\\"
+            ]
+        ];
     }
 
     public function testShouldBeAbleToPrependANewRulePrefix()
@@ -66,16 +99,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Respect\Validation\Exceptions\ComponentException
-     * @expectedExceptionMessage "Respect\Validation\TestNonRule" is not a valid respect rule
+     * @expectedExceptionMessage "Respect\Validation\Exceptions\AgeException" is not a valid respect rule
      */
     public function testShouldThrowsAnExceptionWhenRuleIsNotInstanceOfRuleInterface()
     {
         $factory = new Factory();
-        $factory->appendRulePrefix('Respect\\Validation\\Test');
-        $factory->rule('nonRule');
+        $factory->appendRulePrefix('Respect\\Validation\\Exceptions\\');
+        $factory->rule('AgeException');
     }
-}
-
-class TestNonRule
-{
 }


### PR DESCRIPTION
Appending a prefix to search new rules under required that the namespace
(prefix) being added always ended with a trailing namespace character so
rules could successfully be found under it. This ensures that the
separator is always present.

Changes a test for a rule which does not implement Respect's interface
to an actual class so we don't need to declare one to use as a stub.