### PR TITLE
PHPDoc, parameter types, and return types for main classes

### DIFF
--- a/library/Factory.php
+++ b/library/Factory.php
@@ -16,14 +16,23 @@ use Respect\Validation\Exceptions\ComponentException;
 
 class Factory
 {
+    /** @var string[] */
     protected $rulePrefixes = ['Respect\\Validation\\Rules\\'];
 
-    public function getRulePrefixes()
+    /**
+     * @return string[]
+     */
+    public function getRulePrefixes(): array
     {
         return $this->rulePrefixes;
     }
 
-    private function filterRulePrefix($rulePrefix)
+    /**
+     * @param string $rulePrefix
+     *
+     * @return string
+     */
+    private function filterRulePrefix(string $rulePrefix): string
     {
         $namespaceSeparator = '\\';
         $rulePrefix = rtrim($rulePrefix, $namespaceSeparator);
@@ -31,17 +40,35 @@ class Factory
         return $rulePrefix.$namespaceSeparator;
     }
 
-    public function appendRulePrefix($rulePrefix)
+    /**
+     * @param string $rulePrefix
+     *
+     * @return void
+     */
+    public function appendRulePrefix(string $rulePrefix)
     {
         array_push($this->rulePrefixes, $this->filterRulePrefix($rulePrefix));
     }
 
-    public function prependRulePrefix($rulePrefix)
+    /**
+     * @param string $rulePrefix
+     *
+     * @return void
+     */
+    public function prependRulePrefix(string $rulePrefix)
     {
         array_unshift($this->rulePrefixes, $this->filterRulePrefix($rulePrefix));
     }
 
-    public function rule($ruleName, array $arguments = [])
+    /**
+     * @param string|Validatable $ruleName
+     * @param array              $arguments = []
+     *
+     * @return Validatable
+     *
+     * @throws ComponentException
+     */
+    public function rule($ruleName, array $arguments = []): Validatable
     {
         if ($ruleName instanceof Validatable) {
             return $ruleName;
@@ -58,7 +85,10 @@ class Factory
                 throw new ComponentException(sprintf('"%s" is not a valid respect rule', $className));
             }
 
-            return $reflection->newInstanceArgs($arguments);
+            /** @var Validatable $validator */
+            $validator = $reflection->newInstanceArgs($arguments);
+
+            return $validator;
         }
 
         throw new ComponentException(sprintf('"%s" is not a valid rule name', $ruleName));

--- a/library/Validatable.php
+++ b/library/Validatable.php
@@ -11,20 +11,50 @@
 
 namespace Respect\Validation;
 
+use Respect\Validation\Exceptions\ValidationException;
+
 /** Interface for validation rules */
 interface Validatable
 {
+    /**
+     * @param mixed $input
+     * @return bool|ValidationException
+     */
     public function assert($input);
 
+    /**
+     * @param mixed $input
+     * @return bool|ValidationException
+     */
     public function check($input);
 
+    /**
+     * @return string
+     */
     public function getName();
 
+    /**
+     * @param mixed $input
+     * @param array $relatedExceptions = []
+     * @return bool|ValidationException
+     */
     public function reportError($input, array $relatedExceptions = []);
 
+    /**
+     * @param string $name
+     * @return Validatable
+     */
     public function setName($name);
 
+    /**
+     * @param string $template
+     * @return Validatable
+     */
     public function setTemplate($template);
 
+    /**
+     * @param mixed $input
+     * @return bool
+     */
     public function validate($input);
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -159,12 +159,13 @@ use Respect\Validation\Rules\Key;
  */
 class Validator extends AllOf
 {
+    /** @var Factory */
     protected static $factory;
 
     /**
      * @return Factory
      */
-    protected static function getFactory()
+    protected static function getFactory(): Factory
     {
         if (!static::$factory instanceof Factory) {
             static::$factory = new Factory();
@@ -175,17 +176,21 @@ class Validator extends AllOf
 
     /**
      * @param Factory $factory
+     *
+     * @return void
      */
-    public static function setFactory($factory)
+    public static function setFactory(Factory $factory)
     {
         static::$factory = $factory;
     }
 
     /**
      * @param string $rulePrefix
-     * @param bool   $prepend
+     * @param bool   $prepend  = false
+     *
+     * @return void
      */
-    public static function with($rulePrefix, $prepend = false)
+    public static function with(string $rulePrefix, bool $prepend = false)
     {
         if (false === $prepend) {
             self::getFactory()->appendRulePrefix($rulePrefix);
@@ -194,7 +199,14 @@ class Validator extends AllOf
         }
     }
 
-    public function check($input)
+    /**
+     * @param mixed $input
+     *
+     * @return bool
+     *
+     * @throws ValidationException
+     */
+    public function check($input): bool
     {
         try {
             return parent::check($input);
@@ -211,9 +223,9 @@ class Validator extends AllOf
      * @param string $ruleName
      * @param array  $arguments
      *
-     * @return Validator
+     * @return Validatable
      */
-    public static function __callStatic($ruleName, $arguments)
+    public static function __callStatic(string $ruleName, array $arguments): Validatable
     {
         if ('allOf' === $ruleName) {
             return static::buildRule($ruleName, $arguments);
@@ -225,12 +237,14 @@ class Validator extends AllOf
     }
 
     /**
-     * @param mixed $ruleSpec
-     * @param array $arguments
+     * @param string|Validatable $ruleSpec
+     * @param array              $arguments = []
      *
      * @return Validatable
+     *
+     * @throws ComponentException
      */
-    public static function buildRule($ruleSpec, $arguments = [])
+    public static function buildRule($ruleSpec, array $arguments = []): Validatable
     {
         try {
             return static::getFactory()->rule($ruleSpec, $arguments);
@@ -243,14 +257,17 @@ class Validator extends AllOf
      * @param string $method
      * @param array  $arguments
      *
-     * @return self
+     * @return Validatable
      */
-    public function __call($method, $arguments)
+    public function __call(string $method, array $arguments): Validatable
     {
         return $this->addRule(static::buildRule($method, $arguments));
     }
 
-    protected function createException()
+    /**
+     * @return AllOfException
+     */
+    protected function createException(): AllOfException
     {
         return new AllOfException();
     }
@@ -258,12 +275,15 @@ class Validator extends AllOf
     /**
      * Create instance validator.
      *
-     * @return Validator
+     * @return Validatable
      */
-    public static function create()
+    public static function create(): Validatable
     {
         $ref = new ReflectionClass(__CLASS__);
 
-        return $ref->newInstanceArgs(func_get_args());
+        /** @var Validatable $validator */
+        $validator = $ref->newInstanceArgs(func_get_args());
+
+        return $validator;
     }
 }


### PR DESCRIPTION
I added the following to:

interface: Respect\Validation\Validatable
classes: 
- Respect\Validation\Validator
- Respect\Validation\Factory

* @PHPDoc for parameters, Exceptions thrown, and return types.
* Parameter type hinting on methods where possible (PHP 7.0).
* Return type hinting on all methods where possible (PHP 7.0). 

I did not type hint the interface because I'd have to type hint all the Rules too. I don't have time for that right now. 
