### PR TITLE
Implement \LayerShifter\TLDDatabase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "egulias/email-validator": "Strict (RFC compliant) email validation",
         "symfony/validator": "Use Symfony validator through Respect\\Validation",
         "zendframework/zend-validator": "Use Zend Framework validator through Respect\\Validation",
-        "friendsofphp/php-cs-fixer": "Fix PSR2 and other coding style issues"
+        "friendsofphp/php-cs-fixer": "Fix PSR2 and other coding style issues",
+        "layershifter/tld-database": "Database abstraction for Public Suffix List"
     },
     "autoload": {
         "psr-4": {

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -121,6 +121,12 @@ class Tld extends AbstractRule
 
     public function validate($input)
     {
-        return in_array(strtolower($input), $this->tldList);
+        // prefere LayerShifter\TLDDatabase if available
+        if (class_exists('\LayerShifter\TLDDatabase\Store')) {
+            $tldDb = new \LayerShifter\TLDDatabase\Store();
+            return $tldDb->isExists(strtolower($input));
+        } else {
+            return in_array(strtolower($input), $this->tldList);
+        }
     }
 }


### PR DESCRIPTION
Because tldList is always out of date, one might use \LayerShifter\TLDDatabase.
Changed validation to check for TLDDatabase and test TLD against it.