### PR TITLE
AbstractWrapper should pass on setName calls to the wrapped Validatable.

### DIFF
--- a/library/Rules/AbstractWrapper.php
+++ b/library/Rules/AbstractWrapper.php
@@ -41,4 +41,10 @@ abstract class AbstractWrapper extends AbstractRule
     {
         return $this->getValidatable()->validate($input);
     }
+
+    public function setName($name)
+    {
+        $this->getValidatable()->setName($name);
+        return parent::setName($name);
+    }
 }

--- a/tests/unit/Rules/AbstractWrapperTest.php
+++ b/tests/unit/Rules/AbstractWrapperTest.php
@@ -93,4 +93,21 @@ class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($wrapper->check($input));
     }
+
+    public function testShouldPassNameOnToWrapped()
+    {
+        $name = 'Whatever';
+
+        $validatable = $this->getMock('Respect\Validation\Validatable');
+        $validatable
+            ->expects($this->once())
+            ->method('setName')
+            ->with($name)
+            ->will($this->returnValue($validatable));
+
+        $wrapper = $this->getMockForAbstractClass('Respect\Validation\Rules\AbstractWrapper');
+        $this->bindValidatable($wrapper, $validatable);
+
+        $this->assertSame($wrapper, $wrapper->setName($name));
+    }
 }


### PR DESCRIPTION
When using something like SubdivisionCode setName calls aren't passed on to the particular class that's wrapped (e.g. UsSubdivisionCode). This results in the input value being used as the name in error messages.

Fixes issue #647.