### PR TITLE
#1038 Fix IntVal incorrectly passing on boolean true

### DIFF
--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -19,6 +19,10 @@ class IntVal extends AbstractRule
             return false;
         }
 
+        if (is_bool($input)) {
+            return false;
+        }
+
         return false !== filter_var($input, FILTER_VALIDATE_INT);
     }
 }

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -64,6 +64,8 @@ class IntValTest extends \PHPUnit_Framework_TestCase
             ['1.0'],
             [1.0],
             [' '],
+            [true],
+            [false],
             ['Foo'],
             ['1.44'],
             [1e-5],


### PR DESCRIPTION
Fix for https://github.com/Respect/Validation/issues/1038

Recent update to improve `IntVal` to prevent decimal-like values being accepted as integers introduced a regression allowing boolean `true` to be accepted as integer. This change prevents booleans from being considered valid values.

@henriquemoody @pascalzajac 