### PR TITLE
Make sure that "Email" only validates strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/polyfill-mbstring": "^1.2"
     },
     "require-dev": {
-        "egulias/email-validator": "~1.2",
+        "egulias/email-validator": "~1.2 || ~2.1",
         "mikey179/vfsStream": "^1.5",
         "phpunit/phpunit": "~4.0",
         "symfony/validator": "~2.6.9",

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -33,9 +33,13 @@ class Email extends AbstractRule
 
     public function validate($input)
     {
+        if (!is_string($input)) {
+            return false;
+        }
+
         $emailValidator = $this->getEmailValidator();
         if (!$emailValidator instanceof EmailValidator) {
-            return is_string($input) && filter_var($input, FILTER_VALIDATE_EMAIL);
+            return (bool) filter_var($input, FILTER_VALIDATE_EMAIL);
         }
 
         if (!class_exists('Egulias\\EmailValidator\\Validation\\RFCValidation')) {

--- a/tests/unit/Rules/EmailTest.php
+++ b/tests/unit/Rules/EmailTest.php
@@ -11,6 +11,8 @@
 
 namespace Respect\Validation\Rules;
 
+use stdClass;
+
 function class_exists($className)
 {
     if (isset($GLOBALS['class_exists'][$className])) {
@@ -142,6 +144,10 @@ class EmailTest extends \PHPUnit_Framework_TestCase
             ['test@test..com'],
             ['test@test.com.'],
             ['.test@test.com'],
+            [[]],
+            [new stdClass()],
+            [null],
+            [tmpfile()],
         ];
     }
 }


### PR DESCRIPTION
There shouldn't be possible to consider a non-string value as a valid
email anyways, but the real problem is that the "RFCValidation" from
"egulias/email-validator" casts the input as a string which makes PHP
trigger an error.

***
Close #1142
Fix #1141