### PR TITLE
Fix license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["respect", "validation", "validator"],
     "type": "library",
     "homepage": "http://respect.github.io/Validation/",
-    "license": "BSD Style",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Respect/Validation Contributors",


### PR DESCRIPTION
Currently the license identifier (`BSD Style`) does not comform to the SPDX list of valid identifiers https://spdx.org/licenses/. Having a valid identifier helps automated license checking tools verify your package.

I took the liberty of setting the license to `BSD-3-Clause`. If you want to allow multiple licenses, you could use a SPDX expression e.g. `(BSD-2-Clause OR BSD-3-Clause)`.

Please let me know if you'd like me to make any changes to this PR.

Thanks for your package!