### PR TITLE
Add Docker configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,9 @@ updated as soon as possible.
 
 After run `composer install` on the library's root directory you must run PHPUnit.
 
+Another option is to run it through Docker. Before using it you need to run `docker
+-compose build`. After building it, run `docker-compose run app composer test`.
+
 ### Linux
 
 You can test the project using the commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM composer:1.5
+
+ENV COMPOSER_ARGUMENTS --prefer-lowest --prefer-stable
+
+WORKDIR /app
+COPY . /app
+
+RUN composer update --prefer-dist ${COMPOSER_ARGUMENTS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/app
+      - notused:/app/vendor
+
+# Keep container /vendor
+volumes:
+  notused:


### PR DESCRIPTION
Using `Docker` and `docker-compose` makes easier for any developer to implement new features, as it will be a controlled environment. The only issue is that the tests are not passing inside the composer container (which seems strange).