### PR TITLE
replace deprecated getMock with createMock in test cases

### DIFF
--- a/tests/unit/Rules/AbstractCompositeTest.php
+++ b/tests/unit/Rules/AbstractCompositeTest.php
@@ -17,7 +17,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
         $simpleRuleMock
             ->expects($this->once())
             ->method('getName')
@@ -40,7 +40,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
         $ruleName1 = 'something';
         $ruleName2 = 'something else';
 
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
         $simpleRuleMock
             ->expects($this->at(0))
             ->method('getName')
@@ -69,7 +69,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldNotUpdateInternalRuleAlreadyHasAName()
     {
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
         $simpleRuleMock
             ->expects($this->any())
             ->method('getName')
@@ -90,7 +90,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
         $simpleRuleMock
             ->expects($this->any())
             ->method('getName')
@@ -112,7 +112,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
         $simpleRuleMock
             ->expects($this->any())
             ->method('getName')
@@ -134,7 +134,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
         $simpleRuleMock
             ->expects($this->any())
             ->method('getName')
@@ -153,7 +153,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testRemoveRulesShouldRemoveAllTheAddedRules()
     {
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
 
         $compositeRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractComposite');
         $compositeRuleMock->addRule($simpleRuleMock);
@@ -165,9 +165,9 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
     public function testShouldReturnTheAmountOfAddedRules()
     {
         $compositeRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractComposite');
-        $compositeRuleMock->addRule($this->getMock('Respect\\Validation\\Validatable'));
-        $compositeRuleMock->addRule($this->getMock('Respect\\Validation\\Validatable'));
-        $compositeRuleMock->addRule($this->getMock('Respect\\Validation\\Validatable'));
+        $compositeRuleMock->addRule($this->createMock('Respect\\Validation\\Validatable'));
+        $compositeRuleMock->addRule($this->createMock('Respect\\Validation\\Validatable'));
+        $compositeRuleMock->addRule($this->createMock('Respect\\Validation\\Validatable'));
 
         $this->assertCount(3, $compositeRuleMock->getRules());
     }
@@ -181,19 +181,19 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testHasRuleShouldReturnFalseWhenRuleIsNotFound()
     {
-        $oneSimpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $oneSimpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
 
         $compositeRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractComposite');
         $compositeRuleMock->addRule($oneSimpleRuleMock);
 
-        $anotherSimpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $anotherSimpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
 
         $this->assertFalse($compositeRuleMock->hasRule($anotherSimpleRuleMock));
     }
 
     public function testHasRuleShouldReturnFalseWhenRulePassedAsStringIsNotFound()
     {
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
 
         $compositeRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractComposite');
         $compositeRuleMock->addRule($simpleRuleMock);
@@ -203,7 +203,7 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testHasRuleShouldReturnTrueWhenRuleIsFound()
     {
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
 
         $compositeRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractComposite');
         $compositeRuleMock->addRule($simpleRuleMock);
@@ -213,8 +213,8 @@ class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldAddRulesByPassingThroughConstructor()
     {
-        $simpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
-        $anotherSimpleRuleMock = $this->getMock('Respect\\Validation\\Validatable');
+        $simpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
+        $anotherSimpleRuleMock = $this->createMock('Respect\\Validation\\Validatable');
 
         $compositeRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractComposite', [
             $simpleRuleMock,

--- a/tests/unit/Rules/AbstractRelatedTest.php
+++ b/tests/unit/Rules/AbstractRelatedTest.php
@@ -24,7 +24,7 @@ class AbstractRelatedTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructionOfAbstractRelatedClass()
     {
-        $validatableMock = $this->getMock('Respect\\Validation\\Validatable');
+        $validatableMock = $this->createMock('Respect\\Validation\\Validatable');
         $relatedRuleMock = $this->getMockForAbstractClass('Respect\\Validation\\Rules\\AbstractRelated', ['foo', $validatableMock]);
 
         $this->assertEquals('foo', $relatedRuleMock->getName());
@@ -38,7 +38,7 @@ class AbstractRelatedTest extends \PHPUnit_Framework_TestCase
      */
     public function testOperationsShouldReturnTrueWhenReferenceValidatesItsValue($method)
     {
-        $validatableMock = $this->getMock('Respect\\Validation\\Validatable');
+        $validatableMock = $this->createMock('Respect\\Validation\\Validatable');
         $validatableMock->expects($this->any())
             ->method($method)
             ->will($this->returnValue(true));

--- a/tests/unit/Rules/AbstractWrapperTest.php
+++ b/tests/unit/Rules/AbstractWrapperTest.php
@@ -35,7 +35,7 @@ class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldReturnDefinedValidatable()
     {
-        $validatable = $this->getMock('Respect\Validation\Validatable');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
 
         $wrapper = $this->getMockForAbstractClass('Respect\Validation\Rules\AbstractWrapper');
         $this->bindValidatable($wrapper, $validatable);
@@ -47,7 +47,7 @@ class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $input = 'Whatever';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
         $validatable
             ->expects($this->once())
             ->method('validate')
@@ -64,7 +64,7 @@ class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $input = 'Whatever';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
         $validatable
             ->expects($this->once())
             ->method('assert')
@@ -81,7 +81,7 @@ class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $input = 'Whatever';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
         $validatable
             ->expects($this->once())
             ->method('check')
@@ -98,7 +98,7 @@ class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $name = 'Whatever';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
         $validatable
             ->expects($this->once())
             ->method('setName')

--- a/tests/unit/Rules/BankAccountTest.php
+++ b/tests/unit/Rules/BankAccountTest.php
@@ -23,8 +23,8 @@ class BankAccountTest extends LocaleTestCase
         $countryCode = 'XX';
         $bank = '123456';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
-        $factory = $this->getMock('Respect\Validation\Rules\Locale\Factory');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
+        $factory = $this->createMock('Respect\Validation\Rules\Locale\Factory');
         $factory
             ->expects($this->once())
             ->method('bankAccount')

--- a/tests/unit/Rules/BankTest.php
+++ b/tests/unit/Rules/BankTest.php
@@ -22,8 +22,8 @@ class BankTest extends LocaleTestCase
     {
         $countryCode = 'XX';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
-        $factory = $this->getMock('Respect\Validation\Rules\Locale\Factory');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
+        $factory = $this->createMock('Respect\Validation\Rules\Locale\Factory');
         $factory
             ->expects($this->once())
             ->method('bank')

--- a/tests/unit/Rules/BicTest.php
+++ b/tests/unit/Rules/BicTest.php
@@ -22,8 +22,8 @@ class BicTest extends LocaleTestCase
     {
         $countryCode = 'XX';
 
-        $validatable = $this->getMock('Respect\Validation\Validatable');
-        $factory = $this->getMock('Respect\Validation\Rules\Locale\Factory');
+        $validatable = $this->createMock('Respect\Validation\Validatable');
+        $factory = $this->createMock('Respect\Validation\Rules\Locale\Factory');
         $factory
             ->expects($this->once())
             ->method('bic')

--- a/tests/unit/Rules/ExecutableTest.php
+++ b/tests/unit/Rules/ExecutableTest.php
@@ -52,7 +52,7 @@ class ExecutableTest extends \PHPUnit_Framework_TestCase
     public function testShouldValidateObjects()
     {
         $rule = new Executable();
-        $object = $this->getMock('SplFileInfo', ['isExecutable'], ['somefile.txt']);
+        $object = $this->createMock('SplFileInfo', ['isExecutable'], ['somefile.txt']);
         $object->expects($this->once())
                 ->method('isExecutable')
                 ->will($this->returnValue(true));

--- a/tests/unit/Rules/FileTest.php
+++ b/tests/unit/Rules/FileTest.php
@@ -61,7 +61,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
     public function testShouldValidateObjects()
     {
         $rule = new File();
-        $object = $this->getMock('SplFileInfo', ['isFile'], ['somefile.txt']);
+        $object = $this->createMock('SplFileInfo', ['isFile'], ['somefile.txt']);
         $object->expects($this->once())
                 ->method('isFile')
                 ->will($this->returnValue(true));

--- a/tests/unit/Rules/OptionalTest.php
+++ b/tests/unit/Rules/OptionalTest.php
@@ -50,7 +50,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldAcceptInstanceOfValidatobleOnConstructor()
     {
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $rule = new Optional($validatable);
 
         $this->assertSame($validatable, $rule->getValidatable());
@@ -61,7 +61,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldNotValidateRuleWhenInputIsOptional($input)
     {
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $validatable
             ->expects($this->never())
             ->method('validate');
@@ -76,7 +76,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testShouldValidateRuleWhenInputIsNotOptional($input)
     {
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $validatable
             ->expects($this->once())
             ->method('validate')
@@ -90,7 +90,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldNotAssertRuleWhenInputIsOptional()
     {
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $validatable
             ->expects($this->never())
             ->method('assert');
@@ -104,7 +104,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
     {
         $input = 'foo';
 
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $validatable
             ->expects($this->once())
             ->method('assert')
@@ -118,7 +118,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldNotCheckRuleWhenInputIsOptional()
     {
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $validatable
             ->expects($this->never())
             ->method('check');
@@ -132,7 +132,7 @@ class OptionalTest extends \PHPUnit_Framework_TestCase
     {
         $input = 'foo';
 
-        $validatable = $this->getMock('Respect\\Validation\\Validatable');
+        $validatable = $this->createMock('Respect\\Validation\\Validatable');
         $validatable
             ->expects($this->once())
             ->method('check')

--- a/tests/unit/Rules/ReadableTest.php
+++ b/tests/unit/Rules/ReadableTest.php
@@ -61,7 +61,7 @@ class ReadableTest extends \PHPUnit_Framework_TestCase
     public function testShouldValidateObjects()
     {
         $rule = new Readable();
-        $object = $this->getMock('SplFileInfo', ['isReadable'], ['somefile.txt']);
+        $object = $this->createMock('SplFileInfo', ['isReadable'], ['somefile.txt']);
         $object->expects($this->once())
                 ->method('isReadable')
                 ->will($this->returnValue(true));

--- a/tests/unit/Rules/SymbolicLinkTest.php
+++ b/tests/unit/Rules/SymbolicLinkTest.php
@@ -61,7 +61,7 @@ class SymbolicLinkTest extends \PHPUnit_Framework_TestCase
     public function testShouldValidateObjects()
     {
         $rule = new SymbolicLink();
-        $object = $this->getMock('SplFileInfo', ['isLink'], ['somelink.lnk']);
+        $object = $this->createMock('SplFileInfo', ['isLink'], ['somelink.lnk']);
         $object->expects($this->once())
                 ->method('isLink')
                 ->will($this->returnValue(true));

--- a/tests/unit/Rules/WritableTest.php
+++ b/tests/unit/Rules/WritableTest.php
@@ -61,7 +61,7 @@ class WritableTest extends \PHPUnit_Framework_TestCase
     public function testShouldValidateObjects()
     {
         $rule = new Writable();
-        $object = $this->getMock('SplFileInfo', ['isWritable'], ['somefile.txt']);
+        $object = $this->createMock('SplFileInfo', ['isWritable'], ['somefile.txt']);
         $object->expects($this->once())
                 ->method('isWritable')
                 ->will($this->returnValue(true));


### PR DESCRIPTION
It's better to have those unit tests pass without warnings :sunglasses: 