### PR TITLE
Fix wrong behaviour on AbstractRelated

### DIFF
--- a/library/Exceptions/NestedValidationException.php
+++ b/library/Exceptions/NestedValidationException.php
@@ -68,7 +68,9 @@ class NestedValidationException extends ValidationException implements IteratorA
             $numericKey = is_numeric($key);
             $path = $numericKey ? $value : $key;
 
-            $exception = $this->findRelated($path);
+            if (!($exception = $this->getRelatedByName($path))) {
+                $exception = $this->findRelated($path);
+            }
 
             $path = str_replace('.', '_', $path);
 

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -324,7 +324,7 @@ class ValidationException extends InvalidArgumentException implements ExceptionI
         return static::$defaultTemplates[$this->mode][$templateKey];
     }
 
-    protected function guessId()
+    public function guessId()
     {
         if (!empty($this->id) && $this->id != 'validation') {
             return $this->id;

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -26,11 +26,14 @@ abstract class AbstractRelated extends AbstractRule
 
     public function __construct($reference, Validatable $validator = null, $mandatory = true)
     {
+        $this->setName($reference);
+        if ($validator && !$validator->getName()) {
+            $validator->setName($reference);
+        }
+
         $this->reference = $reference;
         $this->validator = $validator;
         $this->mandatory = $mandatory;
-
-        $this->setName($reference);
     }
 
     public function setName($name)

--- a/tests/integration/find_messages_should_apply_templates_to_flattened_messages.phpt
+++ b/tests/integration/find_messages_should_apply_templates_to_flattened_messages.phpt
@@ -47,5 +47,5 @@ try {
 Array
 (
     [allOf] => Invalid Validation Form
-    [first_name_length] => Invalid length for security_question "fiif"
+    [first_name_length] => Invalid length for first_name "fiif"
 )

--- a/tests/integration/find_messages_should_return_composite_validation_messages_flattened.phpt
+++ b/tests/integration/find_messages_should_return_composite_validation_messages_flattened.phpt
@@ -41,5 +41,5 @@ try {
 Array
 (
     [allOf] => All of the required rules must pass for Validation Form
-    [first_name_length] => security_question must have a length between 5 and 256
+    [first_name_length] => first_name must have a length between 5 and 256
 )

--- a/tests/integration/issue-620.phpt
+++ b/tests/integration/issue-620.phpt
@@ -1,0 +1,27 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+$object = new \stdClass;
+$object->email = 'Not an email';
+$object->password = 'Ale xandre';
+
+try {
+    v::create()
+        ->attribute('email', v::email()->setName('Email Field'))
+        ->attribute('password', v::noWhitespace()->setName('Password Field'))
+        ->assert($object);
+} catch (NestedValidationException $exception) {
+    print_r($exception->getMessages());
+}
+?>
+--EXPECTF--
+Array
+(
+    [0] => Email Field must be valid email
+    [1] => Password Field must not contain whitespace
+)

--- a/tests/integration/issue-620.phpt
+++ b/tests/integration/issue-620.phpt
@@ -17,6 +17,10 @@ try {
         ->assert($object);
 } catch (NestedValidationException $exception) {
     print_r($exception->getMessages());
+    print_r($exception->findMessages([
+        'email' => 'Error: {{name}}',
+        'noWhitespace' => 'Error: {{name}}'
+    ]));
 }
 ?>
 --EXPECTF--
@@ -24,4 +28,9 @@ Array
 (
     [0] => Email Field must be valid email
     [1] => Password Field must not contain whitespace
+)
+Array
+(
+    [email] => Error: Email Field
+    [noWhitespace] => Error: Password Field
 )

--- a/tests/integration/issue-689.phpt
+++ b/tests/integration/issue-689.phpt
@@ -1,0 +1,57 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+$input = [
+    'organization' => [
+        'name' => 'N',
+        'address' => 'A',
+    ],
+    'contact' => [
+        'name' => 'wd',
+        'email' => 'ffesfewf2232313123212',
+        'password' => ' ',
+        'position' => 'wdwdwf',
+        'number' => '£"!@£;21#£:"!:£~!":£\'21;',
+    ],
+];
+
+try {
+    v::create()
+        ->key(
+            'organization',
+            v::create()
+                ->key('name', v::length(2, 50)->notEmpty())
+                ->key('address', v::length(2, 50)->notEmpty())
+        )
+        ->keyNested('contact.name', v::length(1, 50)->notEmpty())
+        ->keyNested('contact.email', v::email()->notEmpty())
+        ->keyNested('contact.password', v::length(3, 100)->notEmpty())
+        ->keyNested('contact.position', v::length(1, 100)->notEmpty())
+        ->keyNested('contact.number', v::phone()->notEmpty())
+        ->assert($input);
+} catch (NestedValidationException $exception) {
+    print_r(array_filter($exception->findMessages([
+        'organization.name' => 'Center name',
+        'organization.address' => 'Center address',
+        'contact.name' => 'Contact name',
+        'contact.password' => 'Contact name',
+        'contact.position' => 'Contact name',
+        'contact.number' => 'Contact name',
+        'contact.email' => 'Contact name',
+    ])));
+}
+?>
+--EXPECTF--
+Array
+(
+    [organization_name] => Center name
+    [organization_address] => Center address
+    [contact_password] => Contact name
+    [contact_number] => Contact name
+    [contact_email] => Contact name
+)

--- a/tests/integration/issue-719.phpt
+++ b/tests/integration/issue-719.phpt
@@ -1,0 +1,33 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+$input = [
+    'user_name' => 'MyName111',
+    'user_surname' => 'MySurname111',
+    'user_tel' => 'asd123'
+];
+
+$rules = [
+    v::key('user_name',     v::numeric())->setName('First Name'),
+    v::key('user_surname',  v::numeric())->setName('Second Name'),
+    v::key('user_tel',      v::phone())->setName('Phone number'),
+];
+
+try{
+    v::allOf($rules)->setName('Validation Form')->assert($input);
+} catch (NestedValidationException $exception) {
+    print_r($exception->findMessages(array_keys($input)));
+}
+?>
+--EXPECTF--
+Array
+(
+    [user_name] => user_name must be numeric
+    [user_surname] => user_surname must be numeric
+    [user_tel] => user_tel must be a valid telephone number
+)

--- a/tests/integration/should_not_overwrite_defined_names.phpt
+++ b/tests/integration/should_not_overwrite_defined_names.phpt
@@ -1,0 +1,33 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validator as v;
+
+$input = ['email' => 'not an email'];
+
+try {
+    v::key('email', v::email()->setName('Email'))->setName('Foo')->check($input);
+} catch (ValidationException $exception) {
+    echo $exception->getMainMessage().PHP_EOL;
+}
+
+try {
+    // This is a trick thing: the call to `setName()` here seems to be the one
+    // from the `Key` rule but it's actually from the `Validator`.
+    v::key('email', v::email())->setName('Email')->check($input);
+} catch (ValidationException $exception) {
+    echo $exception->getMainMessage().PHP_EOL;
+}
+
+try {
+    v::key('email', v::email())->check($input);
+} catch (ValidationException $exception) {
+    echo $exception->getMainMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+Email must be valid email
+email must be valid email
+email must be valid email

--- a/tests/unit/Rules/AbstractRelatedTest.php
+++ b/tests/unit/Rules/AbstractRelatedTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+final class AbstractRelatedTest extends \PHPUnit_Framework_TestCase
+{
+    const NAME = 'Respect\\Validation\\Rules\\AbstractRelated';
+
+    public function testShouldAcceptReferenceOnConstructor()
+    {
+        $reference = 'something';
+
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs([$reference])
+            ->getMock();
+
+        $this->assertSame($reference, $abstractMock->reference);
+    }
+
+    public function testShouldBeMandatoryByDefault()
+    {
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs(['something'])
+            ->getMock();
+
+        $this->assertTrue($abstractMock->mandatory);
+    }
+
+    public function testShouldAcceptReferenceAndRuleOnConstructor()
+    {
+        $ruleMock = $this->getMock('Respect\\Validation\\Validatable');
+
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs(['something', $ruleMock])
+            ->getMock();
+
+        $this->assertSame($ruleMock, $abstractMock->validator);
+    }
+
+    public function testShouldDefineRuleNameAsReferenceWhenRuleDoesNotHaveAName()
+    {
+        $reference = 'something';
+
+        $ruleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $ruleMock
+            ->expects($this->at(0))
+            ->method('getName')
+            ->will($this->returnValue(null));
+        $ruleMock
+            ->expects($this->at(1))
+            ->method('setName')
+            ->with($reference);
+
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs(['something', $ruleMock])
+            ->getMock();
+
+        $this->assertSame($ruleMock, $abstractMock->validator);
+    }
+
+    public function testShouldNotDefineRuleNameAsReferenceWhenRuleDoesHaveAName()
+    {
+        $reference = 'something';
+
+        $ruleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $ruleMock
+            ->expects($this->at(0))
+            ->method('getName')
+            ->will($this->returnValue('something else'));
+        $ruleMock
+            ->expects($this->never())
+            ->method('setName');
+
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs(['something', $ruleMock])
+            ->getMock();
+
+        $this->assertSame($ruleMock, $abstractMock->validator);
+    }
+
+    public function testShouldAcceptMandatoryFlagOnConstructor()
+    {
+        $mandatory = false;
+
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs(['something', $this->getMock('Respect\\Validation\\Validatable'), $mandatory])
+            ->getMock();
+
+        $this->assertSame($mandatory, $abstractMock->mandatory);
+    }
+
+    public function testShouldDefineChildNameWhenDefiningTheNameOfTheParent()
+    {
+        $name = 'My new name';
+        $reference = 'something';
+
+        $ruleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $ruleMock
+            ->expects($this->at(0))
+            ->method('getName')
+            ->will($this->returnValue('something else'));
+        $ruleMock
+            ->expects($this->at(1))
+            ->method('setName')
+            ->with($name);
+
+        $abstractMock = $this
+            ->getMockBuilder(self::NAME)
+            ->setConstructorArgs(['something', $ruleMock])
+            ->getMock();
+
+        $ruleMock->setName($name);
+    }
+}


### PR DESCRIPTION
When you define the name for an `AbstractRelated` instance, you expect
that it also define the name for its child. But, when the child already
had a name the `AbstractRelated` was overwriting its name with the
`reference`.

***
Closes #724 
Closes #725
Fixes #719
Fixes #620
Fixes #689