### PR TITLE
Replace fabpot/php-cs-fixer with friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "egulias/email-validator": "Strict (RFC compliant) email validation",
         "symfony/validator": "Use Symfony validator through Respect\\Validation",
         "zendframework/zend-validator": "Use Zend Framework validator through Respect\\Validation",
-        "fabpot/php-cs-fixer": "Fix PSR2 and other coding style issues"
+        "friendsofphp/php-cs-fixer": "Fix PSR2 and other coding style issues"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The fapbot version is abandoned accord to packagist and suggests the
friendsofphp version.

https://packagist.org/packages/fabpot/php-cs-fixer