### PR TITLE
Fix wrong date parsing on Date rule

### DIFF
--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -31,9 +31,8 @@ class Date extends AbstractRule
             $this->format = $exceptionalFormats[ $this->format ];
         }
 
-        $dateFromFormat = DateTime::createFromFormat($this->format, $input);
+        $info = date_parse_from_format($this->format, $input);
 
-        return $dateFromFormat
-               && $input === $dateFromFormat->format($this->format);
+        return ($info['error_count'] === 0 && $info['warning_count'] === 0);
     }
 }

--- a/tests/Rules/DateTest.php
+++ b/tests/Rules/DateTest.php
@@ -93,6 +93,11 @@ class DateTest extends \PHPUnit_Framework_TestCase
      */
     public function providerForDateTimeTimezoneStrings(){
         return array(
+                array('UTC', 'Ym', '202302',),
+                array('UTC', 'Ym', '202304',),
+                array('UTC', 'Ym', '202306',),
+                array('UTC', 'Ym', '202309',),
+                array('UTC', 'Ym', '202311',),
                 array('UTC', 'c', '2005-12-30T01:02:03+01:00',),
                 array('UTC', 'c', '2004-02-12T15:19:21+00:00',),
                 array('UTC', 'r', 'Thu, 29 Dec 2005 01:02:03 +0000',),


### PR DESCRIPTION
The `DateTime::createFromFormat()` tries to guess the date too much and
sometimes wrong parsing may happen:

```php
echo DateTime::createFromFormat('Ym', '202309')->format('Ym');
```

The output of the above code is "202310", not "202309".

Using `date_parse_from_format()` we get a more precise parsing.