### PR TITLE
Set template for the first rule in the chain

### DIFF
--- a/library/Validator.php
+++ b/library/Validator.php
@@ -15,6 +15,7 @@ use finfo;
 use ReflectionClass;
 use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Exceptions\ComponentException;
+use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Rules\AllOf;
 use Respect\Validation\Rules\Key;
 
@@ -182,6 +183,19 @@ class Validator extends AllOf
             self::getFactory()->appendRulePrefix($rulePrefix);
         } else {
             self::getFactory()->prependRulePrefix($rulePrefix);
+        }
+    }
+
+    public function check($input)
+    {
+        try {
+            return parent::check($input);
+        } catch (ValidationException $exception) {
+            if (count($this->getRules()) == 1 && $this->template) {
+                $exception->setTemplate($this->template);
+            }
+
+            throw $exception;
         }
     }
 

--- a/tests/integration/set_template_with_single_validator_should_use_template_as_main_message.phpt
+++ b/tests/integration/set_template_with_single_validator_should_use_template_as_main_message.phpt
@@ -8,11 +8,21 @@ use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Rules\Callback;
 use Respect\Validation\Validator;
 
+$rule = Validator::callback('is_int')->setTemplate('{{name}} is not tasty');
 try {
-    Validator::callback('is_int')->setTemplate('{{name}} is not tasty')->assert('something');
+    $rule->assert('something');
+} catch (NestedValidationException $e) {
+    echo $e->getMainMessage();
+}
+
+echo PHP_EOL;
+
+try {
+    $rule->check('something');
 } catch (NestedValidationException $e) {
     echo $e->getMainMessage();
 }
 ?>
 --EXPECTF--
+"something" is not tasty
 "something" is not tasty


### PR DESCRIPTION
When there is just one rule in the chain and the there is a defined template for that, the expected behaviour when using the `check()` method is to see the exception message with the defined template.

***
Fix #662