### PR TITLE
Extends the UUID validation to test for a specific version

### DIFF
--- a/docs/rules/Uuid.md
+++ b/docs/rules/Uuid.md
@@ -1,12 +1,15 @@
 # Uuid
 
-- `Uuid()`
+- `Uuid(string $version = Uuid::VERSION_ALL)`
 
-Validates whether the type of an input is a valid UUID. Both version 1 and version 4 or supported.
+Validates whether the type of an input is a valid UUID.  
+It's optional possible to test for a specific version.
 
 ```php
 v::uuid()->validate('Hello World!'); // false
 v::uuid()->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid(Uuid::VERSION_1)->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // false
+v::uuid(Uuid::VERSION_4)->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
 ```
 
 ## Changelog

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Respect\Validation\Exceptions\ComponentException;
 use function is_scalar;
 use function preg_match;
-use Respect\Validation\Exceptions\ComponentException;
 
 /**
  * This class validates UUIDs.
@@ -56,12 +56,13 @@ class Uuid extends AbstractRule
     /**
      * Uuid constructor.
      *
-     * @param string $version Use one of the Uuid class constants.
+     * @param string $version use one of the Uuid class constants
+     *
      * @throws ComponentException
      */
     public function __construct(string $version = self::VERSION_ALL)
     {
-        if (in_array($version, self::VERSIONS) === false) {
+        if (false === in_array($version, self::VERSIONS)) {
             $message = sprintf('invalid version %s given, possible: %s', $version, join(', ', self::VERSIONS));
             throw new ComponentException($message);
         }
@@ -72,7 +73,8 @@ class Uuid extends AbstractRule
     /**
      * Validates whether input is an UUID.
      *
-     * @param mixed $input The value to test.
+     * @param mixed $input the value to test
+     *
      * @return bool
      */
     public function validate($input): bool
@@ -82,6 +84,7 @@ class Uuid extends AbstractRule
         }
 
         $pattern = sprintf(self::PATTERN, $this->version);
+
         return preg_match($pattern, (string) $input) > 0;
     }
 }

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -15,17 +15,73 @@ namespace Respect\Validation\Rules;
 
 use function is_scalar;
 use function preg_match;
+use Respect\Validation\Exceptions\ComponentException;
 
