### PR TITLE
Contribution Guidelines - SymbolicLink

### DIFF
--- a/library/Exceptions/SymbolicLinkException.php
+++ b/library/Exceptions/SymbolicLinkException.php
@@ -16,8 +16,11 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
-class SymbolicLinkException extends ValidationException
+final class SymbolicLinkException extends ValidationException
 {
+    /**
+     * {@inheritdoc}
+     */
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
             self::STANDARD => '{{name}} must be a symbolic link',

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -16,8 +16,11 @@ namespace Respect\Validation\Rules;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
-class SymbolicLink extends AbstractRule
+final class SymbolicLink extends AbstractRule
 {
+    /**
+     * {@inheritdoc}
+     */
     public function validate($input): bool
     {
         if ($input instanceof \SplFileInfo) {

--- a/tests/integration/rules/symbolicLink.phpt
+++ b/tests/integration/rules/symbolicLink.phpt
@@ -1,0 +1,61 @@
+--FILE--
+<?php
+namespace Respect\Validation\Rules;
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\SymbolicLinkException;
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Validator as v;
+
+$GLOBALS['is_link'] = null;
+
+// This override is only needed for the test, since 
+// symbolic links cannot be mocked properly in PHP.
+// See this issue for more info: https://github.com/mikey179/vfsStream/issues/89
+function is_link($link)
+{
+    $return = \is_link($link);
+    if (null !== $GLOBALS['is_link']) {
+        $return = $GLOBALS['is_link'];
+        $GLOBALS['is_link'] = null;
+    }
+
+    return $return;
+}
+
+try {
+    $GLOBALS['is_link'] = false;
+    v::symbolicLink()->check('/path/of/invalid/symbolic/link');
+} catch (SymbolicLinkException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    $GLOBALS['is_link'] = true;
+    v::not(v::symbolicLink())->check('/path/of/valid/symbolic/link');
+} catch (SymbolicLinkException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    $GLOBALS['is_link'] = false;
+    v::symbolicLink()->assert('/path/of/invalid/symbolic/link');
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+
+try {
+    $GLOBALS['is_link'] = true;
+    v::not(v::symbolicLink())->assert('/path/of/valid/symbolic/link');
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+
+?>
+--EXPECTF--
+"/path/of/invalid/symbolic/link" must be a symbolic link
+"/path/of/valid/symbolic/link" must not be a symbolic link
+- "/path/of/invalid/symbolic/link" must be a symbolic link
+- "/path/of/valid/symbolic/link" must not be a symbolic link
+


### PR DESCRIPTION
Hi, this adapts the SymbolicLink rules to match the contribution guidelines noted on #921.

I'm not sure about the monkey patching done in the `SymbolicLinkTest` (overriding `is_link`), but since it was already there I did not want to change it, and I also implemented the same idea on the integration test (`symbolicLink.phpt`). 