### PR TITLE
Update MasterCard BIN Range

### DIFF
--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -35,7 +35,7 @@ class CreditCard extends AbstractRule
         self::DINERS_CLUB => '/^3(?:0[0-5]|[68]\d)\d{11}$/',
         self::DISCOVER => '/^6(?:011|5\d{2})\d{12}$/',
         self::JCB => '/^(?:2131|1800|35\d{3})\d{11}$/',
-        self::MASTERCARD => '/^5[1-5]\d{14}$/',
+        self::MASTERCARD => '/(5[1-5]|2[2-7])\d{14}$/',
         self::VISA => '/^4\d{12}(?:\d{3})?$/',
     ];
 

--- a/tests/unit/Rules/CreditCardTest.php
+++ b/tests/unit/Rules/CreditCardTest.php
@@ -54,8 +54,10 @@ class CreditCardTest extends RuleTestCase
         $visa = new CreditCard(CreditCard::VISA);
 
         return [
-            [$general, '5376 7473 9720 8720'], // MasterCard
+            [$general, '5376 7473 9720 8720'], // MasterCard 5 BIN Range
             [$master, '5376 7473 9720 8720'],
+            [$general, '2223000048400011'], // MasterCard 2 BIN Range
+            [$master, '2222 4000 4124 0011'],
             [$general, '4024.0071.5336.1885'], // Visa 16
             [$visa, '4024.0071.5336.1885'],
             [$general, '4024 007 193 879'], // Visa 13


### PR DESCRIPTION
MasterCard has announced that they are increasing the number of potentially valid credit card numbers by adding new BINs (bank identification numbers, i.e., the first six digits of the credit card number). Effective January 2017, banks may begin to issue MasterCard credit cards starting with "2" instead of the usual "5". This major change was announced last year, and MasterCard is expecting acceptance compliance by June 2017.

This PR updates the valid MasterCard card number ranges, modifying the regular expression to support 16-digit card numbers starting with 22-27. Additionally, it adds a published test card number to the CreditCard unit test. No updates to the Exception are necessary.

Additional information on the BIN range update can be found at:
https://www.mastercard.us/en-us/issuers/get-support/2-series-bin-expansion.html