### PR TITLE
Fix Nif Validator

### DIFF
--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -90,7 +90,7 @@ final class Nif extends AbstractRule
         }
 
         $digits = str_split($code);
-        $lastDigit = array_pop($digits);
+        $lastDigit = (int) array_pop($digits);
         $key = $lastDigit === 0 ? 0 : (10 - $lastDigit);
 
         if (is_numeric($control)) {

--- a/tests/unit/Rules/NifTest.php
+++ b/tests/unit/Rules/NifTest.php
@@ -41,7 +41,8 @@ final class NifTest extends RuleTestCase
             [$rule, 'Y1168744J'],
             [$rule, 'Y1168744J'],
 
-            // CIF
+            // CIF            
+            [$rule, 'B56109770'],
             [$rule, 'V8002614I'],
             [$rule, 'R1332622H'],
             [$rule, 'Q6771656C'],
@@ -75,6 +76,7 @@ final class NifTest extends RuleTestCase
             [$rule, 'X3155250B'],
 
             // CIF
+            [$rule, 'B56109771'],
             [$rule, 'v8002614i'],
             [$rule, 'C0325664D'],
             [$rule, 'R27038239'],


### PR DESCRIPTION
Output of str_split is an array of strings. It's necessary to cast the output to "int" to be able to compare $lastDigit to 0 with an identical operator.