### PR TITLE
Make "Between" always inclusive

### DIFF
--- a/docs/Between.md
+++ b/docs/Between.md
@@ -1,12 +1,13 @@
 # Between
 
 - `Between(mixed $minimum, mixed $maximum)`
-- `Between(mixed $minimum, mixed $maximum, bool $inclusive)`
 
 Validates whether the input is between two other values.
 
 ```php
+v::intVal()->between(10, 20)->validate(10); // true
 v::intVal()->between(10, 20)->validate(15); // true
+v::intVal()->between(10, 20)->validate(20); // true
 ```
 
 The type as the first validator in a chain is a good practice,
@@ -22,16 +23,10 @@ Also very powerful with dates:
 v::dateTime()->between('2009-01-01', '2013-01-01')->validate('2010-01-01'); // true
 ```
 
-Date ranges accept strtotime values:
+Date ranges accept date intervals:
 
 ```php
 v::dateTime()->between('yesterday', 'tomorrow')->validate('now'); // true
-```
-
-A third parameter may be passed to validate the passed values inclusive:
-
-```php
-v::dateTime()->between(10, 20, true)->validate(20); // true
 ```
 
 Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
@@ -40,12 +35,15 @@ Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
 
 Version | Description
 --------|-------------
+  2.0.0 | Became always inclusive
   1.0.0 | Became inclusive by default
   0.3.9 | Created
 
 ***
 See also:
 
+- [GreaterThan](GreaterThan.md)
 - [Length](Length.md)
-- [Min](Min.md)
+- [LessThan](LessThan.md)
 - [Max](Max.md)
+- [Min](Min.md)

--- a/library/Exceptions/BetweenException.php
+++ b/library/Exceptions/BetweenException.php
@@ -24,10 +24,10 @@ final class BetweenException extends NestedValidationException
      */
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be between {{minimum}} and {{maximum}}',
+            self::STANDARD => '{{name}} must be between {{minValue}} and {{maxValue}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be between {{minimum}} and {{maximum}}',
+            self::STANDARD => '{{name}} must not be between {{minValue}} and {{maxValue}}',
         ],
     ];
 }

--- a/library/Rules/Between.php
+++ b/library/Rules/Between.php
@@ -29,27 +29,25 @@ final class Between extends AbstractEnvelope
     /**
      * Initializes the rule.
      *
-     * @param mixed $minimum
-     * @param mixed $maximum
-     * @param bool $inclusive
+     * @param mixed $minValue
+     * @param mixed $maxValue
      *
      * @throws ComponentException
      */
-    public function __construct($minimum, $maximum, bool $inclusive = true)
+    public function __construct($minValue, $maxValue)
     {
-        if ($this->toComparable($minimum) >= $this->toComparable($maximum)) {
+        if ($this->toComparable($minValue) >= $this->toComparable($maxValue)) {
             throw new ComponentException('Minimum cannot be less than or equals to maximum');
         }
 
         parent::__construct(
             new AllOf(
-                new Min($minimum, $inclusive),
-                new Max($maximum, $inclusive)
+                new Min($minValue, true),
+                new Max($maxValue, true)
             ),
             [
-                'minimum' => $minimum,
-                'maximum' => $maximum,
-                'inclusive' => $inclusive,
+                'minValue' => $minValue,
+                'maxValue' => $maxValue,
             ]
         );
     }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -32,7 +32,7 @@ use Respect\Validation\Rules\Key;
  * @method static Validator attribute(string $reference, Validatable $validator = null, bool $mandatory = true)
  * @method static Validator base()
  * @method static Validator base64()
- * @method static Validator between($minimum, $maximum, bool $inclusive = true)
+ * @method static Validator between($minimum, $maximum)
  * @method static Validator bic(string $countryCode)
  * @method static Validator boolType()
  * @method static Validator boolVal()

--- a/tests/unit/Rules/BetweenTest.php
+++ b/tests/unit/Rules/BetweenTest.php
@@ -29,14 +29,14 @@ final class BetweenTest extends RuleTestCase
     public function providerForValidInput(): array
     {
         return [
-            [new Between(0, 1, true), 1],
-            [new Between(0, 1, true), 0],
-            [new Between(10, 20, false), 15],
-            [new Between(10, 20, true), 20],
-            [new Between(-10, 20, false), -5],
-            [new Between(-10, 20, false), 0],
-            [new Between('a', 'z', false), 'j'],
-            [new Between(new DateTime('yesterday'), new DateTime('tomorrow'), false), new DateTime('now')],
+            [new Between(0, 1), 1],
+            [new Between(0, 1), 0],
+            [new Between(10, 20), 15],
+            [new Between(10, 20), 20],
+            [new Between(-10, 20), -5],
+            [new Between(-10, 20), 0],
+            [new Between('a', 'z'), 'j'],
+            [new Between(new DateTime('yesterday'), new DateTime('tomorrow')), new DateTime('now')],
         ];
     }
 
@@ -46,17 +46,14 @@ final class BetweenTest extends RuleTestCase
     public function providerForInvalidInput(): array
     {
         return [
-            [new Between(10, 20, false), ''],
-            [new Between(10, 20, true), ''],
-            [new Between(0, 1, false), 0],
-            [new Between(0, 1, false), 1],
-            [new Between(0, 1, false), 2],
-            [new Between(0, 1, false), -1],
-            [new Between(10, 20, false), 999],
-            [new Between(10, 20, false), 20],
-            [new Between(-10, 20, false), -11],
-            [new Between('a', 'j', false), 'z'],
-            [new Between(new DateTime('yesterday'), new DateTime('now'), false), new DateTime('tomorrow')],
+            [new Between(10, 20), ''],
+            [new Between(10, 20), ''],
+            [new Between(0, 1), 2],
+            [new Between(0, 1), -1],
+            [new Between(10, 20), 999],
+            [new Between(-10, 20), -11],
+            [new Between('a', 'j'), 'z'],
+            [new Between(new DateTime('yesterday'), new DateTime('now')), new DateTime('tomorrow')],
         ];
     }
 


### PR DESCRIPTION
Generally speaking it makes more sense to have it always inclusive. Even
though the word "between" does not imply that it is inclusive or
exclusive it's more natural this way.

Besides, users can always use "GreaterThan" and "LessThan" rules in case
that is necessary.

Removing this boolean parameter reduces a bit of the complexity of the
rule.