### PR TITLE
Validate month format using UNIX epoch

### DIFF
--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -35,6 +35,10 @@ class Date extends AbstractRule
         $exceptionalFormats = [
             'c' => 'Y-m-d\TH:i:sP',
             'r' => 'D, d M Y H:i:s O',
+            'm' => '!m',
+            'n' => '!n',
+            'F' => '!F',
+            'M' => '!M'
         ];
 
         if (in_array($this->format, array_keys($exceptionalFormats))) {

--- a/tests/unit/Rules/DateTest.php
+++ b/tests/unit/Rules/DateTest.php
@@ -93,13 +93,22 @@ class DateTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->dateValidator->assert('2009-09-09'));
     }
 
-    public function testDateTimeExceptionalFormatsThatShouldBeValid()
+    /**
+     * @dataProvider provideFormatAndValidInput
+     */
+    public function testDateTimeExceptionalFormatsThatShouldBeValid($format, $validInput)
     {
-        $this->dateValidator = new Date('c');
-        $this->assertTrue($this->dateValidator->assert('2004-02-12T15:19:21+00:00'));
+        $this->dateValidator = new Date($format);
+        $this->assertTrue($this->dateValidator->assert($validInput));
+    }
 
-        $this->dateValidator = new Date('r');
-        $this->assertTrue($this->dateValidator->assert('Thu, 29 Dec 2005 01:02:03 +0000'));
+    public function provideFormatAndValidInput()
+    {
+        return array(
+            array('c', '2004-02-12T15:19:21+00:00'),
+            array('r', 'Thu, 29 Dec 2005 01:02:03 +0000'),
+            array('m', '02')
+        );
     }
 
     /**


### PR DESCRIPTION
When using `date` rule to validate only the month portion of a date,
depending of *when* you validate something you might [have a strange
behavior][1].

If you want to validate `v::date('m')->validate('02')` for instance, if
you are on the 30th or 31th of a month you will get a `false` as an
answer. This happens because we use `DateTime::createFromFormat` and it
uses the current time for portions of the format which are omited.
So, the following happens internally:

    php > echo date('Y-m-d', strtotime('2015-02-30'));
    2015-03-02

As the month given by the `DateTime` object will be "03", the date check
now fails.
This fixes the problem by using `!` in the format (if it is only related
trying to validate a month) which forces the `createFromFormat` method
to use the Unix Epoch as the rest of the date instead of the current
time. Making this happen:

    php > echo date('Y-m-d', strtotime('1970-02-01'));
    1970-02-01

The test made will only break on 30th and 31th (and 29th depending on
the year), so it is not perfect.

  [1]: http://stackoverflow.com/questions/29346953