### PR TITLE
Fixes 'KeySet' rule when input is not array type

### DIFF
--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -87,6 +87,10 @@ class KeySet extends AllOf
      */
     private function hasValidStructure($input)
     {
+        if (!is_array($input)) {
+            return false;
+        }
+
         foreach ($this->getRules() as $keyRule) {
             if (!array_key_exists($keyRule->reference, $input) && $keyRule->mandatory) {
                 return false;

--- a/tests/unit/Rules/KeySetTest.php
+++ b/tests/unit/Rules/KeySetTest.php
@@ -172,4 +172,25 @@ class KeySetTest extends PHPUnit_Framework_TestCase
         $keySet = new KeySet($key1, $key2);
         $keySet->assert($input);
     }
+
+    /**
+     * @expectedException Respect\Validation\Exceptions\KeySetException
+     * @expectedExceptionMessage Must have keys { "name" }
+     * @dataProvider providerForInvalidArguments
+     */
+    public function testShouldThrowExceptionInCaseArgumentIsAnythingOtherThanArray($input)
+    {
+        $keySet = new KeySet(new Key('name'));
+        $keySet->assert($input);
+    }
+
+    public function providerForInvalidArguments()
+    {
+        return [
+            [''],
+            [null],
+            [0],
+            [new \stdClass()]
+        ];
+    }
 }


### PR DESCRIPTION
Reported on #670