### PR TITLE
Do not consider any float as integer

### DIFF
--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -15,6 +15,10 @@ class IntVal extends AbstractRule
 {
     public function validate($input)
     {
-        return is_numeric($input) && (int) $input == $input;
+        if (is_float($input)) {
+            return false;
+        }
+
+        return false !== filter_var($input, FILTER_VALIDATE_INT);
     }
 }

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -61,6 +61,8 @@ class IntValTest extends \PHPUnit_Framework_TestCase
             [''],
             [null],
             ['a'],
+            ['1.0'],
+            [1.0],
             [' '],
             ['Foo'],
             ['1.44'],


### PR DESCRIPTION
Values like "500.00" or 1.0 should not be considered as integer values
even though there is no data loss when they're converted to integer.

Fix #849