### PR TITLE
Create "FilteredValidationException" class

### DIFF
--- a/library/Exceptions/AlnumException.php
+++ b/library/Exceptions/AlnumException.php
@@ -17,7 +17,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
-final class AlnumException extends AlphaException
+final class AlnumException extends FilteredValidationException
 {
     /**
      * {@inheritdoc}

--- a/library/Exceptions/AlphaException.php
+++ b/library/Exceptions/AlphaException.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class AlphaException extends ValidationException
+class AlphaException extends FilteredValidationException
 {
-    public const EXTRA = 'extra';
-
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
             self::STANDARD => '{{name}} must contain only letters (a-z)',
@@ -27,9 +25,4 @@ class AlphaException extends ValidationException
             self::EXTRA => '{{name}} must not contain letters (a-z) or "{{additionalChars}}"',
         ],
     ];
-
-    protected function chooseTemplate(): string
-    {
-        return $this->getParam('additionalChars') ? static::EXTRA : static::STANDARD;
-    }
 }

--- a/library/Exceptions/CntrlException.php
+++ b/library/Exceptions/CntrlException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class CntrlException extends AlphaException
+class CntrlException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/ConsonantException.php
+++ b/library/Exceptions/ConsonantException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class ConsonantException extends AlphaException
+class ConsonantException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/DigitException.php
+++ b/library/Exceptions/DigitException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class DigitException extends AlphaException
+class DigitException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/FilteredValidationException.php
+++ b/library/Exceptions/FilteredValidationException.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Exceptions;
+
+/**
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ */
+class FilteredValidationException extends ValidationException
+{
+    public const EXTRA = 'extra';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function chooseTemplate(): string
+    {
+        return $this->getParam('additionalChars') ? static::EXTRA : static::STANDARD;
+    }
+}

--- a/library/Exceptions/GraphException.php
+++ b/library/Exceptions/GraphException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class GraphException extends AlphaException
+class GraphException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/PrintableException.php
+++ b/library/Exceptions/PrintableException.php
@@ -20,7 +20,7 @@ namespace Respect\Validation\Exceptions;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
-final class PrintableException extends AlphaException
+final class PrintableException extends FilteredValidationException
 {
     /**
      * {@inheritdoc}

--- a/library/Exceptions/PunctException.php
+++ b/library/Exceptions/PunctException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class PunctException extends AlphaException
+class PunctException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/SpaceException.php
+++ b/library/Exceptions/SpaceException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class SpaceException extends AlphaException
+class SpaceException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/VowelException.php
+++ b/library/Exceptions/VowelException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class VowelException extends AlphaException
+class VowelException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [

--- a/library/Exceptions/XdigitException.php
+++ b/library/Exceptions/XdigitException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
-class XdigitException extends AlphaException
+class XdigitException extends FilteredValidationException
 {
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [


### PR DESCRIPTION
All the classes that were extending "AbstractFilterRule" were throwing
exceptions that were extending "AlphaException". That can cause some
issues when the user has a validation chain with "Alpha" and another
child of "AbstractFilterRule" and expects "AlphaException" specifically.

This commit creates "FilterValidationException" that can be used as the
parent of the exceptions thrown by rules that extend the class
"AbstractFilterRule".
