### PR TITLE
Avoid using unset keys in IpException

### DIFF
--- a/library/Exceptions/IpException.php
+++ b/library/Exceptions/IpException.php
@@ -29,6 +29,7 @@ class IpException extends ValidationException
 
     public function configure($name, array $params = [])
     {
+        $params += ['networkRange' => null, 'min' => null];
         if ($params['networkRange']) {
             $range = $params['networkRange'];
             $message = $range['min'];


### PR DESCRIPTION
The "IpException" was triggering an error when the parameters
"networkRange" or "min" were not defined.

Fix #1012