### PR TITLE
Added support for Symfony Validator >= 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "malkusch/bav": "~1.0",
         "mikey179/vfsStream": "^1.5",
         "phpunit/phpunit": "~4.0",
-        "symfony/validator": "~2.6.9",
+        "symfony/validator": ">=3.0",
         "zendframework/zend-validator": "~2.3"
     },
     "suggest": {

--- a/library/Rules/Sf.php
+++ b/library/Rules/Sf.php
@@ -50,7 +50,7 @@ class Sf extends AbstractRule
     {
         $validator = Validation::createValidator(); // You gotta love those Symfony namings
 
-        return $validator->validateValue($valueToValidate, $symfonyConstraint);
+        return $validator->validate($valueToValidate, $symfonyConstraint);
     }
 
     public function assert($input)


### PR DESCRIPTION
Version 1.1 is not compatible with symfony/validator >=3.0, it's using a deprecated method `validateValue()`, which was renamed to `validate()`.

I guess it should also work also with the symfony/validator ~2.6