### PR TITLE
Rename method "validate()" to "isValid()"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ create a validator that validates if a string is equal to "Hello World".
 
 The rule itself needs to implement the `Validatable` interface but, it is
 convenient to just extend the `AbstractRule` class.
-Doing that, you'll only need to declare one method: `validate($input)`.
+Doing that, you'll only need to declare one method: `isValid($input)`.
 This method must return `true` or `false`.
 
 If your validator class is `HelloWorld`, it will be available as `v::helloWorld()`
@@ -77,7 +77,7 @@ final class HelloWorld extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return $input === 'Hello World';
     }
@@ -137,8 +137,8 @@ are able to use any methods of it. By extending `RuleTestCase` you should
 implement two methods that should return a [data provider][] with the rule as
 first item of the arrays:
 
-- `providerForValidInput`: Will test when `validate()` should return `true`
-- `providerForInvalidInput`: Will test when `validate()` should return `false`
+- `providerForValidInput`: Will test when `isValid()` should return `true`
+- `providerForInvalidInput`: Will test when `isValid()` should return `false`
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [The most awesome validation engine ever created for PHP.](http://bit.ly/1a1oeQv)
 
-- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->validate($input)`.
+- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->isValid($input)`.
 - Granularity control for advanced reporting.
 - More than 130 (fully tested) validation rules.
 - A concrete API for non fluent usage.

--- a/docs/concrete-api.md
+++ b/docs/concrete-api.md
@@ -8,7 +8,7 @@ or magic methods. We'll use a traditional dependency injection approach.
 use Respect\Validation\Validator as v;
 
 $usernameValidator = v::alnum()->noWhitespace()->length(1,15);
-$usernameValidator->validate('alganet'); // true
+$usernameValidator->isValid('alganet'); // true
 ```
 
 If you `var_dump($usernameValidator)`, you'll see a composite of objects with
@@ -24,7 +24,7 @@ $usernameValidator = new Rules\AllOf(
     new Rules\NoWhitespace(),
     new Rules\Length(1, 15)
 );
-$usernameValidator->validate('alganet'); // true
+$usernameValidator->isValid('alganet'); // true
 ```
 
 This is still a very lean API. You can use it in any dependency injection
@@ -39,7 +39,7 @@ $usernameValidator = new Rules\AllOf(
     new Rules\Length(1, 15)
 );
 $userValidator = new Rules\Key('name', $usernameValidator);
-$userValidator->validate(['name' => 'alganet']); // true
+$userValidator->isValid(['name' => 'alganet']); // true
 ```
 
 ## How It Works?

--- a/docs/feature-guide.md
+++ b/docs/feature-guide.md
@@ -15,7 +15,7 @@ The Hello World validator is something like this:
 
 ```php
 $number = 123;
-v::numericVal()->validate($number); // true
+v::numericVal()->isValid($number); // true
 ```
 
 ## Chained validation
@@ -25,7 +25,7 @@ containing numbers and letters, no whitespace and length between 1 and 15.
 
 ```php
 $usernameValidator = v::alnum()->noWhitespace()->length(1, 15);
-$usernameValidator->validate('alganet'); // true
+$usernameValidator->isValid('alganet'); // true
 ```
 
 ## Validating object attributes
@@ -44,7 +44,7 @@ Is possible to validate its attributes in a single chain:
 $userValidator = v::attribute('name', v::stringType()->length(1,32))
                   ->attribute('birthdate', v::dateTime()->age(18));
 
-$userValidator->validate($user); // true
+$userValidator->isValid($user); // true
 ```
 
 Validating array keys is also possible using `v::key()`
@@ -78,7 +78,7 @@ v::key(
         ->key('field2', v::stringType())
         ->key('field3', v::boolType())
     )
-    ->assert($data); // You can also use check() or validate()
+    ->assert($data); // You can also use check() or isValid()
 ```
 
 ## Input optional
@@ -93,11 +93,11 @@ For that reason all rules are mandatory now but if you want to treat a value as
 optional you can use `v::optional()` rule:
 
 ```php
-v::alpha()->validate(''); // false input required
-v::alpha()->validate(null); // false input required
+v::alpha()->isValid(''); // false input required
+v::alpha()->isValid(null); // false input required
 
-v::optional(v::alpha())->validate(''); // true
-v::optional(v::alpha())->validate(null); // true
+v::optional(v::alpha())->isValid(''); // true
+v::optional(v::alpha())->isValid(null); // true
 ```
 
 By _optional_ we consider `null` or an empty string (`''`).
@@ -109,7 +109,7 @@ See more on [Optional](rules/Optional.md).
 You can use the `v::not()` to negate any rule:
 
 ```php
-v::not(v::intVal())->validate(10); // false, input must not be integer
+v::not(v::intVal())->isValid(10); // false, input must not be integer
 ```
 
 ## Validator reuse
@@ -117,9 +117,9 @@ v::not(v::intVal())->validate(10); // false, input must not be integer
 Once created, you can reuse your validator anywhere. Remember `$usernameValidator`?
 
 ```php
-$usernameValidator->validate('respect');            //true
-$usernameValidator->validate('alexandre gaigalas'); // false
-$usernameValidator->validate('#$%');                //false
+$usernameValidator->isValid('respect');            //true
+$usernameValidator->isValid('alexandre gaigalas'); // false
+$usernameValidator->isValid('#$%');                //false
 ```
 
 ## Exception types
@@ -144,7 +144,7 @@ $usernameValidator->validate('#$%');                //false
 ## Informative exceptions
 
 When something goes wrong, Validation can tell you exactly what's going on. For this,
-we use the `assert()` method instead of `validate()`:
+we use the `assert()` method instead of `isValid()`:
 
 ```php
 use Respect\Validation\Exceptions\NestedValidationException;
@@ -260,7 +260,7 @@ use Respect\Validation\Rules\AbstractRule;
 
 class MyRule extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         // Do something here with the $input and return a boolean value
     }
@@ -339,7 +339,7 @@ $timeValidator     = v::sf('Time')->assert('22:00:01');
 
 ## Validation methods
 
