### PR TITLE
Create "Pis" rule

### DIFF
--- a/docs/Pis.md
+++ b/docs/Pis.md
@@ -1,0 +1,20 @@
+# Pis
+
+- `v::pis()`
+
+Validates a Brazilian PIS/NIS number ignoring any non-digit char.
+
+```php
+v::pis()->validate('120.0340.678-8'); // true
+v::pis()->validate('120.03406788'); // true
+v::pis()->validate('120.0340.6788'); // true
+v::pis()->validate('1.2.0.0.3.4.0.6.7.8.8'); // true
+v::pis()->validate('12003406788'); // true
+```
+
+***
+See also:
+
+  * [Cpf](Cpf.md)
+  * [Cnpj](Cnpj.md)
+  * [Cnh](Cnh.md)

--- a/library/Exceptions/PisException.php
+++ b/library/Exceptions/PisException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions;
+
+class PisException extends ValidationException
+{
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{name}} must be a valid PIS number',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{name}} must not be a valid PIS number',
+        ],
+    ];
+}

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+/**
+ * Validates a Brazilian PIS/NIS number.
+ *
+ * @author Bruno Koga <brunokoga187@gmail.com>
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+class Pis extends AbstractRule
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($input)
+    {
+        if (!is_scalar($input)) {
+            return false;
+        }
+
+        $digits = preg_replace('/\D/', '', $input);
+        if (mb_strlen($digits) != 11 || preg_match("/^{$digits[0]}{11}$/", $digits)) {
+            return false;
+        }
+
+        $multipliers = [3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+        $summation = 0;
+        for ($position = 0; $position < 10; ++$position) {
+            $summation += $digits[$position] * $multipliers[$position];
+        }
+
+        $checkDigit = (int) $digits[10];
+
+        $modulo = $summation % 11;
+
+        return $checkDigit === (($modulo < 2) ? 0 : 11 - $modulo);
+    }
+}

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -119,6 +119,7 @@ use Respect\Validation\Rules\Key;
  * @method static Validator pesel()
  * @method static Validator phone()
  * @method static Validator phpLabel()
+ * @method static Validator pis()
  * @method static Validator positive()
  * @method static Validator postalCode(string $countryCode)
  * @method static Validator primeNumber()

--- a/tests/integration/rules/pis_1.phpt
+++ b/tests/integration/rules/pis_1.phpt
@@ -1,0 +1,11 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+
+v::pis()->check('12017723640');
+v::pis()->assert('120.6671.406-4');
+?>
+--EXPECTF--

--- a/tests/integration/rules/pis_2.phpt
+++ b/tests/integration/rules/pis_2.phpt
@@ -1,0 +1,17 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\PisException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::pis()->check('this thing');
+} catch (PisException $e) {
+    echo $e->getMainMessage();
+}
+
+?>
+--EXPECTF--
+"this thing" must be a valid PIS number

--- a/tests/integration/rules/pis_3.phpt
+++ b/tests/integration/rules/pis_3.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\AllOfException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::pis()->assert('your mother');
+} catch (AllOfException $e) {
+    echo $e->getFullMessage();
+}
+?>
+--EXPECTF--
+- "your mother" must be a valid PIS number

--- a/tests/integration/rules/pis_4.phpt
+++ b/tests/integration/rules/pis_4.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\PisException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::not(v::pis())->check('120.6671.406-4');
+} catch (PisException $e) {
+    echo $e->getMainMessage();
+}
+?>
+--EXPECTF--
+"120.6671.406-4" must not be a valid PIS number

--- a/tests/integration/rules/pis_5.phpt
+++ b/tests/integration/rules/pis_5.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\AllOfException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::not(v::pis())->assert('120.9378.174-5');
+} catch (AllOfException $e) {
+    echo $e->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+- "120.9378.174-5" must not be a valid PIS number

--- a/tests/unit/Rules/PisTest.php
+++ b/tests/unit/Rules/PisTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+use stdClass;
+
+/**
+ * @group  rule
+ * @covers \Respect\Validation\Rules\Pis
+ * @covers \Respect\Validation\Exceptions\PisException
+ *
+ * @author Bruno Koga <brunokoga187@gmail.com>
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+class PisTest extends RuleTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function providerForValidInput()
+    {
+        $rule = new Pis();
+
+        return [
+            [$rule, '120.4454.683-5'],
+            [$rule, '120.8995.084-8'],
+            [$rule, '120.5146.8577'],
+            [$rule, '120.01842459'],
+            [$rule, '1.2.0.7.9.8.1.6.7.8.2'],
+            [$rule, '12044546835'],
+            [$rule, '12089950848'],
+            [$rule, '12051468577'],
+            [$rule, '12001842459'],
+            [$rule, '12079816782'],
+            [$rule, 12079816782],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function providerForInvalidInput()
+    {
+        $rule = new Pis();
+
+        return [
+            [$rule, ''],
+            [$rule, '000.0000.000-0'],
+            [$rule, '111.2222.444-5'],
+            [$rule, '999999999.99'],
+            [$rule, '8.8.8.8.8.8.8.8.8.8.8'],
+            [$rule, '693-3129-110-1'],
+            [$rule, '698.1131-111.2'],
+            [$rule, '11111111111'],
+            [$rule, '22222222222'],
+            [$rule, '12345678901'],
+            [$rule, '99299929384'],
+            [$rule, '84434895894'],
+            [$rule, '44242340002'],
+            [$rule, '1'],
+            [$rule, '22'],
+            [$rule, '123'],
+            [$rule, '992999999999929384'],
+            [$rule, false],
+            [$rule, []],
+            [$rule, new stdClass()],
+        ];
+    }
+}


### PR DESCRIPTION
- `v::pis()`

Validates a Brazilian PIS/NIS number ignoring any non-digit char.

```php
v::pis()->validate('120.0340.678-8'); // true
v::pis()->validate('120.03406788'); // true
v::pis()->validate('120.0340.6788'); // true
v::pis()->validate('1.2.0.0.3.4.0.6.7.8.8'); // true
v::pis()->validate('12003406788'); // true
```
***
Close #802