+/**
+ * This class validates UUIDs.
+ *
+ * Henrique Moody <henriquemoody@gmail.com>
+ * Michael Weimann <mail@michael-weimann.eu>
+ */
 class Uuid extends AbstractRule
 {
-    private const PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+    public const VERSION_ALL = '[1-5]';
+    public const VERSION_1 = '1';
+    public const VERSION_2 = '2';
+    public const VERSION_3 = '3';
+    public const VERSION_4 = '4';
+    public const VERSION_5 = '5';
 
+    public const VERSIONS = [
+        self::VERSION_ALL,
+        self::VERSION_1,
+        self::VERSION_2,
+        self::VERSION_3,
+        self::VERSION_4,
+        self::VERSION_5,
+    ];
+
+    /**
+     * Uuid regex pattern with sprint version placeholder.
+     */
+    private const PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-%s[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+
+    /**
+     * The UUID version to validate for.
+     *
+     * string
+     */
+    private $version;
+
+    /**
+     * Uuid constructor.
+     *
+     * @param string $version Use one of the Uuid class constants.
+     * @throws ComponentException
+     */
+    public function __construct(string $version = self::VERSION_ALL)
+    {
+        if (in_array($version, self::VERSIONS) === false) {
+            $message = sprintf('invalid version %s given, possible: %s', $version, join(', ', self::VERSIONS));
+            throw new ComponentException($message);
+        }
+
+        $this->version = $version;
+    }
+
+    /**
+     * Validates whether input is an UUID.
+     *
+     * @param mixed $input The value to test.
+     * @return bool
+     */
     public function validate($input): bool
     {
         if (!is_scalar($input)) {
             return false;
         }
 
-        return preg_match(self::PATTERN, (string) $input) > 0;
+        $pattern = sprintf(self::PATTERN, $this->version);
+        return preg_match($pattern, (string) $input) > 0;
     }
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -157,7 +157,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method static Validator uploaded()
  * @method static Validator uppercase()
  * @method static Validator url()
- * @method static Validator uuid()
+ * @method static Validator uuid(string $version = '[1-5]')
  * @method static Validator vatin(string $countryCode)
  * @method static Validator version()
  * @method static Validator videoUrl(string $service = null)

--- a/tests/integration/rules/uuid.phpt
+++ b/tests/integration/rules/uuid.phpt
@@ -12,13 +12,13 @@ v::uuid(Uuid::VERSION_3)->check('3b152a69-5117-3612-aa30-cacd114cfbc4');
 try {
     v::uuid()->check('4785effc-383b-6507-b27a-3db6369060b9');
 } catch (UuidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
+    echo $exception->getMessage().PHP_EOL;
 }
 
 try {
     v::uuid(Uuid::VERSION_2)->check('3111e7ae-3ce2-4ea8-b9e5-371345f8552a');
 } catch (UuidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
+    echo $exception->getMessage().PHP_EOL;
 }
 
 ?>

--- a/tests/integration/rules/uuid.phpt
+++ b/tests/integration/rules/uuid.phpt
@@ -1,0 +1,27 @@
+--FILE--
+<?php
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\UuidException;
+use Respect\Validation\Rules\Uuid;
+use Respect\Validation\Validator as v;
+
+v::uuid()->check('3b152a69-5117-4612-aa30-cacd114cfbc4');
+v::uuid(Uuid::VERSION_3)->check('3b152a69-5117-3612-aa30-cacd114cfbc4');
+
+try {
+    v::uuid()->check('4785effc-383b-6507-b27a-3db6369060b9');
+} catch (UuidException $exception) {
+    echo $exception->getMessage() . PHP_EOL;
+}
+
+try {
+    v::uuid(Uuid::VERSION_2)->check('3111e7ae-3ce2-4ea8-b9e5-371345f8552a');
+} catch (UuidException $exception) {
+    echo $exception->getMessage() . PHP_EOL;
+}
+
+?>
+--EXPECTF--
+"4785effc-383b-6507-b27a-3db6369060b9" must be a valid UUID
+"3111e7ae-3ce2-4ea8-b9e5-371345f8552a" must be a valid UUID

--- a/tests/unit/Rules/UuidTest.php
+++ b/tests/unit/Rules/UuidTest.php
@@ -51,9 +51,8 @@ class UuidTest extends RuleTestCase
      * @dataProvider provideValidUuidConstructorParams
      *
      * @param mixed $version The version passed to the constructor
-     * @return void
      */
-    public function testInstantiate($version)
+    public function instantiate($version): void
     {
         self::expectNotToPerformAssertions();
         new Uuid($version);
@@ -80,9 +79,8 @@ class UuidTest extends RuleTestCase
      * @dataProvider provideInvalidUuidConstructorParams
      *
      * @param mixed $version The version passed to the constructor
-     * @return void
      */
-    public function testInstantiationError($version)
+    public function instantiationError($version): void
     {
         $expectedMessage = sprintf('invalid version %s given, possible: [1-5], 1, 2, 3, 4, 5', $version);
         self::expectException(ComponentException::class);

--- a/tests/unit/Rules/UuidTest.php
+++ b/tests/unit/Rules/UuidTest.php
@@ -13,45 +13,184 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Test\RuleTestCase;
 
 /**
+ * This class provides tests for the UUID validation.
+ *
  * @group  rule
  * @covers \Respect\Validation\Rules\Uuid
+ *
+ * @author Henrique Moody <henriquemoody@gmail.com>
+ * @author Michael Weimann <mail@michael-weimann.eu>
  */
 class UuidTest extends RuleTestCase
 {
-    public function providerForValidInput(): array
+    /**
+     * Provides valid Uuid version params.
+     *
+     * @return array
+     */
+    public function provideValidUuidConstructorParams(): array
     {
-        $rule = new Uuid();
-
         return [
-            // Version 1
-            [$rule, 'a71a18f4-3a13-11e7-a919-92ebcb67fe33'],
-            [$rule, 'afa0eb06-3a13-11e7-a919-92ebcb67fe33'],
-            [$rule, 'b46e09d4-3a13-11e7-a919-92ebcb67fe33'],
-            // Version 4
-            [$rule, '541b0e81-7afe-4fc4-a5f7-c01e9150df00'],
-            [$rule, '2481103e-2cd1-4c7a-b4c9-19defde3dd94'],
-            [$rule, '74077441-ea55-478a-a6f2-7dcd92239645'],
+            [Uuid::VERSION_ALL],
+            [Uuid::VERSION_1],
+            [Uuid::VERSION_2],
+            [Uuid::VERSION_3],
+            [Uuid::VERSION_4],
+            [Uuid::VERSION_5],
         ];
     }
 
+    /**
+     * Tests that the Uuid validation can be instantiated with correct params.
+     *
+     * @test
+     * @dataProvider provideValidUuidConstructorParams
+     *
+     * @param mixed $version The version passed to the constructor
+     * @return void
+     */
+    public function testInstantiate($version)
+    {
+        self::expectNotToPerformAssertions();
+        new Uuid($version);
+    }
+
+    /**
+     * Provides invalid Uuid version params.
+     *
+     * @return array
+     */
+    public function provideInvalidUuidConstructorParams(): array
+    {
+        return [
+            '0' => ['0'],
+            '7' => ['7'],
+            'a' => ['a'],
+        ];
+    }
+
+    /**
+     * Tests that Uuid cannot be instantiated with invalid constructor params.
+     *
+     * @test
+     * @dataProvider provideInvalidUuidConstructorParams
+     *
+     * @param mixed $version The version passed to the constructor
+     * @return void
+     */
+    public function testInstantiationError($version)
+    {
+        $expectedMessage = sprintf('invalid version %s given, possible: [1-5], 1, 2, 3, 4, 5', $version);
+        self::expectException(ComponentException::class);
+        self::expectExceptionMessage($expectedMessage);
+        new Uuid($version);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function providerForValidInput(): array
+    {
+        $uuidRule = new Uuid();
+        $uuidVersionAllRule = new Uuid(Uuid::VERSION_ALL);
+        $uuidVersion1Rule = new Uuid(Uuid::VERSION_1);
+        $uuidVersion2Rule = new Uuid(Uuid::VERSION_2);
+        $uuidVersion3Rule = new Uuid(Uuid::VERSION_3);
+        $uuidVersion4Rule = new Uuid(Uuid::VERSION_4);
+        $uuidVersion5Rule = new Uuid(Uuid::VERSION_5);
+
+        return [
+            // Version 1
+            [$uuidRule, 'a71a18f4-3a13-11e7-a919-92ebcb67fe33'],
+            [$uuidRule, 'afa0eb06-3a13-11e7-a919-92ebcb67fe33'],
+            [$uuidRule, 'b46e09d4-3a13-11e7-a919-92ebcb67fe33'],
+            // Version 4
+            [$uuidRule, '541b0e81-7afe-4fc4-a5f7-c01e9150df00'],
+            [$uuidRule, '2481103e-2cd1-4c7a-b4c9-19defde3dd94'],
+            [$uuidRule, '74077441-ea55-478a-a6f2-7dcd92239645'],
+            // All versions validation
+            [$uuidVersionAllRule, '4f75668d-78c3-1986-bcc1-a4a235a4b843'],
+            [$uuidVersionAllRule, 'a71a18f4-3a13-21e7-a919-92ebcb67fe33'],
+            [$uuidVersionAllRule, 'd36045b8-fe09-35f6-81a7-170e4e470964'],
+            [$uuidVersionAllRule, '84cd4e68-015b-42fb-be57-ec3ef014328f'],
+            [$uuidVersionAllRule, '541b0e81-7afe-5fc4-a5f7-c01e9150df00'],
+            // Version 1 validation
+            [$uuidVersion1Rule, 'a71a18f4-3a13-11e7-a919-92ebcb67fe33'],
+            [$uuidVersion1Rule, 'afa0eb06-3a13-11e7-a919-92ebcb67fe33'],
+            [$uuidVersion1Rule, 'b46e09d4-3a13-11e7-a919-92ebcb67fe33'],
+            // Version 2 validation
+            [$uuidVersion2Rule, 'e0b5ffb9-9caf-2a34-9673-8fc91db78be6'],
+            [$uuidVersion2Rule, '3c8d84d3-4e00-2cc2-8036-d7dc167f9874'],
+            [$uuidVersion2Rule, 'fb3a7909-8034-29f5-8f38-21adbc168db7'],
+            // Version 3 validation
+            [$uuidVersion3Rule, 'e0b5ffb9-9caf-3a34-9673-8fc91db78be6'],
+            [$uuidVersion3Rule, '3c8d84d3-4e00-3cc2-8036-d7dc167f9874'],
+            [$uuidVersion3Rule, 'fb3a7909-8034-39f5-8f38-21adbc168db7'],
+            // Version 4 validation
+            [$uuidVersion4Rule, 'e0b5ffb9-9caf-4a34-9673-8fc91db78be6'],
+            [$uuidVersion4Rule, '3c8d84d3-4e00-4cc2-8036-d7dc167f9874'],
+            [$uuidVersion4Rule, 'fb3a7909-8034-49f5-8f38-21adbc168db7'],
+            // Version 5 validation
+            [$uuidVersion5Rule, 'e0b5ffb9-9caf-5a34-9673-8fc91db78be6'],
+            [$uuidVersion5Rule, '3c8d84d3-4e00-5cc2-8036-d7dc167f9874'],
+            [$uuidVersion5Rule, 'fb3a7909-8034-59f5-8f38-21adbc168db7'],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function providerForInvalidInput(): array
     {
-        $rule = new Uuid();
+        $uuidRule = new Uuid();
+        $uuidVersionAllRule = new Uuid(Uuid::VERSION_ALL);
+        $uuidVersion1Rule = new Uuid(Uuid::VERSION_1);
+        $uuidVersion2Rule = new Uuid(Uuid::VERSION_2);
+        $uuidVersion3Rule = new Uuid(Uuid::VERSION_3);
+        $uuidVersion4Rule = new Uuid(Uuid::VERSION_4);
+        $uuidVersion5Rule = new Uuid(Uuid::VERSION_5);
 
         return [
             // Nil/Empty UUID
-            [$rule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidRule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidVersionAllRule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidVersion1Rule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidVersion2Rule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidVersion3Rule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidVersion4Rule, '00000000-0000-0000-0000-000000000000'],
+            [$uuidVersion5Rule, '00000000-0000-0000-0000-000000000000'],
             // Text
-            [$rule, 'Not a UUID'],
+            [$uuidRule, 'Not an UUID'],
+            [$uuidVersionAllRule, 'Not an UUID'],
+            [$uuidVersion1Rule, 'Not an UUID'],
+            [$uuidVersion2Rule, 'Not an UUID'],
+            [$uuidVersion3Rule, 'Not an UUID'],
+            [$uuidVersion4Rule, 'Not an UUID'],
+            [$uuidVersion5Rule, 'Not an UUID'],
             // Invalid UUID's
-            [$rule, 'g71a18f4-3a13-11e7-a919-92ebcb67fe33'],
-            [$rule, 'a71a18f4-3g13-11e7-a919-92ebcb67fe33'],
-            [$rule, 'a71a18f4-3a13-11g7-a919-92ebcb67fe33'],
-            [$rule, 'a71a18f4-3a13-11e7-g919-92ebcb67fe33'],
-            [$rule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidRule, 'g71a18f4-3a13-11e7-a919-92ebcb67fe33'],
+            [$uuidRule, 'a71a18f4-3g13-11e7-a919-92ebcb67fe33'],
+            [$uuidRule, 'a71a18f4-3a13-11g7-a919-92ebcb67fe33'],
+            [$uuidRule, 'a71a18f4-3a13-11e7-g919-92ebcb67fe33'],
+            [$uuidRule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidVersionAllRule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidVersion1Rule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidVersion2Rule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidVersion3Rule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidVersion4Rule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            [$uuidVersion5Rule, 'a71a18f4-3a13-11e7-a919-92gbcb67fe33'],
+            // Invalid variant
+            [$uuidRule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
+            [$uuidVersionAllRule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
+            [$uuidVersion1Rule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
+            [$uuidVersion2Rule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
+            [$uuidVersion3Rule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
+            [$uuidVersion4Rule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
+            [$uuidVersion5Rule, '96e37027-1247-4d9a-c5b5-74b6ba0b9e24'],
         ];
     }
 }


### PR DESCRIPTION
The UUID validation now takes a version param. The possible values are defined as constants at the Uuid validation class. Tests are extended and code is cleaned up.

Closes #1052