### PR TITLE
do not skip `AttributeException` during recursive iteration

### DIFF
--- a/library/Exceptions/AbstractRelatedExceptionInterface.php
+++ b/library/Exceptions/AbstractRelatedExceptionInterface.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class CallException extends GroupedValidationException implements AbstractRelatedExceptionInterface
+interface AbstractRelatedExceptionInterface extends ExceptionInterface
 {
+
 }

--- a/library/Exceptions/AttributeException.php
+++ b/library/Exceptions/AttributeException.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class AttributeException extends NestedValidationException
+class AttributeException extends NestedValidationException implements AbstractRelatedExceptionInterface
 {
     const NOT_PRESENT = 0;
     const INVALID = 1;

--- a/library/Exceptions/NestedValidationException.php
+++ b/library/Exceptions/NestedValidationException.php
@@ -137,11 +137,12 @@ class NestedValidationException extends ValidationException implements IteratorA
         $knownDepths = [];
         foreach ($recursiveIteratorIterator as $childException) {
             if ($childException instanceof self
-                && $childException->getRelated()->count() > 0
-                && $childException->getRelated()->count() < 2) {
-                continue;
+                && $childException->getRelated()->count() === 1) {
+                $relatedException = iterator_to_array($childException->getRelated())[0];
+                if (! $relatedException instanceof  AbstractRelatedExceptionInterface) {
+                    continue;
+                }
             }
-
             $currentDepth = $lastDepth;
             $currentDepthOriginal = $recursiveIteratorIterator->getDepth() + 1;
 

--- a/tests/integration/assert-with-attributes.phpt
+++ b/tests/integration/assert-with-attributes.phpt
@@ -1,0 +1,53 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    $array = [
+        'mysql' => [
+            'host' => 42,
+            'user' => 'user',
+            'password' => 'password',
+            'schema' => 'schema',
+        ],
+        'postgresql' => [
+            'host' => 'host',
+            'user' => 42,
+            'password' => 'password',
+            'schema' => 'schema',
+        ],
+    ];
+    $object = json_decode(json_encode($array));
+    v::create()
+        ->attribute(
+            'mysql',
+            v::create()
+                ->attribute('host', v::stringType(), true)
+                ->attribute('user', v::stringType(), true)
+                ->attribute('password', v::stringType(), true)
+                ->attribute('schema', v::stringType(), true),
+            true
+        )
+        ->attribute(
+            'postgresql',
+            v::create()
+                ->attribute('host', v::stringType(), true)
+                ->attribute('user', v::stringType(), true)
+                ->attribute('password', v::stringType(), true)
+                ->attribute('schema', v::stringType(), true),
+            true
+        )
+        ->setName('the given data')
+        ->assert($object);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+- All of the required rules must pass for the given data
+  - These rules must pass for mysql
+    - host must be a string
+  - These rules must pass for postgresql
+    - user must be a string

--- a/tests/integration/issue-796.phpt
+++ b/tests/integration/issue-796.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::create()
+        ->key(
+            'mysql',
+            v::create()
+                ->key('host', v::stringType(), true)
+                ->key('user', v::stringType(), true)
+                ->key('password', v::stringType(), true)
+                ->key('schema', v::stringType(), true),
+            true
+        )
+        ->key(
+            'postgresql',
+            v::create()
+                ->key('host', v::stringType(), true)
+                ->key('user', v::stringType(), true)
+                ->key('password', v::stringType(), true)
+                ->key('schema', v::stringType(), true),
+            true
+        )
+        ->setName('the given data')
+        ->assert([
+            'mysql' => [
+                'host' => 42,
+                'user' => 'user',
+                'password' => 'password',
+                'schema' => 'schema',
+            ],
+            'postgresql' => [
+                'host' => 'host',
+                'user' => 42,
+                'password' => 'password',
+                'schema' => 'schema',
+            ],
+        ]);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+- All of the required rules must pass for the given data
+  - These rules must pass for mysql
+    - host must be a string
+  - These rules must pass for postgresql
+    - user must be a string


### PR DESCRIPTION
`AttributeException` instances always indicate an interesting nested
context, which should not be omitted from the final result.

Fixes #796 