### PR TITLE
Do not trigger PHP errors in the "Call" rule

### DIFF
--- a/docs/Call.md
+++ b/docs/Call.md
@@ -2,8 +2,9 @@
 
 - `Call(callable $callable, Rule $rule)`
 
-This is a very low level validator. It calls a function, method or closure
-for the input and then validates it. Consider the following variable:
+Validates the return of a [callable][] for a given input.
+
+Consider the following variable:
 
 ```php
 $url = 'http://www.google.com/search?q=respect.github.com';
@@ -49,3 +50,5 @@ Version | Description
 See also:
 
 - [Callback](Callback.md)
+
+- [callable]: http://php.net/callable

--- a/library/Exceptions/CallException.php
+++ b/library/Exceptions/CallException.php
@@ -13,6 +13,21 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class CallException extends GroupedValidationException implements NonOmissibleException
+/**
+ * @author Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+final class CallException extends NestedValidationException
 {
+    /**
+     * {@inheritdoc}
+     */
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{input}} must be valid when executed with {{callable}}',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{input}} must not be valid when executed with {{callable}}',
+        ],
+    ];
 }

--- a/library/Rules/Call.php
+++ b/library/Rules/Call.php
@@ -13,15 +13,85 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
-class Call extends AbstractRelated
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validatable;
+use function call_user_func;
+use function restore_error_handler;
+use function set_error_handler;
+
+/**
+ * Validates the return of a callable for a given input.
+ *
+ * @author Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+final class Call extends AbstractRule
 {
-    public function getReferenceValue($input)
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @var Validatable
+     */
+    private $rule;
+
+    /**
+     * Initializes the rule with the callable to be executed after the input is passed.
+     *
+     * @param callable $callable
+     * @param Validatable $rule
+     */
+    public function __construct(callable $callable, Validatable $rule)
     {
-        return call_user_func_array($this->reference, [&$input]);
+        $this->callable = $callable;
+        $this->rule = $rule;
     }
 
-    public function hasReference($input): bool
+    /**
+     * {@inheritdoc}
+     */
+    public function assert($input): void
     {
-        return is_callable($this->reference);
+        $this->setErrorHandler($input);
+
+        $this->rule->assert(call_user_func($this->callable, $input));
+
+        restore_error_handler();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function check($input): void
+    {
+        $this->setErrorHandler($input);
+
+        $this->rule->check(call_user_func($this->callable, $input));
+
+        restore_error_handler();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($input): bool
+    {
+        try {
+            $this->check($input);
+        } catch (ValidationException $exception) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function setErrorHandler($input): void
+    {
+        set_error_handler(function () use ($input): void {
+            throw $this->reportError($input);
+        });
     }
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -36,7 +36,7 @@ use Respect\Validation\Rules\Key;
  * @method static Validator boolType()
  * @method static Validator boolVal()
  * @method static Validator bsn()
- * @method static Validator call()
+ * @method static Validator call(callable $callable, Validatable $rule)
  * @method static Validator callableType()
  * @method static Validator callback(callable $callback)
  * @method static Validator charset(string ...$charset)

--- a/tests/integration/rules/call.phpt
+++ b/tests/integration/rules/call.phpt
@@ -1,0 +1,52 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\CallException;
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::call('trim', v::noWhitespace())->check(' two words ');
+} catch (ValidationException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    v::not(v::call('trim', v::stringType()))->check(' something ');
+} catch (CallException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    v::call('trim', v::alwaysValid())->check([]);
+} catch (ValidationException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    v::call('strval', v::intType())->assert(1234);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+
+try {
+    v::not(v::call('is_float', v::boolType()))->assert(1.2);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+
+try {
+    v::call('array_walk', v::alwaysValid())->assert(INF);
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECT--
+"two words" must not contain whitespace
+" something " must not be valid when executed with "trim"
+`{ }` must be valid when executed with "trim"
+- "1234" must be of type integer
+- 1.2 must not be valid when executed with "is_float"
+- `INF` must be valid when executed with "array_walk"


### PR DESCRIPTION
This commit make sure that when the callable is executed by the "Call"
rule and PHP triggers an error, the user does not have to deal with it,
and instead the rule will "CallException".

Because of the many changes that were made, it didn't make sense to keep
the class "Call" extending the "AbstractRelated" class.

One thing that is a bit problematic with this rule - and with other
rules as well - is that Validation only knows details of a validation
when it fails, because of that we cannot invert the validations that
passed, meaning that the "Not" rule cannot give the proper response to
a validation that passed. This is a know issue that can only be fixed
is we provide a way for Validation do have more granularity control.