### PR TITLE
Apply contribution guidelines to "Uploaded" rule

### DIFF
--- a/library/Exceptions/UploadedException.php
+++ b/library/Exceptions/UploadedException.php
@@ -13,8 +13,18 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class UploadedException extends ValidationException
+/**
+ * Exceptions thrown by Uploaded rule.
+ *
+ * @author FKhairil <fajar90alone@gmail.com>
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ * @author Paul Karikari <paulkarikari1@gmail.com>
+ */
+final class UploadedException extends ValidationException
 {
+    /**
+     * {@inheritdoc}
+     */
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
             self::STANDARD => '{{name}} must be an uploaded file',

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -13,8 +13,20 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
-class Uploaded extends AbstractRule
+use is_string;
+
+/**
+ * Validates if the given data is a file that
+ * was uploaded via HTTP POST.
+ *
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ * @author Paul Karikari <paulkarikari1@gmail.com>
+ */
+final class Uploaded extends AbstractRule
 {
+    /**
+     * {@inheritdoc}
+     */
     public function validate($input): bool
     {
         if ($input instanceof \SplFileInfo) {

--- a/tests/unit/Rules/UploadedTest.php
+++ b/tests/unit/Rules/UploadedTest.php
@@ -29,11 +29,15 @@ function is_uploaded_file($uploaded)
 }
 
 /**
- * @group  rule
+ * @group rule
+ *
  * @covers \Respect\Validation\Rules\Uploaded
- * @covers \Respect\Validation\Exceptions\UploadedException
+ *
+ * @author Gabriel Caruso <carusogabriel34@gmail.com>
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ * @author Paul Karikari <paulkarikari1@gmail.com>
  */
-class UploadedTest extends TestCase
+final class UploadedTest extends TestCase
 {
     /**
      * @covers \Respect\Validation\Rules\Uploaded::validate


### PR DESCRIPTION
This PR applies some of the guidelines listed in #921.

**Test didn't extend RuleTestCase.**
I keep getting false instead of true when the "shouldValidateValidInput" method of "RuleTestCase" class is called.

**Didn't include .phpt file**
Adding an integration test for files uploaded means the test will be system dependent ie. it will depend on the specific file path given which I think is not ideal.

