### PR TITLE
Fix casting error in AbstractInterval classes

### DIFF
--- a/library/Rules/AbstractInterval.php
+++ b/library/Rules/AbstractInterval.php
@@ -25,6 +25,11 @@ abstract class AbstractInterval extends AbstractRule
         $this->inclusive = $inclusive;
     }
 
+    protected function isAbleToCompareValues($left, $right)
+    {
+        return is_scalar($left) === is_scalar($right);
+    }
+
     protected function filterInterval($value)
     {
         if (!is_string($value) || is_numeric($value) || empty($value)) {

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -15,10 +15,17 @@ class Max extends AbstractInterval
 {
     public function validate($input)
     {
-        if ($this->inclusive) {
-            return $this->filterInterval($input) <= $this->filterInterval($this->interval);
+        $filteredInput = $this->filterInterval($input);
+        $filteredInterval = $this->filterInterval($this->interval);
+
+        if (!$this->isAbleToCompareValues($filteredInput, $filteredInterval)) {
+            return false;
         }
 
-        return $this->filterInterval($input) < $this->filterInterval($this->interval);
+        if ($this->inclusive) {
+            return $filteredInput <= $filteredInterval;
+        }
+
+        return $filteredInput < $filteredInterval;
     }
 }

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -15,10 +15,17 @@ class Min extends AbstractInterval
 {
     public function validate($input)
     {
-        if ($this->inclusive) {
-            return $this->filterInterval($input) >= $this->filterInterval($this->interval);
+        $filteredInput = $this->filterInterval($input);
+        $filteredInterval = $this->filterInterval($this->interval);
+
+        if (!$this->isAbleToCompareValues($filteredInput, $filteredInterval)) {
+            return false;
         }
 
-        return $this->filterInterval($input) > $this->filterInterval($this->interval);
+        if ($this->inclusive) {
+            return $filteredInput >= $filteredInterval;
+        }
+
+        return $filteredInput > $filteredInterval;
     }
 }

--- a/tests/unit/Rules/MaxTest.php
+++ b/tests/unit/Rules/MaxTest.php
@@ -62,6 +62,8 @@ class MaxTest extends \PHPUnit_Framework_TestCase
             [200, false, 250],
             [200, false, 1500],
             [200, false, 200],
+            [1900, false, '2018-01-25'],
+            [10.5, false, '2018-01-25'],
         ];
     }
 }

--- a/tests/unit/Rules/MinTest.php
+++ b/tests/unit/Rules/MinTest.php
@@ -70,6 +70,8 @@ class MinTest extends \PHPUnit_Framework_TestCase
             [0, false, -250],
             [0, false, -50],
             [50, false, 50],
+            [2040, false, '2018-01-25'],
+            [10.5, false, '2018-01-25'],
         ];
     }
 }


### PR DESCRIPTION
The classes that are children of "AbstractInterval" convert their values
before comparing them.

Because PHP tries to convert values when making comparisons and an
"DateTime" object cannot be converted to integer or float some
validations would result into PHP triggering an error like:

> Object of class DateTime could not be converted to int
> Object of class DateTime could not be converted to float

This commit prevents that to happen by verifying if both compared values
are scalar or not before comparing them with each other.

Fix #908