### PR TITLE
CurrencyCode Validator - BYR should be BYN

### DIFF
--- a/library/Rules/CurrencyCode.php
+++ b/library/Rules/CurrencyCode.php
@@ -46,7 +46,7 @@ class CurrencyCode extends AbstractRule
         'BSD', // Bahamian Dollar
         'BTN', // Ngultrum
         'BWP', // Pula
-        'BYR', // Belarussian Ruble
+        'BYN', // Belarussian Ruble
         'BZD', // Belize Dollar
         'CAD', // Canadian Dollar
         'CDF', // Congolese Franc


### PR DESCRIPTION
References:
https://en.wikipedia.org/wiki/ISO_4217
www.xe.com/iso4217.php