### PR TITLE
Create "Base64" rule

### DIFF
--- a/docs/Base64.md
+++ b/docs/Base64.md
@@ -1,0 +1,21 @@
+# Base64
+
+- `Base64()`
+
+Validate if a string is Base64-encoded.
+
+```php
+v::base64()->validate('cmVzcGVjdCE='); // true
+v::base64()->validate('respect!'); // false
+```
+
+## Changelog
+
+Version | Description
+--------|-------------
+  2.0.0 | Created
+
+***
+See also:
+
+- [Base](Base.md)

--- a/docs/VALIDATORS.md
+++ b/docs/VALIDATORS.md
@@ -176,6 +176,7 @@
 
 ## Other
 
+- [Base64](Base64.md)
 - [Bsn](Bsn.md)
 - [Cnh](Cnh.md)
 - [Cnpj](Cnpj.md)
@@ -221,6 +222,7 @@
 - [Bank](Bank.md)
 - [BankAccount](BankAccount.md)
 - [Base](Base.md)
+- [Base64](Base64.md)
 - [Between](Between.md)
 - [Bic](Bic.md)
 - [BoolType](BoolType.md)

--- a/library/Exceptions/Base64Exception.php
+++ b/library/Exceptions/Base64Exception.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions;
+
+class Base64Exception extends ValidationException
+{
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{name}} must be Base64-encoded',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{name}} must not be Base64-encoded',
+        ],
+    ];
+}

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+class Base64 extends AbstractRule
+{
+    public function validate($input)
+    {
+        if (!is_string($input)) {
+            return false;
+        }
+
+        if (!preg_match('#^[A-Za-z0-9+/\n\r]+={0,2}$#', $input)) {
+            return false;
+        }
+
+        return strlen($input) % 4 === 0;
+    }
+}

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -33,6 +33,7 @@ use Respect\Validation\Rules\Key;
  * @method static Validator bank(string $countryCode)
  * @method static Validator bankAccount(string $countryCode)
  * @method static Validator base()
+ * @method static Validator base64()
  * @method static Validator between(mixed $min = null, mixed $max = null, bool $inclusive = true)
  * @method static Validator bic(string $countryCode)
  * @method static Validator boolType()

--- a/tests/integration/rules/base64_1.phpt
+++ b/tests/integration/rules/base64_1.phpt
@@ -1,0 +1,24 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\AllOfException;
+use Respect\Validation\Exceptions\Base64Exception;
+use Respect\Validation\Validator as v;
+
+try {
+    v::base64()->check('=c3VyZS4');
+} catch (Base64Exception $exception) {
+    echo $exception->getMainMessage().PHP_EOL;
+}
+
+try {
+    v::base64()->assert('=c3VyZS4');
+} catch (AllOfException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+"=c3VyZS4" must be Base64-encoded
+- "=c3VyZS4" must be Base64-encoded

--- a/tests/integration/rules/base64_2.phpt
+++ b/tests/integration/rules/base64_2.phpt
@@ -1,0 +1,24 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\AllOfException;
+use Respect\Validation\Exceptions\Base64Exception;
+use Respect\Validation\Validator as v;
+
+try {
+    v::not(v::base64())->check('c3VyZS4=');
+} catch (Base64Exception $exception) {
+    echo $exception->getMainMessage().PHP_EOL;
+}
+
+try {
+    v::not(v::base64())->assert('c3VyZS4=');
+} catch (AllOfException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECTF--
+"c3VyZS4=" must not be Base64-encoded
+- "c3VyZS4=" must not be Base64-encoded

--- a/tests/unit/Rules/Base64Test.php
+++ b/tests/unit/Rules/Base64Test.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+/**
+ * @group  rule
+ * @covers \Respect\Validation\Rules\Base64
+ */
+class Base64Test extends RuleTestCase
+{
+    public function providerForValidInput()
+    {
+        $rule = new Base64();
+
+        $lines = [
+            'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz',
+            'IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg',
+            'dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu',
+            'dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo',
+            'ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=',
+        ];
+
+        return [
+            [$rule, 'YW55IGNhcm5hbCBwbGVhc3VyZS4='],
+            [$rule, 'YW55IGNhcm5hbCBwbGVhc3VyZQ=='],
+            [$rule, 'YW55IGNhcm5hbCBwbGVhc3Vy'],
+            [$rule, 'YW55IGNhcm5hbCBwbGVhc3U='],
+            [$rule, 'YW55IGNhcm5hbCBwbGVhcw=='],
+            [$rule, 'cGxlYXN1cmUu'],
+            [$rule, 'bGVhc3VyZS4='],
+            [$rule, 'ZWFzdXJlLg=='],
+            [$rule, 'YXN1cmUu'],
+            [$rule, 'c3VyZS4='],
+            [$rule, 'WeJcFMQ/8+8QJ/w0hHh+0g=='],
+            [$rule, implode("\n", $lines)],
+            [$rule, implode("\r\n", $lines)],
+        ];
+    }
+
+    public function providerForInvalidInput()
+    {
+        $rule = new Base64();
+
+        return [
+            [$rule, ''],
+            [$rule, 'hello!'],
+            [$rule, '=c3VyZS4'],
+            [$rule, 'YW55IGNhcm5hbCBwbGVhc3VyZ==='],
+        ];
+    }
+}


### PR DESCRIPTION
# Base64

- `Base64()`

Validate if a string is Base64-encoded.

```php
v::base64()->validate('cmVzcGVjdCE='); // true
v::base64()->validate('respect!'); // false
```

## Changelog

Version | Description
--------|-------------
  2.0.0 | Created

***
Close #838