### PR TITLE
Added Method validation

### DIFF
--- a/library/Exceptions/MethodException.php
+++ b/library/Exceptions/MethodException.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions;
+
+class MethodException extends NestedValidationException
+{
+    const NOT_PRESENT = 0;
+    const INVALID = 1;
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::NOT_PRESENT => 'Method {{name}} must be present',
+            self::INVALID => 'Method {{name}} must be valid',
+        ],
+        self::MODE_NEGATIVE => [
+            self::NOT_PRESENT => 'Method {{name}} must not be present',
+            self::INVALID => 'Method {{name}} must not validate',
+        ],
+    ];
+
+    public function chooseTemplate()
+    {
+        return $this->getParam('hasReference') ? static::INVALID : static::NOT_PRESENT;
+    }
+}

--- a/library/Rules/Method.php
+++ b/library/Rules/Method.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+use ReflectionMethod;
+use Respect\Validation\Exceptions\ComponentException;
+use Respect\Validation\Validatable;
+
+class Method extends AbstractRelated
+{
+
+    /**
+     * An array of arguments that should be passed to the method.
+     *
+     * @var array
+     */
+    protected $methodArgs = [];
+
+    public function __construct($reference, Validatable $validator = null, $mandatory = true, $methodArgs = [])
+    {
+        if(!is_string($reference) || empty($reference)) {
+            throw new ComponentException('Invalid method name');
+        }
+
+        parent::__construct($reference, $validator, $mandatory);
+    }
+
+    public function getReferenceValue($input)
+    {
+        $methodMirror = new ReflectionMethod($input, $this->reference);
+        $methodMirror->setAccessible(true);
+
+        return $methodMirror->invokeArgs($input, $this->methodArgs);
+    }
+
+    public function hasReference($input)
+    {
+        return is_object($input) && method_exists($input, $this->reference);
+    }
+}

--- a/tests/unit/Rules/MethodTest.php
+++ b/tests/unit/Rules/MethodTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+class PrivMethodClass
+{
+    private $bar = 'foo';
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+
+    private function getPrivateBar()
+    {
+        return $this->bar;
+    }
+}
+
+/**
+ * @group  rule
+ * @covers Respect\Validation\Rules\Method
+ * @covers Respect\Validation\Exceptions\MethodException
+ */
+class MethodTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMethodWithNoExtraValidationShouldCheckItsPresence()
+    {
+        $validator = new Method('getBar');
+        $obj = new PrivMethodClass();
+        $this->assertTrue($validator->check($obj));
+        $this->assertTrue($validator->__invoke($obj));
+        $this->assertTrue($validator->assert($obj));
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\MethodException
+     */
+    public function testAbsentMethodShouldRaiseMethodException()
+    {
+        $validator = new Method('getMadeupBar');
+        $obj = new PrivMethodClass();
+        $this->assertFalse($validator->__invoke($obj));
+        $this->assertFalse($validator->assert($obj));
+    }
+    /**
+     * @expectedException Respect\Validation\Exceptions\ValidationException
+     */
+    public function testAbsentMethodShouldRaiseMethodException_on_check()
+    {
+        $validator = new Method('getMadeupBar');
+        $obj = new PrivMethodClass();
+        $this->assertFalse($validator->__invoke($obj));
+        $this->assertFalse($validator->check($obj));
+    }
+
+    /**
+     * @dataProvider providerForInvalidMethodNames
+     * @expectedException Respect\Validation\Exceptions\ComponentException
+     */
+    public function testInvalidConstructorArgumentsShouldThrowComponentException($methodName)
+    {
+        $validator = new Method($methodName);
+    }
+
+    public function providerForInvalidMethodNames()
+    {
+        return [
+            [new \stdClass()],
+            [123],
+            [''],
+        ];
+    }
+
+    public function testExtraValidatorRulesForMethod()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getBar', $subValidator);
+        $obj = new PrivMethodClass();
+        $this->assertTrue($validator->__invoke($obj));
+        $this->assertTrue($validator->assert($obj));
+        $this->assertTrue($validator->check($obj));
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\MethodException
+     */
+    public function testShouldNotValidateEmptyString()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getBar', $subValidator);
+
+        $this->assertFalse($validator->__invoke(''));
+        $validator->assert('');
+    }
+
+    public function testExtraValidatorRulesForMethod_should_fail_if_invalid()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getBar', $subValidator);
+        $obj = new PrivMethodClass();
+        $obj->setBar('foo hey this has more than 3 chars');
+        $this->assertFalse($validator->__invoke($obj));
+    }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\LengthException
+     */
+    public function testExtraValidatorRulesForMethod_should_raise_extra_validator_exception_on_check()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getBar', $subValidator);
+        $obj = new PrivMethodClass();
+        $obj->setBar('foo hey this has more than 3 chars');
+        $this->assertFalse($validator->check($obj));
+    }
+    /**
+     * @expectedException Respect\Validation\Exceptions\MethodException
+     */
+    public function testExtraValidatorRulesForMethod_should_raise_MethodException_on_assert()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getBar', $subValidator);
+        $obj = new PrivMethodClass();
+        $obj->setBar('foo hey this has more than 3 chars');
+        $this->assertFalse($validator->assert($obj));
+    }
+
+    public function testNotMandatoryMethodShouldNotFailWhenMethodIsAbsent()
+    {
+        $validator = new Method('getMadeupBar', null, false);
+        $obj = new PrivMethodClass();
+        $this->assertTrue($validator->__invoke($obj));
+    }
+
+    public function testNotMandatoryMethodShouldNotFailWhenMethodIsAbsent_with_extra_validator()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getMadeupBar', $subValidator, false);
+        $obj = new PrivMethodClass();
+        $this->assertTrue($validator->__invoke($obj));
+    }
+
+    public function testPrivateMethodShouldAlsoBeChecked()
+    {
+        $subValidator = new Length(1, 3);
+        $validator = new Method('getPrivateBar', $subValidator);
+        $obj = new PrivMethodClass();
+        $this->assertTrue($validator->assert($obj));
+    }
+
+    public function testPrivateMethodShouldFailIfNotValid()
+    {
+        $subValidator = new Length(33333, 888888);
+        $validator = new Method('getPrivateBar', $subValidator);
+        $obj = new PrivMethodClass();
+        $this->assertFalse($validator->__invoke($obj));
+    }
+}
+


### PR DESCRIPTION
This adds the ability to validate a class instance based on method return values. Its based off the `Attribute` rule.

The use case for this is classes which must implement an interface. In these cases, you can't rely on properties existing so the attribute rule can't be used.

Example:
```
interface MyInterface
{
    public function getMyValue();
}

class MyClass implements MyInterface
{
    protected $myValue = 'My value';
    public function getMyValue()
    {
        return $this->myValue;
    }
}

class MyOtherClass implements MyInterface
{
    protected $dataSource;
    public function getMyValue()
    {
        return $this->dataSource->get('myValue').
     }
}
````

I'd be happy to write some docs for this but would like to hear some feedback before moving forward.

Thanks.