### PR TITLE
Simplify "AbstractComposite" class

### DIFF
--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -17,8 +17,8 @@ class AllOf extends AbstractComposite
 {
     public function assert($input): void
     {
-        $exceptions = $this->validateRules($input);
-        $numRules = count($this->rules);
+        $exceptions = $this->getAllThrownExceptions($input);
+        $numRules = count($this->getRules());
         $numExceptions = count($exceptions);
         $summary = [
             'total' => $numRules,

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -20,7 +20,7 @@ class AnyOf extends AbstractComposite
     public function assert($input): void
     {
         $validators = $this->getRules();
-        $exceptions = $this->validateRules($input);
+        $exceptions = $this->getAllThrownExceptions($input);
         $numRules = count($validators);
         $numExceptions = count($exceptions);
         if ($numExceptions === $numRules) {

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -17,7 +17,7 @@ class NoneOf extends AbstractComposite
 {
     public function assert($input): void
     {
-        $exceptions = $this->validateRules($input);
+        $exceptions = $this->getAllThrownExceptions($input);
         $numRules = count($this->getRules());
         $numExceptions = count($exceptions);
         if ($numRules !== $numExceptions) {

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -24,7 +24,7 @@ class OneOf extends AbstractComposite
     public function assert($input): void
     {
         $validators = $this->getRules();
-        $exceptions = $this->validateRules($input);
+        $exceptions = $this->getAllThrownExceptions($input);
         $numRules = count($validators);
         $numExceptions = count($exceptions);
         if ($numExceptions !== $numRules - 1) {

--- a/tests/unit/Rules/AbstractCompositeTest.php
+++ b/tests/unit/Rules/AbstractCompositeTest.php
@@ -17,9 +17,15 @@ use PHPUnit\Framework\TestCase;
 use Respect\Validation\Validatable;
 
 /**
+ * @group rule
+ *
  * @covers \Respect\Validation\Rules\AbstractComposite
+ *
+ * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
+ * @author Gabriel Caruso <carusogabriel34@gmail.com>
+ * @author Henrique Moody <henriquemoody@gmail.com>
  */
-class AbstractCompositeTest extends TestCase
+final class AbstractCompositeTest extends TestCase
 {
     /**
      * @test
@@ -28,22 +34,23 @@ class AbstractCompositeTest extends TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->createMock(Validatable::class);
-        $simpleRuleMock
+        $rule = $this->createMock(Validatable::class);
+        $rule
             ->expects(self::once())
             ->method('getName')
             ->will(self::returnValue(null));
-        $simpleRuleMock
+        $rule
             ->expects(self::once())
             ->method('setName')
             ->with($ruleName);
 
-        $compositeRuleMock = $this
+        $sut = $this
             ->getMockBuilder(AbstractComposite::class)
             ->setMethods(['validate'])
             ->getMockForAbstractClass();
-        $compositeRuleMock->setName($ruleName);
-        $compositeRuleMock->addRule($simpleRuleMock);
+
+        $sut->setName($ruleName);
+        $sut->addRule($rule);
     }
 
     /**
@@ -54,31 +61,31 @@ class AbstractCompositeTest extends TestCase
         $ruleName1 = 'something';
         $ruleName2 = 'something else';
 
-        $simpleRuleMock = $this->createMock(Validatable::class);
-        $simpleRuleMock
+        $rule = $this->createMock(Validatable::class);
+        $rule
             ->expects(self::at(0))
             ->method('getName')
             ->will(self::returnValue(null));
-        $simpleRuleMock
+        $rule
             ->expects(self::at(2))
             ->method('getName')
             ->will(self::returnValue($ruleName1));
-        $simpleRuleMock
+        $rule
             ->expects(self::at(1))
             ->method('setName')
             ->with($ruleName1);
-        $simpleRuleMock
+        $rule
             ->expects(self::at(3))
             ->method('setName')
             ->with($ruleName2);
 
-        $compositeRuleMock = $this
+        $sut = $this
             ->getMockBuilder(AbstractComposite::class)
             ->setMethods(['validate'])
             ->getMockForAbstractClass();
-        $compositeRuleMock->setName($ruleName1);
-        $compositeRuleMock->addRule($simpleRuleMock);
-        $compositeRuleMock->setName($ruleName2);
+        $sut->setName($ruleName1);
+        $sut->addRule($rule);
+        $sut->setName($ruleName2);
     }
 
     /**
@@ -86,21 +93,21 @@ class AbstractCompositeTest extends TestCase
      */
     public function shouldNotUpdateInternalRuleAlreadyHasAName(): void
     {
-        $simpleRuleMock = $this->createMock(Validatable::class);
-        $simpleRuleMock
+        $rule = $this->createMock(Validatable::class);
+        $rule
             ->expects(self::any())
             ->method('getName')
             ->will(self::returnValue('something'));
-        $simpleRuleMock
+        $rule
             ->expects(self::never())
             ->method('setName');
 
-        $compositeRuleMock = $this
+        $sut = $this
             ->getMockBuilder(AbstractComposite::class)
             ->setMethods(['validate'])
             ->getMockForAbstractClass();
-        $compositeRuleMock->addRule($simpleRuleMock);
-        $compositeRuleMock->setName('Whatever');
+        $sut->addRule($rule);
+        $sut->setName('Whatever');
     }
 
     /**
@@ -110,22 +117,23 @@ class AbstractCompositeTest extends TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->createMock(Validatable::class);
-        $simpleRuleMock
+        $rule = $this->createMock(Validatable::class);
+        $rule
             ->expects(self::any())
             ->method('getName')
             ->will(self::returnValue(null));
-        $simpleRuleMock
+        $rule
             ->expects(self::once())
             ->method('setName')
             ->with($ruleName);
 
-        $compositeRuleMock = $this
+        $sut = $this
             ->getMockBuilder(AbstractComposite::class)
             ->setMethods(['validate'])
             ->getMockForAbstractClass();
-        $compositeRuleMock->addRule($simpleRuleMock);
-        $compositeRuleMock->setName($ruleName);
+
+        $sut->addRule($rule);
+        $sut->setName($ruleName);
     }
 
     /**
@@ -135,22 +143,23 @@ class AbstractCompositeTest extends TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->createMock(Validatable::class);
-        $simpleRuleMock
+        $rule = $this->createMock(Validatable::class);
+        $rule
             ->expects(self::any())
             ->method('getName')
             ->will(self::returnValue(null));
-        $simpleRuleMock
+        $rule
             ->expects(self::once())
             ->method('setName')
             ->with($ruleName);
 
-        $compositeRuleMock = $this
+        $sut = $this
             ->getMockBuilder(AbstractComposite::class)
             ->setMethods(['validate'])
             ->getMockForAbstractClass();
-        $compositeRuleMock->addRule($simpleRuleMock);
-        $compositeRuleMock->setName($ruleName);
+
+        $sut->addRule($rule);
+        $sut->setName($ruleName);
     }
 
     /**
@@ -160,35 +169,22 @@ class AbstractCompositeTest extends TestCase
     {
         $ruleName = 'something';
 
-        $simpleRuleMock = $this->createMock(Validatable::class);
-        $simpleRuleMock
+        $rule = $this->createMock(Validatable::class);
+        $rule
             ->expects(self::any())
             ->method('getName')
             ->will(self::returnValue($ruleName));
-        $simpleRuleMock
+        $rule
             ->expects(self::never())
             ->method('setName');
 
-        $compositeRuleMock = $this
+        $sut = $this
             ->getMockBuilder(AbstractComposite::class)
             ->setMethods(['validate'])
             ->getMockForAbstractClass();
-        $compositeRuleMock->addRule($simpleRuleMock);
-        $compositeRuleMock->setName($ruleName);
-    }
 
-    /**
-     * @test
-     */
-    public function removeRulesShouldRemoveAllTheAddedRules(): void
-    {
-        $simpleRuleMock = $this->createMock(Validatable::class);
-
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class);
-        $compositeRuleMock->addRule($simpleRuleMock);
-        $compositeRuleMock->removeRules();
-
-        self::assertEmpty($compositeRuleMock->getRules());
+        $sut->addRule($rule);
+        $sut->setName($ruleName);
     }
 
     /**
@@ -196,63 +192,12 @@ class AbstractCompositeTest extends TestCase
      */
     public function shouldReturnTheAmountOfAddedRules(): void
     {
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class);
-        $compositeRuleMock->addRule($this->createMock(Validatable::class));
-        $compositeRuleMock->addRule($this->createMock(Validatable::class));
-        $compositeRuleMock->addRule($this->createMock(Validatable::class));
+        $sut = $this->getMockForAbstractClass(AbstractComposite::class);
+        $sut->addRule($this->createMock(Validatable::class));
+        $sut->addRule($this->createMock(Validatable::class));
+        $sut->addRule($this->createMock(Validatable::class));
 
-        self::assertCount(3, $compositeRuleMock->getRules());
-    }
-
-    /**
-     * @test
-     */
-    public function hasRuleShouldReturnFalseWhenThereIsNoRuleAppended(): void
-    {
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class);
-
-        self::assertFalse($compositeRuleMock->hasRule(''));
-    }
-
-    /**
-     * @test
-     */
-    public function hasRuleShouldReturnFalseWhenRuleIsNotFound(): void
-    {
-        $oneSimpleRuleMock = $this->createMock(Validatable::class);
-
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class);
-        $compositeRuleMock->addRule($oneSimpleRuleMock);
-
-        $anotherSimpleRuleMock = $this->createMock(Validatable::class);
-
-        self::assertFalse($compositeRuleMock->hasRule($anotherSimpleRuleMock));
-    }
-
-    /**
-     * @test
-     */
-    public function hasRuleShouldReturnFalseWhenRulePassedAsStringIsNotFound(): void
-    {
-        $simpleRuleMock = $this->createMock(Validatable::class);
-
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class);
-        $compositeRuleMock->addRule($simpleRuleMock);
-
-        self::assertFalse($compositeRuleMock->hasRule('SomeRule'));
-    }
-
-    /**
-     * @test
-     */
-    public function hasRuleShouldReturnTrueWhenRuleIsFound(): void
-    {
-        $simpleRuleMock = $this->createMock(Validatable::class);
-
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class);
-        $compositeRuleMock->addRule($simpleRuleMock);
-
-        self::assertTrue($compositeRuleMock->hasRule($simpleRuleMock));
+        self::assertCount(3, $sut->getRules());
     }
 
     /**
@@ -260,14 +205,14 @@ class AbstractCompositeTest extends TestCase
      */
     public function shouldAddRulesByPassingThroughConstructor(): void
     {
-        $simpleRuleMock = $this->createMock(Validatable::class);
+        $rule = $this->createMock(Validatable::class);
         $anotherSimpleRuleMock = $this->createMock(Validatable::class);
 
-        $compositeRuleMock = $this->getMockForAbstractClass(AbstractComposite::class, [
-            $simpleRuleMock,
+        $sut = $this->getMockForAbstractClass(AbstractComposite::class, [
+            $rule,
             $anotherSimpleRuleMock,
         ]);
 
-        self::assertCount(2, $compositeRuleMock->getRules());
+        self::assertCount(2, $sut->getRules());
     }
 }

--- a/tests/unit/Rules/AllOfTest.php
+++ b/tests/unit/Rules/AllOfTest.php
@@ -25,41 +25,6 @@ class AllOfTest extends TestCase
     /**
      * @test
      */
-    public function removeRulesShouldRemoveAllRules(): void
-    {
-        $o = new AllOf(new IntVal(), new Positive());
-        $o->removeRules();
-        self::assertCount(0, $o->getRules());
-    }
-
-    /**
-     * @test
-     */
-    public function addRulesUsingArrayOfRules(): void
-    {
-        $o = new AllOf();
-        $o->addRules(
-            [
-                [$x = new IntVal(), new Positive()],
-            ]
-        );
-        self::assertTrue($o->hasRule($x));
-        self::assertTrue($o->hasRule('Positive'));
-    }
-
-    /**
-     * @test
-     */
-    public function addRulesUsingSpecificationArray(): void
-    {
-        $o = new AllOf();
-        $o->addRules(['Between' => [1, 2]]);
-        self::assertTrue($o->hasRule('Between'));
-    }
-
-    /**
-     * @test
-     */
     public function validationShouldWorkIfAllRulesReturnTrue(): void
     {
         $valid1 = new Callback(function () {


### PR DESCRIPTION
There is a log of magic in the "AbstractComposite" that allows an user
to add a rule in multiple ways, remove rules, verify if a rule is
inserted or not. Because of that the class has a lot of complexity and
for unnecessary reasons since we do not use these features internally.

The ideal would be to make this class immutable, however due to many
usages is not possible to do it now, but that is the plan for a near
future - hopefully.