### PR TITLE
improve grammar

### DIFF
--- a/library/Exceptions/EqualsException.php
+++ b/library/Exceptions/EqualsException.php
@@ -15,10 +15,10 @@ class EqualsException extends ValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be equals {{compareTo}}',
+            self::STANDARD => '{{name}} must equal {{compareTo}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be equals {{compareTo}}',
+            self::STANDARD => '{{name}} must not equal {{compareTo}}',
         ],
     ];
 }


### PR DESCRIPTION
'must equal' is better than 'must be equals'. Equally correct is 'must be equal to', but is more verbose.