-We've seen `validate()` that returns true or false and `assert()` that throws a complete
+We've seen `isValid()` that returns true or false and `assert()` that throws a complete
 validation report. There is also a `check()` method that returns an Exception
 only with the first error found:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 
 [The most awesome validation engine ever created for PHP.](http://bit.ly/1a1oeQv)
 
-- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->validate($input)`.
+- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->isValid($input)`.
 - [Granularity control](feature-guide.md#validation-methods) for advanced reporting.
 - [More than 130](list-of-rules.md) (fully tested) validation rules.
 - [A concrete API](concrete-api.md) for non fluent usage.

--- a/docs/rules/AllOf.md
+++ b/docs/rules/AllOf.md
@@ -5,7 +5,7 @@
 Will validate if all inner validators validates.
 
 ```php
-v::allOf(v::intVal(), v::positive())->validate(15); // true
+v::allOf(v::intVal(), v::positive())->isValid(15); // true
 ```
 
 ## Changelog

--- a/docs/rules/Alnum.md
+++ b/docs/rules/Alnum.md
@@ -6,30 +6,30 @@
 Validates alphanumeric characters from a-Z and 0-9.
 
 ```php
-v::alnum()->validate('foo 123'); // true
-v::alnum()->validate('number 100%'); // false
-v::alnum('%')->validate('number 100%'); // true
+v::alnum()->isValid('foo 123'); // true
+v::alnum()->isValid('number 100%'); // false
+v::alnum('%')->isValid('number 100%'); // true
 ```
 
 Because this rule allows whitespaces by default, you can separate additional
 characters with a whitespace:
 
 ```php
-v::alnum('- ! :')->validate('foo :- 123 !'); // true
+v::alnum('- ! :')->isValid('foo :- 123 !'); // true
 ```
 
 This validator allows whitespace, if you want to
 remove them add `->noWhitespace()` to the chain:
 
 ```php
-v::alnum()->noWhitespace()->validate('foo 123'); // false
+v::alnum()->noWhitespace()->isValid('foo 123'); // false
 ```
 
 You can restrict case using the `->lowercase()` and
 `->uppercase()` validators:
 
 ```php
-v::alnum()->uppercase()->validate('aaa'); // false
+v::alnum()->uppercase()->isValid('aaa'); // false
 ```
 
 Message template for this validator includes `{{additionalChars}}` as

--- a/docs/rules/AlwaysInvalid.md
+++ b/docs/rules/AlwaysInvalid.md
@@ -5,7 +5,7 @@
 Validates any input as invalid.
 
 ```php
-v::alwaysInvalid()->validate('whatever'); // false
+v::alwaysInvalid()->isValid('whatever'); // false
 ```
 
 ## Changelog

--- a/docs/rules/AlwaysValid.md
+++ b/docs/rules/AlwaysValid.md
@@ -5,7 +5,7 @@
 Validates any input as valid.
 
 ```php
-v::alwaysValid()->validate('whatever'); // true
+v::alwaysValid()->isValid('whatever'); // true
 ```
 
 ## Changelog

--- a/docs/rules/AnyOf.md
+++ b/docs/rules/AnyOf.md
@@ -5,7 +5,7 @@
 This is a group validator that acts as an OR operator.
 
 ```php
-v::anyOf(v::intVal(), v::floatVal())->validate(15.5); // true
+v::anyOf(v::intVal(), v::floatVal())->isValid(15.5); // true
 ```
 
 In the sample above, `IntVal()` doesn't validates, but `FloatVal()` validates,

--- a/docs/rules/ArrayType.md
+++ b/docs/rules/ArrayType.md
@@ -5,9 +5,9 @@
 Validates whether the type of an input is array.
 
 ```php
-v::arrayType()->validate([]); // true
-v::arrayType()->validate([1, 2, 3]); // true
-v::arrayType()->validate(new ArrayObject()); // false
+v::arrayType()->isValid([]); // true
+v::arrayType()->isValid([1, 2, 3]); // true
+v::arrayType()->isValid(new ArrayObject()); // false
 ```
 
 ## Changelog

--- a/docs/rules/ArrayVal.md
+++ b/docs/rules/ArrayVal.md
@@ -6,9 +6,9 @@ Validates if the input is an array or if the input can be used as an array
 (instance of `ArrayAccess` or `SimpleXMLElement`).
 
 ```php
-v::arrayVal()->validate([]); // true
-v::arrayVal()->validate(new ArrayObject); // true
-v::arrayVal()->validate(new SimpleXMLElement('<xml></xml>')); // true
+v::arrayVal()->isValid([]); // true
+v::arrayVal()->isValid(new ArrayObject); // true
+v::arrayVal()->isValid(new SimpleXMLElement('<xml></xml>')); // true
 ```
 
 ## Changelog

--- a/docs/rules/Attribute.md
+++ b/docs/rules/Attribute.md
@@ -10,19 +10,19 @@ Validates an object attribute, even private ones.
 $obj = new stdClass;
 $obj->foo = 'bar';
 
-v::attribute('foo')->validate($obj); // true
+v::attribute('foo')->isValid($obj); // true
 ```
 
 You can also validate the attribute itself:
 
 ```php
-v::attribute('foo', v::equals('bar'))->validate($obj); // true
+v::attribute('foo', v::equals('bar'))->isValid($obj); // true
 ```
 
 Third parameter makes the attribute presence optional:
 
 ```php
-v::attribute('lorem', v::stringType(), false)->validate($obj); // true
+v::attribute('lorem', v::stringType(), false)->isValid($obj); // true
 ```
 
 The name of this validator is automatically set to the attribute name.

--- a/docs/rules/Base.md
+++ b/docs/rules/Base.md
@@ -5,11 +5,11 @@
 Validate numbers in any base, even with non regular bases.
 
 ```php
-v::base(2)->validate('011010001'); // true
-v::base(3)->validate('0120122001'); // true
-v::base(8)->validate('01234567520'); // true
-v::base(16)->validate('012a34f5675c20d'); // true
-v::base(2)->validate('0120122001'); // false
+v::base(2)->isValid('011010001'); // true
+v::base(3)->isValid('0120122001'); // true
+v::base(8)->isValid('01234567520'); // true
+v::base(16)->isValid('012a34f5675c20d'); // true
+v::base(2)->isValid('0120122001'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Base64.md
+++ b/docs/rules/Base64.md
@@ -5,8 +5,8 @@
 Validate if a string is Base64-encoded.
 
 ```php
-v::base64()->validate('cmVzcGVjdCE='); // true
-v::base64()->validate('respect!'); // false
+v::base64()->isValid('cmVzcGVjdCE='); // true
+v::base64()->isValid('respect!'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Between.md
+++ b/docs/rules/Between.md
@@ -5,9 +5,9 @@
 Validates whether the input is between two other values.
 
 ```php
-v::intVal()->between(10, 20)->validate(10); // true
-v::intVal()->between(10, 20)->validate(15); // true
-v::intVal()->between(10, 20)->validate(20); // true
+v::intVal()->between(10, 20)->isValid(10); // true
+v::intVal()->between(10, 20)->isValid(15); // true
+v::intVal()->between(10, 20)->isValid(20); // true
 ```
 
 Validation makes comparison easier, check out our supported 

--- a/docs/rules/BoolType.md
+++ b/docs/rules/BoolType.md
@@ -5,8 +5,8 @@
 Validates whether the type of the input is [boolean](http://php.net/types.boolean).
 
 ```php
-v::boolType()->validate(true); // true
-v::boolType()->validate(false); // true
+v::boolType()->isValid(true); // true
+v::boolType()->isValid(false); // true
 ```
 
 ## Changelog

--- a/docs/rules/BoolVal.md
+++ b/docs/rules/BoolVal.md
@@ -5,12 +5,12 @@
 Validates if the input results in a boolean value:
 
 ```php
-v::boolVal()->validate('on'); // true
-v::boolVal()->validate('off'); // true
-v::boolVal()->validate('yes'); // true
-v::boolVal()->validate('no'); // true
-v::boolVal()->validate(1); // true
-v::boolVal()->validate(0); // true
+v::boolVal()->isValid('on'); // true
+v::boolVal()->isValid('off'); // true
+v::boolVal()->isValid('yes'); // true
+v::boolVal()->isValid('no'); // true
+v::boolVal()->isValid(1); // true
+v::boolVal()->isValid(0); // true
 ```
 
 ## Changelog

--- a/docs/rules/Bsn.md
+++ b/docs/rules/Bsn.md
@@ -5,7 +5,7 @@
 Validates a Dutch citizen service number ([BSN](https://nl.wikipedia.org/wiki/Burgerservicenummer)).
 
 ```php
-v::bsn()->validate('612890053'); // true
+v::bsn()->isValid('612890053'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Call.md
+++ b/docs/rules/Call.md
@@ -37,7 +37,7 @@ v::call(
         ->key('host',   v::domain())
         ->key('path',   v::stringType())
         ->key('query',  v::notEmpty())
-)->validate($url);
+)->isValid($url);
 ```
 
 ## Changelog

--- a/docs/rules/CallableType.md
+++ b/docs/rules/CallableType.md
@@ -5,9 +5,9 @@
 Validates whether the pseudo-type of the input is [callable](http://php.net/types.callable).
 
 ```php
-v::callableType()->validate(function () {}); // true
-v::callableType()->validate('trim'); // true
-v::callableType()->validate([new DateTime(), 'format']); // true
+v::callableType()->isValid(function () {}); // true
+v::callableType()->isValid('trim'); // true
+v::callableType()->isValid([new DateTime(), 'format']); // true
 ```
 
 ## Changelog

--- a/docs/rules/Callback.md
+++ b/docs/rules/Callback.md
@@ -9,7 +9,7 @@ v::callback(
     function (int $input): bool {
         return $input + ($input / 2) == 15;
     }
-)->validate(10); // true
+)->isValid(10); // true
 ```
 
 ## Changelog

--- a/docs/rules/Charset.md
+++ b/docs/rules/Charset.md
@@ -5,9 +5,9 @@
 Validates if a string is in a specific charset.
 
 ```php
-v::charset('ASCII')->validate('açúcar'); // false
-v::charset('ASCII')->validate('sugar');  //true
-v::charset('ISO-8859-1', 'EUC-JP')->validate('日本国'); // true
+v::charset('ASCII')->isValid('açúcar'); // false
+v::charset('ASCII')->isValid('sugar');  //true
+v::charset('ISO-8859-1', 'EUC-JP')->isValid('日本国'); // true
 ```
 
 The array format is a logic OR, not AND.

--- a/docs/rules/Cnh.md
+++ b/docs/rules/Cnh.md
@@ -5,7 +5,7 @@
 Validates a Brazilian driver's license.
 
 ```php
-v::cnh()->validate('02650306461'); // true
+v::cnh()->isValid('02650306461'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Cntrl.md
+++ b/docs/rules/Cntrl.md
@@ -6,7 +6,7 @@
 This is similar to `Alnum()`, but only accepts control characters:
 
 ```php
-v::cntrl()->validate("\n\r\t"); // true
+v::cntrl()->isValid("\n\r\t"); // true
 ```
 
 ## Changelog

--- a/docs/rules/ComparableValues.md
+++ b/docs/rules/ComparableValues.md
@@ -16,15 +16,15 @@ that can be parsed by PHP
 Below you can see some examples:
 
 ```php
-v::min(100)->validate($collection); // true if it has at least 100 items
+v::min(100)->isValid($collection); // true if it has at least 100 items
 
 v::dateTime()
     ->between(new DateTime('yesterday'), new DateTime('tomorrow'))
-    ->validate(new DateTime('now')); // true
+    ->isValid(new DateTime('now')); // true
 
-v::numericVal()->max(10)->validate(5); // true
+v::numericVal()->max(10)->isValid(5); // true
 
-v::stringVal()->between('a', 'f')->validate('d'); // true
+v::stringVal()->between('a', 'f')->isValid('d'); // true
 
-v::dateTime()->between('yesterday', 'tomorrow')->validate('now'); // true
+v::dateTime()->between('yesterday', 'tomorrow')->isValid('now'); // true
 ```

--- a/docs/rules/Consonant.md
+++ b/docs/rules/Consonant.md
@@ -6,7 +6,7 @@
 Similar to `Alnum()`. Validates strings that contain only consonants:
 
 ```php
-v::consonant()->validate('xkcd'); // true
+v::consonant()->isValid('xkcd'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Contains.md
+++ b/docs/rules/Contains.md
@@ -8,13 +8,13 @@ Validates if the input contains some value.
 For strings:
 
 ```php
-v::contains('ipsum')->validate('lorem ipsum'); // true
+v::contains('ipsum')->isValid('lorem ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::contains('ipsum')->validate(['ipsum', 'lorem']); // true
+v::contains('ipsum')->isValid(['ipsum', 'lorem']); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/Countable.md
+++ b/docs/rules/Countable.md
@@ -6,9 +6,9 @@ Validates if the input is countable, in other words, if you're allowed to use
 [count()](http://php.net/count) function on it.
 
 ```php
-v::countable()->validate([]); // true
-v::countable()->validate(new ArrayObject()); // true
-v::countable()->validate('string'); // false
+v::countable()->isValid([]); // true
+v::countable()->isValid(new ArrayObject()); // true
+v::countable()->isValid('string'); // false
 ```
 
 ## Changelog

--- a/docs/rules/CountryCode.md
+++ b/docs/rules/CountryCode.md
@@ -6,11 +6,11 @@
 Validates whether the input is a country code in [ISO 3166-1][] standard.
 
 ```php
-v::countryCode()->validate('BR'); // true
+v::countryCode()->isValid('BR'); // true
 
-v::countryCode('alpha-2')->validate('NL'); // true
-v::countryCode('alpha-3')->validate('USA'); // true
-v::countryCode('numeric')->validate('504'); // true
+v::countryCode('alpha-2')->isValid('NL'); // true
+v::countryCode('alpha-3')->isValid('USA'); // true
+v::countryCode('numeric')->isValid('504'); // true
 ```
 
 This rule supports the three sets of country codes:

--- a/docs/rules/Cpf.md
+++ b/docs/rules/Cpf.md
@@ -5,20 +5,20 @@
 Validates a Brazillian CPF number.
 
 ```php
-v::cpf()->validate('11598647644'); // true
+v::cpf()->isValid('11598647644'); // true
 ```
 
 It ignores any non-digit char:
 
 ```php
-v::cpf()->validate('693.319.118-40'); // true
+v::cpf()->isValid('693.319.118-40'); // true
 ```
 
 If you need to validate digits only, add `->digit()` to
 the chain:
 
 ```php
-v::digit()->cpf()->validate('11598647644'); // true
+v::digit()->cpf()->isValid('11598647644'); // true
 ```
 
 ## Changelog

--- a/docs/rules/CreditCard.md
+++ b/docs/rules/CreditCard.md
@@ -6,16 +6,16 @@
 Validates a credit card number.
 
 ```php
-v::creditCard()->validate('5376 7473 9720 8720'); // true
-v::creditCard()->validate('5376-7473-9720-8720'); // true
-v::creditCard()->validate('5376.7473.9720.8720'); // true
+v::creditCard()->isValid('5376 7473 9720 8720'); // true
+v::creditCard()->isValid('5376-7473-9720-8720'); // true
+v::creditCard()->isValid('5376.7473.9720.8720'); // true
 
-v::creditCard('American_Express')->validate('340316193809364'); // true
-v::creditCard('Diners_Club')->validate('30351042633884'); // true
-v::creditCard('Discover')->validate('6011000990139424'); // true
-v::creditCard('JCB')->validate('3566002020360505'); // true
-v::creditCard('Mastercard')->validate('5376747397208720'); // true
-v::creditCard('Visa')->validate('4024007153361885'); // true
+v::creditCard('American_Express')->isValid('340316193809364'); // true
+v::creditCard('Diners_Club')->isValid('30351042633884'); // true
+v::creditCard('Discover')->isValid('6011000990139424'); // true
+v::creditCard('JCB')->isValid('3566002020360505'); // true
+v::creditCard('Mastercard')->isValid('5376747397208720'); // true
+v::creditCard('Visa')->isValid('4024007153361885'); // true
 ```
 
 The current supported brands are:
@@ -31,7 +31,7 @@ It ignores any non-numeric characters, use [Digit](Digit.md),
 [NoWhitespace](NoWhitespace.md), or [Regex](Regex.md) when appropriate.
 
 ```php
-v::digit()->creditCard()->validate('5376747397208720'); // true
+v::digit()->creditCard()->isValid('5376747397208720'); // true
 ```
 
 ## Changelog

--- a/docs/rules/CurrencyCode.md
+++ b/docs/rules/CurrencyCode.md
@@ -5,7 +5,7 @@
 Validates an [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code like GBP or EUR.
 
 ```php
-v::currencyCode()->validate('GBP'); // true
+v::currencyCode()->isValid('GBP'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Date.md
+++ b/docs/rules/Date.md
@@ -22,12 +22,12 @@ Format  | Description                                                           
 When a `$format` is not given its default value is `Y-m-d`. 
 
 ```php
-v::date()->validate('2017-12-31'); // true
-v::date()->validate('2020-02-29'); // true
-v::date()->validate('2019-02-29'); // false
-v::date('m/d/y')->validate('12/31/17'); // true
-v::date('F jS, Y')->validate('May 1st, 2017'); // true
-v::date('Ydm')->validate(20173112); // true
+v::date()->isValid('2017-12-31'); // true
+v::date()->isValid('2020-02-29'); // true
+v::date()->isValid('2019-02-29'); // false
+v::date('m/d/y')->isValid('12/31/17'); // true
+v::date('F jS, Y')->isValid('May 1st, 2017'); // true
+v::date('Ydm')->isValid(20173112); // true
 ```
 
 ## Changelog

--- a/docs/rules/DateTime.md
+++ b/docs/rules/DateTime.md
@@ -7,26 +7,26 @@ Validates whether an input is a date/time or not. The `$format` argument should
 be in accordance to PHP's [date()](http://php.net/date) function.
 
 ```php
-v::dateTime()->validate('2009-01-01'); // true
+v::dateTime()->isValid('2009-01-01'); // true
 ```
 
 Also accepts strtotime values:
 
 ```php
-v::dateTime()->validate('now'); // true
+v::dateTime()->isValid('now'); // true
 ```
 
 And `DateTimeInterface` instances:
 
 ```php
-v::dateTime()->validate(new DateTime()); // true
-v::dateTime()->validate(new DateTimeImmutable()); // true
+v::dateTime()->isValid(new DateTime()); // true
+v::dateTime()->isValid(new DateTimeImmutable()); // true
 ```
 
 You can pass a format when validating strings:
 
 ```php
-v::dateTime('Y-m-d')->validate('01-01-2009'); // false
+v::dateTime('Y-m-d')->isValid('01-01-2009'); // false
 ```
 
 Format has no effect when validating DateTime instances.

--- a/docs/rules/Directory.md
+++ b/docs/rules/Directory.md
@@ -5,15 +5,15 @@
 Validates if the given path is a directory.
 
 ```php
-v::directory()->validate(__DIR__); // true
-v::directory()->validate(__FILE__); // false
+v::directory()->isValid(__DIR__); // true
+v::directory()->isValid(__FILE__); // false
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
 
 ```php
-v::directory()->validate(new SplFileInfo('library/'));
-v::directory()->validate(dir('/'));
+v::directory()->isValid(new SplFileInfo('library/'));
+v::directory()->isValid(dir('/'));
 ```
 
 ## Changelog

--- a/docs/rules/Domain.md
+++ b/docs/rules/Domain.md
@@ -6,14 +6,14 @@
 Validates domain names.
 
 ```php
-v::domain()->validate('google.com');
+v::domain()->isValid('google.com');
 ```
 
 You can skip *top level domain* (TLD) checks to validate internal
 domain names:
 
 ```php
-v::domain(false)->validate('dev.machine.local');
+v::domain(false)->isValid('dev.machine.local');
 ```
 
 This is a composite validator, it validates several rules

--- a/docs/rules/Each.md
+++ b/docs/rules/Each.md
@@ -11,13 +11,13 @@ $releaseDates = [
     'relational' => '2011-02-05',
 ];
 
-v::each(v::dateTime())->validate($releaseDates); // true
+v::each(v::dateTime())->isValid($releaseDates); // true
 ```
 
 You can also validate array keys combining this rule with [Call](Call.md):
 
 ```php
-v::call('array_keys', v::each(v::stringType()))->validate($releaseDates); // true
+v::call('array_keys', v::each(v::stringType()))->isValid($releaseDates); // true
 ```
 
 This rule will not validate values that are not iterable, to have a more detailed
@@ -27,8 +27,8 @@ If the input is empty this rule will consider the value as valid, you use
 [NotEmpty](NotEmpty.md) if convenient:
 
 ```php
-v::each(v::dateTime())->validate([]); // true
-v::notEmpty()->each(v::dateTime())->validate([]); // false
+v::each(v::dateTime())->isValid([]); // true
+v::notEmpty()->each(v::dateTime())->isValid([]); // false
 ```
 
 ## Changelog

--- a/docs/rules/Email.md
+++ b/docs/rules/Email.md
@@ -5,7 +5,7 @@
 Validates an email address.
 
 ```php
-v::email()->validate('alexandre@gaigalas.net'); // true
+v::email()->isValid('alexandre@gaigalas.net'); // true
 ```
 
 ## Changelog

--- a/docs/rules/EndsWith.md
+++ b/docs/rules/EndsWith.md
@@ -9,13 +9,13 @@ only if the value is at the end of the input.
 For strings:
 
 ```php
-v::endsWith('ipsum')->validate('lorem ipsum'); // true
+v::endsWith('ipsum')->isValid('lorem ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::endsWith('ipsum')->validate(['lorem', 'ipsum']); // true
+v::endsWith('ipsum')->isValid(['lorem', 'ipsum']); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/Equals.md
+++ b/docs/rules/Equals.md
@@ -5,7 +5,7 @@
 Validates if the input is equal to some value.
 
 ```php
-v::equals('alganet')->validate('alganet'); // true
+v::equals('alganet')->isValid('alganet'); // true
 ```
 
 Message template for this validator includes `{{compareTo}}`.

--- a/docs/rules/Equivalent.md
+++ b/docs/rules/Equivalent.md
@@ -5,9 +5,9 @@
 Validates if the input is equivalent to some value.
 
 ```php
-v::equivalent(1)->validate(true); // true
-v::equivalent('Something')->validate('someThing'); // true
-v::equivalent(new ArrayObject([1, 2, 3, 4, 5]))->validate(new ArrayObject([1, 2, 3, 4, 5])); // true
+v::equivalent(1)->isValid(true); // true
+v::equivalent('Something')->isValid('someThing'); // true
+v::equivalent(new ArrayObject([1, 2, 3, 4, 5]))->isValid(new ArrayObject([1, 2, 3, 4, 5])); // true
 ```
 
 This rule is very similar to [Equals](Equals.md) but it does not make case-sensitive

--- a/docs/rules/Even.md
+++ b/docs/rules/Even.md
@@ -5,7 +5,7 @@
 Validates whether the input is an even number or not.
 
 ```php
-v::intVal()->even()->validate(2); // true
+v::intVal()->even()->isValid(2); // true
 ```
 
 Using `int()` before `even()` is a best practice.

--- a/docs/rules/Executable.md
+++ b/docs/rules/Executable.md
@@ -5,7 +5,7 @@
 Validates if a file is an executable.
 
 ```php
-v::executable()->validate('script.sh'); // true
+v::executable()->isValid('script.sh'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Exists.md
+++ b/docs/rules/Exists.md
@@ -5,14 +5,14 @@
 Validates files or directories.
 
 ```php
-v::exists()->validate(__FILE__); // true
-v::exists()->validate(__DIR__); // true
+v::exists()->isValid(__FILE__); // true
+v::exists()->isValid(__DIR__); // true
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
 
 ```php
-v::exists()->validate(new SplFileInfo('file.txt'));
+v::exists()->isValid(new SplFileInfo('file.txt'));
 ```
 
 ## Changelog

--- a/docs/rules/Extension.md
+++ b/docs/rules/Extension.md
@@ -5,7 +5,7 @@
 Validates if the file extension matches the expected one:
 
 ```php
-v::extension('png')->validate('image.png'); // true
+v::extension('png')->isValid('image.png'); // true
 ```
 
 This rule is case-sensitive.

--- a/docs/rules/Factor.md
+++ b/docs/rules/Factor.md
@@ -5,9 +5,9 @@
 Validates if the input is a factor of the defined dividend.
 
 ```php
-v::factor(0)->validate(5); // true
-v::factor(4)->validate(2); // true
-v::factor(4)->validate(3); // false
+v::factor(0)->isValid(5); // true
+v::factor(4)->isValid(2); // true
+v::factor(4)->isValid(3); // false
 ```
 
 ## Changelog

--- a/docs/rules/FalseVal.md
+++ b/docs/rules/FalseVal.md
@@ -5,14 +5,14 @@
 Validates if a value is considered as `false`.
 
 ```php
-v::falseVal()->validate(false); // true
-v::falseVal()->validate(0); // true
-v::falseVal()->validate('0'); // true
-v::falseVal()->validate('false'); // true
-v::falseVal()->validate('off'); // true
-v::falseVal()->validate('no'); // true
-v::falseVal()->validate('0.5'); // false
-v::falseVal()->validate('2'); // false
+v::falseVal()->isValid(false); // true
+v::falseVal()->isValid(0); // true
+v::falseVal()->isValid('0'); // true
+v::falseVal()->isValid('false'); // true
+v::falseVal()->isValid('off'); // true
+v::falseVal()->isValid('no'); // true
+v::falseVal()->isValid('0.5'); // false
+v::falseVal()->isValid('2'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Fibonacci.md
+++ b/docs/rules/Fibonacci.md
@@ -5,9 +5,9 @@
 Validates whether the input follows the Fibonacci integer sequence.
 
 ```php
-v::fibonacci()->validate(1); // true
-v::fibonacci()->validate('34'); // true
-v::fibonacci()->validate(6); // false
+v::fibonacci()->isValid(1); // true
+v::fibonacci()->isValid('34'); // true
+v::fibonacci()->isValid(6); // false
 ```
 
 ## Changelog

--- a/docs/rules/File.md
+++ b/docs/rules/File.md
@@ -5,14 +5,14 @@
 Validates files.
 
 ```php
-v::file()->validate(__FILE__); // true
-v::file()->validate(__DIR__); // false
+v::file()->isValid(__FILE__); // true
+v::file()->isValid(__DIR__); // false
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
 
 ```php
-v::file()->validate(new SplFileInfo('file.txt'));
+v::file()->isValid(new SplFileInfo('file.txt'));
 ```
 
 ## Changelog

--- a/docs/rules/FilterVar.md
+++ b/docs/rules/FilterVar.md
@@ -6,10 +6,10 @@
 Validates the input with the PHP's [filter_var()](http://php.net/filter_var) function.
 
 ```php
-v::filterVar(FILTER_VALIDATE_EMAIL)->validate('bob@example.com'); // true
-v::filterVar(FILTER_VALIDATE_URL)->validate('http://example.com'); // true
-v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://example.com'); // false
-v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://example.com/path'); // true
+v::filterVar(FILTER_VALIDATE_EMAIL)->isValid('bob@example.com'); // true
+v::filterVar(FILTER_VALIDATE_URL)->isValid('http://example.com'); // true
+v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->isValid('http://example.com'); // false
+v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->isValid('http://example.com/path'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Finite.md
+++ b/docs/rules/Finite.md
@@ -5,8 +5,8 @@
 Validates if the input is a finite number.
 
 ```php
-v::finite()->validate('10'); // true
-v::finite()->validate(10); // true
+v::finite()->isValid('10'); // true
+v::finite()->isValid(10); // true
 ```
 
 ## Changelog

--- a/docs/rules/FloatType.md
+++ b/docs/rules/FloatType.md
@@ -5,9 +5,9 @@
 Validates whether the type of the input is [float](http://php.net/types.float).
 
 ```php
-v::floatType()->validate(1.5); // true
-v::floatType()->validate('1.5'); // false
-v::floatType()->validate(0e5); // true
+v::floatType()->isValid(1.5); // true
+v::floatType()->isValid('1.5'); // false
+v::floatType()->isValid(0e5); // true
 ```
 
 ## Changelog

--- a/docs/rules/FloatVal.md
+++ b/docs/rules/FloatVal.md
@@ -5,8 +5,8 @@
 Validate whether the input value is float.
 
 ```php
-v::floatVal()->validate(1.5); // true
-v::floatVal()->validate('1e5'); // true
+v::floatVal()->isValid(1.5); // true
+v::floatVal()->isValid('1e5'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Graph.md
+++ b/docs/rules/Graph.md
@@ -6,7 +6,7 @@
 Validates all characters that are graphically represented.
 
 ```php
-v::graph()->validate('LKM@#$%4;'); // true
+v::graph()->isValid('LKM@#$%4;'); // true
 ```
 
 ## Changelog

--- a/docs/rules/GreaterThan.md
+++ b/docs/rules/GreaterThan.md
@@ -5,8 +5,8 @@
 Validates whether the input is greater than a value.
 
 ```php
-v::greaterThan(10)->validate(11); // true
-v::greaterThan(10)->validate(9); // false
+v::greaterThan(10)->isValid(11); // true
+v::greaterThan(10)->isValid(9); // false
 ```
 
 Validation makes comparison easier, check out our supported 

--- a/docs/rules/HexRgbColor.md
+++ b/docs/rules/HexRgbColor.md
@@ -5,9 +5,9 @@
 Validates a hex RGB color
 
 ```php
-v::hexRgbColor()->validate('#FFFAAA'); // true
-v::hexRgbColor()->validate('123123'); // true
-v::hexRgbColor()->validate('FCD'); // true
+v::hexRgbColor()->isValid('#FFFAAA'); // true
+v::hexRgbColor()->isValid('123123'); // true
+v::hexRgbColor()->isValid('FCD'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Identical.md
+++ b/docs/rules/Identical.md
@@ -5,8 +5,8 @@
 Validates if the input is identical to some value.
 
 ```php
-v::identical(42)->validate(42); // true
-v::identical(42)->validate('42'); // false
+v::identical(42)->isValid(42); // true
+v::identical(42)->isValid('42'); // false
 ```
 
 Message template for this validator includes `{{compareTo}}`.

--- a/docs/rules/IdentityCard.md
+++ b/docs/rules/IdentityCard.md
@@ -5,10 +5,10 @@
 Validates Identity Card numbers according to the defined country.
 
 ```php
-v::identityCard('PL')->validate('AYW036733'); // true
-v::identityCard('PL')->validate('APH505567'); // true
-v::identityCard('PL')->validate('APH 505567'); // false
-v::identityCard('PL')->validate('AYW036731'); // false
+v::identityCard('PL')->isValid('AYW036733'); // true
+v::identityCard('PL')->isValid('APH505567'); // true
+v::identityCard('PL')->isValid('APH 505567'); // false
+v::identityCard('PL')->isValid('AYW036731'); // false
 ```
 
 For now this rule only accepts Polish Identity Card numbers (Dowód Osobisty).

--- a/docs/rules/Image.md
+++ b/docs/rules/Image.md
@@ -6,9 +6,9 @@
 Validates if the file is a valid image by checking its MIME type.
 
 ```php
-v::image()->validate('image.gif'); // true
-v::image()->validate('image.jpg'); // true
-v::image()->validate('image.png'); // true
+v::image()->isValid('image.gif'); // true
+v::image()->isValid('image.jpg'); // true
+v::image()->isValid('image.png'); // true
 ```
 
 All the validations above must return `false` if the input is not a valid file

--- a/docs/rules/Imei.md
+++ b/docs/rules/Imei.md
@@ -5,8 +5,8 @@
 Validates is the input is a valid [IMEI][].
 
 ```php
-v::imei()->validate('35-209900-176148-1'); // true
-v::imei()->validate('490154203237518'); // true
+v::imei()->isValid('35-209900-176148-1'); // true
+v::imei()->isValid('490154203237518'); // true
 ```
 
 ## Changelog

--- a/docs/rules/In.md
+++ b/docs/rules/In.md
@@ -8,13 +8,13 @@ Validates if the input is contained in a specific haystack.
 For strings:
 
 ```php
-v::in('lorem ipsum')->validate('ipsum'); // true
+v::in('lorem ipsum')->isValid('ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::in(['lorem', 'ipsum'])->validate('lorem'); // true
+v::in(['lorem', 'ipsum'])->isValid('lorem'); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/Infinite.md
+++ b/docs/rules/Infinite.md
@@ -5,7 +5,7 @@
 Validates if the input is an infinite number.
 
 ```php
-v::infinite()->validate(INF); // true
+v::infinite()->isValid(INF); // true
 ```
 
 ## Changelog

--- a/docs/rules/Instance.md
+++ b/docs/rules/Instance.md
@@ -5,8 +5,8 @@
 Validates if the input is an instance of the given class or interface.
 
 ```php
-v::instance('DateTime')->validate(new DateTime); // true
-v::instance('Traversable')->validate(new ArrayObject); // true
+v::instance('DateTime')->isValid(new DateTime); // true
+v::instance('Traversable')->isValid(new ArrayObject); // true
 ```
 
 Message template for this validator includes `{{instanceName}}`.

--- a/docs/rules/IntType.md
+++ b/docs/rules/IntType.md
@@ -5,8 +5,8 @@
 Validates whether the type of the input is [integer](http://php.net/types.integer).
 
 ```php
-v::intType()->validate(42); // true
-v::intType()->validate('10'); // false
+v::intType()->isValid(42); // true
+v::intType()->isValid('10'); // false
 ```
 
 ## Changelog

--- a/docs/rules/IntVal.md
+++ b/docs/rules/IntVal.md
@@ -5,8 +5,8 @@
 Validates if the input is an integer.
 
 ```php
-v::intVal()->validate('10'); // true
-v::intVal()->validate(10); // true
+v::intVal()->isValid('10'); // true
+v::intVal()->isValid(10); // true
 ```
 
 ## Changelog

--- a/docs/rules/Ip.md
+++ b/docs/rules/Ip.md
@@ -7,15 +7,15 @@ Validates IP Addresses. This validator uses the native filter_var()
 PHP function.
 
 ```php
-v::ip()->validate('127.0.0.1'); // true
-v::ip('220.78.168.0/21')->validate('220.78.173.2'); // true
-v::ip('220.78.168.0/21')->validate('220.78.176.2'); // false
+v::ip()->isValid('127.0.0.1'); // true
+v::ip('220.78.168.0/21')->isValid('220.78.173.2'); // true
+v::ip('220.78.168.0/21')->isValid('220.78.176.2'); // false
 ```
 
 You can pass a parameter with filter_var flags for IP.
 
 ```php
-v::ip(FILTER_FLAG_NO_PRIV_RANGE)->validate('192.168.0.1'); // false
+v::ip(FILTER_FLAG_NO_PRIV_RANGE)->isValid('192.168.0.1'); // false
 ```
 
 ## Changelog

--- a/docs/rules/IterableType.md
+++ b/docs/rules/IterableType.md
@@ -7,10 +7,10 @@ if you're able to iterate over it with [foreach](http://php.net/foreach) languag
 construct.
 
 ```php
-v::iterableType()->validate([]); // true
-v::iterableType()->validate(new ArrayObject()); // true
-v::iterableType()->validate(new stdClass()); // true
-v::iterableType()->validate('string'); // false
+v::iterableType()->isValid([]); // true
+v::iterableType()->isValid(new ArrayObject()); // true
+v::iterableType()->isValid(new stdClass()); // true
+v::iterableType()->isValid('string'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Json.md
+++ b/docs/rules/Json.md
@@ -5,7 +5,7 @@
 Validates if the given input is a valid JSON.
 
 ```php
-v::json()->validate('{"foo":"bar"}'); // true
+v::json()->isValid('{"foo":"bar"}'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Key.md
+++ b/docs/rules/Key.md
@@ -11,19 +11,19 @@ $dict = [
     'foo' => 'bar'
 ];
 
-v::key('foo')->validate($dict); // true
+v::key('foo')->isValid($dict); // true
 ```
 
 You can also validate the key value itself:
 
 ```php
-v::key('foo', v::equals('bar'))->validate($dict); // true
+v::key('foo', v::equals('bar'))->isValid($dict); // true
 ```
 
 Third parameter makes the key presence optional:
 
 ```php
-v::key('lorem', v::stringType(), false)->validate($dict); // true
+v::key('lorem', v::stringType(), false)->isValid($dict); // true
 ```
 
 The name of this validator is automatically set to the key name.

--- a/docs/rules/KeyNested.md
+++ b/docs/rules/KeyNested.md
@@ -15,7 +15,7 @@ $array = [
     ],
 ];
 
-v::keyNested('foo.bar')->validate($array); // true
+v::keyNested('foo.bar')->isValid($array); // true
 ```
 
 Validating object properties:
@@ -25,7 +25,7 @@ $object = new stdClass();
 $object->foo = new stdClass();
 $object->foo->bar = 42;
 
-v::keyNested('foo.bar')->validate($object); // true
+v::keyNested('foo.bar')->isValid($object); // true
 ```
 
 This rule was inspired by [Yii2 ArrayHelper][].

--- a/docs/rules/KeySet.md
+++ b/docs/rules/KeySet.md
@@ -9,7 +9,7 @@ $dict = ['foo' => 42];
 
 v::keySet(
     v::key('foo', v::intVal())
-)->validate($dict); // true
+)->isValid($dict); // true
 ```
 
 Extra keys are not allowed:
@@ -18,7 +18,7 @@ $dict = ['foo' => 42, 'bar' => 'String'];
 
 v::keySet(
     v::key('foo', v::intVal())
-)->validate($dict); // false
+)->isValid($dict); // false
 ```
 
 Missing required keys are not allowed:
@@ -29,7 +29,7 @@ v::keySet(
     v::key('foo', v::intVal()),
     v::key('bar', v::stringType()),
     v::key('baz', v::boolType())
-)->validate($dict); // false
+)->isValid($dict); // false
 ```
 
 Missing non-required keys are allowed:
@@ -40,7 +40,7 @@ v::keySet(
     v::key('foo', v::intVal()),
     v::key('bar', v::stringType()),
     v::key('baz', v::boolType(), false)
-)->validate($dict); // true
+)->isValid($dict); // true
 ```
 
 The keys' order is not considered in the validation.

--- a/docs/rules/KeyValue.md
+++ b/docs/rules/KeyValue.md
@@ -10,8 +10,8 @@ another key value and that may cause some ugly code since you need the input
 before the validation, making some checking manually:
 
 ```php
-v::key('password', v::notEmpty())->validate($_POST);
-v::key('password_confirmation', v::equals($_POST['password'] ?? null))->validate($_POST);
+v::key('password', v::notEmpty())->isValid($_POST);
+v::key('password_confirmation', v::equals($_POST['password'] ?? null))->isValid($_POST);
 ```
 
 The problem with the above code is because you do not know if `password` is a
@@ -22,7 +22,7 @@ The `keyValue()` rule makes this job easier by creating a rule named on
 `$ruleName` passing `$baseKey` as the first argument of this rule, see an example:
 
 ```php
-v::keyValue('password_confirmation', 'equals', 'password')->validate($_POST);
+v::keyValue('password_confirmation', 'equals', 'password')->isValid($_POST);
 ```
 
 The above code will result on `true` if _`$_POST['password_confirmation']` is
@@ -31,7 +31,7 @@ The above code will result on `true` if _`$_POST['password_confirmation']` is
 See another example:
 
 ```php
-v::keyValue('state', 'subdivisionCode', 'country')->validate($_POST);
+v::keyValue('state', 'subdivisionCode', 'country')->isValid($_POST);
 ```
 
 The above code will result on `true` if _`$_POST['state']` is a

--- a/docs/rules/LanguageCode.md
+++ b/docs/rules/LanguageCode.md
@@ -5,11 +5,11 @@
 Validates a language code based on ISO 639:
 
 ```php
-v::languageCode()->validate('pt'); // true
-v::languageCode()->validate('en'); // true
-v::languageCode()->validate('it'); // true
-v::languageCode('alpha-3')->validate('ita'); // true
-v::languageCode('alpha-3')->validate('eng'); // true
+v::languageCode()->isValid('pt'); // true
+v::languageCode()->isValid('en'); // true
+v::languageCode()->isValid('it'); // true
+v::languageCode('alpha-3')->isValid('ita'); // true
+v::languageCode('alpha-3')->isValid('eng'); // true
 ```
 
 You can choose between alpha-2 and alpha-3, alpha-2 is set by default.

--- a/docs/rules/LeapDate.md
+++ b/docs/rules/LeapDate.md
@@ -5,7 +5,7 @@
 Validates if a date is leap.
 
 ```php
-v::leapDate('Y-m-d')->validate('1988-02-29'); // true
+v::leapDate('Y-m-d')->isValid('1988-02-29'); // true
 ```
 
 This validator accepts DateTime instances as well. The $format

--- a/docs/rules/LeapYear.md
+++ b/docs/rules/LeapYear.md
@@ -5,7 +5,7 @@
 Validates if a year is leap.
 
 ```php
-v::leapYear()->validate('1988'); // true
+v::leapYear()->isValid('1988'); // true
 ```
 
 This validator accepts DateTime instances as well.

--- a/docs/rules/Length.md
+++ b/docs/rules/Length.md
@@ -8,32 +8,32 @@
 Validates lengths. Most simple example:
 
 ```php
-v::stringType()->length(1, 5)->validate('abc'); // true
+v::stringType()->length(1, 5)->isValid('abc'); // true
 ```
 
 You can also validate only minimum length:
 
 ```php
-v::stringType()->length(5, null)->validate('abcdef'); // true
+v::stringType()->length(5, null)->isValid('abcdef'); // true
 ```
 
 Only maximum length:
 
 ```php
-v::stringType()->length(null, 5)->validate('abc'); // true
+v::stringType()->length(null, 5)->isValid('abc'); // true
 ```
 
 The type as the first validator in a chain is a good practice,
 since length accepts many types:
 
 ```php
-v::arrayVal()->length(1, 5)->validate(['foo', 'bar']); // true
+v::arrayVal()->length(1, 5)->isValid(['foo', 'bar']); // true
 ```
 
 A third parameter may be passed to validate the passed values inclusive:
 
 ```php
-v::stringType()->length(1, 5, true)->validate('a'); // true
+v::stringType()->length(1, 5, true)->isValid('a'); // true
 ```
 
 Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.

--- a/docs/rules/LessThan.md
+++ b/docs/rules/LessThan.md
@@ -5,8 +5,8 @@
 Validates whether the input is less than a value.
 
 ```php
-v::lessThan(10)->validate(9); // true
-v::lessThan(10)->validate(10); // false
+v::lessThan(10)->isValid(9); // true
+v::lessThan(10)->isValid(10); // false
 ```
 
 Validation makes comparison easier, check out our supported 

--- a/docs/rules/Lowercase.md
+++ b/docs/rules/Lowercase.md
@@ -5,7 +5,7 @@
 Validates whether the characters in the input are lowercase.
 
 ```php
-v::stringType()->lowercase()->validate('xkcd'); // true
+v::stringType()->lowercase()->isValid('xkcd'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Luhn.md
+++ b/docs/rules/Luhn.md
@@ -5,8 +5,8 @@
 Validate whether a given input is a [Luhn][] number.
 
 ```php
-v::luhn()->validate('2222400041240011'); // true
-v::luhn()->validate('respect!'); // false
+v::luhn()->isValid('2222400041240011'); // true
+v::luhn()->isValid('respect!'); // false
 ```
 
 ## Changelog

--- a/docs/rules/MacAddress.md
+++ b/docs/rules/MacAddress.md
@@ -5,8 +5,8 @@
 Validates a Mac Address.
 
 ```php
-v::macAddress()->validate('00:11:22:33:44:55'); // true
-v::macAddress()->validate('af-AA-22-33-44-55'); // true
+v::macAddress()->isValid('00:11:22:33:44:55'); // true
+v::macAddress()->isValid('af-AA-22-33-44-55'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Max.md
+++ b/docs/rules/Max.md
@@ -5,9 +5,9 @@
 Validates whether the input is less than or equal to a value.
 
 ```php
-v::max(10)->validate(9); // true
-v::max(10)->validate(10); // true
-v::max(10)->validate(11); // false
+v::max(10)->isValid(9); // true
+v::max(10)->isValid(10); // true
+v::max(10)->isValid(11); // false
 ```
 
 Validation makes comparison easier, check out our supported 

--- a/docs/rules/MaxAge.md
+++ b/docs/rules/MaxAge.md
@@ -8,11 +8,11 @@ accordance to PHP's [date()][] function. When `$format` is not  given this rule
 accepts [Supported Date and Time Formats][] by PHP (see [strtotime()][]).
 
 ```php
-v::maxAge(12)->validate('12 years ago'); // true
-v::maxAge(12, 'Y-m-d')->validate('2013-07-31'); // true
+v::maxAge(12)->isValid('12 years ago'); // true
+v::maxAge(12, 'Y-m-d')->isValid('2013-07-31'); // true
 
-v::maxAge(12)->validate('13 years ago'); // false
-v::maxAge(18, 'Y-m-d')->validate('1988-09-09'); // false
+v::maxAge(12)->isValid('13 years ago'); // false
+v::maxAge(18, 'Y-m-d')->isValid('1988-09-09'); // false
 ```
 
 Using [Date](Date.md) before is a best-practice.

--- a/docs/rules/Mimetype.md
+++ b/docs/rules/Mimetype.md
@@ -5,8 +5,8 @@
 Validates if the file mimetype matches the expected one:
 
 ```php
-v::mimetype('image/png')->validate('image.png'); // true
-v::mimetype('image/jpeg')->validate('image.jpg'); // true
+v::mimetype('image/png')->isValid('image.png'); // true
+v::mimetype('image/jpeg')->isValid('image.jpg'); // true
 ```
 
 This rule is case-sensitive and requires [fileinfo](http://php.net/fileinfo) PHP extension.

--- a/docs/rules/Min.md
+++ b/docs/rules/Min.md
@@ -5,9 +5,9 @@
 Validates whether the input is greater than or equal to a value.
 
 ```php
-v::intVal()->min(10)->validate(9); // false
-v::intVal()->min(10)->validate(10); // true
-v::intVal()->min(10)->validate(11); // true
+v::intVal()->min(10)->isValid(9); // false
+v::intVal()->min(10)->isValid(10); // true
+v::intVal()->min(10)->isValid(11); // true
 ```
 
 Validation makes comparison easier, check out our supported 

--- a/docs/rules/MinAge.md
+++ b/docs/rules/MinAge.md
@@ -8,11 +8,11 @@ accordance to PHP's [date()][] function. When `$format` is not  given this rule
 accepts [Supported Date and Time Formats][] by PHP (see [strtotime()][]).
 
 ```php
-v::minAge(18)->validate('18 years ago'); // true
-v::minAge(18, 'Y-m-d')->validate('1987-01-01'); // true
+v::minAge(18)->isValid('18 years ago'); // true
+v::minAge(18, 'Y-m-d')->isValid('1987-01-01'); // true
 
-v::minAge(18)->validate('17 years ago'); // false
-v::minAge(18, 'Y-m-d')->validate('2010-09-07'); // false
+v::minAge(18)->isValid('17 years ago'); // false
+v::minAge(18, 'Y-m-d')->isValid('2010-09-07'); // false
 ```
 
 Using [Date](Date.md) before is a best-practice.

--- a/docs/rules/Multiple.md
+++ b/docs/rules/Multiple.md
@@ -5,7 +5,7 @@
 Validates if the input is a multiple of the given parameter
 
 ```php
-v::intVal()->multiple(3)->validate(9); // true
+v::intVal()->multiple(3)->isValid(9); // true
 ```
 
 ## Changelog

--- a/docs/rules/Negative.md
+++ b/docs/rules/Negative.md
@@ -5,7 +5,7 @@
 Validates whether the input is a negative number.
 
 ```php
-v::numericVal()->negative()->validate(-15); // true
+v::numericVal()->negative()->isValid(-15); // true
 ```
 
 ## Changelog

--- a/docs/rules/NfeAccessKey.md
+++ b/docs/rules/NfeAccessKey.md
@@ -5,7 +5,7 @@
 Validates the access key of the Brazilian electronic invoice (NFe).
 
 ```php
-v::nfeAccessKey()->validate('31841136830118868211870485416765268625116906'); // true
+v::nfeAccessKey()->isValid('31841136830118868211870485416765268625116906'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Nif.md
+++ b/docs/rules/Nif.md
@@ -5,8 +5,8 @@
 Validates Spain's fiscal identification number ([NIF](https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal)).
 
 ```php
-v::nif()->validate('49294492H'); // true
-v::nif()->validate('P6437358A'); // false
+v::nif()->isValid('49294492H'); // true
+v::nif()->isValid('P6437358A'); // false
 ```
 
 ## Changelog

--- a/docs/rules/No.md
+++ b/docs/rules/No.md
@@ -6,12 +6,12 @@
 Validates if value is considered as "No".
 
 ```php
-v::no()->validate('N'); // true
-v::no()->validate('Nay'); // true
-v::no()->validate('Nix'); // true
-v::no()->validate('No'); // true
-v::no()->validate('Nope'); // true
-v::no()->validate('Not'); // true
+v::no()->isValid('N'); // true
+v::no()->isValid('Nay'); // true
+v::no()->isValid('Nix'); // true
+v::no()->isValid('No'); // true
+v::no()->isValid('Nope'); // true
+v::no()->isValid('Not'); // true
 ```
 
 This rule is case insensitive.

--- a/docs/rules/NoWhitespace.md
+++ b/docs/rules/NoWhitespace.md
@@ -5,8 +5,8 @@
 Validates if a string contains no whitespace (spaces, tabs and line breaks);
 
 ```php
-v::noWhitespace()->validate('foo bar');  //false
-v::noWhitespace()->validate("foo\nbar"); // false
+v::noWhitespace()->isValid('foo bar');  //false
+v::noWhitespace()->isValid("foo\nbar"); // false
 ```
 
 This is most useful when chaining with other validators such as `Alnum()`

--- a/docs/rules/NoneOf.md
+++ b/docs/rules/NoneOf.md
@@ -8,7 +8,7 @@ Validates if NONE of the given validators validate:
 v::noneOf(
     v::intVal(),
     v::floatVal()
-)->validate('foo'); // true
+)->isValid('foo'); // true
 ```
 
 In the sample above, 'foo' isn't a integer nor a float, so noneOf returns true.

--- a/docs/rules/Not.md
+++ b/docs/rules/Not.md
@@ -5,7 +5,7 @@
 Negates any rule.
 
 ```php
-v::not(v::ip())->validate('foo'); // true
+v::not(v::ip())->isValid('foo'); // true
 ```
 
 In the sample above, validator returns true because 'foo' isn't an IP Address.
@@ -13,7 +13,7 @@ In the sample above, validator returns true because 'foo' isn't an IP Address.
 You can negate complex, grouped or chained validators as well:
 
 ```php
-v::not(v::intVal()->positive())->validate(-1.5); // true
+v::not(v::intVal()->positive())->isValid(-1.5); // true
 ```
 
 Each other validation has custom messages for negated rules.

--- a/docs/rules/NotBlank.md
+++ b/docs/rules/NotBlank.md
@@ -6,22 +6,22 @@ Validates if the given input is not a blank value (`null`, zeros, empty strings
 or empty arrays, recursively).
 
 ```php
-v::notBlank()->validate(null); // false
-v::notBlank()->validate(''); // false
-v::notBlank()->validate([]); // false
-v::notBlank()->validate(' '); // false
-v::notBlank()->validate(0); // false
-v::notBlank()->validate('0'); // false
-v::notBlank()->validate(0); // false
-v::notBlank()->validate('0.0'); // false
-v::notBlank()->validate(false); // false
-v::notBlank()->validate(['']); // false
-v::notBlank()->validate([' ']); // false
-v::notBlank()->validate([0]); // false
-v::notBlank()->validate(['0']); // false
-v::notBlank()->validate([false]); // false
-v::notBlank()->validate([[''], [0]]); // false
-v::notBlank()->validate(new stdClass()); // false
+v::notBlank()->isValid(null); // false
+v::notBlank()->isValid(''); // false
+v::notBlank()->isValid([]); // false
+v::notBlank()->isValid(' '); // false
+v::notBlank()->isValid(0); // false
+v::notBlank()->isValid('0'); // false
+v::notBlank()->isValid(0); // false
+v::notBlank()->isValid('0.0'); // false
+v::notBlank()->isValid(false); // false
+v::notBlank()->isValid(['']); // false
+v::notBlank()->isValid([' ']); // false
+v::notBlank()->isValid([0]); // false
+v::notBlank()->isValid(['0']); // false
+v::notBlank()->isValid([false]); // false
+v::notBlank()->isValid([[''], [0]]); // false
+v::notBlank()->isValid(new stdClass()); // false
 ```
 
 It's similar to [NotEmpty](NotEmpty.md) but it's way more strict.

--- a/docs/rules/NotEmpty.md
+++ b/docs/rules/NotEmpty.md
@@ -7,32 +7,32 @@ into account, use `noWhitespace()` if no spaces or linebreaks and other
 whitespace anywhere in the input is desired.
 
 ```php
-v::stringType()->notEmpty()->validate(''); // false
+v::stringType()->notEmpty()->isValid(''); // false
 ```
 
 Null values are empty:
 
 ```php
-v::notEmpty()->validate(null); // false
+v::notEmpty()->isValid(null); // false
 ```
 
 Numbers:
 
 ```php
-v::intVal()->notEmpty()->validate(0); // false
+v::intVal()->notEmpty()->isValid(0); // false
 ```
 
 Empty arrays:
 
 ```php
-v::arrayVal()->notEmpty()->validate([]); // false
+v::arrayVal()->notEmpty()->isValid([]); // false
 ```
 
 Whitespace:
 
 ```php
-v::stringType()->notEmpty()->validate('        ');  //false
-v::stringType()->notEmpty()->validate("\t \n \r");  //false
+v::stringType()->notEmpty()->isValid('        ');  //false
+v::stringType()->notEmpty()->isValid("\t \n \r");  //false
 ```
 
 ## Changelog

--- a/docs/rules/NotOptional.md
+++ b/docs/rules/NotOptional.md
@@ -6,27 +6,27 @@ Validates if the given input is not optional. By _optional_ we consider `null`
 or an empty string (`''`).
 
 ```php
-v::notOptional()->validate(''); // false
-v::notOptional()->validate(null); // false
+v::notOptional()->isValid(''); // false
+v::notOptional()->isValid(null); // false
 ```
 
 Other values:
 
 ```php
-v::notOptional()->validate([]); // true
-v::notOptional()->validate(' '); // true
-v::notOptional()->validate(0); // true
-v::notOptional()->validate('0'); // true
-v::notOptional()->validate(0); // true
-v::notOptional()->validate('0.0'); // true
-v::notOptional()->validate(false); // true
-v::notOptional()->validate(['']); // true
-v::notOptional()->validate([' ']); // true
-v::notOptional()->validate([0]); // true
-v::notOptional()->validate(['0']); // true
-v::notOptional()->validate([false]); // true
-v::notOptional()->validate([[''), [0]]); // true
-v::notOptional()->validate(new stdClass()); // true
+v::notOptional()->isValid([]); // true
+v::notOptional()->isValid(' '); // true
+v::notOptional()->isValid(0); // true
+v::notOptional()->isValid('0'); // true
+v::notOptional()->isValid(0); // true
+v::notOptional()->isValid('0.0'); // true
+v::notOptional()->isValid(false); // true
+v::notOptional()->isValid(['']); // true
+v::notOptional()->isValid([' ']); // true
+v::notOptional()->isValid([0]); // true
+v::notOptional()->isValid(['0']); // true
+v::notOptional()->isValid([false]); // true
+v::notOptional()->isValid([[''), [0]]); // true
+v::notOptional()->isValid(new stdClass()); // true
 ```
 
 ## Changelog

--- a/docs/rules/NullType.md
+++ b/docs/rules/NullType.md
@@ -5,7 +5,7 @@
 Validates whether the input is [null](http://php.net/types.null).
 
 ```php
-v::nullType()->validate(null); // true
+v::nullType()->isValid(null); // true
 ```
 
 ## Changelog

--- a/docs/rules/Nullable.md
+++ b/docs/rules/Nullable.md
@@ -5,9 +5,9 @@
 Validates the given input with a defined rule when input is not NULL.
 
 ```php
-v::nullable(v::email())->validate(null); // true
-v::nullable(v::email())->validate('example@example.com'); // true
-v::nullable(v::email())->validate('not an email'); // false
+v::nullable(v::email())->isValid(null); // true
+v::nullable(v::email())->isValid('example@example.com'); // true
+v::nullable(v::email())->isValid('not an email'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Number.md
+++ b/docs/rules/Number.md
@@ -5,8 +5,8 @@
 Validates if the input is a number.
 
 ```php
-v::number()->validate(42); // true
-v::number()->validate(acos(8)); // false
+v::number()->isValid(42); // true
+v::number()->isValid(acos(8)); // false
 ```
 
 > "In computing, NaN, standing for not a number, is a numeric data type value

--- a/docs/rules/NumericVal.md
+++ b/docs/rules/NumericVal.md
@@ -5,8 +5,8 @@
 Validates on any numeric value.
 
 ```php
-v::numericVal()->validate(-12); // true
-v::numericVal()->validate('135.0'); // true
+v::numericVal()->isValid(-12); // true
+v::numericVal()->isValid('135.0'); // true
 ```
 
 This rule doesn't validate if the data is a valid number, for that purpose

--- a/docs/rules/ObjectType.md
+++ b/docs/rules/ObjectType.md
@@ -5,7 +5,7 @@
 Validates whether the input is an [object](http://php.net/types.object).
 
 ```php
-v::objectType()->validate(new stdClass); // true
+v::objectType()->isValid(new stdClass); // true
 ```
 
 ## Changelog

--- a/docs/rules/Odd.md
+++ b/docs/rules/Odd.md
@@ -5,8 +5,8 @@
 Validates whether the input is an odd number or not.
 
 ```php
-v::odd()->validate(0); // false
-v::odd()->validate(3); // true
+v::odd()->isValid(0); // false
+v::odd()->isValid(3); // true
 ```
 
 Using `intVal()` before `odd()` is a best practice.

--- a/docs/rules/OneOf.md
+++ b/docs/rules/OneOf.md
@@ -5,10 +5,10 @@
 Will validate if exactly one inner validator passes.
 
 ```php
-v::oneOf(v::digit(), v::alpha())->validate('AB'); // true
-v::oneOf(v::digit(), v::alpha())->validate('12'); // true
-v::oneOf(v::digit(), v::alpha())->validate('AB12'); // false
-v::oneOf(v::digit(), v::alpha())->validate('*'); // false
+v::oneOf(v::digit(), v::alpha())->isValid('AB'); // true
+v::oneOf(v::digit(), v::alpha())->isValid('12'); // true
+v::oneOf(v::digit(), v::alpha())->isValid('AB12'); // false
+v::oneOf(v::digit(), v::alpha())->isValid('*'); // false
 ```
 
 The chains above validate if the input is either a digit or an alphabetic

--- a/docs/rules/Optional.md
+++ b/docs/rules/Optional.md
@@ -6,8 +6,8 @@ Validates if the given input is optional or not. By _optional_ we consider `null
 or an empty string (`''`).
 
 ```php
-v::optional(v::alpha())->validate(''); // true
-v::optional(v::digit())->validate(null); // true
+v::optional(v::alpha())->isValid(''); // true
+v::optional(v::digit())->isValid(null); // true
 ```
 
 ## Changelog

--- a/docs/rules/PerfectSquare.md
+++ b/docs/rules/PerfectSquare.md
@@ -5,8 +5,8 @@
 Validates whether the input is a perfect square.
 
 ```php
-v::perfectSquare()->validate(25); // true (5*5)
-v::perfectSquare()->validate(9); // true (3*3)
+v::perfectSquare()->isValid(25); // true (5*5)
+v::perfectSquare()->isValid(9); // true (3*3)
 ```
 
 ## Changelog

--- a/docs/rules/Pesel.md
+++ b/docs/rules/Pesel.md
@@ -5,10 +5,10 @@
 Validates PESEL (Polish human identification number).
 
 ```php
-v::pesel()->validate('21120209256'); // true
-v::pesel()->validate('97072704800'); // true
-v::pesel()->validate('97072704801'); // false
-v::pesel()->validate('PESEL123456'); // false
+v::pesel()->isValid('21120209256'); // true
+v::pesel()->isValid('97072704800'); // true
+v::pesel()->isValid('97072704801'); // false
+v::pesel()->isValid('PESEL123456'); // false
 ```
 
 ## Changelog

--- a/docs/rules/PhpLabel.md
+++ b/docs/rules/PhpLabel.md
@@ -9,9 +9,9 @@ Reference:
 http://php.net/manual/en/language.variables.basics.php
 
 ```php
-v::phpLabel()->validate('person'); //true
-v::phpLabel()->validate('foo'); //true
-v::phpLabel()->validate('4ccess'); //false
+v::phpLabel()->isValid('person'); //true
+v::phpLabel()->isValid('foo'); //true
+v::phpLabel()->isValid('4ccess'); //false
 ```
 
 ## Changelog

--- a/docs/rules/Pis.md
+++ b/docs/rules/Pis.md
@@ -5,11 +5,11 @@
 Validates a Brazilian PIS/NIS number ignoring any non-digit char.
 
 ```php
-v::pis()->validate('120.0340.678-8'); // true
-v::pis()->validate('120.03406788'); // true
-v::pis()->validate('120.0340.6788'); // true
-v::pis()->validate('1.2.0.0.3.4.0.6.7.8.8'); // true
-v::pis()->validate('12003406788'); // true
+v::pis()->isValid('120.0340.678-8'); // true
+v::pis()->isValid('120.03406788'); // true
+v::pis()->isValid('120.0340.6788'); // true
+v::pis()->isValid('1.2.0.0.3.4.0.6.7.8.8'); // true
+v::pis()->isValid('12003406788'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Positive.md
+++ b/docs/rules/Positive.md
@@ -5,9 +5,9 @@
 Validates whether the input is a positive number.
 
 ```php
-v::positive()->validate(1); // true
-v::positive()->validate(0); // false
-v::positive()->validate(-15); // false
+v::positive()->isValid(1); // true
+v::positive()->isValid(0); // false
+v::positive()->isValid(-15); // false
 ```
 
 ## Changelog

--- a/docs/rules/PostalCode.md
+++ b/docs/rules/PostalCode.md
@@ -5,11 +5,11 @@
 Validates a postal code according to the given country code.
 
 ```php
-v::postalCode('BR')->validate('02179000'); // true
-v::postalCode('BR')->validate('02179-000'); // true
-v::postalCode('US')->validate('02179-000'); // false
-v::postalCode('US')->validate('55372'); // true
-v::postalCode('PL')->validate('99-300'); // true
+v::postalCode('BR')->isValid('02179000'); // true
+v::postalCode('BR')->isValid('02179-000'); // true
+v::postalCode('US')->isValid('02179-000'); // false
+v::postalCode('US')->isValid('55372'); // true
+v::postalCode('PL')->isValid('99-300'); // true
 ```
 
 Message template for this validator includes `{{countryCode}}`.

--- a/docs/rules/PrimeNumber.md
+++ b/docs/rules/PrimeNumber.md
@@ -5,7 +5,7 @@
 Validates a prime number
 
 ```php
-v::primeNumber()->validate(7); // true
+v::primeNumber()->isValid(7); // true
 ```
 
 ## Changelog

--- a/docs/rules/Printable.md
+++ b/docs/rules/Printable.md
@@ -6,7 +6,7 @@
 Similar to `Graph` but accepts whitespace.
 
 ```php
-v::printable()->validate('LMKA0$% _123'); // true
+v::printable()->isValid('LMKA0$% _123'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Punct.md
+++ b/docs/rules/Punct.md
@@ -6,7 +6,7 @@
 Accepts only punctuation characters:
 
 ```php
-v::punct()->validate('&,.;[]'); // true
+v::punct()->isValid('&,.;[]'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Readable.md
+++ b/docs/rules/Readable.md
@@ -5,7 +5,7 @@
 Validates if the given data is a file exists and is readable.
 
 ```php
-v::readable()->validate('file.txt'); // true
+v::readable()->isValid('file.txt'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Regex.md
+++ b/docs/rules/Regex.md
@@ -5,7 +5,7 @@
 Evaluates a regex on the input and validates if matches
 
 ```php
-v::regex('/[a-z]/')->validate('a'); // true
+v::regex('/[a-z]/')->isValid('a'); // true
 ```
 
 Message template for this validator includes `{{regex}}`

--- a/docs/rules/ResourceType.md
+++ b/docs/rules/ResourceType.md
@@ -5,7 +5,7 @@
 Validates whether the input is a [resource](http://php.net/types.resource).
 
 ```php
-v::resourceType()->validate(fopen('/path/to/file.txt', 'w')); // true
+v::resourceType()->isValid(fopen('/path/to/file.txt', 'w')); // true
 ```
 
 ## Changelog

--- a/docs/rules/Roman.md
+++ b/docs/rules/Roman.md
@@ -5,7 +5,7 @@
 Validates roman numbers
 
 ```php
-v::roman()->validate('IV'); // true
+v::roman()->isValid('IV'); // true
 ```
 
 ## Changelog

--- a/docs/rules/ScalarVal.md
+++ b/docs/rules/ScalarVal.md
@@ -5,8 +5,8 @@
 Validates whether the input is a scalar value or not.
 
 ```php
-v::scalarVal()->validate([]); // false
-v::scalarVal()->validate(135.0); // true
+v::scalarVal()->isValid([]); // false
+v::scalarVal()->isValid(135.0); // true
 ```
 
 ## Changelog

--- a/docs/rules/Sf.md
+++ b/docs/rules/Sf.md
@@ -8,7 +8,7 @@ Validate the input with a Symfony Validator (>=4.0 or >=3.0) Constraint.
 ```php
 use Symfony\Component\Validator\Constraint\Iban;
 
-v::sf(new Iban())->validate('NL39 RABO 0300 0652 64'); // true
+v::sf(new Iban())->isValid('NL39 RABO 0300 0652 64'); // true
 ```
 
 This rule will keep all the messages returned from Symfony.

--- a/docs/rules/Size.md
+++ b/docs/rules/Size.md
@@ -7,9 +7,9 @@
 Validates file sizes:
 
 ```php
-v::size('1KB')->validate($filename); // Must have at least 1KB size
-v::size('1MB', '2MB')->validate($filename); // Must have the size between 1MB and 2MB
-v::size(null, '1GB')->validate($filename); // Must not be greater than 1GB
+v::size('1KB')->isValid($filename); // Must have at least 1KB size
+v::size('1MB', '2MB')->isValid($filename); // Must have the size between 1MB and 2MB
+v::size(null, '1GB')->isValid($filename); // Must not be greater than 1GB
 ```
 
 Sizes are not case-sensitive and the accepted values are:
@@ -28,7 +28,7 @@ This validator will consider `SplFileInfo` instances, like:
 
 ```php
 $fileInfo = new SplFileInfo($filename);
-v::size('1.5mb')->validate($fileInfo); // Will return true or false
+v::size('1.5mb')->isValid($fileInfo); // Will return true or false
 ```
 
 Message template for this validator includes `{{minSize}}` and `{{maxSize}}`.

--- a/docs/rules/Slug.md
+++ b/docs/rules/Slug.md
@@ -5,9 +5,9 @@
 Validates slug-like strings:
 
 ```php
-v::slug()->validate('my-wordpress-title'); // true
-v::slug()->validate('my-wordpress--title'); // false
-v::slug()->validate('my-wordpress-title-'); // false
+v::slug()->isValid('my-wordpress-title'); // true
+v::slug()->isValid('my-wordpress--title'); // false
+v::slug()->isValid('my-wordpress-title-'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Sorted.md
+++ b/docs/rules/Sorted.md
@@ -5,12 +5,12 @@
 Validates if the input is Sorted
 
 ```php
-v::sorted()->validate([1,2,3]); // true
-v::sorted()->validate([1,6,3]); // false
-v::sorted(null, false)->validate([3,2,1]); // true
+v::sorted()->isValid([1,2,3]); // true
+v::sorted()->isValid([1,6,3]); // false
+v::sorted(null, false)->isValid([3,2,1]); // true
 v::sorted(function($x){
     return $x['key'];
-})->validate([
+})->isValid([
     [
         'key' => 1,
     ],
@@ -23,7 +23,7 @@ v::sorted(function($x){
 ]); // true
 v::sorted(function($x){
     return $x['key'];
-})->validate([
+})->isValid([
     [
         'key' => 1,
     ],

--- a/docs/rules/Space.md
+++ b/docs/rules/Space.md
@@ -6,7 +6,7 @@
 Accepts only whitespace:
 
 ```php
-v::space()->validate('    '); // true
+v::space()->isValid('    '); // true
 ```
 
 ## Changelog

--- a/docs/rules/StartsWith.md
+++ b/docs/rules/StartsWith.md
@@ -9,13 +9,13 @@ only if the value is at the beginning of the input.
 For strings:
 
 ```php
-v::startsWith('lorem')->validate('lorem ipsum'); // true
+v::startsWith('lorem')->isValid('lorem ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::startsWith('lorem')->validate(['lorem', 'ipsum']); // true
+v::startsWith('lorem')->isValid(['lorem', 'ipsum']); // true
 ```
 
 `true` may be passed as a parameter to indicate identical comparison

--- a/docs/rules/StringType.md
+++ b/docs/rules/StringType.md
@@ -5,7 +5,7 @@
 Validates whether the type of an input is string or not.
 
 ```php
-v::stringType()->validate('hi'); // true
+v::stringType()->isValid('hi'); // true
 ```
 
 ## Changelog

--- a/docs/rules/StringVal.md
+++ b/docs/rules/StringVal.md
@@ -5,13 +5,13 @@
 Validates whether the input can be used as a string.
 
 ```php
-v::stringVal()->validate('6'); // true
-v::stringVal()->validate('String'); // true
-v::stringVal()->validate(1.0); // true
-v::stringVal()->validate(42); // true
-v::stringVal()->validate(false); // true
-v::stringVal()->validate(true); // true
-v::stringVal()->validate(new ClassWithToString()); // true if ClassWithToString implements `__toString`
+v::stringVal()->isValid('6'); // true
+v::stringVal()->isValid('String'); // true
+v::stringVal()->isValid(1.0); // true
+v::stringVal()->isValid(42); // true
+v::stringVal()->isValid(false); // true
+v::stringVal()->isValid(true); // true
+v::stringVal()->isValid(new ClassWithToString()); // true if ClassWithToString implements `__toString`
 ```
 
 ## Changelog

--- a/docs/rules/SubdivisionCode.md
+++ b/docs/rules/SubdivisionCode.md
@@ -7,8 +7,8 @@ Validates subdivision country codes according to [ISO 3166-2][].
 The `$countryCode` must be a country in [ISO 3166-1 alpha-2][] format.
 
 ```php
-v::subdivisionCode('BR')->validate('SP'); // true
-v::subdivisionCode('US')->validate('CA'); // true
+v::subdivisionCode('BR')->isValid('SP'); // true
+v::subdivisionCode('US')->isValid('CA'); // true
 ```
 
 This rule is case sensitive.

--- a/docs/rules/Subset.md
+++ b/docs/rules/Subset.md
@@ -5,8 +5,8 @@
 Validates whether the input is a subset of a given value.
 
 ```php
-v::subset([1, 2, 3])->validate([1, 2]); // true
-v::subset([1, 2])->validate([1, 2, 3]); // false
+v::subset([1, 2, 3])->isValid([1, 2]); // true
+v::subset([1, 2])->isValid([1, 2, 3]); // false
 ```
 
 ## Changelog

--- a/docs/rules/SymbolicLink.md
+++ b/docs/rules/SymbolicLink.md
@@ -5,7 +5,7 @@
 Validates if the given data is a path of a valid symbolic link.
 
 ```php
-v::symbolicLink()->validate('/path/of/valid/symbolic/link'); // true
+v::symbolicLink()->isValid('/path/of/valid/symbolic/link'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Time.md
+++ b/docs/rules/Time.md
@@ -23,15 +23,15 @@ Format  | Description                                        | Values
 When a `$format` is not given its default value is `H:i:s`. 
 
 ```php
-v::time()->validate('00:00:00'); // true
-v::time()->validate('23:20:59'); // true
-v::time('H:i')->validate('23:59'); // true
-v::time('g:i A')->validate('8:13 AM'); // true
-v::time('His')->validate(232059); // true
+v::time()->isValid('00:00:00'); // true
+v::time()->isValid('23:20:59'); // true
+v::time('H:i')->isValid('23:59'); // true
+v::time('g:i A')->isValid('8:13 AM'); // true
+v::time('His')->isValid(232059); // true
 
-v::time()->validate('24:00:00'); // false
-v::time()->validate(new DateTime()); // false
-v::time()->validate(new DateTimeImmutable()); // false
+v::time()->isValid('24:00:00'); // false
+v::time()->isValid(new DateTime()); // false
+v::time()->isValid(new DateTimeImmutable()); // false
 ```
 
 ## Changelog

--- a/docs/rules/Tld.md
+++ b/docs/rules/Tld.md
@@ -5,9 +5,9 @@
 Validates whether the input is a top-level domain.
 
 ```php
-v::tld()->validate('com'); // true
-v::tld()->validate('ly'); // true
-v::tld()->validate('org'); // true
+v::tld()->isValid('com'); // true
+v::tld()->isValid('ly'); // true
+v::tld()->isValid('org'); // true
 ```
 
 ## Changelog

--- a/docs/rules/TrueVal.md
+++ b/docs/rules/TrueVal.md
@@ -5,14 +5,14 @@
 Validates if a value is considered as `true`.
 
 ```php
-v::trueVal()->validate(true); // true
-v::trueVal()->validate(1); // true
-v::trueVal()->validate('1'); // true
-v::trueVal()->validate('true'); // true
-v::trueVal()->validate('on'); // true
-v::trueVal()->validate('yes'); // true
-v::trueVal()->validate('0.5'); // false
-v::trueVal()->validate('2'); // false
+v::trueVal()->isValid(true); // true
+v::trueVal()->isValid(1); // true
+v::trueVal()->isValid('1'); // true
+v::trueVal()->isValid('true'); // true
+v::trueVal()->isValid('on'); // true
+v::trueVal()->isValid('yes'); // true
+v::trueVal()->isValid('0.5'); // false
+v::trueVal()->isValid('2'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Type.md
+++ b/docs/rules/Type.md
@@ -5,9 +5,9 @@
 Validates the type of input.
 
 ```php
-v::type('bool')->validate(true); // true
-v::type('callable')->validate(function (){}); // true
-v::type('object')->validate(new stdClass()); // true
+v::type('bool')->isValid(true); // true
+v::type('callable')->isValid(function (){}); // true
+v::type('object')->isValid(new stdClass()); // true
 ```
 
 ## Changelog

--- a/docs/rules/Unique.md
+++ b/docs/rules/Unique.md
@@ -5,10 +5,10 @@
 Validates whether the input array contains only unique values.
 
 ```php
-v::unique()->validate([]); // true
-v::unique()->validate([1, 2, 3]); // true
-v::unique()->validate([1, 2, 2, 3]); // false
-v::unique()->validate([1, 2, 3, 1]); // false
+v::unique()->isValid([]); // true
+v::unique()->isValid([1, 2, 3]); // true
+v::unique()->isValid([1, 2, 2, 3]); // false
+v::unique()->isValid([1, 2, 3, 1]); // false
 ```
 
 ***

--- a/docs/rules/Uploaded.md
+++ b/docs/rules/Uploaded.md
@@ -5,7 +5,7 @@
 Validates if the given data is a file that was uploaded via HTTP POST.
 
 ```php
-v::uploaded()->validate('/path/of/an/uploaded/file'); // true
+v::uploaded()->isValid('/path/of/an/uploaded/file'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Uppercase.md
+++ b/docs/rules/Uppercase.md
@@ -5,7 +5,7 @@
 Validates whether the characters in the input are uppercase.
 
 ```php
-v::uppercase()->validate('W3C'); // true
+v::uppercase()->isValid('W3C'); // true
 ```
 
 This rule does not validate if the input a numeric value, so `123` and `%` will
@@ -13,9 +13,9 @@ be valid. Please add more validations to the chain if you want to refine your
 validation.
 
 ```php
-v::not(v::numericVal())->uppercase()->validate('42'); // false
-v::alnum()->uppercase()->validate('#$%!'); // false
-v::not(v::numericVal())->alnum()->uppercase()->validate('W3C'); // true
+v::not(v::numericVal())->uppercase()->isValid('42'); // false
+v::alnum()->uppercase()->isValid('#$%!'); // false
+v::not(v::numericVal())->alnum()->uppercase()->isValid('W3C'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Url.md
+++ b/docs/rules/Url.md
@@ -5,11 +5,11 @@
 Validates whether the input is a URL.
 
 ```php
-v::url()->validate('http://example.com'); // true
-v::url()->validate('https://www.youtube.com/watch?v=6FOUqQt3Kg0'); // true
-v::url()->validate('ldap://[::1]'); // true
-v::url()->validate('mailto:john.doe@example.com'); // true
-v::url()->validate('news:new.example.com'); // true
+v::url()->isValid('http://example.com'); // true
+v::url()->isValid('https://www.youtube.com/watch?v=6FOUqQt3Kg0'); // true
+v::url()->isValid('ldap://[::1]'); // true
+v::url()->isValid('mailto:john.doe@example.com'); // true
+v::url()->isValid('news:new.example.com'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Uuid.md
+++ b/docs/rules/Uuid.md
@@ -5,8 +5,8 @@
 Validates whether the type of an input is a valid UUID. Both version 1 and version 4 or supported.
 
 ```php
-v::uuid()->validate('Hello World!'); // false
-v::uuid()->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid()->isValid('Hello World!'); // false
+v::uuid()->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Vatin.md
+++ b/docs/rules/Vatin.md
@@ -5,11 +5,11 @@
 Validates VAT identification number according to the defined country.
 
 ```php
-v::vatin('PL')->validate('1645865777'); // true
-v::vatin('PL')->validate('1645865778'); // false
-v::vatin('PL')->validate('1234567890'); // false
-v::vatin('PL')->validate('164-586-57-77'); // false
-v::vatin('PL')->validate('164-58-65-777'); // false
+v::vatin('PL')->isValid('1645865777'); // true
+v::vatin('PL')->isValid('1645865778'); // false
+v::vatin('PL')->isValid('1234567890'); // false
+v::vatin('PL')->isValid('164-586-57-77'); // false
+v::vatin('PL')->isValid('164-58-65-777'); // false
 ```
 
 For now this rule only accepts Polish VAT identification number (NIP).

--- a/docs/rules/Version.md
+++ b/docs/rules/Version.md
@@ -5,7 +5,7 @@
 Validates version numbers using Semantic Versioning.
 
 ```php
-v::version()->validate('1.0.0');
+v::version()->isValid('1.0.0');
 ```
 
 ## Changelog

--- a/docs/rules/VideoUrl.md
+++ b/docs/rules/VideoUrl.md
@@ -6,17 +6,17 @@
 Validates if the input is a video URL value:
 
 ```php
-v::videoUrl()->validate('https://player.vimeo.com/video/71787467'); // true
-v::videoUrl()->validate('https://vimeo.com/71787467'); // true
-v::videoUrl()->validate('https://www.youtube.com/embed/netHLn9TScY'); // true
-v::videoUrl()->validate('https://www.youtube.com/watch?v=netHLn9TScY'); // true
-v::videoUrl()->validate('https://youtu.be/netHLn9TScY'); // true
+v::videoUrl()->isValid('https://player.vimeo.com/video/71787467'); // true
+v::videoUrl()->isValid('https://vimeo.com/71787467'); // true
+v::videoUrl()->isValid('https://www.youtube.com/embed/netHLn9TScY'); // true
+v::videoUrl()->isValid('https://www.youtube.com/watch?v=netHLn9TScY'); // true
+v::videoUrl()->isValid('https://youtu.be/netHLn9TScY'); // true
 
-v::videoUrl('youtube')->validate('https://www.youtube.com/watch?v=netHLn9TScY'); // true
-v::videoUrl('vimeo')->validate('https://vimeo.com/71787467'); // true
+v::videoUrl('youtube')->isValid('https://www.youtube.com/watch?v=netHLn9TScY'); // true
+v::videoUrl('vimeo')->isValid('https://vimeo.com/71787467'); // true
 
-v::videoUrl()->validate('https://youtube.com'); // false
-v::videoUrl('youtube')->validate('https://vimeo.com/71787467'); // false
+v::videoUrl()->isValid('https://youtube.com'); // false
+v::videoUrl('youtube')->isValid('https://vimeo.com/71787467'); // false
 ```
 
 The services accepted are:

--- a/docs/rules/Vowel.md
+++ b/docs/rules/Vowel.md
@@ -5,7 +5,7 @@
 Similar to `Alnum()`. Validates strings that contains only vowels:
 
 ```php
-v::vowel()->validate('aei'); // true
+v::vowel()->isValid('aei'); // true
 ```
 
 ## Changelog

--- a/docs/rules/When.md
+++ b/docs/rules/When.md
@@ -9,11 +9,11 @@ When the `$if` validates, returns validation for `$then`.
 When the `$if` doesn't validate, returns validation for `$else`, if defined.
 
 ```php
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate(1); // true
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate('not empty'); // true
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid(1); // true
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid('not empty'); // true
 
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate(-1); // false
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate(''); // false
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid(-1); // false
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid(''); // false
 ```
 
 In the sample above, if `$input` is an integer, then it must be positive.

--- a/docs/rules/Writable.md
+++ b/docs/rules/Writable.md
@@ -5,7 +5,7 @@
 Validates if the given input is writable file.
 
 ```php
-v::writable()->validate('file.txt'); // true
+v::writable()->isValid('file.txt'); // true
 ```
 
 ## Changelog

--- a/docs/rules/Xdigit.md
+++ b/docs/rules/Xdigit.md
@@ -5,13 +5,13 @@
 Accepts an hexadecimal number:
 
 ```php
-v::xdigit()->validate('abc123'); // true
+v::xdigit()->isValid('abc123'); // true
 ```
 
 Notice, however, that it doesn't accept strings starting with 0x:
 
 ```php
-v::xdigit()->validate('0x1f'); // false
+v::xdigit()->isValid('0x1f'); // false
 ```
 
 ## Changelog

--- a/docs/rules/Yes.md
+++ b/docs/rules/Yes.md
@@ -6,11 +6,11 @@
 Validates if value is considered as "Yes".
 
 ```php
-v::yes()->validate('Y'); // true
-v::yes()->validate('Yea'); // true
-v::yes()->validate('Yeah'); // true
-v::yes()->validate('Yep'); // true
-v::yes()->validate('Yes'); // true
+v::yes()->isValid('Y'); // true
+v::yes()->isValid('Yea'); // true
+v::yes()->isValid('Yeah'); // true
+v::yes()->isValid('Yep'); // true
+v::yes()->isValid('Yes'); // true
 ```
 
 This rule is case insensitive.

--- a/docs/rules/Zend.md
+++ b/docs/rules/Zend.md
@@ -6,7 +6,7 @@ Use Zend validators inside Respect\Validation flow. Messages
 are preserved.
 
 ```php
-v::zend('Hostname')->validate('google.com');
+v::zend('Hostname')->isValid('google.com');
 ```
 
 Respect\Validation supports version >=2.0.3 of Zend\Validator.

--- a/library/Rules/AbstractAge.php
+++ b/library/Rules/AbstractAge.php
@@ -72,7 +72,7 @@ abstract class AbstractAge extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/AbstractComparison.php
+++ b/library/Rules/AbstractComparison.php
@@ -42,7 +42,7 @@ abstract class AbstractComparison extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $left = $this->toComparable($input);
         $right = $this->toComparable($this->compareTo);

--- a/library/Rules/AbstractEnvelope.php
+++ b/library/Rules/AbstractEnvelope.php
@@ -51,9 +51,9 @@ abstract class AbstractEnvelope extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
-        return $this->validatable->validate($input);
+        return $this->validatable->isValid($input);
     }
 
     /**

--- a/library/Rules/AbstractFilterRule.php
+++ b/library/Rules/AbstractFilterRule.php
@@ -35,7 +35,7 @@ abstract class AbstractFilterRule extends AbstractRule
         return str_replace(str_split($this->additionalChars), '', $input);
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -78,14 +78,14 @@ abstract class AbstractRelated extends AbstractRule
         $this->decision('check', $hasReference, $input);
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $hasReference = $this->hasReference($input);
         if ($this->mandatory && !$hasReference) {
             return false;
         }
 
-        return $this->decision('validate', $hasReference, $input);
+        return $this->decision('isValid', $hasReference, $input);
     }
 
     private function decision(string $type, bool $hasReference, $input)

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -24,12 +24,12 @@ abstract class AbstractRule implements Validatable
 
     public function __invoke($input)
     {
-        return $this->validate($input);
+        return $this->isValid($input);
     }
 
     public function assert($input): void
     {
-        if ($this->validate($input)) {
+        if ($this->isValid($input)) {
             return;
         }
 

--- a/library/Rules/AbstractSearcher.php
+++ b/library/Rules/AbstractSearcher.php
@@ -32,7 +32,7 @@ abstract class AbstractSearcher extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $dataSource = $this->getDataSource();
         if ($this->isUndefined($input) && empty($dataSource)) {

--- a/library/Rules/AbstractWrapper.php
+++ b/library/Rules/AbstractWrapper.php
@@ -56,9 +56,9 @@ abstract class AbstractWrapper extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
-        return $this->validatable->validate($input);
+        return $this->validatable->isValid($input);
     }
 
     /**

--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -37,10 +37,10 @@ class AllOf extends AbstractComposite
         }
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         foreach ($this->getRules() as $rule) {
-            if (!$rule->validate($input)) {
+            if (!$rule->isValid($input)) {
                 return false;
             }
         }

--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -25,7 +25,7 @@ final class AlwaysInvalid extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return false;
     }

--- a/library/Rules/AlwaysValid.php
+++ b/library/Rules/AlwaysValid.php
@@ -25,7 +25,7 @@ final class AlwaysValid extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return true;
     }

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -28,10 +28,10 @@ class AnyOf extends AbstractComposite
         }
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         foreach ($this->getRules() as $v) {
-            if ($v->validate($input)) {
+            if ($v->isValid($input)) {
                 return true;
             }
         }

--- a/library/Rules/ArrayType.php
+++ b/library/Rules/ArrayType.php
@@ -24,7 +24,7 @@ final class ArrayType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_array($input);
     }

--- a/library/Rules/ArrayVal.php
+++ b/library/Rules/ArrayVal.php
@@ -27,7 +27,7 @@ final class ArrayVal extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_array($input) || $input instanceof ArrayAccess || $input instanceof SimpleXMLElement;
     }

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -60,7 +60,7 @@ final class Base extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $valid = mb_substr($this->chars, 0, $this->base);
 

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -29,7 +29,7 @@ final class Base64 extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/BoolType.php
+++ b/library/Rules/BoolType.php
@@ -26,7 +26,7 @@ final class BoolType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_bool($input);
     }

--- a/library/Rules/BoolVal.php
+++ b/library/Rules/BoolVal.php
@@ -30,7 +30,7 @@ final class BoolVal extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_bool(filter_var($input, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
     }

--- a/library/Rules/Bsn.php
+++ b/library/Rules/Bsn.php
@@ -30,7 +30,7 @@ final class Bsn extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!ctype_digit($input)) {
             return false;

--- a/library/Rules/Call.php
+++ b/library/Rules/Call.php
@@ -90,7 +90,7 @@ final class Call extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         try {
             $this->check($input);

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -25,7 +25,7 @@ final class CallableType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_callable($input);
     }

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -49,7 +49,7 @@ final class Callback extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return (bool) call_user_func($this->callback, $input, ...$this->arguments);
     }

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -53,7 +53,7 @@ final class Charset extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $detectedEncoding = mb_detect_encoding($input, $this->charset, true);
 

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -30,7 +30,7 @@ final class Cnh extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -32,7 +32,7 @@ final class Cnpj extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -54,7 +54,7 @@ final class Contains extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($this->identical) {
             return $this->validateIdentical($input);

--- a/library/Rules/Countable.php
+++ b/library/Rules/Countable.php
@@ -28,7 +28,7 @@ final class Countable extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_array($input) || $input instanceof CountableInterface;
     }

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -32,7 +32,7 @@ final class Cpf extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         // Code ported from jsfromhell.com
         $c = preg_replace('/\D/', '', $input);

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -110,14 +110,14 @@ final class CreditCard extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;
         }
 
         $input = preg_replace('/[ .-]/', '', (string) $input);
-        if (!(new Luhn())->validate($input)) {
+        if (!(new Luhn())->isValid($input)) {
             return false;
         }
 

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -59,7 +59,7 @@ final class Date extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/DateTime.php
+++ b/library/Rules/DateTime.php
@@ -51,7 +51,7 @@ final class DateTime extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof DateTimeInterface) {
             return null === $this->format;

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -29,7 +29,7 @@ final class Directory extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isDir();

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -59,21 +59,21 @@ class Domain extends AbstractComposite
         return true;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         foreach ($this->checks as $chk) {
-            if (!$chk->validate($input)) {
+            if (!$chk->isValid($input)) {
                 return false;
             }
         }
 
         if (count($parts = explode('.', (string) $input)) < 2
-            || !$this->tld->validate(array_pop($parts))) {
+            || !$this->tld->isValid(array_pop($parts))) {
             return false;
         }
 
         foreach ($parts as $p) {
-            if (!$this->otherParts->validate($p)) {
+            if (!$this->otherParts->isValid($p)) {
                 return false;
             }
         }

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -70,7 +70,7 @@ final class Each extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         try {
             $this->assert($input);

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -49,7 +49,7 @@ final class Email extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -53,7 +53,7 @@ final class EndsWith extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($this->identical) {
             return $this->validateIdentical($input);

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -39,7 +39,7 @@ final class Equals extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return $input == $this->compareTo;
     }

--- a/library/Rules/Equivalent.php
+++ b/library/Rules/Equivalent.php
@@ -41,7 +41,7 @@ final class Equivalent extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (is_scalar($input)) {
             return $this->isStringEquivalent((string) $input);

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -28,7 +28,7 @@ final class Even extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (false === filter_var($input, FILTER_VALIDATE_INT)) {
             return false;

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -28,7 +28,7 @@ final class Executable extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isExecutable();

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -25,7 +25,7 @@ final class Exists extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof \SplFileInfo) {
             $input = $input->getPathname();

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -38,7 +38,7 @@ class Extension extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->getExtension() == $this->extension;

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -33,7 +33,7 @@ class Factor extends AbstractRule
         $this->dividend = (int) $dividend;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         // Every integer is a factor of zero, and zero is the only integer that
         // has zero for a factor.

--- a/library/Rules/FalseVal.php
+++ b/library/Rules/FalseVal.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class FalseVal extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (false === $input) { // PHP 5.3 workaround
             return true;

--- a/library/Rules/Fibonacci.php
+++ b/library/Rules/Fibonacci.php
@@ -21,7 +21,7 @@ class Fibonacci extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class File extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof \SplFileInfo) {
             return $input->isFile();

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -21,7 +21,7 @@ class Finite extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_numeric($input) && is_finite((float) $input);
     }

--- a/library/Rules/FloatType.php
+++ b/library/Rules/FloatType.php
@@ -26,7 +26,7 @@ final class FloatType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_float($input);
     }

--- a/library/Rules/FloatVal.php
+++ b/library/Rules/FloatVal.php
@@ -29,7 +29,7 @@ final class FloatVal extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_float(filter_var($input, FILTER_VALIDATE_FLOAT));
     }

--- a/library/Rules/HexRgbColor.php
+++ b/library/Rules/HexRgbColor.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class HexRgbColor extends Xdigit
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input)) {
             return false;
@@ -30,6 +30,6 @@ class HexRgbColor extends Xdigit
             return false;
         }
 
-        return parent::validate($input);
+        return parent::isValid($input);
     }
 }

--- a/library/Rules/Identical.php
+++ b/library/Rules/Identical.php
@@ -38,7 +38,7 @@ final class Identical extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return $input === $this->compareTo;
     }

--- a/library/Rules/Image.php
+++ b/library/Rules/Image.php
@@ -46,10 +46,10 @@ final class Image extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
-            return $this->validate($input->getPathname());
+            return $this->isValid($input->getPathname());
         }
 
         if (!is_string($input)) {

--- a/library/Rules/Imei.php
+++ b/library/Rules/Imei.php
@@ -34,7 +34,7 @@ final class Imei extends AbstractRule
      *
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;
@@ -45,6 +45,6 @@ final class Imei extends AbstractRule
             return false;
         }
 
-        return (new Luhn())->validate($numbers);
+        return (new Luhn())->isValid($numbers);
     }
 }

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -82,7 +82,7 @@ final class In extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($this->compareIdentical) {
             return $this->validateIdentical($input);

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -27,7 +27,7 @@ final class Infinite extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_numeric($input) && is_infinite((float) $input);
     }

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -40,7 +40,7 @@ final class Instance extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return $input instanceof $this->instanceName;
     }

--- a/library/Rules/IntType.php
+++ b/library/Rules/IntType.php
@@ -25,7 +25,7 @@ final class IntType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_int($input);
     }

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -25,7 +25,7 @@ use function is_float;
  */
 final class IntVal extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (is_float($input) || is_bool($input)) {
             return false;

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -121,7 +121,7 @@ class Ip extends AbstractRule
         $range['mask'] = sprintf('%032b', ip2long(long2ip(~(2 ** (32 - $input[1]) - 1))));
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return $this->verifyAddress($input) && $this->verifyNetwork($input);
     }

--- a/library/Rules/IterableType.php
+++ b/library/Rules/IterableType.php
@@ -27,7 +27,7 @@ final class IterableType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return $this->isIterable($input);
     }

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -28,7 +28,7 @@ final class Json extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input) || '' === $input) {
             return false;

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -132,12 +132,12 @@ final class KeySet extends AbstractWrapper
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!$this->hasValidStructure($input)) {
             return false;
         }
 
-        return parent::validate($input);
+        return parent::isValid($input);
     }
 }

--- a/library/Rules/KeyValue.php
+++ b/library/Rules/KeyValue.php
@@ -89,7 +89,7 @@ class KeyValue extends AbstractRule
         }
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         try {
             $rule = $this->getRule($input);
@@ -97,6 +97,6 @@ class KeyValue extends AbstractRule
             return false;
         }
 
-        return $rule->validate($input[$this->comparedKey]);
+        return $rule->isValid($input[$this->comparedKey]);
     }
 }

--- a/library/Rules/LanguageCode.php
+++ b/library/Rules/LanguageCode.php
@@ -551,7 +551,7 @@ class LanguageCode extends AbstractRule
         return $languageList;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input) || '' === $input) {
             return false;

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -25,7 +25,7 @@ class LeapDate extends AbstractRule
         $this->format = $format;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (is_string($input)) {
             $date = DateTimeImmutable::createFromFormat($this->format, $input);

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -17,7 +17,7 @@ use DateTimeInterface;
 
 class LeapYear extends AbstractRule
 {
-    public function validate($year): bool
+    public function isValid($year): bool
     {
         if (is_numeric($year)) {
             $year = (int) $year;

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -27,13 +27,13 @@ class Length extends AbstractRule
         $this->maxValue = $max;
         $this->inclusive = $inclusive;
         $paramValidator = new AnyOf(new NumericVal(), new NullType());
-        if (!$paramValidator->validate($min)) {
+        if (!$paramValidator->isValid($min)) {
             throw new ComponentException(
                 sprintf('%s is not a valid numeric length', $min)
             );
         }
 
-        if (!$paramValidator->validate($max)) {
+        if (!$paramValidator->isValid($max)) {
             throw new ComponentException(
                 sprintf('%s is not a valid numeric length', $max)
             );
@@ -46,7 +46,7 @@ class Length extends AbstractRule
         }
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $length = $this->extractLength($input);
 

--- a/library/Rules/Locale/PlIdentityCard.php
+++ b/library/Rules/Locale/PlIdentityCard.php
@@ -22,7 +22,7 @@ use Respect\Validation\Rules\AbstractRule;
  */
 class PlIdentityCard extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!preg_match('/^[A-Z0-9]{9}$/', $input)) {
             return false;

--- a/library/Rules/Locale/PlVatin.php
+++ b/library/Rules/Locale/PlVatin.php
@@ -22,7 +22,7 @@ use Respect\Validation\Rules\AbstractRule;
  */
 final class PlVatin extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -30,7 +30,7 @@ final class Lowercase extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Luhn.php
+++ b/library/Rules/Luhn.php
@@ -21,16 +21,16 @@ class Luhn extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
-        if (!(new Digit())->validate($input)) {
+        if (!(new Digit())->isValid($input)) {
             return false;
         }
 
-        return $this->isValid($input);
+        return $this->isLuhn($input);
     }
 
-    private function isValid($input): bool
+    private function isLuhn($input): bool
     {
         $sum = 0;
         $numDigits = mb_strlen($input);

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class MacAddress extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return !empty($input) && preg_match('/^(([0-9a-fA-F]{2}-){5}|([0-9a-fA-F]{2}:){5})[0-9a-fA-F]{2}$/', $input);
     }

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -46,7 +46,7 @@ class Mimetype extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
             $input = $input->getPathname();

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -36,7 +36,7 @@ final class Multiple extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (0 == $this->multipleOf) {
             return 0 == $input;

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -27,7 +27,7 @@ final class Negative extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -28,7 +28,7 @@ class NfeAccessKey extends AbstractRule
      *
      * @return bool
      */
-    public function validate($aK): bool
+    public function isValid($aK): bool
     {
         if (44 !== mb_strlen($aK)) {
             return false;

--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -25,7 +25,7 @@ final class Nif extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -30,7 +30,7 @@ final class NoWhitespace extends AbstractRule
     /*
     * {@inheritdoc}
     */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (is_null($input)) {
             return true;

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -25,10 +25,10 @@ class NoneOf extends AbstractComposite
         }
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         foreach ($this->getRules() as $rule) {
-            if ($rule->validate($input)) {
+            if ($rule->isValid($input)) {
                 return false;
             }
         }

--- a/library/Rules/Not.php
+++ b/library/Rules/Not.php
@@ -32,14 +32,14 @@ class Not extends AbstractRule
         return parent::setName($name);
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
-        return false === $this->rule->validate($input);
+        return false === $this->rule->isValid($input);
     }
 
     public function assert($input): void
     {
-        if ($this->validate($input)) {
+        if ($this->isValid($input)) {
             return;
         }
 
@@ -63,7 +63,7 @@ class Not extends AbstractRule
                 continue;
             }
 
-            if (!$rule->validate($input)) {
+            if (!$rule->isValid($input)) {
                 continue;
             }
 

--- a/library/Rules/NotBlank.php
+++ b/library/Rules/NotBlank.php
@@ -17,7 +17,7 @@ use stdClass;
 
 class NotBlank extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (is_numeric($input)) {
             return 0 != $input;

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -24,7 +24,7 @@ class NotEmpty extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (is_string($input)) {
             $input = trim($input);

--- a/library/Rules/NotOptional.php
+++ b/library/Rules/NotOptional.php
@@ -19,7 +19,7 @@ class NotOptional extends AbstractRule
 {
     use UndefinedHelper;
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return false === $this->isUndefined($input);
     }

--- a/library/Rules/NullType.php
+++ b/library/Rules/NullType.php
@@ -26,7 +26,7 @@ final class NullType extends NotEmpty
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_null($input);
     }

--- a/library/Rules/Nullable.php
+++ b/library/Rules/Nullable.php
@@ -47,12 +47,12 @@ final class Nullable extends AbstractWrapper
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (null === $input) {
             return true;
         }
 
-        return parent::validate($input);
+        return parent::isValid($input);
     }
 }

--- a/library/Rules/Number.php
+++ b/library/Rules/Number.php
@@ -28,7 +28,7 @@ final class Number extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/NumericVal.php
+++ b/library/Rules/NumericVal.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class NumericVal extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_numeric($input);
     }

--- a/library/Rules/ObjectType.php
+++ b/library/Rules/ObjectType.php
@@ -26,7 +26,7 @@ final class ObjectType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_object($input);
     }

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -25,7 +25,7 @@ use function is_numeric;
  */
 final class Odd extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -32,11 +32,11 @@ class OneOf extends AbstractComposite
         }
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $rulesPassedCount = 0;
         foreach ($this->getRules() as $rule) {
-            if (!$rule->validate($input)) {
+            if (!$rule->isValid($input)) {
                 continue;
             }
 

--- a/library/Rules/Optional.php
+++ b/library/Rules/Optional.php
@@ -37,12 +37,12 @@ class Optional extends AbstractWrapper
         parent::check($input);
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($this->isUndefined($input)) {
             return true;
         }
 
-        return parent::validate($input);
+        return parent::isValid($input);
     }
 }

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -30,7 +30,7 @@ final class PerfectSquare extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_numeric($input) && floor(sqrt((float) $input)) == sqrt((float) $input);
     }

--- a/library/Rules/Pesel.php
+++ b/library/Rules/Pesel.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class Pesel extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!preg_match('/^\d{11}$/', (string) $input)) {
             return false;

--- a/library/Rules/PhpLabel.php
+++ b/library/Rules/PhpLabel.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class PhpLabel extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_string($input) && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $input);
     }

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -24,7 +24,7 @@ class Pis extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -27,7 +27,7 @@ final class Positive extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -181,7 +181,7 @@ class PostalCode extends Regex
     public function __construct($countryCode, CountryCode $countryCodeRule = null)
     {
         $countryCodeRule = $countryCodeRule ?: new CountryCode();
-        if (!$countryCodeRule->validate($countryCode)) {
+        if (!$countryCodeRule->isValid($countryCode)) {
             throw new ComponentException(sprintf('Cannot validate postal code from "%s" country', $countryCode));
         }
 

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -31,7 +31,7 @@ final class PrimeNumber extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_numeric($input) || $input <= 1) {
             return false;

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class Readable extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof \SplFileInfo) {
             return $input->isReadable();

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -22,7 +22,7 @@ class Regex extends AbstractRule
         $this->regex = $regex;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/ResourceType.php
+++ b/library/Rules/ResourceType.php
@@ -25,7 +25,7 @@ final class ResourceType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_resource($input);
     }

--- a/library/Rules/ScalarVal.php
+++ b/library/Rules/ScalarVal.php
@@ -25,7 +25,7 @@ final class ScalarVal extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_scalar($input);
     }

--- a/library/Rules/Sf.php
+++ b/library/Rules/Sf.php
@@ -85,7 +85,7 @@ final class Sf extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         try {
             $this->assert($input);

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -102,7 +102,7 @@ class Size extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $this->isValidSize($input->getSize());

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class Slug extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (mb_strstr($input, '--')) {
             return false;

--- a/library/Rules/Sorted.php
+++ b/library/Rules/Sorted.php
@@ -24,7 +24,7 @@ class Sorted extends AbstractRule
         $this->ascending = $ascending;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $count = count($input);
         if ($count < 2) {

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -24,7 +24,7 @@ class StartsWith extends AbstractRule
         $this->identical = $identical;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($this->identical) {
             return $this->validateIdentical($input);

--- a/library/Rules/StringType.php
+++ b/library/Rules/StringType.php
@@ -26,7 +26,7 @@ final class StringType extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_string($input);
     }

--- a/library/Rules/StringVal.php
+++ b/library/Rules/StringVal.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class StringVal extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return is_scalar($input) || (is_object($input) && method_exists($input, '__toString'));
     }

--- a/library/Rules/Subset.php
+++ b/library/Rules/Subset.php
@@ -42,7 +42,7 @@ final class Subset extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_array($input)) {
             return false;

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class SymbolicLink extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof \SplFileInfo) {
             return $input->isLink();

--- a/library/Rules/Time.php
+++ b/library/Rules/Time.php
@@ -58,7 +58,7 @@ final class Time extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -262,7 +262,7 @@ final class Tld extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/TrueVal.php
+++ b/library/Rules/TrueVal.php
@@ -28,7 +28,7 @@ final class TrueVal extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return true === filter_var($input, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
     }

--- a/library/Rules/Type.php
+++ b/library/Rules/Type.php
@@ -81,7 +81,7 @@ final class Type extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ('callable' === $this->type) {
             return is_callable($input);

--- a/library/Rules/Unique.php
+++ b/library/Rules/Unique.php
@@ -29,7 +29,7 @@ final class Unique extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_array($input)) {
             return false;

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -28,10 +28,10 @@ final class Uploaded extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof SplFileInfo) {
-            return $this->validate($input->getPathname());
+            return $this->isValid($input->getPathname());
         }
 
         if (!is_scalar($input)) {

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -30,7 +30,7 @@ final class Uppercase extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -18,7 +18,7 @@ namespace Respect\Validation\Rules;
  */
 class Version extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $pattern = '/^[0-9]+\.[0-9]+\.[0-9]+([+-][^+-][0-9A-Za-z-.]*)?$/';
 

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -54,7 +54,7 @@ class VideoUrl extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if (isset($this->services[$this->serviceKey])) {
             return preg_match($this->services[$this->serviceKey], (string) $input) > 0;

--- a/library/Rules/When.php
+++ b/library/Rules/When.php
@@ -34,18 +34,18 @@ class When extends AbstractRule
         $this->else = $else;
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
-        if ($this->when->validate($input)) {
-            return $this->then->validate($input);
+        if ($this->when->isValid($input)) {
+            return $this->then->isValid($input);
         }
 
-        return $this->else->validate($input);
+        return $this->else->isValid($input);
     }
 
     public function assert($input): void
     {
-        if ($this->when->validate($input)) {
+        if ($this->when->isValid($input)) {
             $this->then->assert($input);
 
             return;
@@ -56,7 +56,7 @@ class When extends AbstractRule
 
     public function check($input): void
     {
-        if ($this->when->validate($input)) {
+        if ($this->when->isValid($input)) {
             $this->then->check($input);
 
             return;

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -15,7 +15,7 @@ namespace Respect\Validation\Rules;
 
 class Writable extends AbstractRule
 {
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         if ($input instanceof \SplFileInfo) {
             return $input->isWritable();

--- a/library/Rules/Zend.php
+++ b/library/Rules/Zend.php
@@ -62,7 +62,7 @@ class Zend extends AbstractRule
         throw $this->reportError($input)->addChildren($exceptions);
     }
 
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $validator = clone $this->zendValidator;
 

--- a/library/Validatable.php
+++ b/library/Validatable.php
@@ -30,5 +30,5 @@ interface Validatable
 
     public function setTemplate(string $template): Validatable;
 
-    public function validate($input): bool;
+    public function isValid($input): bool;
 }

--- a/tests/integration/not_should_work_by_builder.phpt
+++ b/tests/integration/not_should_work_by_builder.phpt
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Validator;
 
-var_dump(Validator::not(Validator::intVal())->validate(10));
+var_dump(Validator::not(Validator::intVal())->isValid(10));
 ?>
 --EXPECTF--
 bool(false)

--- a/tests/integration/rules/alnum_6_expected_char.phpt
+++ b/tests/integration/rules/alnum_6_expected_char.phpt
@@ -4,7 +4,7 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Validator as v;
 
-if (!v::alnum('-')->validate('bla - bla')) {
+if (!v::alnum('-')->isValid('bla - bla')) {
     echo 'ok';
 }
 

--- a/tests/integration/rules/alnum_7_not_empty.phpt
+++ b/tests/integration/rules/alnum_7_not_empty.phpt
@@ -4,7 +4,7 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Validator as v;
 
-if (v::alnum()->notEmpty()->validate('')) {
+if (v::alnum()->notEmpty()->isValid('')) {
     echo 'error';
 }
 

--- a/tests/integration/rules/alnum_8_uppercase.phpt
+++ b/tests/integration/rules/alnum_8_uppercase.phpt
@@ -4,7 +4,7 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Validator as v;
 
-if (!v::alnum()->uppercase()->validate('ASDF')) {
+if (!v::alnum()->uppercase()->isValid('ASDF')) {
     echo 'ok';
 }
 

--- a/tests/integration/rules/ip_1.phpt
+++ b/tests/integration/rules/ip_1.phpt
@@ -7,11 +7,11 @@ use Respect\Validation\Rules\Ip;
 $ip = new Ip();
 
 var_dump(
-    $ip->validate('10.0.0.1'),
-    $ip->validate('192.168.1.150'),
-    $ip->validate('127.0.0.1'),
-    $ip->validate('10,0.0.1'),
-    $ip->validate(null)
+    $ip->isValid('10.0.0.1'),
+    $ip->isValid('192.168.1.150'),
+    $ip->isValid('127.0.0.1'),
+    $ip->isValid('10,0.0.1'),
+    $ip->isValid(null)
 );
 
 ?>

--- a/tests/integration/rules/keyNested_1.phpt
+++ b/tests/integration/rules/keyNested_1.phpt
@@ -16,13 +16,13 @@ $object = new stdClass();
 $object->foo = new stdClass();
 $object->foo->bar = 42;
 
-var_dump(v::keyNested('foo.bar.baz')->validate(['foo.bar.baz' => false]));
-var_dump(v::keyNested('foo.bar')->validate($array));
-var_dump(v::keyNested('foo.bar')->validate(new ArrayObject($array)));
-var_dump(v::keyNested('foo.bar', v::negative())->validate($array));
-var_dump(v::keyNested('foo.bar')->validate($object));
-var_dump(v::keyNested('foo.bar', v::stringType())->validate($object));
-var_dump(v::keyNested('foo.bar.baz', v::notEmpty(), false)->validate($object));
+var_dump(v::keyNested('foo.bar.baz')->isValid(['foo.bar.baz' => false]));
+var_dump(v::keyNested('foo.bar')->isValid($array));
+var_dump(v::keyNested('foo.bar')->isValid(new ArrayObject($array)));
+var_dump(v::keyNested('foo.bar', v::negative())->isValid($array));
+var_dump(v::keyNested('foo.bar')->isValid($object));
+var_dump(v::keyNested('foo.bar', v::stringType())->isValid($object));
+var_dump(v::keyNested('foo.bar.baz', v::notEmpty(), false)->isValid($object));
 ?>
 --EXPECTF--
 bool(false)

--- a/tests/integration/rules/length_1.phpt
+++ b/tests/integration/rules/length_1.phpt
@@ -7,8 +7,8 @@ use Respect\Validation\Validator as v;
 
 $validator = v::length(0, 10);
 
-$validator->validate('phpsp');
-v::not($validator)->validate('phpsp');
+$validator->isValid('phpsp');
+v::not($validator)->isValid('phpsp');
 $validator->assert('nickolas');
 $validator->check('nawarian');
 ?>

--- a/tests/integration/rules/optional-validate.phpt
+++ b/tests/integration/rules/optional-validate.phpt
@@ -5,11 +5,11 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Validator as v;
 
-var_dump(v::alpha()->validate(''));
-var_dump(v::alpha()->validate(null));
+var_dump(v::alpha()->isValid(''));
+var_dump(v::alpha()->isValid(null));
 
-var_dump(v::optional(v::alpha())->validate(''));
-var_dump(v::optional(v::alpha())->validate(null));
+var_dump(v::optional(v::alpha())->isValid(''));
+var_dump(v::optional(v::alpha())->isValid(null));
 ?>
 --EXPECTF--
 bool(false)

--- a/tests/integration/rules/optional_1.phpt
+++ b/tests/integration/rules/optional_1.phpt
@@ -5,10 +5,10 @@ require 'vendor/autoload.php';
 use Respect\Validation\Validator as v;
 
 var_dump(
-    v::alpha()->validate(''),
-    v::alpha()->validate(null),
-    v::optional(v::alpha())->validate(''),
-    v::optional(v::alpha())->validate(null)
+    v::alpha()->isValid(''),
+    v::alpha()->isValid(null),
+    v::optional(v::alpha())->isValid(''),
+    v::optional(v::alpha())->isValid(null)
 );
 ?>
 --EXPECTF--

--- a/tests/integration/rules/optional_4.phpt
+++ b/tests/integration/rules/optional_4.phpt
@@ -4,8 +4,8 @@ require 'vendor/autoload.php';
 
 use Respect\Validation\Validator as v;
 
-v::optional(v::alpha())->validate('');
-v::optional(v::alpha())->validate(null);
+v::optional(v::alpha())->isValid('');
+v::optional(v::alpha())->isValid(null);
 
 ?>
 --EXPECTF--

--- a/tests/integration/rules/when_1.phpt
+++ b/tests/integration/rules/when_1.phpt
@@ -9,11 +9,11 @@ use Respect\Validation\Rules\NotEmpty;
 use Respect\Validation\Validator as v;
 
 var_dump(
-    v::when(new IntVal(), new Between(1, 5), new NotEmpty())->validate(3),
-    v::when(new IntVal(), new Between(1, 5), new NotEmpty())->validate('aaa'),
-    v::when(new IntVal(), new Between(1, 5))->validate(3),
-    v::when(new IntVal(), new Between(1, 5), new NotEmpty())->validate(''),
-    v::when(new IntVal(), new Between(1, 5))->validate(15)
+    v::when(new IntVal(), new Between(1, 5), new NotEmpty())->isValid(3),
+    v::when(new IntVal(), new Between(1, 5), new NotEmpty())->isValid('aaa'),
+    v::when(new IntVal(), new Between(1, 5))->isValid(3),
+    v::when(new IntVal(), new Between(1, 5), new NotEmpty())->isValid(''),
+    v::when(new IntVal(), new Between(1, 5))->isValid(15)
 );
 
 ?>

--- a/tests/library/RuleTestCase.php
+++ b/tests/library/RuleTestCase.php
@@ -68,7 +68,7 @@ abstract class RuleTestCase extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(
                 [
-                    'assert', 'check', 'getName', 'reportError', 'setName', 'setTemplate', 'validate',
+                    'assert', 'check', 'getName', 'reportError', 'setName', 'setTemplate', 'isValid',
                 ]
             )
             ->setMockClassName($mockClassName)
@@ -76,7 +76,7 @@ abstract class RuleTestCase extends TestCase
 
         $validatableMocked
             ->expects(self::any())
-            ->method('validate')
+            ->method('isValid')
             ->willReturn($expectedResult);
 
         if ($expectedResult) {
@@ -144,11 +144,11 @@ abstract class RuleTestCase extends TestCase
 
     public static function assertValidInput(Validatable $rule, $input): void
     {
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     public static function assertInvalidInput(Validatable $rule, $input): void
     {
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 }

--- a/tests/library/Rules/Stub.php
+++ b/tests/library/Rules/Stub.php
@@ -48,7 +48,7 @@ final class Stub extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         $this->inputs[] = $input;
 

--- a/tests/library/Rules/Valid.php
+++ b/tests/library/Rules/Valid.php
@@ -20,7 +20,7 @@ final class Valid extends AbstractRule
     /**
      * {@inheritdoc}
      */
-    public function validate($input): bool
+    public function isValid($input): bool
     {
         return true;
     }

--- a/tests/unit/Rules/AbstractCompositeTest.php
+++ b/tests/unit/Rules/AbstractCompositeTest.php
@@ -46,7 +46,7 @@ final class AbstractCompositeTest extends TestCase
 
         $sut = $this
             ->getMockBuilder(AbstractComposite::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
 
         $sut->setName($ruleName);
@@ -81,7 +81,7 @@ final class AbstractCompositeTest extends TestCase
 
         $sut = $this
             ->getMockBuilder(AbstractComposite::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
         $sut->setName($ruleName1);
         $sut->addRule($rule);
@@ -104,7 +104,7 @@ final class AbstractCompositeTest extends TestCase
 
         $sut = $this
             ->getMockBuilder(AbstractComposite::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
         $sut->addRule($rule);
         $sut->setName('Whatever');
@@ -129,7 +129,7 @@ final class AbstractCompositeTest extends TestCase
 
         $sut = $this
             ->getMockBuilder(AbstractComposite::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
 
         $sut->addRule($rule);
@@ -155,7 +155,7 @@ final class AbstractCompositeTest extends TestCase
 
         $sut = $this
             ->getMockBuilder(AbstractComposite::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
 
         $sut->addRule($rule);
@@ -180,7 +180,7 @@ final class AbstractCompositeTest extends TestCase
 
         $sut = $this
             ->getMockBuilder(AbstractComposite::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
 
         $sut->addRule($rule);

--- a/tests/unit/Rules/AbstractEnvelopeTest.php
+++ b/tests/unit/Rules/AbstractEnvelopeTest.php
@@ -35,13 +35,13 @@ final class AbstractEnvelopeTest extends TestCase
         $innerRule = $this->createMock(Validatable::class);
         $innerRule
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->willReturn(true);
 
         $rule = $this->getMockForAbstractClass(AbstractEnvelope::class, [$innerRule, []]);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -54,13 +54,13 @@ final class AbstractEnvelopeTest extends TestCase
         $innerRule = $this->createMock(Validatable::class);
         $innerRule
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->willReturn(false);
 
         $rule = $this->getMockForAbstractClass(AbstractEnvelope::class, [$innerRule, []]);
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/AbstractFilterRuleTest.php
+++ b/tests/unit/Rules/AbstractFilterRuleTest.php
@@ -34,27 +34,27 @@ class AbstractFilterRuleTest extends TestCase
     /**
      * @test
      */
-    public function validateShouldReturnTrueForValidArguments(): void
+    public function isValidShouldReturnTrueForValidArguments(): void
     {
         $filterRuleMock = $this->getMockForAbstractClass(AbstractFilterRule::class);
         $filterRuleMock->expects(self::any())
             ->method('validateClean')
             ->will(self::returnValue(true));
 
-        self::assertTrue($filterRuleMock->validate('hey'));
+        self::assertTrue($filterRuleMock->isValid('hey'));
     }
 
     /**
      * @test
      */
-    public function validateShouldReturnFalseForInvalidArguments(): void
+    public function isValidShouldReturnFalseForInvalidArguments(): void
     {
         $filterRuleMock = $this->getMockForAbstractClass(AbstractFilterRule::class);
         $filterRuleMock->expects(self::any())
             ->method('validateClean')
             ->will(self::returnValue(true));
 
-        self::assertFalse($filterRuleMock->validate(''));
-        self::assertFalse($filterRuleMock->validate([]));
+        self::assertFalse($filterRuleMock->isValid(''));
+        self::assertFalse($filterRuleMock->isValid([]));
     }
 }

--- a/tests/unit/Rules/AbstractRelatedTest.php
+++ b/tests/unit/Rules/AbstractRelatedTest.php
@@ -24,7 +24,7 @@ final class AbstractRelatedTest extends TestCase
     public function providerForOperations()
     {
         return [
-            ['validate'],
+            ['isValid'],
         ];
     }
 
@@ -65,14 +65,14 @@ final class AbstractRelatedTest extends TestCase
     /**
      * @test
      */
-    public function validateShouldReturnFalseWhenIsMandatoryAndThereIsNoReference(): void
+    public function isValidShouldReturnFalseWhenIsMandatoryAndThereIsNoReference(): void
     {
         $relatedRuleMock = $this->getMockForAbstractClass(AbstractRelated::class, ['foo']);
         $relatedRuleMock->expects(self::any())
             ->method('hasReference')
             ->will(self::returnValue(false));
 
-        self::assertFalse($relatedRuleMock->validate('foo'));
+        self::assertFalse($relatedRuleMock->isValid('foo'));
     }
 
     /**

--- a/tests/unit/Rules/AbstractRuleTest.php
+++ b/tests/unit/Rules/AbstractRuleTest.php
@@ -41,12 +41,12 @@ class AbstractRuleTest extends TestCase
 
         $abstractRuleMock = $this
             ->getMockBuilder(AbstractRule::class)
-            ->setMethods(['validate'])
+            ->setMethods(['isValid'])
             ->getMockForAbstractClass();
 
         $abstractRuleMock
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->will(self::returnValue($booleanResult));
 
@@ -54,7 +54,7 @@ class AbstractRuleTest extends TestCase
             $booleanResult,
             // Invoking it to trigger __invoke
             $abstractRuleMock($input),
-            'When invoking an instance of AbstractRule, the method validate should be called with the same input and return the same result.'
+            'When invoking an instance of AbstractRule, the method isValid should be called with the same input and return the same result.'
         );
     }
 
@@ -69,12 +69,12 @@ class AbstractRuleTest extends TestCase
 
         $abstractRuleMock = $this
             ->getMockBuilder(AbstractRule::class)
-            ->setMethods(['validate', 'reportError'])
+            ->setMethods(['isValid', 'reportError'])
             ->getMockForAbstractClass();
 
         $abstractRuleMock
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->will(self::returnValue(true));
 
@@ -97,12 +97,12 @@ class AbstractRuleTest extends TestCase
 
         $abstractRuleMock = $this
             ->getMockBuilder(AbstractRule::class)
-            ->setMethods(['validate', 'reportError'])
+            ->setMethods(['isValid', 'reportError'])
             ->getMockForAbstractClass();
 
         $abstractRuleMock
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->will(self::returnValue(false));
 

--- a/tests/unit/Rules/AbstractSearcherTest.php
+++ b/tests/unit/Rules/AbstractSearcherTest.php
@@ -40,7 +40,7 @@ final class AbstractSearcherTest extends TestCase
             ->method('getDataSource')
             ->willReturn(['foo', $input, 'baz']);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -56,7 +56,7 @@ final class AbstractSearcherTest extends TestCase
             ->method('getDataSource')
             ->willReturn([1, (int) $input, 3]);
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**
@@ -71,7 +71,7 @@ final class AbstractSearcherTest extends TestCase
             ->method('getDataSource')
             ->willReturn([]);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -86,6 +86,6 @@ final class AbstractSearcherTest extends TestCase
             ->method('getDataSource')
             ->willReturn([]);
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 }

--- a/tests/unit/Rules/AbstractWrapperTest.php
+++ b/tests/unit/Rules/AbstractWrapperTest.php
@@ -47,13 +47,13 @@ final class AbstractWrapperTest extends TestCase
         $validatable = $this->createMock(Validatable::class);
         $validatable
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->will(self::returnValue(true));
 
         $wrapper = $this->getMockForAbstractClass(AbstractWrapper::class, [$validatable]);
 
-        self::assertTrue($wrapper->validate($input));
+        self::assertTrue($wrapper->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/AlnumTest.php
+++ b/tests/unit/Rules/AlnumTest.php
@@ -30,7 +30,7 @@ class AlnumTest extends TestCase
     public function validAlnumCharsShouldReturnTrue($validAlnum, $additional): void
     {
         $validator = new Alnum($additional);
-        self::assertTrue($validator->validate($validAlnum));
+        self::assertTrue($validator->isValid($validAlnum));
     }
 
     /**
@@ -42,7 +42,7 @@ class AlnumTest extends TestCase
     public function invalidAlnumCharsShouldThrowAlnumExceptionAndReturnFalse($invalidAlnum, $additional): void
     {
         $validator = new Alnum($additional);
-        self::assertFalse($validator->validate($invalidAlnum));
+        self::assertFalse($validator->isValid($invalidAlnum));
         $validator->assert($invalidAlnum);
     }
 
@@ -65,7 +65,7 @@ class AlnumTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Alnum($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/AlphaTest.php
+++ b/tests/unit/Rules/AlphaTest.php
@@ -30,7 +30,7 @@ class AlphaTest extends TestCase
     public function validAlphanumericCharsShouldReturnTrue($validAlpha, $additional): void
     {
         $validator = new Alpha($additional);
-        self::assertTrue($validator->validate($validAlpha));
+        self::assertTrue($validator->isValid($validAlpha));
         $validator->check($validAlpha);
         $validator->assert($validAlpha);
     }
@@ -44,7 +44,7 @@ class AlphaTest extends TestCase
     public function invalidAlphanumericCharsShouldThrowAlphaException($invalidAlpha, $additional): void
     {
         $validator = new Alpha($additional);
-        self::assertFalse($validator->validate($invalidAlpha));
+        self::assertFalse($validator->isValid($invalidAlpha));
         $validator->assert($invalidAlpha);
     }
 
@@ -67,7 +67,7 @@ class AlphaTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Alpha($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/AlwaysInvalidTest.php
+++ b/tests/unit/Rules/AlwaysInvalidTest.php
@@ -51,6 +51,6 @@ final class AlwaysInvalidTest extends TestCase
     {
         $rule = new AlwaysInvalid();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 }

--- a/tests/unit/Rules/AlwaysValidTest.php
+++ b/tests/unit/Rules/AlwaysValidTest.php
@@ -51,6 +51,6 @@ final class AlwaysValidTest extends TestCase
     {
         $rule = new AlwaysValid();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 }

--- a/tests/unit/Rules/AnyOfTest.php
+++ b/tests/unit/Rules/AnyOfTest.php
@@ -37,7 +37,7 @@ class AnyOfTest extends TestCase
             return false;
         });
         $o = new AnyOf($valid1, $valid2, $valid3);
-        self::assertTrue($o->validate('any'));
+        self::assertTrue($o->isValid('any'));
         $o->assert('any');
         $o->check('any');
     }
@@ -59,7 +59,7 @@ class AnyOfTest extends TestCase
             return false;
         });
         $o = new AnyOf($valid1, $valid2, $valid3);
-        self::assertFalse($o->validate('any'));
+        self::assertFalse($o->isValid('any'));
         $o->assert('any');
     }
 
@@ -71,7 +71,7 @@ class AnyOfTest extends TestCase
     public function invalidCheck(): void
     {
         $o = new AnyOf(new Xdigit(), new Alnum());
-        self::assertFalse($o->validate(-10));
+        self::assertFalse($o->isValid(-10));
         $o->check(-10);
     }
 }

--- a/tests/unit/Rules/AttributeTest.php
+++ b/tests/unit/Rules/AttributeTest.php
@@ -32,7 +32,7 @@ final class AttributeTest extends RuleTestCase
         $obj->bar = 'foo';
 
         $extraValidator = $this->createMock(Validatable::class);
-        $extraValidator->method('validate')
+        $extraValidator->method('isValid')
             ->willReturn(true);
 
         return [
@@ -53,7 +53,7 @@ final class AttributeTest extends RuleTestCase
         $obj->bar = 'foo';
 
         $extraValidatorMock = $this->createMock(Validatable::class);
-        $extraValidatorMock->method('validate')->willReturn(false);
+        $extraValidatorMock->method('isValid')->willReturn(false);
 
         return [
             'Is not valid when attribute is absent without extra validator' => [new Attribute('barr'), $obj],

--- a/tests/unit/Rules/CallTest.php
+++ b/tests/unit/Rules/CallTest.php
@@ -179,7 +179,7 @@ final class CallTest extends TestCase
     /**
      * @test
      */
-    public function validateShouldExecuteCallable(): void
+    public function isValidShouldExecuteCallable(): void
     {
         $input = ' input ';
         $callable = 'trim';
@@ -192,13 +192,13 @@ final class CallTest extends TestCase
 
         $sut = new Call($callable, $rule);
 
-        self::assertTrue($sut->validate($input));
+        self::assertTrue($sut->isValid($input));
     }
 
     /**
      * @test
      */
-    public function validateShouldReturnFalseWhenPhpTriggersAnError(): void
+    public function isValidShouldReturnFalseWhenPhpTriggersAnError(): void
     {
         $input = [];
         $callable = 'trim';
@@ -210,16 +210,16 @@ final class CallTest extends TestCase
 
         $sut = new Call($callable, $rule);
 
-        self::assertFalse($sut->validate($input));
+        self::assertFalse($sut->isValid($input));
     }
 
     /**
      * @test
      */
-    public function validateShouldReturnFalseWhenDefinedRuleFails(): void
+    public function isValidShouldReturnFalseWhenDefinedRuleFails(): void
     {
         $sut = new Call('trim', new AlwaysInvalid());
 
-        self::assertFalse($sut->validate('something'));
+        self::assertFalse($sut->isValid('something'));
     }
 }

--- a/tests/unit/Rules/CntrlTest.php
+++ b/tests/unit/Rules/CntrlTest.php
@@ -30,7 +30,7 @@ class CntrlTest extends TestCase
     public function validDataWithCntrlShouldReturnTrue($validCntrl, $additional = ''): void
     {
         $validator = new Cntrl($additional);
-        self::assertTrue($validator->validate($validCntrl));
+        self::assertTrue($validator->isValid($validCntrl));
     }
 
     /**
@@ -42,7 +42,7 @@ class CntrlTest extends TestCase
     public function invalidCntrlShouldFailAndThrowCntrlException($invalidCntrl, $additional = ''): void
     {
         $validator = new Cntrl($additional);
-        self::assertFalse($validator->validate($invalidCntrl));
+        self::assertFalse($validator->isValid($invalidCntrl));
         $validator->assert($invalidCntrl);
     }
 
@@ -65,7 +65,7 @@ class CntrlTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Cntrl($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/ConsonantTest.php
+++ b/tests/unit/Rules/ConsonantTest.php
@@ -30,7 +30,7 @@ class ConsonantTest extends TestCase
     public function validDataWithConsonantsShouldReturnTrue($validConsonants, $additional = ''): void
     {
         $validator = new Consonant($additional);
-        self::assertTrue($validator->validate($validConsonants));
+        self::assertTrue($validator->isValid($validConsonants));
     }
 
     /**
@@ -42,7 +42,7 @@ class ConsonantTest extends TestCase
     public function invalidConsonantsShouldFailAndThrowConsonantException($invalidConsonants, $additional = ''): void
     {
         $validator = new Consonant($additional);
-        self::assertFalse($validator->validate($invalidConsonants));
+        self::assertFalse($validator->isValid($invalidConsonants));
         $validator->assert($invalidConsonants);
     }
 
@@ -65,7 +65,7 @@ class ConsonantTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Consonant($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/DateTimeTest.php
+++ b/tests/unit/Rules/DateTimeTest.php
@@ -122,7 +122,7 @@ final class DateTimeTest extends RuleTestCase
 
         $rule = new DateTime($format);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
 
         date_default_timezone_set($currentTimezone);
     }

--- a/tests/unit/Rules/DigitTest.php
+++ b/tests/unit/Rules/DigitTest.php
@@ -30,7 +30,7 @@ class DigitTest extends TestCase
     public function validDataWithDigitsShouldReturnTrue($validDigits, $additional = ''): void
     {
         $validator = new Digit($additional);
-        self::assertTrue($validator->validate($validDigits));
+        self::assertTrue($validator->isValid($validDigits));
     }
 
     /**
@@ -42,7 +42,7 @@ class DigitTest extends TestCase
     public function invalidDigitsShouldFailAndThrowDigitException($invalidDigits, $additional = ''): void
     {
         $validator = new Digit($additional);
-        self::assertFalse($validator->validate($invalidDigits));
+        self::assertFalse($validator->isValid($invalidDigits));
         $validator->assert($invalidDigits);
     }
 
@@ -65,7 +65,7 @@ class DigitTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Digit($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/DomainTest.php
+++ b/tests/unit/Rules/DomainTest.php
@@ -105,7 +105,7 @@ class DomainTest extends TestCase
     public function builder($validDomain, $checkTLD = true): void
     {
         self::assertTrue(
-            v::domain($checkTLD)->validate($validDomain),
+            v::domain($checkTLD)->isValid($validDomain),
             sprintf('Domain "%s" should be valid. (Check TLD: %s)', $validDomain, var_export($checkTLD, true))
         );
     }

--- a/tests/unit/Rules/EmailTest.php
+++ b/tests/unit/Rules/EmailTest.php
@@ -48,7 +48,7 @@ final class EmailTest extends RuleTestCase
 
         $sut = new Email($emailValidator);
 
-        self::assertTrue($sut->validate($input));
+        self::assertTrue($sut->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/ExtensionTest.php
+++ b/tests/unit/Rules/ExtensionTest.php
@@ -43,7 +43,7 @@ class ExtensionTest extends TestCase
     {
         $rule = new Extension($extension);
 
-        self::assertTrue($rule->validate($filename));
+        self::assertTrue($rule->isValid($filename));
     }
 
     /**
@@ -55,7 +55,7 @@ class ExtensionTest extends TestCase
 
         $rule = new Extension('php');
 
-        self::assertTrue($rule->validate($fileInfo));
+        self::assertTrue($rule->isValid($fileInfo));
     }
 
     /**
@@ -67,7 +67,7 @@ class ExtensionTest extends TestCase
 
         $rule = new Extension('php');
 
-        self::assertFalse($rule->validate($nonFile));
+        self::assertFalse($rule->isValid($nonFile));
     }
 
     /**

--- a/tests/unit/Rules/FalseValTest.php
+++ b/tests/unit/Rules/FalseValTest.php
@@ -31,7 +31,7 @@ class FalseValTest extends TestCase
     {
         $rule = new FalseVal();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     public function validFalseProvider()
@@ -61,7 +61,7 @@ class FalseValTest extends TestCase
     {
         $rule = new FalseVal();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     public function invalidFalseProvider()

--- a/tests/unit/Rules/FileTest.php
+++ b/tests/unit/Rules/FileTest.php
@@ -36,7 +36,7 @@ function is_file($file)
 class FileTest extends TestCase
 {
     /**
-     * @covers \Respect\Validation\Rules\File::validate
+     * @covers \Respect\Validation\Rules\File::isValid
      *
      * @test
      */
@@ -46,11 +46,11 @@ class FileTest extends TestCase
 
         $rule = new File();
         $input = '/path/of/a/valid/file.txt';
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\File::validate
+     * @covers \Respect\Validation\Rules\File::isValid
      *
      * @test
      */
@@ -60,11 +60,11 @@ class FileTest extends TestCase
 
         $rule = new File();
         $input = '/path/of/an/invalid/file.txt';
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\File::validate
+     * @covers \Respect\Validation\Rules\File::isValid
      *
      * @test
      */
@@ -76,6 +76,6 @@ class FileTest extends TestCase
                 ->method('isFile')
                 ->will(self::returnValue(true));
 
-        self::assertTrue($rule->validate($object));
+        self::assertTrue($rule->isValid($object));
     }
 }

--- a/tests/unit/Rules/FiniteTest.php
+++ b/tests/unit/Rules/FiniteTest.php
@@ -36,7 +36,7 @@ class FiniteTest extends TestCase
      */
     public function shouldValidateFiniteNumbers($input): void
     {
-        self::assertTrue($this->rule->validate($input));
+        self::assertTrue($this->rule->isValid($input));
     }
 
     /**
@@ -46,7 +46,7 @@ class FiniteTest extends TestCase
      */
     public function shouldNotValidateNonFiniteNumbers($input): void
     {
-        self::assertFalse($this->rule->validate($input));
+        self::assertFalse($this->rule->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/GraphTest.php
+++ b/tests/unit/Rules/GraphTest.php
@@ -30,7 +30,7 @@ class GraphTest extends TestCase
     public function validDataWithGraphCharsShouldReturnTrue($validGraph, $additional = ''): void
     {
         $validator = new Graph($additional);
-        self::assertTrue($validator->validate($validGraph));
+        self::assertTrue($validator->isValid($validGraph));
     }
 
     /**
@@ -42,7 +42,7 @@ class GraphTest extends TestCase
     public function invalidGraphShouldFailAndThrowGraphException($invalidGraph, $additional = ''): void
     {
         $validator = new Graph($additional);
-        self::assertFalse($validator->validate($invalidGraph));
+        self::assertFalse($validator->isValid($invalidGraph));
         $validator->assert($invalidGraph);
     }
 
@@ -65,7 +65,7 @@ class GraphTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Graph($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/HexRgbColorTest.php
+++ b/tests/unit/Rules/HexRgbColorTest.php
@@ -31,7 +31,7 @@ class HexRgbColorTest extends TestCase
     {
         $validator = new HexRgbColor();
 
-        self::assertTrue($validator->validate($validHexRgbColor));
+        self::assertTrue($validator->isValid($validHexRgbColor));
     }
 
     /**
@@ -43,7 +43,7 @@ class HexRgbColorTest extends TestCase
     {
         $validator = new HexRgbColor();
 
-        self::assertFalse($validator->validate($invalidHexRgbColor));
+        self::assertFalse($validator->isValid($invalidHexRgbColor));
     }
 
     public function providerForValidHexRgbColor()

--- a/tests/unit/Rules/ImageTest.php
+++ b/tests/unit/Rules/ImageTest.php
@@ -78,7 +78,7 @@ final class ImageTest extends RuleTestCase
 
         $rule = new Image($finfo);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     private function getFixtureDirectory(): string

--- a/tests/unit/Rules/KeyNestedTest.php
+++ b/tests/unit/Rules/KeyNestedTest.php
@@ -42,7 +42,7 @@ class KeyNestedTest extends TestCase
 
         $rule = new KeyNested('bar.foo.baz');
 
-        self::assertTrue($rule->validate($array));
+        self::assertTrue($rule->isValid($array));
     }
 
     /**
@@ -82,7 +82,7 @@ class KeyNestedTest extends TestCase
 
         $rule = new KeyNested('bar.foo');
 
-        self::assertTrue($rule->validate($array));
+        self::assertTrue($rule->isValid($array));
     }
 
     /**
@@ -103,7 +103,7 @@ class KeyNestedTest extends TestCase
 
         $rule = new KeyNested('bar.foooo.');
 
-        self::assertTrue($rule->validate($object));
+        self::assertTrue($rule->isValid($object));
     }
 
     /**
@@ -113,7 +113,7 @@ class KeyNestedTest extends TestCase
     {
         $rule = new KeyNested('bar.foo.baz');
 
-        self::assertFalse($rule->validate(''));
+        self::assertFalse($rule->isValid(''));
     }
 
     /**
@@ -146,7 +146,7 @@ class KeyNestedTest extends TestCase
         $rule = new KeyNested('emptyKey');
         $input = ['emptyKey' => ''];
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -204,7 +204,7 @@ class KeyNestedTest extends TestCase
         $subValidator = new Length(1, 3);
         $validator = new KeyNested('bar.rab', $subValidator, false);
         $object = new \stdClass();
-        self::assertTrue($validator->validate($object));
+        self::assertTrue($validator->isValid($object));
     }
 
     /**
@@ -225,6 +225,6 @@ class KeyNestedTest extends TestCase
 
         $rule = new KeyNested('bar.foo.baz');
 
-        self::assertTrue($rule->validate($arrayAccess));
+        self::assertTrue($rule->isValid($arrayAccess));
     }
 }

--- a/tests/unit/Rules/KeySetTest.php
+++ b/tests/unit/Rules/KeySetTest.php
@@ -117,7 +117,7 @@ final class KeySetTest extends TestCase
 
         $keySet = new KeySet($key1, $key2);
 
-        self::assertFalse($keySet->validate($input));
+        self::assertFalse($keySet->isValid($input));
     }
 
     /**
@@ -134,7 +134,7 @@ final class KeySetTest extends TestCase
 
         $keySet = new KeySet($key1, $key2);
 
-        self::assertTrue($keySet->validate($input));
+        self::assertTrue($keySet->isValid($input));
     }
 
     /**
@@ -153,7 +153,7 @@ final class KeySetTest extends TestCase
 
         $keySet = new KeySet($key1, $key2);
 
-        self::assertFalse($keySet->validate($input));
+        self::assertFalse($keySet->isValid($input));
     }
 
     /**
@@ -168,7 +168,7 @@ final class KeySetTest extends TestCase
 
         $keySet = new KeySet($key1, $key2);
 
-        self::assertFalse($keySet->validate($input));
+        self::assertFalse($keySet->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/KeyTest.php
+++ b/tests/unit/Rules/KeyTest.php
@@ -30,7 +30,7 @@ class KeyTest extends TestCase
         $validator = new Key('bar');
         $someArray = [];
         $someArray['bar'] = 'foo';
-        self::assertTrue($validator->validate($someArray));
+        self::assertTrue($validator->isValid($someArray));
     }
 
     /**
@@ -41,7 +41,7 @@ class KeyTest extends TestCase
         $validator = new Key(0);
         $someArray = [];
         $someArray[0] = 'foo';
-        self::assertTrue($validator->validate($someArray));
+        self::assertTrue($validator->isValid($someArray));
     }
 
     /**
@@ -52,7 +52,7 @@ class KeyTest extends TestCase
         $validator = new Key('someEmptyKey');
         $input = '';
 
-        self::assertFalse($validator->validate($input));
+        self::assertFalse($validator->isValid($input));
     }
 
     /**
@@ -86,7 +86,7 @@ class KeyTest extends TestCase
         $input = [];
         $input['someEmptyKey'] = '';
 
-        self::assertTrue($validator->validate($input));
+        self::assertTrue($validator->isValid($input));
     }
 
     /**
@@ -109,7 +109,7 @@ class KeyTest extends TestCase
         } catch (\Exception $e) {
         }
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**
@@ -169,6 +169,6 @@ class KeyTest extends TestCase
         $subValidator = new Length(1, 3);
         $validator = new Key('bar', $subValidator, false);
         $someArray = [];
-        self::assertTrue($validator->validate($someArray));
+        self::assertTrue($validator->isValid($someArray));
     }
 }

--- a/tests/unit/Rules/KeyValueTest.php
+++ b/tests/unit/Rules/KeyValueTest.php
@@ -45,7 +45,7 @@ class KeyValueTest extends TestCase
     {
         $rule = new KeyValue('foo', 'equals', 'bar');
 
-        self::assertFalse($rule->validate(['bar' => 42]));
+        self::assertFalse($rule->isValid(['bar' => 42]));
     }
 
     /**
@@ -55,7 +55,7 @@ class KeyValueTest extends TestCase
     {
         $rule = new KeyValue('foo', 'equals', 'bar');
 
-        self::assertFalse($rule->validate(['foo' => true]));
+        self::assertFalse($rule->isValid(['foo' => true]));
     }
 
     /**
@@ -65,7 +65,7 @@ class KeyValueTest extends TestCase
     {
         $rule = new KeyValue('foo', 'probably_not_a_rule', 'bar');
 
-        self::assertFalse($rule->validate(['foo' => true, 'bar' => false]));
+        self::assertFalse($rule->isValid(['foo' => true, 'bar' => false]));
     }
 
     /**
@@ -75,7 +75,7 @@ class KeyValueTest extends TestCase
     {
         $rule = new KeyValue('foo', 'equals', 'bar');
 
-        self::assertTrue($rule->validate(['foo' => 42, 'bar' => 42]));
+        self::assertTrue($rule->isValid(['foo' => 42, 'bar' => 42]));
     }
 
     /**
@@ -85,7 +85,7 @@ class KeyValueTest extends TestCase
     {
         $rule = new KeyValue('foo', 'equals', 'bar');
 
-        self::assertFalse($rule->validate(['foo' => 43, 'bar' => 42]));
+        self::assertFalse($rule->isValid(['foo' => 43, 'bar' => 42]));
     }
 
     /**

--- a/tests/unit/Rules/LeapDateTest.php
+++ b/tests/unit/Rules/LeapDateTest.php
@@ -35,7 +35,7 @@ class LeapDateTest extends TestCase
      */
     public function validLeapDate_with_string(): void
     {
-        self::assertTrue($this->leapDateValidator->validate('1988-02-29'));
+        self::assertTrue($this->leapDateValidator->isValid('1988-02-29'));
     }
 
     /**
@@ -43,7 +43,7 @@ class LeapDateTest extends TestCase
      */
     public function validLeapDate_with_date_time(): void
     {
-        self::assertTrue($this->leapDateValidator->validate(
+        self::assertTrue($this->leapDateValidator->isValid(
             new DateTime('1988-02-29')));
     }
 
@@ -52,7 +52,7 @@ class LeapDateTest extends TestCase
      */
     public function invalidLeapDate_with_string(): void
     {
-        self::assertFalse($this->leapDateValidator->validate('1989-02-29'));
+        self::assertFalse($this->leapDateValidator->isValid('1989-02-29'));
     }
 
     /**
@@ -60,7 +60,7 @@ class LeapDateTest extends TestCase
      */
     public function invalidLeapDate_with_date_time(): void
     {
-        self::assertFalse($this->leapDateValidator->validate(
+        self::assertFalse($this->leapDateValidator->isValid(
             new DateTime('1989-02-29')));
     }
 
@@ -69,6 +69,6 @@ class LeapDateTest extends TestCase
      */
     public function invalidLeapDate_input(): void
     {
-        self::assertFalse($this->leapDateValidator->validate([]));
+        self::assertFalse($this->leapDateValidator->isValid([]));
     }
 }

--- a/tests/unit/Rules/LengthTest.php
+++ b/tests/unit/Rules/LengthTest.php
@@ -30,7 +30,7 @@ class LengthTest extends TestCase
     public function lengthInsideBoundsForInclusiveCasesReturnTrue($string, $min, $max): void
     {
         $validator = new Length($min, $max, true);
-        self::assertTrue($validator->validate($string));
+        self::assertTrue($validator->isValid($string));
     }
 
     /**
@@ -41,7 +41,7 @@ class LengthTest extends TestCase
     public function lengthInsideBoundsForNonInclusiveCasesShouldReturnTrue($string, $min, $max): void
     {
         $validator = new Length($min, $max, false);
-        self::assertTrue($validator->validate($string));
+        self::assertTrue($validator->isValid($string));
     }
 
     /**
@@ -52,7 +52,7 @@ class LengthTest extends TestCase
     public function lengthOutsideBoundsForInclusiveCasesReturnFalse($string, $min, $max): void
     {
         $validator = new Length($min, $max, true);
-        self::assertfalse($validator->validate($string));
+        self::assertfalse($validator->isValid($string));
     }
 
     /**
@@ -63,7 +63,7 @@ class LengthTest extends TestCase
     public function lengthOutsideBoundsForNonInclusiveCasesReturnFalse($string, $min, $max): void
     {
         $validator = new Length($min, $max, false);
-        self::assertfalse($validator->validate($string));
+        self::assertfalse($validator->isValid($string));
     }
 
     /**

--- a/tests/unit/Rules/MimetypeTest.php
+++ b/tests/unit/Rules/MimetypeTest.php
@@ -59,7 +59,7 @@ class MimetypeTest extends TestCase
 
         $rule = new Mimetype($mimetype, $fileInfoMock);
 
-        $rule->validate($this->filename);
+        $rule->isValid($this->filename);
     }
 
     /**
@@ -84,7 +84,7 @@ class MimetypeTest extends TestCase
 
         $rule = new Mimetype($mimetype, $fileInfoMock);
 
-        self::assertTrue($rule->validate($fileInfo));
+        self::assertTrue($rule->isValid($fileInfo));
     }
 
     /**
@@ -94,7 +94,7 @@ class MimetypeTest extends TestCase
     {
         $rule = new Mimetype('application/octet-stream');
 
-        self::assertFalse($rule->validate([__FILE__]));
+        self::assertFalse($rule->isValid([__FILE__]));
     }
 
     /**
@@ -104,7 +104,7 @@ class MimetypeTest extends TestCase
     {
         $rule = new Mimetype('application/octet-stream');
 
-        self::assertFalse($rule->validate(__DIR__));
+        self::assertFalse($rule->isValid(__DIR__));
     }
 
     /**

--- a/tests/unit/Rules/NoTest.php
+++ b/tests/unit/Rules/NoTest.php
@@ -63,7 +63,7 @@ class NoTest extends TestCase
     {
         $rule = new No();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     public function validNoProvider()
@@ -87,7 +87,7 @@ class NoTest extends TestCase
     {
         $rule = new No();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     public function invalidNoProvider()

--- a/tests/unit/Rules/NoneOfTest.php
+++ b/tests/unit/Rules/NoneOfTest.php
@@ -37,7 +37,7 @@ class NoneOfTest extends TestCase
             return false;
         });
         $o = new NoneOf($valid1, $valid2, $valid3);
-        self::assertTrue($o->validate('any'));
+        self::assertTrue($o->isValid('any'));
         $o->assert('any');
         $o->check('any');
     }
@@ -59,7 +59,7 @@ class NoneOfTest extends TestCase
             return true;
         });
         $o = new NoneOf($valid1, $valid2, $valid3);
-        self::assertFalse($o->validate('any'));
+        self::assertFalse($o->isValid('any'));
         $o->assert('any');
     }
 }

--- a/tests/unit/Rules/NotBlankTest.php
+++ b/tests/unit/Rules/NotBlankTest.php
@@ -32,7 +32,7 @@ class NotBlankTest extends TestCase
     {
         $rule = new NotBlank();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -44,7 +44,7 @@ class NotBlankTest extends TestCase
     {
         $rule = new NotBlank();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/NotOptionalTest.php
+++ b/tests/unit/Rules/NotOptionalTest.php
@@ -31,7 +31,7 @@ class NotOptionalTest extends TestCase
     {
         $rule = new NotOptional();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -43,7 +43,7 @@ class NotOptionalTest extends TestCase
     {
         $rule = new NotOptional();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     public function providerForNotOptional()

--- a/tests/unit/Rules/NullableTest.php
+++ b/tests/unit/Rules/NullableTest.php
@@ -61,11 +61,11 @@ final class NullableTest extends TestCase
         $validatable = $this->createMock(Validatable::class);
         $validatable
             ->expects(self::never())
-            ->method('validate');
+            ->method('isValid');
 
         $rule = new Nullable($validatable);
 
-        self::assertTrue($rule->validate(null));
+        self::assertTrue($rule->isValid(null));
     }
 
     /**
@@ -80,13 +80,13 @@ final class NullableTest extends TestCase
         $validatable = $this->createMock(Validatable::class);
         $validatable
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->will(self::returnValue(true));
 
         $rule = new Nullable($validatable);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/OneOfTest.php
+++ b/tests/unit/Rules/OneOfTest.php
@@ -39,7 +39,7 @@ class OneOfTest extends TestCase
 
         $rule = new OneOf($valid1, $valid2, $valid3);
 
-        self::assertTrue($rule->validate('any'));
+        self::assertTrue($rule->isValid('any'));
         $rule->assert('any');
         $rule->check('any');
     }
@@ -53,7 +53,7 @@ class OneOfTest extends TestCase
     {
         $rule = new OneOf();
 
-        self::assertFalse($rule->validate('any'));
+        self::assertFalse($rule->isValid('any'));
         $rule->check('any');
     }
 
@@ -74,7 +74,7 @@ class OneOfTest extends TestCase
             return false;
         });
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertFalse($rule->isValid('any'));
         $rule->assert('any');
     }
 
@@ -95,7 +95,7 @@ class OneOfTest extends TestCase
             return false;
         });
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertFalse($rule->isValid('any'));
 
         $rule->assert('any');
     }
@@ -118,7 +118,7 @@ class OneOfTest extends TestCase
         });
 
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertFalse($rule->isValid('any'));
 
         $rule->check('any');
     }
@@ -141,7 +141,7 @@ class OneOfTest extends TestCase
         });
 
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertFalse($rule->isValid('any'));
 
         $rule->check('any');
     }
@@ -154,7 +154,7 @@ class OneOfTest extends TestCase
     public function invalidCheck(): void
     {
         $rule = new OneOf(new Xdigit(), new Alnum());
-        self::assertFalse($rule->validate(-10));
+        self::assertFalse($rule->isValid(-10));
 
         $rule->check(-10);
     }

--- a/tests/unit/Rules/OptionalTest.php
+++ b/tests/unit/Rules/OptionalTest.php
@@ -62,11 +62,11 @@ class OptionalTest extends TestCase
         $validatable = $this->createMock(Validatable::class);
         $validatable
             ->expects(self::never())
-            ->method('validate');
+            ->method('isValid');
 
         $rule = new Optional($validatable);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -79,13 +79,13 @@ class OptionalTest extends TestCase
         $validatable = $this->createMock(Validatable::class);
         $validatable
             ->expects(self::once())
-            ->method('validate')
+            ->method('isValid')
             ->with($input)
             ->will(self::returnValue(true));
 
         $rule = new Optional($validatable);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/PostalCodeTest.php
+++ b/tests/unit/Rules/PostalCodeTest.php
@@ -57,7 +57,7 @@ class PostalCodeTest extends TestCase
     {
         $rule = new PostalCode('ZW');
 
-        self::assertTrue($rule->validate(''));
+        self::assertTrue($rule->isValid(''));
     }
 
     /**
@@ -67,7 +67,7 @@ class PostalCodeTest extends TestCase
     {
         $rule = new PostalCode('ZW');
 
-        self::assertFalse($rule->validate(' '));
+        self::assertFalse($rule->isValid(' '));
     }
 
     /**
@@ -90,7 +90,7 @@ class PostalCodeTest extends TestCase
     {
         $rule = new PostalCode($countryCode);
 
-        self::assertTrue($rule->validate($postalCode));
+        self::assertTrue($rule->isValid($postalCode));
     }
 
     public function validPostalCodesProvider()
@@ -119,7 +119,7 @@ class PostalCodeTest extends TestCase
     {
         $rule = new PostalCode($countryCode);
 
-        self::assertFalse($rule->validate($postalCode));
+        self::assertFalse($rule->isValid($postalCode));
     }
 
     /**

--- a/tests/unit/Rules/PunctTest.php
+++ b/tests/unit/Rules/PunctTest.php
@@ -30,7 +30,7 @@ class PunctTest extends TestCase
     public function validDataWithPunctShouldReturnTrue($validPunct, $additional = ''): void
     {
         $validator = new Punct($additional);
-        self::assertTrue($validator->validate($validPunct));
+        self::assertTrue($validator->isValid($validPunct));
     }
 
     /**
@@ -42,7 +42,7 @@ class PunctTest extends TestCase
     public function invalidPunctShouldFailAndThrowPunctException($invalidPunct, $additional = ''): void
     {
         $validator = new Punct($additional);
-        self::assertFalse($validator->validate($invalidPunct));
+        self::assertFalse($validator->isValid($invalidPunct));
         $validator->assert($invalidPunct);
     }
 
@@ -65,7 +65,7 @@ class PunctTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Punct($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/ReadableTest.php
+++ b/tests/unit/Rules/ReadableTest.php
@@ -36,7 +36,7 @@ function is_readable($readable)
 class ReadableTest extends TestCase
 {
     /**
-     * @covers \Respect\Validation\Rules\Readable::validate
+     * @covers \Respect\Validation\Rules\Readable::isValid
      *
      * @test
      */
@@ -46,11 +46,11 @@ class ReadableTest extends TestCase
 
         $rule = new Readable();
         $input = '/path/of/a/valid/readable/file.txt';
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\Readable::validate
+     * @covers \Respect\Validation\Rules\Readable::isValid
      *
      * @test
      */
@@ -60,11 +60,11 @@ class ReadableTest extends TestCase
 
         $rule = new Readable();
         $input = '/path/of/an/invalid/readable/file.txt';
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\Readable::validate
+     * @covers \Respect\Validation\Rules\Readable::isValid
      *
      * @test
      */
@@ -76,6 +76,6 @@ class ReadableTest extends TestCase
                 ->method('isReadable')
                 ->will(self::returnValue(true));
 
-        self::assertTrue($rule->validate($object));
+        self::assertTrue($rule->isValid($object));
     }
 }

--- a/tests/unit/Rules/SfTest.php
+++ b/tests/unit/Rules/SfTest.php
@@ -39,7 +39,7 @@ final class SfTest extends TestCase
     {
         $sut = new Sf(new IsNull());
 
-        self::assertTrue($sut->validate(null));
+        self::assertTrue($sut->isValid(null));
     }
 
     /**
@@ -49,7 +49,7 @@ final class SfTest extends TestCase
     {
         $sut = new Sf(new IsFalse());
 
-        self::assertFalse($sut->validate(true));
+        self::assertFalse($sut->isValid(true));
     }
 
     /**
@@ -76,7 +76,7 @@ final class SfTest extends TestCase
         $validator = new TraceableValidator(Validation::createValidator());
 
         $sut = new Sf(new IsNull(), $validator);
-        $sut->validate($input);
+        $sut->isValid($input);
 
         self::assertSame($input, $validator->getCollectedData()[0]['context']['value']);
     }

--- a/tests/unit/Rules/SizeTest.php
+++ b/tests/unit/Rules/SizeTest.php
@@ -104,7 +104,7 @@ class SizeTest extends TestCase
     {
         $rule = new Size($minSize, $maxSize);
 
-        self::assertEquals($expectedValidation, $rule->validate($filename));
+        self::assertEquals($expectedValidation, $rule->isValid($filename));
     }
 
     /**
@@ -118,7 +118,7 @@ class SizeTest extends TestCase
 
         $rule = new Size('1MB', '2GB');
 
-        self::assertTrue($rule->validate($file1GbObject));
+        self::assertTrue($rule->isValid($file1GbObject));
     }
 
     /**

--- a/tests/unit/Rules/SlugTest.php
+++ b/tests/unit/Rules/SlugTest.php
@@ -30,7 +30,7 @@ class SlugTest extends TestCase
     {
         $rule = new Slug();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -42,7 +42,7 @@ class SlugTest extends TestCase
     {
         $rule = new Slug();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     public function providerValidSlug()

--- a/tests/unit/Rules/SortedTest.php
+++ b/tests/unit/Rules/SortedTest.php
@@ -30,7 +30,7 @@ class SortedTest extends TestCase
         $arr = [1, 2, 3];
         $rule = new Sorted();
 
-        self::assertTrue($rule->validate($arr));
+        self::assertTrue($rule->isValid($arr));
         $rule->assert($arr);
         $rule->check($arr);
     }
@@ -43,7 +43,7 @@ class SortedTest extends TestCase
         $arr = [1, 2, 2, 3];
         $rule = new Sorted();
 
-        self::assertTrue($rule->validate($arr));
+        self::assertTrue($rule->isValid($arr));
         $rule->assert($arr);
         $rule->check($arr);
     }
@@ -58,7 +58,7 @@ class SortedTest extends TestCase
         $arr = [1, 2, 4, 3];
         $rule = new Sorted();
 
-        self::assertFalse($rule->validate($arr));
+        self::assertFalse($rule->isValid($arr));
         $rule->check($arr);
     }
 
@@ -70,7 +70,7 @@ class SortedTest extends TestCase
         $arr = [10, 9, 8];
         $rule = new Sorted(null, false);
 
-        self::assertTrue($rule->validate($arr));
+        self::assertTrue($rule->isValid($arr));
         $rule->assert($arr);
         $rule->check($arr);
     }
@@ -83,7 +83,7 @@ class SortedTest extends TestCase
         $arr = [10, 9, 9, 8];
         $rule = new Sorted(null, false);
 
-        self::assertTrue($rule->validate($arr));
+        self::assertTrue($rule->isValid($arr));
         $rule->assert($arr);
         $rule->check($arr);
     }
@@ -108,7 +108,7 @@ class SortedTest extends TestCase
             return $x['key'];
         });
 
-        self::assertTrue($rule->validate($arr));
+        self::assertTrue($rule->isValid($arr));
         $rule->assert($arr);
         $rule->check($arr);
     }
@@ -135,7 +135,7 @@ class SortedTest extends TestCase
             return $x['key'];
         });
 
-        self::assertFalse($rule->validate($arr));
+        self::assertFalse($rule->isValid($arr));
         $rule->check($arr);
     }
 }

--- a/tests/unit/Rules/SpaceTest.php
+++ b/tests/unit/Rules/SpaceTest.php
@@ -30,7 +30,7 @@ class SpaceTest extends TestCase
     public function validDataWithSpaceShouldReturnTrue($validSpace, $additional = ''): void
     {
         $validator = new Space($additional);
-        self::assertTrue($validator->validate($validSpace));
+        self::assertTrue($validator->isValid($validSpace));
     }
 
     /**
@@ -42,7 +42,7 @@ class SpaceTest extends TestCase
     public function invalidSpaceShouldFailAndThrowSpaceException($invalidSpace, $additional = ''): void
     {
         $validator = new Space($additional);
-        self::assertFalse($validator->validate($invalidSpace));
+        self::assertFalse($validator->isValid($invalidSpace));
         $validator->assert($invalidSpace);
     }
 
@@ -65,7 +65,7 @@ class SpaceTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Space($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/SubdivisionCodeTest.php
+++ b/tests/unit/Rules/SubdivisionCodeTest.php
@@ -74,7 +74,7 @@ class SubdivisionCodeTest extends TestCase
     {
         $countrySubdivision = new SubdivisionCode($countryCode);
 
-        self::assertTrue($countrySubdivision->validate($input));
+        self::assertTrue($countrySubdivision->isValid($input));
     }
 
     public function providerForInvalidSubdivisionCodeInformation()
@@ -95,7 +95,7 @@ class SubdivisionCodeTest extends TestCase
     {
         $countrySubdivision = new SubdivisionCode($countryCode);
 
-        self::assertFalse($countrySubdivision->validate($input));
+        self::assertFalse($countrySubdivision->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/SymbolicLinkTest.php
+++ b/tests/unit/Rules/SymbolicLinkTest.php
@@ -36,7 +36,7 @@ function is_link($link)
 class SymbolicLinkTest extends TestCase
 {
     /**
-     * @covers \Respect\Validation\Rules\SymbolicLink::validate
+     * @covers \Respect\Validation\Rules\SymbolicLink::isValid
      *
      * @test
      */
@@ -46,11 +46,11 @@ class SymbolicLinkTest extends TestCase
 
         $rule = new SymbolicLink();
         $input = '/path/of/a/valid/link.lnk';
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\SymbolicLink::validate
+     * @covers \Respect\Validation\Rules\SymbolicLink::isValid
      *
      * @test
      */
@@ -60,11 +60,11 @@ class SymbolicLinkTest extends TestCase
 
         $rule = new SymbolicLink();
         $input = '/path/of/an/invalid/link.lnk';
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\SymbolicLink::validate
+     * @covers \Respect\Validation\Rules\SymbolicLink::isValid
      *
      * @test
      */
@@ -76,6 +76,6 @@ class SymbolicLinkTest extends TestCase
                 ->method('isLink')
                 ->will(self::returnValue(true));
 
-        self::assertTrue($rule->validate($object));
+        self::assertTrue($rule->isValid($object));
     }
 }

--- a/tests/unit/Rules/VideoUrlTest.php
+++ b/tests/unit/Rules/VideoUrlTest.php
@@ -75,7 +75,7 @@ class VideoUrlTest extends TestCase
     {
         $rule = new VideoUrl($service);
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
@@ -87,7 +87,7 @@ class VideoUrlTest extends TestCase
     {
         $rule = new VideoUrl($service);
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**

--- a/tests/unit/Rules/VowelTest.php
+++ b/tests/unit/Rules/VowelTest.php
@@ -30,7 +30,7 @@ class VowelTest extends TestCase
     public function validDataWithVowelsShouldReturnTrue($validVowels, $additional = ''): void
     {
         $validator = new Vowel($additional);
-        self::assertTrue($validator->validate($validVowels));
+        self::assertTrue($validator->isValid($validVowels));
     }
 
     /**
@@ -42,7 +42,7 @@ class VowelTest extends TestCase
     public function invalidVowelsShouldFailAndThrowVowelException($invalidVowels, $additional = ''): void
     {
         $validator = new Vowel($additional);
-        self::assertFalse($validator->validate($invalidVowels));
+        self::assertFalse($validator->isValid($invalidVowels));
         $validator->assert($invalidVowels);
     }
 
@@ -65,7 +65,7 @@ class VowelTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Vowel($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/WritableTest.php
+++ b/tests/unit/Rules/WritableTest.php
@@ -36,7 +36,7 @@ function is_writable($writable)
 class WritableTest extends TestCase
 {
     /**
-     * @covers \Respect\Validation\Rules\Writable::validate
+     * @covers \Respect\Validation\Rules\Writable::isValid
      *
      * @test
      */
@@ -46,11 +46,11 @@ class WritableTest extends TestCase
 
         $rule = new Writable();
         $input = '/path/of/a/valid/writable/file.txt';
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\Writable::validate
+     * @covers \Respect\Validation\Rules\Writable::isValid
      *
      * @test
      */
@@ -60,11 +60,11 @@ class WritableTest extends TestCase
 
         $rule = new Writable();
         $input = '/path/of/an/invalid/writable/file.txt';
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     /**
-     * @covers \Respect\Validation\Rules\Writable::validate
+     * @covers \Respect\Validation\Rules\Writable::isValid
      *
      * @test
      */
@@ -76,6 +76,6 @@ class WritableTest extends TestCase
                 ->method('isWritable')
                 ->will(self::returnValue(true));
 
-        self::assertTrue($rule->validate($object));
+        self::assertTrue($rule->isValid($object));
     }
 }

--- a/tests/unit/Rules/XdigitTest.php
+++ b/tests/unit/Rules/XdigitTest.php
@@ -38,7 +38,7 @@ class XdigitTest extends TestCase
     {
         $this->xdigitsValidator->assert($input);
         $this->xdigitsValidator->check($input);
-        self::assertTrue($this->xdigitsValidator->validate($input));
+        self::assertTrue($this->xdigitsValidator->isValid($input));
     }
 
     /**
@@ -49,7 +49,7 @@ class XdigitTest extends TestCase
      */
     public function invalidHexadecimalDigitsShouldThrowXdigitException($input): void
     {
-        self::assertFalse($this->xdigitsValidator->validate($input));
+        self::assertFalse($this->xdigitsValidator->isValid($input));
         $this->xdigitsValidator->assert($input);
     }
 
@@ -61,7 +61,7 @@ class XdigitTest extends TestCase
     public function additionalCharsShouldBeRespected($additional, $query): void
     {
         $validator = new Xdigit($additional);
-        self::assertTrue($validator->validate($query));
+        self::assertTrue($validator->isValid($query));
     }
 
     public function providerAdditionalChars()

--- a/tests/unit/Rules/YesTest.php
+++ b/tests/unit/Rules/YesTest.php
@@ -63,7 +63,7 @@ class YesTest extends TestCase
     {
         $rule = new Yes();
 
-        self::assertTrue($rule->validate($input));
+        self::assertTrue($rule->isValid($input));
     }
 
     public function validYesProvider()
@@ -86,7 +86,7 @@ class YesTest extends TestCase
     {
         $rule = new Yes();
 
-        self::assertFalse($rule->validate($input));
+        self::assertFalse($rule->isValid($input));
     }
 
     public function invalidYesProvider()

--- a/tests/unit/Rules/ZendTest.php
+++ b/tests/unit/Rules/ZendTest.php
@@ -107,7 +107,7 @@ class ZendTest extends TestCase
         $zendValidatorParams = ['min' => 10, 'max' => 25];
         $v = new Zend($zendValidatorName, $zendValidatorParams);
         self::assertTrue(
-            $v->validate('12345678901'),
+            $v->isValid('12345678901'),
             'The value should be valid for Zend\'s validator'
         );
     }
@@ -121,7 +121,7 @@ class ZendTest extends TestCase
     {
         $v = new Zend('Date');
         $date = new DateTime();
-        self::assertTrue($v->validate($date));
+        self::assertTrue($v->isValid($date));
         $v->assert($date);
     }
 
@@ -137,7 +137,7 @@ class ZendTest extends TestCase
         $v = new Zend('Date');
         $notValid = 'a';
         self::assertFalse(
-            $v->validate($notValid),
+            $v->isValid($notValid),
             'The validator returned true for an invalid value, this won\'t cause an exception later on.'
         );
         self::assertFalse(


### PR DESCRIPTION
Semantically it makes more sense that the method that returns whether
the input is valid or not for a specific rule be called "isValid()"
than "validate()". Also, in many languages, it's very common to prefix
methods that return boolean values in response to some logic with "is",
"can", "has", etc.