### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "egulias/email-validator": "^2.0",
-        "malkusch/bav": "^1.1",
+        "malkusch/bav": "^1.2",
         "malukenho/docheader": "^0.1.4",
         "mikey179/vfsStream": "^1.6",
         "phpunit/phpunit": "^6.4",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "malkusch/bav": "^1.1",
         "malukenho/docheader": "^0.1.4",
         "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit": "^5.6",
+        "phpunit/phpunit": "^6.4",
         "symfony/validator": "^3.0",
         "zendframework/zend-validator": "^2.0"
     },

--- a/tests/library/Rules/LocaleTestCase.php
+++ b/tests/library/Rules/LocaleTestCase.php
@@ -15,8 +15,9 @@ use malkusch\bav\BAV;
 use malkusch\bav\ConfigurationRegistry;
 use malkusch\bav\DataBackend;
 use malkusch\bav\DataBackendContainer;
+use PHPUnit\Framework\TestCase;
 
-class LocaleTestCase extends \PHPUnit_Framework_TestCase
+class LocaleTestCase extends TestCase
 {
     protected function getBavMock()
     {

--- a/tests/library/Rules/RuleTestCase.php
+++ b/tests/library/Rules/RuleTestCase.php
@@ -11,10 +11,11 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validatable;
 
-abstract class RuleTestCase extends \PHPUnit_Framework_TestCase
+abstract class RuleTestCase extends TestCase
 {
     /**
      * It is to provide constructor arguments and.

--- a/tests/unit/Exceptions/CheckExceptionsTest.php
+++ b/tests/unit/Exceptions/CheckExceptionsTest.php
@@ -12,9 +12,10 @@
 namespace Respect\Validation\Exceptions;
 
 use DirectoryIterator;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-class CheckExceptionsTest extends \PHPUnit_Framework_TestCase
+class CheckExceptionsTest extends TestCase
 {
     protected $deprecateds = [];
 

--- a/tests/unit/Exceptions/NestedValidationExceptionTest.php
+++ b/tests/unit/Exceptions/NestedValidationExceptionTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Exceptions;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * phpunit has an issue with mocking exceptions when in HHVM:
  * https://github.com/sebastianbergmann/phpunit-mock-objects/issues/207.
@@ -19,7 +21,7 @@ class PrivateNestedValidationException extends NestedValidationException
 {
 }
 
-class NestedValidationExceptionTest extends \PHPUnit_Framework_TestCase
+class NestedValidationExceptionTest extends TestCase
 {
     public function testGetRelatedShouldReturnExceptionAddedByAddRelated()
     {

--- a/tests/unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/unit/Exceptions/ValidationExceptionTest.php
@@ -14,10 +14,11 @@ namespace Respect\Validation\Exceptions;
 use ArrayIterator;
 use DateTime;
 use Exception;
+use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 use stdClass;
 
-class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
+class ValidationExceptionTest extends TestCase
 {
     public function testItImplementsExceptionInterface()
     {

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -11,12 +11,13 @@
 
 namespace Respect\Validation;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Rules\Uppercase;
 
 /**
  * @covers \Respect\Validation\Factory
  */
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     public function testShouldHaveRulePrefixesByDefault()
     {

--- a/tests/unit/Rules/AbstractCompositeTest.php
+++ b/tests/unit/Rules/AbstractCompositeTest.php
@@ -11,9 +11,10 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validatable;
 
-class AbstractCompositeTest extends \PHPUnit_Framework_TestCase
+class AbstractCompositeTest extends TestCase
 {
     public function testShouldDefineNameForInternalWhenAppendRuleToCompositeRule()
     {

--- a/tests/unit/Rules/AbstractCtypeRuleTest.php
+++ b/tests/unit/Rules/AbstractCtypeRuleTest.php
@@ -11,7 +11,9 @@
 
 namespace Respect\Validation\Rules;
 
-class AbstractCtypeRuleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractCtypeRuleTest extends TestCase
 {
     public function testValidateCleanShouldReturnTrueWhenCtypeFunctionReturnsTrue()
     {

--- a/tests/unit/Rules/AbstractFilterRuleTest.php
+++ b/tests/unit/Rules/AbstractFilterRuleTest.php
@@ -11,7 +11,9 @@
 
 namespace Respect\Validation\Rules;
 
-class AbstractFilterRuleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractFilterRuleTest extends TestCase
 {
     /**
      * @expectedException \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/AbstractRegexRuleTest.php
+++ b/tests/unit/Rules/AbstractRegexRuleTest.php
@@ -11,7 +11,9 @@
 
 namespace Respect\Validation\Rules;
 
-class AbstractRegexRuleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractRegexRuleTest extends TestCase
 {
     public function testValidateCleanShouldReturnOneIfPatternIsFound()
     {

--- a/tests/unit/Rules/AbstractRelatedTest.php
+++ b/tests/unit/Rules/AbstractRelatedTest.php
@@ -11,9 +11,10 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validatable;
 
-final class AbstractRelatedTest extends \PHPUnit_Framework_TestCase
+final class AbstractRelatedTest extends TestCase
 {
     public function providerForOperations()
     {

--- a/tests/unit/Rules/AbstractRuleTest.php
+++ b/tests/unit/Rules/AbstractRuleTest.php
@@ -11,9 +11,10 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ValidationException;
 
-class AbstractRuleTest extends \PHPUnit_Framework_TestCase
+class AbstractRuleTest extends TestCase
 {
     public function providerForTrueAndFalse()
     {

--- a/tests/unit/Rules/AbstractSearcherTest.php
+++ b/tests/unit/Rules/AbstractSearcherTest.php
@@ -11,7 +11,9 @@
 
 namespace Respect\Validation\Rules;
 
-class AbstractSearcherTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AbstractSearcherTest extends TestCase
 {
     protected $searcherRuleMock;
 

--- a/tests/unit/Rules/AbstractWrapperTest.php
+++ b/tests/unit/Rules/AbstractWrapperTest.php
@@ -11,10 +11,11 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Respect\Validation\Validatable;
 
-class AbstractWrapperTest extends \PHPUnit_Framework_TestCase
+class AbstractWrapperTest extends TestCase
 {
     /**
      * @expectedException \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/AgeTest.php
+++ b/tests/unit/Rules/AgeTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Age
  * @covers \Respect\Validation\Exceptions\AgeException
  */
-class AgeTest extends \PHPUnit_Framework_TestCase
+class AgeTest extends TestCase
 {
     /**
      * @expectedException \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/AllOfTest.php
+++ b/tests/unit/Rules/AllOfTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\AllOf
  * @covers \Respect\Validation\Exceptions\AllOfException
  */
-class AllOfTest extends \PHPUnit_Framework_TestCase
+class AllOfTest extends TestCase
 {
     public function testRemoveRulesShouldRemoveAllRules()
     {

--- a/tests/unit/Rules/AlnumTest.php
+++ b/tests/unit/Rules/AlnumTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Alnum
  * @covers \Respect\Validation\Exceptions\AlnumException
  */
-class AlnumTest extends \PHPUnit_Framework_TestCase
+class AlnumTest extends TestCase
 {
     /**
      * @dataProvider providerForValidAlnum

--- a/tests/unit/Rules/AlphaTest.php
+++ b/tests/unit/Rules/AlphaTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Alpha
  * @covers \Respect\Validation\Exceptions\AlphaException
  */
-class AlphaTest extends \PHPUnit_Framework_TestCase
+class AlphaTest extends TestCase
 {
     /**
      * @dataProvider providerForValidAlpha

--- a/tests/unit/Rules/AlwaysInvalidTest.php
+++ b/tests/unit/Rules/AlwaysInvalidTest.php
@@ -11,11 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\AlwaysInvalid
  */
-class AlwaysInvalidTest extends \PHPUnit_Framework_TestCase
+class AlwaysInvalidTest extends TestCase
 {
     public function providerForValidAlwaysInvalid()
     {

--- a/tests/unit/Rules/AlwaysValidTest.php
+++ b/tests/unit/Rules/AlwaysValidTest.php
@@ -11,11 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\AlwaysValid
  */
-class AlwaysValidTest extends \PHPUnit_Framework_TestCase
+class AlwaysValidTest extends TestCase
 {
     public function providerForValidAlwaysValid()
     {

--- a/tests/unit/Rules/AnyOfTest.php
+++ b/tests/unit/Rules/AnyOfTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\AnyOf
  * @covers \Respect\Validation\Exceptions\AnyOfException
  */
-class AnyOfTest extends \PHPUnit_Framework_TestCase
+class AnyOfTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/unit/Rules/AttributeTest.php
+++ b/tests/unit/Rules/AttributeTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 class PrivClass
 {
     private $bar = 'foo';
@@ -21,7 +23,7 @@ class PrivClass
  * @covers \Respect\Validation\Rules\Attribute
  * @covers \Respect\Validation\Exceptions\AttributeException
  */
-class AttributeTest extends \PHPUnit_Framework_TestCase
+class AttributeTest extends TestCase
 {
     public function testAttributeWithNoExtraValidationShouldCheckItsPresence()
     {

--- a/tests/unit/Rules/BaseTest.php
+++ b/tests/unit/Rules/BaseTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Base
  * @covers \Respect\Validation\Exceptions\BaseException
  */
-class BaseTest extends \PHPUnit_Framework_TestCase
+class BaseTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/BetweenTest.php
+++ b/tests/unit/Rules/BetweenTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Between
  * @covers \Respect\Validation\Exceptions\BetweenException
  */
-class BetweenTest extends \PHPUnit_Framework_TestCase
+class BetweenTest extends TestCase
 {
     public function providerValid()
     {

--- a/tests/unit/Rules/BoolTypeTest.php
+++ b/tests/unit/Rules/BoolTypeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\BoolType
  * @covers \Respect\Validation\Exceptions\BoolTypeException
  */
-class BoolTypeTest extends \PHPUnit_Framework_TestCase
+class BoolTypeTest extends TestCase
 {
     public function testBooleanValuesONLYShouldReturnTrue()
     {

--- a/tests/unit/Rules/BsnTest.php
+++ b/tests/unit/Rules/BsnTest.php
@@ -11,14 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Bsn
  * @covers \Respect\Validation\Exceptions\BsnException
  */
-class BsnTest extends PHPUnit_Framework_TestCase
+class BsnTest extends TestCase
 {
     /**
      * @var Bsn

--- a/tests/unit/Rules/CallTest.php
+++ b/tests/unit/Rules/CallTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Call
  * @covers \Respect\Validation\Exceptions\CallException
  */
-class CallTest extends \PHPUnit_Framework_TestCase
+class CallTest extends TestCase
 {
     public function thisIsASampleCallbackUsedInsideThisTest()
     {

--- a/tests/unit/Rules/CallableTypeTest.php
+++ b/tests/unit/Rules/CallableTypeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\CallableType
  * @covers \Respect\Validation\Exceptions\CallableTypeException
  */
-class CallableTypeTest extends \PHPUnit_Framework_TestCase
+class CallableTypeTest extends TestCase
 {
     protected $rule;
 

--- a/tests/unit/Rules/CallbackTest.php
+++ b/tests/unit/Rules/CallbackTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Callback
  * @covers \Respect\Validation\Exceptions\CallbackException
  */
-class CallbackTest extends \PHPUnit_Framework_TestCase
+class CallbackTest extends TestCase
 {
     private $truthy, $falsy;
 

--- a/tests/unit/Rules/CharsetTest.php
+++ b/tests/unit/Rules/CharsetTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Charset
  * @covers \Respect\Validation\Exceptions\CharsetException
  */
-class CharsetTest extends \PHPUnit_Framework_TestCase
+class CharsetTest extends TestCase
 {
     /**
      * @dataProvider providerForValidCharset

--- a/tests/unit/Rules/CnhTest.php
+++ b/tests/unit/Rules/CnhTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Cnh
  * @covers \Respect\Validation\Exceptions\CnhException
  */
-class CnhTest extends \PHPUnit_Framework_TestCase
+class CnhTest extends TestCase
 {
     protected $cnhValidator;
 

--- a/tests/unit/Rules/CnpjTest.php
+++ b/tests/unit/Rules/CnpjTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Cnpj
  * @covers \Respect\Validation\Exceptions\CnpjException
  */
-class CnpjTest extends \PHPUnit_Framework_TestCase
+class CnpjTest extends TestCase
 {
     protected $cnpjValidator;
 

--- a/tests/unit/Rules/CntrlTest.php
+++ b/tests/unit/Rules/CntrlTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Cntrl
  * @covers \Respect\Validation\Exceptions\CntrlException
  */
-class CntrlTest extends \PHPUnit_Framework_TestCase
+class CntrlTest extends TestCase
 {
     /**
      * @dataProvider providerForValidCntrl

--- a/tests/unit/Rules/ConsonantTest.php
+++ b/tests/unit/Rules/ConsonantTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Consonant
  * @covers \Respect\Validation\Exceptions\ConsonantException
  */
-class ConsonantTest extends \PHPUnit_Framework_TestCase
+class ConsonantTest extends TestCase
 {
     /**
      * @dataProvider providerForValidConsonants

--- a/tests/unit/Rules/ContainsTest.php
+++ b/tests/unit/Rules/ContainsTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Contains
  * @covers \Respect\Validation\Exceptions\ContainsException
  */
-class ContainsTest extends \PHPUnit_Framework_TestCase
+class ContainsTest extends TestCase
 {
     /**
      * @dataProvider providerForContainsIdentical

--- a/tests/unit/Rules/CountryCodeTest.php
+++ b/tests/unit/Rules/CountryCodeTest.php
@@ -11,11 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\CountryCode
  */
-class CountryCodeTest extends \PHPUnit_Framework_TestCase
+class CountryCodeTest extends TestCase
 {
     /**
      * @expectedException        \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/CpfTest.php
+++ b/tests/unit/Rules/CpfTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Cpf
  * @covers \Respect\Validation\Exceptions\CpfException
  */
-class CpfTest extends \PHPUnit_Framework_TestCase
+class CpfTest extends TestCase
 {
     protected $cpfValidator;
 

--- a/tests/unit/Rules/CreditCardTest.php
+++ b/tests/unit/Rules/CreditCardTest.php
@@ -38,7 +38,7 @@ class CreditCardTest extends RuleTestCase
         $message = '"RespectCard" is not a valid credit card brand';
         $message .= ' (Available: American Express, Diners Club, Discover, JCB, MasterCard, Visa).';
 
-        $this->setExpectedException(ComponentException::class, $message);
+        $this->expectException(ComponentException::class, $message);
 
         new CreditCard('RespectCard');
     }

--- a/tests/unit/Rules/DateTimeTest.php
+++ b/tests/unit/Rules/DateTimeTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\DateTime
  * @covers \Respect\Validation\Exceptions\DateTimeException
  */
-class DateTimeTest extends \PHPUnit_Framework_TestCase
+class DateTimeTest extends TestCase
 {
     protected $dateValidator;
 

--- a/tests/unit/Rules/DigitTest.php
+++ b/tests/unit/Rules/DigitTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Digit
  * @covers \Respect\Validation\Exceptions\DigitException
  */
-class DigitTest extends \PHPUnit_Framework_TestCase
+class DigitTest extends TestCase
 {
     /**
      * @dataProvider providerForValidDigits

--- a/tests/unit/Rules/DirectoryTest.php
+++ b/tests/unit/Rules/DirectoryTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Directory
  * @covers \Respect\Validation\Exceptions\DirectoryException
  */
-class DirectoryTest extends \PHPUnit_Framework_TestCase
+class DirectoryTest extends TestCase
 {
     /**
      * @dataProvider providerForValidDirectory

--- a/tests/unit/Rules/DomainTest.php
+++ b/tests/unit/Rules/DomainTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validator as v;
 
 /**
@@ -18,7 +19,7 @@ use Respect\Validation\Validator as v;
  * @covers \Respect\Validation\Rules\Domain
  * @covers \Respect\Validation\Exceptions\DomainException
  */
-class DomainTest extends \PHPUnit_Framework_TestCase
+class DomainTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/EmailTest.php
+++ b/tests/unit/Rules/EmailTest.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Rules;
 
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
+use PHPUnit\Framework\TestCase;
 
 function class_exists($className)
 {
@@ -28,7 +29,7 @@ function class_exists($className)
  * @covers \Respect\Validation\Rules\Email
  * @covers \Respect\Validation\Exceptions\EmailException
  */
-class EmailTest extends \PHPUnit_Framework_TestCase
+class EmailTest extends TestCase
 {
     private function setEmailValidatorExists($value)
     {

--- a/tests/unit/Rules/EndsWithTest.php
+++ b/tests/unit/Rules/EndsWithTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\EndsWith
  * @covers \Respect\Validation\Exceptions\EndsWithException
  */
-class EndsWithTest extends \PHPUnit_Framework_TestCase
+class EndsWithTest extends TestCase
 {
     /**
      * @dataProvider providerForEndsWith

--- a/tests/unit/Rules/EqualsTest.php
+++ b/tests/unit/Rules/EqualsTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -18,7 +19,7 @@ use stdClass;
  * @covers \Respect\Validation\Rules\Equals
  * @covers \Respect\Validation\Exceptions\EqualsException
  */
-class EqualsTest extends \PHPUnit_Framework_TestCase
+class EqualsTest extends TestCase
 {
     /**
      * @dataProvider providerForEquals

--- a/tests/unit/Rules/EvenTest.php
+++ b/tests/unit/Rules/EvenTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Even
  * @covers \Respect\Validation\Exceptions\EvenException
  */
-class EvenTest extends \PHPUnit_Framework_TestCase
+class EvenTest extends TestCase
 {
     protected $evenValidator;
 

--- a/tests/unit/Rules/ExecutableTest.php
+++ b/tests/unit/Rules/ExecutableTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 $GLOBALS['is_executable'] = null;
 
 function is_executable($executable)
@@ -29,7 +31,7 @@ function is_executable($executable)
  * @covers \Respect\Validation\Rules\Executable
  * @covers \Respect\Validation\Exceptions\ExecutableException
  */
-class ExecutableTest extends \PHPUnit_Framework_TestCase
+class ExecutableTest extends TestCase
 {
     public function testValidExecutableFileShouldReturnTrue()
     {

--- a/tests/unit/Rules/ExistsTest.php
+++ b/tests/unit/Rules/ExistsTest.php
@@ -13,7 +13,7 @@ namespace Respect\Validation\Rules;
 
 use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
 /**
@@ -21,7 +21,7 @@ use SplFileInfo;
  * @covers \Respect\Validation\Rules\Exists
  * @covers \Respect\Validation\Exceptions\ExistsException
  */
-class ExistsTest extends PHPUnit_Framework_TestCase
+class ExistsTest extends TestCase
 {
     /**
      * @dataProvider fileProvider

--- a/tests/unit/Rules/ExtensionTest.php
+++ b/tests/unit/Rules/ExtensionTest.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
 /**
@@ -20,7 +20,7 @@ use SplFileInfo;
  * @covers \Respect\Validation\Rules\Extension
  * @covers \Respect\Validation\Exceptions\ExtensionException
  */
-class ExtensionTest extends PHPUnit_Framework_TestCase
+class ExtensionTest extends TestCase
 {
     public function providerValidExtension()
     {

--- a/tests/unit/Rules/FactorTest.php
+++ b/tests/unit/Rules/FactorTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Exceptions\FactorException;
 use Respect\Validation\Exceptions\ValidationException;
@@ -22,7 +23,7 @@ use Respect\Validation\Exceptions\ValidationException;
  *
  * @author David Meister <thedavidmeister@gmail.com>
  */
-class FactorTest extends \PHPUnit_Framework_TestCase
+class FactorTest extends TestCase
 {
     /**
      * @dataProvider providerForValidFactor
@@ -40,7 +41,7 @@ class FactorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidFactorShouldThrowFactorException($dividend, $input)
     {
-        $this->setExpectedException(
+        $this->expectException(
             FactorException::class,
             ValidationException::stringify($input).' must be a factor of '.$dividend
         );
@@ -55,7 +56,7 @@ class FactorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidDividentShouldThrowComponentException($dividend, $input)
     {
-        $this->setExpectedException(
+        $this->expectException(
             ComponentException::class,
             'Dividend '.ValidationException::stringify($dividend).' must be an integer'
         );

--- a/tests/unit/Rules/FalseValTest.php
+++ b/tests/unit/Rules/FalseValTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\FalseVal
  * @covers \Respect\Validation\Exceptions\FalseValException
  */
-class FalseValTest extends \PHPUnit_Framework_TestCase
+class FalseValTest extends TestCase
 {
     /**
      * @dataProvider validFalseProvider

--- a/tests/unit/Rules/FileTest.php
+++ b/tests/unit/Rules/FileTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 $GLOBALS['is_file'] = null;
 
 function is_file($file)
@@ -29,7 +31,7 @@ function is_file($file)
  * @covers \Respect\Validation\Rules\File
  * @covers \Respect\Validation\Exceptions\FileException
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     /**
      * @covers \Respect\Validation\Rules\File::validate

--- a/tests/unit/Rules/FilterVarTest.php
+++ b/tests/unit/Rules/FilterVarTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\FilterVar
  * @covers \Respect\Validation\Exceptions\FilterVarException
  */
-class FilterVarTest extends \PHPUnit_Framework_TestCase
+class FilterVarTest extends TestCase
 {
     /**
      * @expectedException \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/FiniteTest.php
+++ b/tests/unit/Rules/FiniteTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Finite
  * @covers \Respect\Validation\Exceptions\FiniteException
  */
-class FiniteTest extends \PHPUnit_Framework_TestCase
+class FiniteTest extends TestCase
 {
     protected $rule;
 

--- a/tests/unit/Rules/FloatValTest.php
+++ b/tests/unit/Rules/FloatValTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\FloatVal
  * @covers \Respect\Validation\Exceptions\FloatValException
  */
-class FloatValTest extends \PHPUnit_Framework_TestCase
+class FloatValTest extends TestCase
 {
     protected $floatValidator;
 

--- a/tests/unit/Rules/GraphTest.php
+++ b/tests/unit/Rules/GraphTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Graph
  * @covers \Respect\Validation\Exceptions\GraphException
  */
-class GraphTest extends \PHPUnit_Framework_TestCase
+class GraphTest extends TestCase
 {
     /**
      * @dataProvider providerForValidGraph

--- a/tests/unit/Rules/HexRgbColorTest.php
+++ b/tests/unit/Rules/HexRgbColorTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\HexRgbColor
  * @covers \Respect\Validation\Exceptions\HexRgbColorException
  */
-class HexRgbColorTest extends \PHPUnit_Framework_TestCase
+class HexRgbColorTest extends TestCase
 {
     /**
      * @dataProvider providerForValidHexRgbColor

--- a/tests/unit/Rules/IdenticalTest.php
+++ b/tests/unit/Rules/IdenticalTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -18,7 +19,7 @@ use stdClass;
  * @covers \Respect\Validation\Rules\Identical
  * @covers \Respect\Validation\Exceptions\IdenticalException
  */
-class IdenticalTest extends \PHPUnit_Framework_TestCase
+class IdenticalTest extends TestCase
 {
     /**
      * @dataProvider providerForIdentical

--- a/tests/unit/Rules/InTest.php
+++ b/tests/unit/Rules/InTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\In
  * @covers \Respect\Validation\Exceptions\InException
  */
-class InTest extends \PHPUnit_Framework_TestCase
+class InTest extends TestCase
 {
     /**
      * @dataProvider providerForIn

--- a/tests/unit/Rules/InfiniteTest.php
+++ b/tests/unit/Rules/InfiniteTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Infinite
  * @covers \Respect\Validation\Exceptions\InfiniteException
  */
-class InfiniteTest extends \PHPUnit_Framework_TestCase
+class InfiniteTest extends TestCase
 {
     protected $rule;
 

--- a/tests/unit/Rules/InstanceTest.php
+++ b/tests/unit/Rules/InstanceTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Instance
  * @covers \Respect\Validation\Exceptions\InstanceException
  */
-class InstanceTest extends \PHPUnit_Framework_TestCase
+class InstanceTest extends TestCase
 {
     protected $instanceValidator;
 

--- a/tests/unit/Rules/IntTypeTest.php
+++ b/tests/unit/Rules/IntTypeTest.php
@@ -11,11 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\IntType
  */
-class IntTypeTest extends \PHPUnit_Framework_TestCase
+class IntTypeTest extends TestCase
 {
     public function providerForValidIntType()
     {

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\IntVal
  * @covers \Respect\Validation\Exceptions\IntValException
  */
-class IntValTest extends \PHPUnit_Framework_TestCase
+class IntValTest extends TestCase
 {
     protected $intValidator;
 

--- a/tests/unit/Rules/IpTest.php
+++ b/tests/unit/Rules/IpTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Ip
  * @covers \Respect\Validation\Exceptions\IpException
  */
-class IpTest extends \PHPUnit_Framework_TestCase
+class IpTest extends TestCase
 {
     /**
      * @dataProvider providerForIp

--- a/tests/unit/Rules/KeyNestedTest.php
+++ b/tests/unit/Rules/KeyNestedTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use ArrayObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\KeyNested
  * @covers \Respect\Validation\Exceptions\KeyNestedException
  */
-class KeyNestedTest extends \PHPUnit_Framework_TestCase
+class KeyNestedTest extends TestCase
 {
     public function testArrayWithPresentKeysWillReturnTrueForFullPathValidator()
     {

--- a/tests/unit/Rules/KeySetTest.php
+++ b/tests/unit/Rules/KeySetTest.php
@@ -11,14 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\KeySet
  * @covers \Respect\Validation\Exceptions\KeySetException
  */
-class KeySetTest extends PHPUnit_Framework_TestCase
+class KeySetTest extends TestCase
 {
     public function testShouldAcceptKeyRule()
     {

--- a/tests/unit/Rules/KeyTest.php
+++ b/tests/unit/Rules/KeyTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Key
  * @covers \Respect\Validation\Exceptions\KeyException
  */
-class KeyTest extends \PHPUnit_Framework_TestCase
+class KeyTest extends TestCase
 {
     public function testArrayWithPresentKeyShouldReturnTrue()
     {

--- a/tests/unit/Rules/KeyValueTest.php
+++ b/tests/unit/Rules/KeyValueTest.php
@@ -11,14 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\KeyValue
  * @covers \Respect\Validation\Exceptions\KeyValueException
  */
-class KeyValueTest extends PHPUnit_Framework_TestCase
+class KeyValueTest extends TestCase
 {
     public function testShouldDefineValuesOnConstructor()
     {

--- a/tests/unit/Rules/LeapDateTest.php
+++ b/tests/unit/Rules/LeapDateTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\LeapDate
  * @covers \Respect\Validation\Exceptions\LeapDateException
  */
-class LeapDateTest extends \PHPUnit_Framework_TestCase
+class LeapDateTest extends TestCase
 {
     protected $leapDateValidator;
 

--- a/tests/unit/Rules/LeapYearTest.php
+++ b/tests/unit/Rules/LeapYearTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\LeapYear
  * @covers \Respect\Validation\Exceptions\LeapYearException
  */
-class LeapYearTest extends \PHPUnit_Framework_TestCase
+class LeapYearTest extends TestCase
 {
     protected $leapYearValidator;
 

--- a/tests/unit/Rules/LengthTest.php
+++ b/tests/unit/Rules/LengthTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Length
  * @covers \Respect\Validation\Exceptions\LengthException
  */
-class LengthTest extends \PHPUnit_Framework_TestCase
+class LengthTest extends TestCase
 {
     /**
      * @dataProvider providerForValidLengthInclusive

--- a/tests/unit/Rules/LowercaseTest.php
+++ b/tests/unit/Rules/LowercaseTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Lowercase
  * @covers \Respect\Validation\Exceptions\LowercaseException
  */
-class LowercaseTest extends \PHPUnit_Framework_TestCase
+class LowercaseTest extends TestCase
 {
     /**
      * @dataProvider providerForValidLowercase

--- a/tests/unit/Rules/MacAddressTest.php
+++ b/tests/unit/Rules/MacAddressTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\MacAddress
  * @covers \Respect\Validation\Exceptions\MacAddressException
  */
-class MacAddressTest extends \PHPUnit_Framework_TestCase
+class MacAddressTest extends TestCase
 {
     protected $macaddressValidator;
 

--- a/tests/unit/Rules/MaxTest.php
+++ b/tests/unit/Rules/MaxTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Max
  * @covers \Respect\Validation\Exceptions\MaxException
  */
-class MaxTest extends \PHPUnit_Framework_TestCase
+class MaxTest extends TestCase
 {
     /**
      * @dataProvider providerForValidMax

--- a/tests/unit/Rules/MimetypeTest.php
+++ b/tests/unit/Rules/MimetypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
 /**
@@ -20,7 +20,7 @@ use SplFileInfo;
  * @covers \Respect\Validation\Rules\Mimetype
  * @covers \Respect\Validation\Exceptions\MimetypeException
  */
-class MimetypeTest extends PHPUnit_Framework_TestCase
+class MimetypeTest extends TestCase
 {
     private $filename;
 

--- a/tests/unit/Rules/MinTest.php
+++ b/tests/unit/Rules/MinTest.php
@@ -12,13 +12,14 @@
 namespace Respect\Validation\Rules;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Min
  * @covers \Respect\Validation\Exceptions\MinException
  */
-class MinTest extends \PHPUnit_Framework_TestCase
+class MinTest extends TestCase
 {
     /**
      * @dataProvider providerForValidMin

--- a/tests/unit/Rules/MininumAgeTest.php
+++ b/tests/unit/Rules/MininumAgeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\MinimumAge
  * @covers \Respect\Validation\Exceptions\MinimumAgeException
  */
-class MininumAgeTest extends \PHPUnit_Framework_TestCase
+class MininumAgeTest extends TestCase
 {
     /**
      * @dataProvider providerForValidDateValidMinimumAge

--- a/tests/unit/Rules/MultipleTest.php
+++ b/tests/unit/Rules/MultipleTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Multiple
  * @covers \Respect\Validation\Exceptions\MultipleException
  */
-class MultipleTest extends \PHPUnit_Framework_TestCase
+class MultipleTest extends TestCase
 {
     /**
      * @dataProvider providerForMultiple

--- a/tests/unit/Rules/NegativeTest.php
+++ b/tests/unit/Rules/NegativeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Negative
  * @covers \Respect\Validation\Exceptions\NegativeException
  */
-class NegativeTest extends \PHPUnit_Framework_TestCase
+class NegativeTest extends TestCase
 {
     protected $negativeValidator;
 

--- a/tests/unit/Rules/NfeAccessKeyTest.php
+++ b/tests/unit/Rules/NfeAccessKeyTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NfeAccessKey
  * @covers \Respect\Validation\Exceptions\NfeAccessKeyException
  */
-class NfeAccessKeyTest extends \PHPUnit_Framework_TestCase
+class NfeAccessKeyTest extends TestCase
 {
     protected $nfeValidator;
 

--- a/tests/unit/Rules/NoTest.php
+++ b/tests/unit/Rules/NoTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\No
  * @covers \Respect\Validation\Exceptions\NoException
  */
-class NoTest extends \PHPUnit_Framework_TestCase
+class NoTest extends TestCase
 {
     public function testShouldUseDefaultPattern()
     {

--- a/tests/unit/Rules/NoWhitespaceTest.php
+++ b/tests/unit/Rules/NoWhitespaceTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NoWhitespace
  * @covers \Respect\Validation\Exceptions\NoWhitespaceException
  */
-class NoWhitespaceTest extends \PHPUnit_Framework_TestCase
+class NoWhitespaceTest extends TestCase
 {
     protected $noWhitespaceValidator;
 

--- a/tests/unit/Rules/NoneOfTest.php
+++ b/tests/unit/Rules/NoneOfTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NoneOf
  * @covers \Respect\Validation\Exceptions\NoneOfException
  */
-class NoneOfTest extends \PHPUnit_Framework_TestCase
+class NoneOfTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/unit/Rules/NotBlankTest.php
+++ b/tests/unit/Rules/NotBlankTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -18,7 +19,7 @@ use stdClass;
  * @covers \Respect\Validation\Rules\NotBlank
  * @covers \Respect\Validation\Exceptions\NotBlankException
  */
-class NotBlankTest extends \PHPUnit_Framework_TestCase
+class NotBlankTest extends TestCase
 {
     /**
      * @dataProvider providerForNotBlank

--- a/tests/unit/Rules/NotEmptyTest.php
+++ b/tests/unit/Rules/NotEmptyTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NotEmpty
  * @covers \Respect\Validation\Exceptions\NotEmptyException
  */
-class NotEmptyTest extends \PHPUnit_Framework_TestCase
+class NotEmptyTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/NotOptionalTest.php
+++ b/tests/unit/Rules/NotOptionalTest.php
@@ -11,13 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NotOptional
  */
-class NotOptionalTest extends \PHPUnit_Framework_TestCase
+class NotOptionalTest extends TestCase
 {
     /**
      * @dataProvider providerForNotOptional

--- a/tests/unit/Rules/NotTest.php
+++ b/tests/unit/Rules/NotTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validator;
 
 /**
@@ -18,7 +19,7 @@ use Respect\Validation\Validator;
  * @covers \Respect\Validation\Rules\Not
  * @covers \Respect\Validation\Exceptions\NotException
  */
-class NotTest extends \PHPUnit_Framework_TestCase
+class NotTest extends TestCase
 {
     /**
      * @dataProvider providerForValidNot

--- a/tests/unit/Rules/NullTypeTest.php
+++ b/tests/unit/Rules/NullTypeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NullType
  * @covers \Respect\Validation\Exceptions\NullTypeException
  */
-class NullTypeTest extends \PHPUnit_Framework_TestCase
+class NullTypeTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/NumericValTest.php
+++ b/tests/unit/Rules/NumericValTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\NumericVal
  * @covers \Respect\Validation\Exceptions\NumericValException
  */
-class NumericValTest extends \PHPUnit_Framework_TestCase
+class NumericValTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/ObjectTypeTest.php
+++ b/tests/unit/Rules/ObjectTypeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\ObjectType
  * @covers \Respect\Validation\Exceptions\ObjectTypeException
  */
-class ObjectTypeTest extends \PHPUnit_Framework_TestCase
+class ObjectTypeTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/OddTest.php
+++ b/tests/unit/Rules/OddTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Odd
  * @covers \Respect\Validation\Exceptions\OddException
  */
-class OddTest extends \PHPUnit_Framework_TestCase
+class OddTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/OneOfTest.php
+++ b/tests/unit/Rules/OneOfTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\OneOf
  * @covers \Respect\Validation\Exceptions\OneOfException
  */
-class OneOfTest extends \PHPUnit_Framework_TestCase
+class OneOfTest extends TestCase
 {
     public function testValid()
     {

--- a/tests/unit/Rules/OptionalTest.php
+++ b/tests/unit/Rules/OptionalTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validatable;
 use stdClass;
 
@@ -18,7 +19,7 @@ use stdClass;
  * @group  rule
  * @covers \Respect\Validation\Rules\Optional
  */
-class OptionalTest extends \PHPUnit_Framework_TestCase
+class OptionalTest extends TestCase
 {
     public function providerForOptional()
     {

--- a/tests/unit/Rules/PerfectSquareTest.php
+++ b/tests/unit/Rules/PerfectSquareTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\PerfectSquare
  * @covers \Respect\Validation\Exceptions\PerfectSquareException
  */
-class PerfectSquareTest extends \PHPUnit_Framework_TestCase
+class PerfectSquareTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/PhoneTest.php
+++ b/tests/unit/Rules/PhoneTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Phone
  * @covers \Respect\Validation\Exceptions\PhoneException
  */
-class PhoneTest extends \PHPUnit_Framework_TestCase
+class PhoneTest extends TestCase
 {
     protected $phoneValidator;
 

--- a/tests/unit/Rules/PositiveTest.php
+++ b/tests/unit/Rules/PositiveTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Positive
  * @covers \Respect\Validation\Exceptions\PositiveException
  */
-class PositiveTest extends \PHPUnit_Framework_TestCase
+class PositiveTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/PostalCodeTest.php
+++ b/tests/unit/Rules/PostalCodeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\PostalCode
  * @covers \Respect\Validation\Exceptions\PostalCodeException
  */
-class PostalCodeTest extends \PHPUnit_Framework_TestCase
+class PostalCodeTest extends TestCase
 {
     public function testShouldUsePatternAccordingToCountryCode()
     {

--- a/tests/unit/Rules/PrimeNumberTest.php
+++ b/tests/unit/Rules/PrimeNumberTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\PrimeNumber
  * @covers \Respect\Validation\Exceptions\PrimeNumberException
  */
-class PrimeNumberTest extends \PHPUnit_Framework_TestCase
+class PrimeNumberTest extends TestCase
 {
     protected $object;
 

--- a/tests/unit/Rules/PrntTest.php
+++ b/tests/unit/Rules/PrntTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Prnt
  * @covers \Respect\Validation\Exceptions\PrntException
  */
-class PrntTest extends \PHPUnit_Framework_TestCase
+class PrntTest extends TestCase
 {
     /**
      * @dataProvider providerForValidPrint

--- a/tests/unit/Rules/PunctTest.php
+++ b/tests/unit/Rules/PunctTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Punct
  * @covers \Respect\Validation\Exceptions\PunctException
  */
-class PunctTest extends \PHPUnit_Framework_TestCase
+class PunctTest extends TestCase
 {
     /**
      * @dataProvider providerForValidPunct

--- a/tests/unit/Rules/ReadableTest.php
+++ b/tests/unit/Rules/ReadableTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 $GLOBALS['is_readable'] = null;
 
 function is_readable($readable)
@@ -29,7 +31,7 @@ function is_readable($readable)
  * @covers \Respect\Validation\Rules\Readable
  * @covers \Respect\Validation\Exceptions\ReadableException
  */
-class ReadableTest extends \PHPUnit_Framework_TestCase
+class ReadableTest extends TestCase
 {
     /**
      * @covers \Respect\Validation\Rules\Readable::validate

--- a/tests/unit/Rules/ResourceTypeTest.php
+++ b/tests/unit/Rules/ResourceTypeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\ResourceType
  * @covers \Respect\Validation\Exceptions\ResourceTypeException
  */
-class ResourceTypeTest extends \PHPUnit_Framework_TestCase
+class ResourceTypeTest extends TestCase
 {
     protected $rule;
 

--- a/tests/unit/Rules/RomanTest.php
+++ b/tests/unit/Rules/RomanTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Roman
  * @covers \Respect\Validation\Exceptions\RomanException
  */
-class RomanTest extends \PHPUnit_Framework_TestCase
+class RomanTest extends TestCase
 {
     protected $romanValidator;
 

--- a/tests/unit/Rules/ScalarValTest.php
+++ b/tests/unit/Rules/ScalarValTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\ScalarVal
  * @covers \Respect\Validation\Exceptions\ScalarValException
  */
-class ScalarValTest extends \PHPUnit_Framework_TestCase
+class ScalarValTest extends TestCase
 {
     protected $rule;
 

--- a/tests/unit/Rules/SfTest.php
+++ b/tests/unit/Rules/SfTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Validator as v;
 
@@ -19,7 +20,7 @@ use Respect\Validation\Validator as v;
  * @covers \Respect\Validation\Rules\Sf
  * @covers \Respect\Validation\Exceptions\SfException
  */
-class SfTest extends \PHPUnit_Framework_TestCase
+class SfTest extends TestCase
 {
     public function testValidationWithAnExistingValidationConstraint()
     {

--- a/tests/unit/Rules/SizeTest.php
+++ b/tests/unit/Rules/SizeTest.php
@@ -13,7 +13,7 @@ namespace Respect\Validation\Rules;
 
 use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
 /**
@@ -22,7 +22,7 @@ use SplFileInfo;
  * @covers \Respect\Validation\Rules\Size
  * @covers \Respect\Validation\Exceptions\SizeException
  */
-class SizeTest extends PHPUnit_Framework_TestCase
+class SizeTest extends TestCase
 {
     public function validSizeProvider()
     {

--- a/tests/unit/Rules/SlugTest.php
+++ b/tests/unit/Rules/SlugTest.php
@@ -11,11 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Slug
  */
-class SlugTest extends \PHPUnit_Framework_TestCase
+class SlugTest extends TestCase
 {
     /**
      * @dataProvider providerValidSlug

--- a/tests/unit/Rules/SortedTest.php
+++ b/tests/unit/Rules/SortedTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Sorted
  * @covers \Respect\Validation\Exceptions\SortedException
  */
-class SortedTest extends \PHPUnit_Framework_TestCase
+class SortedTest extends TestCase
 {
     public function testPasses()
     {

--- a/tests/unit/Rules/SpaceTest.php
+++ b/tests/unit/Rules/SpaceTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Space
  * @covers \Respect\Validation\Exceptions\SpaceException
  */
-class SpaceTest extends \PHPUnit_Framework_TestCase
+class SpaceTest extends TestCase
 {
     /**
      * @dataProvider providerForValidSpace

--- a/tests/unit/Rules/StartsWithTest.php
+++ b/tests/unit/Rules/StartsWithTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\StartsWith
  * @covers \Respect\Validation\Exceptions\StartsWithException
  */
-class StartsWithTest extends \PHPUnit_Framework_TestCase
+class StartsWithTest extends TestCase
 {
     /**
      * @dataProvider providerForStartsWith

--- a/tests/unit/Rules/StringTypeTest.php
+++ b/tests/unit/Rules/StringTypeTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\StringType
  * @covers \Respect\Validation\Exceptions\StringTypeException
  */
-class StringTypeTest extends \PHPUnit_Framework_TestCase
+class StringTypeTest extends TestCase
 {
     /**
      * @dataProvider providerForString

--- a/tests/unit/Rules/SubdivisionCodeTest.php
+++ b/tests/unit/Rules/SubdivisionCodeTest.php
@@ -11,13 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Respect\Validation\Rules\SubdivisionCode
  * @covers \Respect\Validation\Exceptions\SubdivisionCodeException
  */
-class SubdivisionCodeTest extends PHPUnit_Framework_TestCase
+class SubdivisionCodeTest extends TestCase
 {
     /**
      * @expectedException \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/SymbolicLinkTest.php
+++ b/tests/unit/Rules/SymbolicLinkTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 $GLOBALS['is_link'] = null;
 
 function is_link($link)
@@ -29,7 +31,7 @@ function is_link($link)
  * @covers \Respect\Validation\Rules\SymbolicLink
  * @covers \Respect\Validation\Exceptions\SymbolicLinkException
  */
-class SymbolicLinkTest extends \PHPUnit_Framework_TestCase
+class SymbolicLinkTest extends TestCase
 {
     /**
      * @covers \Respect\Validation\Rules\SymbolicLink::validate

--- a/tests/unit/Rules/TldTest.php
+++ b/tests/unit/Rules/TldTest.php
@@ -11,11 +11,13 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Tld
  */
-class TldTest extends \PHPUnit_Framework_TestCase
+class TldTest extends TestCase
 {
     public function providerForValidTld()
     {

--- a/tests/unit/Rules/TrueValTest.php
+++ b/tests/unit/Rules/TrueValTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\TrueVal
  * @covers \Respect\Validation\Exceptions\TrueValException
  */
-class TrueValTest extends \PHPUnit_Framework_TestCase
+class TrueValTest extends TestCase
 {
     /**
      * @dataProvider validTrueProvider

--- a/tests/unit/Rules/TypeTest.php
+++ b/tests/unit/Rules/TypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -18,7 +19,7 @@ use stdClass;
  * @covers \Respect\Validation\Rules\Type
  * @covers \Respect\Validation\Exceptions\TypeException
  */
-class TypeTest extends \PHPUnit_Framework_TestCase
+class TypeTest extends TestCase
 {
     public function testShouldDefineTypeOnConstructor()
     {

--- a/tests/unit/Rules/UploadedTest.php
+++ b/tests/unit/Rules/UploadedTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 $GLOBALS['is_uploaded_file'] = null;
 
 function is_uploaded_file($uploaded)
@@ -29,7 +31,7 @@ function is_uploaded_file($uploaded)
  * @covers \Respect\Validation\Rules\Uploaded
  * @covers \Respect\Validation\Exceptions\UploadedException
  */
-class UploadedTest extends \PHPUnit_Framework_TestCase
+class UploadedTest extends TestCase
 {
     /**
      * @covers \Respect\Validation\Rules\Uploaded::validate

--- a/tests/unit/Rules/UppercaseTest.php
+++ b/tests/unit/Rules/UppercaseTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Uppercase
  * @covers \Respect\Validation\Exceptions\UppercaseException
  */
-class UppercaseTest extends \PHPUnit_Framework_TestCase
+class UppercaseTest extends TestCase
 {
     /**
      * @dataProvider providerForValidUppercase

--- a/tests/unit/Rules/UrlTest.php
+++ b/tests/unit/Rules/UrlTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Url
  * @covers \Respect\Validation\Exceptions\UrlException
  */
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends TestCase
 {
     /**
      * @dataProvider providerForValidUrl

--- a/tests/unit/Rules/VatinTest.php
+++ b/tests/unit/Rules/VatinTest.php
@@ -11,13 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validatable;
 
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Vatin
  */
-final class VatinTest extends \PHPUnit_Framework_TestCase
+final class VatinTest extends TestCase
 {
     public function testShouldAcceptCountryCodeOnConstructor()
     {

--- a/tests/unit/Rules/VersionTest.php
+++ b/tests/unit/Rules/VersionTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Version
  * @covers \Respect\Validation\Exceptions\VersionException
  */
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends TestCase
 {
     /**
      * @dataProvider providerForValidVersion

--- a/tests/unit/Rules/VideoUrlTest.php
+++ b/tests/unit/Rules/VideoUrlTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\VideoUrl
  * @covers \Respect\Validation\Exceptions\VideoUrlException
  */
-class VideoUrlTest extends \PHPUnit_Framework_TestCase
+class VideoUrlTest extends TestCase
 {
     /**
      * @expectedException \Respect\Validation\Exceptions\ComponentException

--- a/tests/unit/Rules/VowelTest.php
+++ b/tests/unit/Rules/VowelTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Vowel
  * @covers \Respect\Validation\Exceptions\VowelException
  */
-class VowelTest extends \PHPUnit_Framework_TestCase
+class VowelTest extends TestCase
 {
     /**
      * @dataProvider providerForValidVowels

--- a/tests/unit/Rules/WritableTest.php
+++ b/tests/unit/Rules/WritableTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 $GLOBALS['is_writable'] = null;
 
 function is_writable($writable)
@@ -29,7 +31,7 @@ function is_writable($writable)
  * @covers \Respect\Validation\Rules\Writable
  * @covers \Respect\Validation\Exceptions\WritableException
  */
-class WritableTest extends \PHPUnit_Framework_TestCase
+class WritableTest extends TestCase
 {
     /**
      * @covers \Respect\Validation\Rules\Writable::validate

--- a/tests/unit/Rules/XdigitTest.php
+++ b/tests/unit/Rules/XdigitTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Xdigit
  * @covers \Respect\Validation\Exceptions\XdigitException
  */
-class XdigitTest extends \PHPUnit_Framework_TestCase
+class XdigitTest extends TestCase
 {
     protected $xdigitsValidator;
 

--- a/tests/unit/Rules/YesTest.php
+++ b/tests/unit/Rules/YesTest.php
@@ -11,12 +11,14 @@
 
 namespace Respect\Validation\Rules;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group  rule
  * @covers \Respect\Validation\Rules\Yes
  * @covers \Respect\Validation\Exceptions\YesException
  */
-class YesTest extends \PHPUnit_Framework_TestCase
+class YesTest extends TestCase
 {
     public function testShouldUseDefaultPattern()
     {

--- a/tests/unit/Rules/ZendTest.php
+++ b/tests/unit/Rules/ZendTest.php
@@ -12,6 +12,7 @@
 namespace Respect\Validation\Rules;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Zend\Validator\Date as ZendDate;
 use Zend\Validator\ValidatorInterface;
 
@@ -20,7 +21,7 @@ use Zend\Validator\ValidatorInterface;
  * @covers \Respect\Validation\Rules\Zend
  * @covers \Respect\Validation\Exceptions\ZendException
  */
-class ZendTest extends \PHPUnit_Framework_TestCase
+class ZendTest extends TestCase
 {
     public function testConstructorWithValidatorName()
     {

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -11,9 +11,10 @@
 
 namespace Respect\Validation;
 
+use PHPUnit\Framework\TestCase;
 use Respect\Validation\Exceptions\ComponentException;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     public function testStaticCreateShouldReturnNewValidator()
     {
@@ -22,7 +23,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidRuleClassShouldThrowComponentException()
     {
-        $this->setExpectedException(ComponentException::class);
+        $this->expectException(ComponentException::class);
         Validator::iDoNotExistSoIShouldThrowException();
     }
 


### PR DESCRIPTION
For a feature release of this package, I've updated the suitcase of tests to version 6 of `PHPUnit`.

The biggest change was namespaces. Previous, the tests extended `PHPUnit_Framework_TestCase`, and now `PHPUnit\Framework\TestCase`.

`setExpectedException` method was also changed to `expectException`.

I used [this article](https://thephp.cc/news/2017/02/migrating-to-phpunit-6) from @sebastianbergmann to help me in this update.

PS: There's only [one Travis CI test](https://travis-ci.org/Respect/Validation/jobs/297167988) that is not passing, probably because of this section in the article:

> Global and super-global variables are no longer backed up before and restored after each test by default

What should we do to fix it? :cry: 