### PR TITLE
Remove unnecessary inheritance from "Yes" rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
   fast_finish: true
 
 before_script:
+  - sudo locale-gen --no-purge --lang nl_NL.UTF-8
+  - sudo locale-gen --no-purge --lang pt_BR.UTF-8
+  - sudo locale-gen --no-purge --lang ru_RU.UTF-8
   - pecl install uopz || echo "Cound not install uopz" 1>&2
   - composer update --prefer-dist ${COMPOSER_ARGUMENTS}
 

--- a/docs/rules/Yes.md
+++ b/docs/rules/Yes.md
@@ -3,7 +3,7 @@
 - `Yes()`
 - `Yes(bool $locale)`
 
-Validates if value is considered as "Yes".
+Validates if the input considered as "Yes".
 
 ```php
 v::yes()->validate('Y'); // true
@@ -15,7 +15,27 @@ v::yes()->validate('Yes'); // true
 
 This rule is case insensitive.
 
-If `$locale` is TRUE, uses the value of [nl_langinfo()](http://php.net/nl_langinfo) with `YESEXPR` constant.
+If `$locale` is `TRUE`, it will use the value of [nl_langinfo][] with `YESEXPR`
+constant, meaning that it will validate the input using your current location:
+
+```php
+setlocale(LC_ALL, 'pt_BR');
+v::yes(true)->validate('Sim'); // true
+```
+
+Be careful when using `$locale` as `TRUE` because the it's very permissive:
+
+```php
+v::yes(true)->validate('Yydoesnotmatter'); // true
+```
+
+Besides that, with `$locale` as  `TRUE` it will consider any character starting
+with "Y" as valid:
+
+```php
+setlocale(LC_ALL, 'ru_RU');
+v::yes(true)->validate('Yes'); // true
+```
 
 ## Changelog
 
@@ -27,3 +47,5 @@ Version | Description
 See also:
 
 - [No](No.md)
+
+[nl_langinfo]: http://php.net/nl_langinfo

--- a/library/Rules/Yes.php
+++ b/library/Rules/Yes.php
@@ -13,17 +13,24 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
-use function defined;
+use const YESEXPR;
+use function is_string;
 use function nl_langinfo;
+use function preg_match;
 
 /**
- * Validates if value is considered as "Yes".
+ * Validates if the input considered as "Yes".
  *
  * @author Cameron Hall <me@chall.id.au>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
-final class Yes extends Regex
+final class Yes extends AbstractRule
 {
+    /**
+     * @var bool
+     */
+    private $useLocale;
+
     /**
      * Initializes the rule.
      *
@@ -31,11 +38,27 @@ final class Yes extends Regex
      */
     public function __construct(bool $useLocale = false)
     {
-        $pattern = '^y(eah?|ep|es)?$';
-        if ($useLocale && defined('YESEXPR')) {
-            $pattern = nl_langinfo(YESEXPR);
+        $this->useLocale = $useLocale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($input): bool
+    {
+        if (!is_string($input)) {
+            return false;
         }
 
-        parent::__construct('/'.$pattern.'/i');
+        return preg_match($this->getPattern(), $input) > 0;
+    }
+
+    private function getPattern(): string
+    {
+        if ($this->useLocale) {
+            return '/'.nl_langinfo(YESEXPR).'/';
+        }
+
+        return '/^y(eah?|ep|es)?$/i';
     }
 }


### PR DESCRIPTION
The "Yes" rule extends "Regex" rule. The only reasons why that is useful
is because "Yes" uses regular expressions to validate the inputs.

However, the "Yes" rule is way more complex simply validating a regular
expressing and having "Regex" as its parent is also a little bit
misleading.

This commit will:

* Remove unnecessary inheritance from "Yes" rule;

* Improve the documentation of the "Yes" rule;

* Enhance the unit tests of the "Yes" rule.
