### PR TITLE
Always display message for `AbstractRelated` rule

### DIFF
--- a/library/Exceptions/AttributeException.php
+++ b/library/Exceptions/AttributeException.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class AttributeException extends NestedValidationException
+class AttributeException extends NestedValidationException implements NonOmittableExceptionInterface
 {
     const NOT_PRESENT = 0;
     const INVALID = 1;

--- a/library/Exceptions/KeyException.php
+++ b/library/Exceptions/KeyException.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class KeyException extends AttributeException
+class KeyException extends AttributeException implements NonOmittableExceptionInterface
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/KeyNestedException.php
+++ b/library/Exceptions/KeyNestedException.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class KeyNestedException extends AttributeException
+class KeyNestedException extends AttributeException implements NonOmittableExceptionInterface
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/KeySetException.php
+++ b/library/Exceptions/KeySetException.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Exceptions;
 
-class KeySetException extends GroupedValidationException
+class KeySetException extends GroupedValidationException implements NonOmittableExceptionInterface
 {
     const STRUCTURE = 2;
 

--- a/library/Exceptions/NestedValidationException.php
+++ b/library/Exceptions/NestedValidationException.php
@@ -137,11 +137,10 @@ class NestedValidationException extends ValidationException implements IteratorA
         $knownDepths = [];
         foreach ($recursiveIteratorIterator as $childException) {
             if ($childException instanceof self
-                && $childException->getRelated()->count() > 0
-                && $childException->getRelated()->count() < 2) {
+                && $childException->getRelated()->count() === 1
+                && !iterator_to_array($childException->getRelated())[0] instanceof NonOmittableExceptionInterface) {
                 continue;
             }
-
             $currentDepth = $lastDepth;
             $currentDepthOriginal = $recursiveIteratorIterator->getDepth() + 1;
 

--- a/library/Exceptions/NonOmittableExceptionInterface.php
+++ b/library/Exceptions/NonOmittableExceptionInterface.php
@@ -11,6 +11,6 @@
 
 namespace Respect\Validation\Exceptions;
 
-class CallException extends GroupedValidationException implements NonOmittableExceptionInterface
+interface NonOmittableExceptionInterface extends ExceptionInterface
 {
 }

--- a/tests/integration/assert-with-attributes.phpt
+++ b/tests/integration/assert-with-attributes.phpt
@@ -1,0 +1,53 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    $array = [
+        'mysql' => [
+            'host' => 42,
+            'user' => 'user',
+            'password' => 'password',
+            'schema' => 'schema',
+        ],
+        'postgresql' => [
+            'host' => 'host',
+            'user' => 42,
+            'password' => 'password',
+            'schema' => 'schema',
+        ],
+    ];
+    $object = json_decode(json_encode($array));
+    v::create()
+        ->attribute(
+            'mysql',
+            v::create()
+                ->attribute('host', v::stringType(), true)
+                ->attribute('user', v::stringType(), true)
+                ->attribute('password', v::stringType(), true)
+                ->attribute('schema', v::stringType(), true),
+            true
+        )
+        ->attribute(
+            'postgresql',
+            v::create()
+                ->attribute('host', v::stringType(), true)
+                ->attribute('user', v::stringType(), true)
+                ->attribute('password', v::stringType(), true)
+                ->attribute('schema', v::stringType(), true),
+            true
+        )
+        ->setName('the given data')
+        ->assert($object);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+- All of the required rules must pass for the given data
+  - These rules must pass for mysql
+    - host must be a string
+  - These rules must pass for postgresql
+    - user must be a string

--- a/tests/integration/issue-796.phpt
+++ b/tests/integration/issue-796.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::create()
+        ->key(
+            'mysql',
+            v::create()
+                ->key('host', v::stringType(), true)
+                ->key('user', v::stringType(), true)
+                ->key('password', v::stringType(), true)
+                ->key('schema', v::stringType(), true),
+            true
+        )
+        ->key(
+            'postgresql',
+            v::create()
+                ->key('host', v::stringType(), true)
+                ->key('user', v::stringType(), true)
+                ->key('password', v::stringType(), true)
+                ->key('schema', v::stringType(), true),
+            true
+        )
+        ->setName('the given data')
+        ->assert([
+            'mysql' => [
+                'host' => 42,
+                'user' => 'user',
+                'password' => 'password',
+                'schema' => 'schema',
+            ],
+            'postgresql' => [
+                'host' => 'host',
+                'user' => 42,
+                'password' => 'password',
+                'schema' => 'schema',
+            ],
+        ]);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+- All of the required rules must pass for the given data
+  - These rules must pass for mysql
+    - host must be a string
+  - These rules must pass for postgresql
+    - user must be a string


### PR DESCRIPTION
`NestedValidationException` should include all `AbstractRelated` rule
exceptions.

`AbstractRelated` rule failures always indicate an interesting nested
context, which should not be omitted from the final result.

`NonOmittableExceptionInterface` is a marker interface for
exceptions thrown by instances of `AbstractRelated`, which
facilitates identification of those rules' exceptions with
`instanceof`.