### PR TITLE
Try to find template from default templates first

### DIFF
--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -305,6 +305,9 @@ class ValidationException extends InvalidArgumentException implements ExceptionI
     public function setTemplate($template)
     {
         $this->customTemplate = true;
+        if (isset(static::$defaultTemplates[$this->mode][$template])) {
+            $template = static::$defaultTemplates[$this->mode][$template];
+        }
         $this->template = $template;
 
         $this->buildMessage();

--- a/tests/integration/issue-739.phpt
+++ b/tests/integration/issue-739.phpt
@@ -1,0 +1,16 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::when(v::alwaysInvalid(), v::alwaysValid())->check('foo');
+} catch (ValidationException $exception) {
+    echo $exception->getMainMessage();
+}
+?>
+--EXPECT--
+"foo" is not valid


### PR DESCRIPTION
When executing `ValidationException::setTemplate()` using a template
key, it does not try to select the template, but instead it uses the
template key as the template itself.

In order to fix this behaviour, there is now a check for a key with the
defined template. In case the template was not found, use the defined
template as the template itself.