### PR TITLE
Make PHP extension mbstring required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "egulias/email-validator": "~1.2",


### PR DESCRIPTION
Issues like [issue 717](https://github.com/Respect/Validation/issues/717) can detected before, just letting composer stop the install if this extension is missing.

I haven't check if any other validator apart from `LengthValidator` use `mb_*` functions, though.