### PR TITLE
Fix Regex for Canadian postal code

### DIFF
--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -41,7 +41,7 @@ class PostalCode extends Regex
         'BN' => '/^([A-Z]{2}\d{4})$/',
         'BR' => '/^\d{5}-?\d{3}$/',
         'BY' => '/^(\d{6})$/',
-        'CA' => '/^([ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ]) ?(\d[ABCEGHJKLMNPRSTVWXYZ]\d)$ /',
+        'CA' => '/^([ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ]) ?(\d[ABCEGHJKLMNPRSTVWXYZ]\d)$/',
         'CH' => '/^(\d{4})$/',
         'CL' => '/^(\d{7})$/',
         'CN' => '/^(\d{6})$/',

--- a/tests/unit/Rules/PostalCodeTest.php
+++ b/tests/unit/Rules/PostalCodeTest.php
@@ -86,6 +86,7 @@ class PostalCodeTest extends \PHPUnit_Framework_TestCase
         return [
             ['BR', '02179-000'],
             ['BR', '02179000'],
+            ['CA', 'A1A 2B2'],
             ['GB', 'GIR 0AA'],
             ['GB', 'PR1 9LY'],
             ['US', '02179'],
@@ -125,6 +126,7 @@ class PostalCodeTest extends \PHPUnit_Framework_TestCase
         return [
             ['BR', '02179'],
             ['BR', '02179.000'],
+            ['CA', '1A1B2B'],
             ['GB', 'GIR 00A'],
             ['GB', 'GIR0AA'],
             ['GB', 'PR19LY'],


### PR DESCRIPTION
Removes the errant space in the CA PostalCode regex.
This space was introduced by 5a067fa.

It also adds unit tests for the CA PostalCode to validate the fix.