### PR TITLE
Always return a valid exception

### DIFF
--- a/library/Exceptions/NestedValidationException.php
+++ b/library/Exceptions/NestedValidationException.php
@@ -53,6 +53,8 @@ class NestedValidationException extends ValidationException implements IteratorA
         foreach ($exception as $subException) {
             return $subException;
         }
+
+        return $exception;
     }
 
     /**

--- a/tests/integration/issue-690.phpt
+++ b/tests/integration/issue-690.phpt
@@ -1,0 +1,61 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+$input = [
+    'contact1' => [
+        'daymark' => 'ffesfewf2232313123212',
+        'building' => [
+            'enable' => 'd',
+            'blank' => 'ffesfewf2232313123212',
+            'powerdown' => '5',
+            'powerup' => 'wdwdwf',
+        ],
+    ],
+    'contact2' => [
+        'name' => 'wd',
+        'daymark' => 'ffesfewf2232313123212',
+        'building' => [
+            'enable' => '1',
+            'blank' => '1',
+            'powerdown' => '1',
+            'powerup' => '1',
+        ],
+    ],
+];
+
+try {
+    v::create()
+        ->each(
+            v::create()
+                ->key('name', v::length(1, 50))
+                ->key('daymark', v::length(1, 50))
+                ->key(
+                    'building',
+                    v::create()
+                        ->key('enable', v::length(2, 50))
+                        ->key('time', v::length(2, 50))
+                        ->key('powerdown', v::length(2, 50))
+                        ->key('powerup', v::length(2, 50))
+                )
+        )
+        ->assert($input);
+} catch (NestedValidationException $exception) {
+    print_r(array_filter($exception->findMessages([
+        'each.name' => 'Center name',
+        'each.building.enable' => 'Center time',
+        'each.building.powerdown' => 'Center time',
+    ])));
+}
+?>
+--EXPECTF--
+Array
+(
+    [each_name] => Center name
+    [each_building_enable] => Center time
+    [each_building_powerdown] => Center time
+)


### PR DESCRIPTION
If calling the method `getExceptionForPath()` when the exception was
nested but had no child it was returning null. This commit ensures that
it always return a valid exception.

***
Fix bug reported on #690.