### PR TITLE
Add NotEmoji Rule

### DIFF
--- a/docs/list-of-rules.md
+++ b/docs/list-of-rules.md
@@ -94,6 +94,7 @@
 - [Length](rules/Length.md)
 - [Lowercase](rules/Lowercase.md)
 - [NotEmpty](rules/NotEmpty.md)
+- [NotEmoji](rules/NotEmoji.md)
 - [NoWhitespace](rules/NoWhitespace.md)
 - [PhpLabel](rules/PhpLabel.md)
 - [Printable](rules/Printable.md)

--- a/docs/rules/NotEmoji.md
+++ b/docs/rules/NotEmoji.md
@@ -1,0 +1,20 @@
+# NotEmoji
+
+- `v::notEmoji()`
+
+Validates if the given input does not contain an Emoji
+
+```php
+v::notEmoji()->validate('🍕');                           //false
+v::notEmoji()->validate('🎈');                           //false
+v::notEmoji()->validate('⚡');                           //false
+v::notEmoji()->validate('this is a spark ⚡');           //false
+v::notEmoji()->validate('🌊🌊🌊🌊🌊🏄🌊🌊🌊🏖🌴');     //false
+
+v::notEmoji()->validate('Hello World, without emoji');    //true
+```
+
+Please consider that the performance of this validator is linear which means the longer the text the longer it takes to perform the check. Though, The validator will break the execution as soon as it finds the first emoji or until it checks the whole text.
+
+*Note: this validator will check the Emoji as they are defined in Unicode V11*
+*check the following link for more details [Unicode v11](https://unicode.org/emoji/charts/full-emoji-list.html)*

--- a/library/Exceptions/NotEmojiException.php
+++ b/library/Exceptions/NotEmojiException.php
@@ -9,16 +9,24 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Respect\Validation\Exceptions;
 
-class NotEmojiException extends ValidationException
+/**
+ * @author Mazen Touati <mazen_touati@hotmail.com>
+ */
+final class NotEmojiException extends ValidationException
 {
+    /**
+     * {@inheritdoc}
+     */
     public static $defaultTemplates = [
         self::MODE_DEFAULT => [
             self::STANDARD => '{{name}} must not contain an Emoji',
         ],
         self::MODE_NEGATIVE => [
             self::STANDARD => '{{name}} must contain an Emoji',
-        ]
+        ],
     ];
 }

--- a/library/Exceptions/NotEmojiException.php
+++ b/library/Exceptions/NotEmojiException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Exceptions;
+
+class NotEmojiException extends ValidationException
+{
+    public static $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{name}} must not contain an Emoji',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{name}} must contain an Emoji',
+        ]
+    ];
+}

--- a/library/Rules/NotEmoji.php
+++ b/library/Rules/NotEmoji.php
@@ -9,13 +9,22 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Respect\Validation\Rules;
 
-class NotEmoji extends AbstractRule
+/**
+ * Validates whether the input does not contain emoji or not
+ *
+ * @author Mazen Touati <mazen_touati@hotmail.com>
+ */
+final class NotEmoji extends AbstractRule
 {
-    public function validate($input)
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($input): bool
     {
-
       // Emoji hex ranges
       // The following data has been gathered, scrapped, organized and treated based on the Unicode V11 specification : https://unicode.org/Public/emoji/11.0/emoji-test.txt
 

--- a/library/Rules/NotEmoji.php
+++ b/library/Rules/NotEmoji.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+class NotEmoji extends AbstractRule
+{
+    public function validate($input)
+    {
+
+      // Emoji hex ranges
+      // The following data has been gathered, scrapped, organized and treated based on the Unicode V11 specification : https://unicode.org/Public/emoji/11.0/emoji-test.txt
+
+      $ranges = '[\x{1F385}-\x{1F9E6}]|[\x{1F331}-\x{1F9A2}]|[\x{1F32D}-\x{1F9C2}]|[\x{1F300}-\x{1F9F3}]|[\x{1F004}-\x{1F9FF}]|[\x{1F399}-\x{1F9FE}]|[\x{1F170}-\x{1F6D0}]|[\x{1F38C}-\x{1F6A9}]|[\x{261D}]|[\x{2620}]|[\x{2639}-\x{263A}]|[\x{26D1}]|[\x{26F7}-\x{26F9}]|[\x{270A}-\x{270D}]|[\x{2763}-\x{2764}]|[\x{2618}]|[\x{2615}]|[\x{231A}-\x{231B}]|[\x{23F0}-\x{23F3}]|[\x{2600}-\x{2604}]|[\x{2614}]|[\x{2668}]|[\x{2693}]|[\x{26A1}]|[\x{26C4}-\x{26C5}]|[\x{26C8}]|[\x{26E9}-\x{26EA}]|[\x{26F0}-\x{26F5}]|[\x{26FA}]|[\x{26FD}]|[\x{2708}]|[\x{2744}]|[\x{2B50}]|[\x{265F}-\x{2660}]|[\x{2663}-\x{2666}]|[\x{26BD}-\x{26BE}]|[\x{26F3}]|[\x{26F8}]|[\x{2728}]|[\x{2328}]|[\x{260E}]|[\x{2692}-\x{2699}]|[\x{26B0}-\x{26B1}]|[\x{26CF}]|[\x{26D3}]|[\x{2702}]|[\x{2709}]|[\x{270F}]|[\x{2712}]|[\x{00A9}]|[\x{00AE}]|[\x{203C}]|[\x{2049}]|[\x{2122}]|[\x{2139}]|[\x{2194}-\x{2199}]|[\x{21A9}-\x{21AA}]|[\x{23CF}]|[\x{23EA}-\x{23EF}]|[\x{23F8}-\x{23FA}]|[\x{24C2}]|[\x{25AA}-\x{25AB}]|[\x{25B6}]|[\x{25C0}]|[\x{25FB}-\x{25FE}]|[\x{2611}]|[\x{2622}-\x{2623}]|[\x{2626}]|[\x{262A}]|[\x{262E}-\x{262F}]|[\x{2638}]|[\x{2640}-\x{2642}]|[\x{2648}-\x{2653}]|[\x{267B}]|[\x{267E}-\x{267F}]|[\x{2695}]|[\x{23E9}]|[\x{269B}-\x{269C}]|[\x{26A0}]|[\x{26AA}-\x{26AB}]|[\x{26CE}]|[\x{26D4}]|[\x{2705}]|[\x{2714}-\x{2716}]|[\x{271D}]|[\x{2721}]|[\x{2733}-\x{2734}]|[\x{2747}]|[\x{274C}-\x{274E}]|[\x{2753}-\x{2757}]|[\x{2795}-\x{2797}]|[\x{27A1}]|[\x{27B0}]|[\x{27BF}]|[\x{2934}-\x{2935}]|[\x{2B05}-\x{2B07}]|[\x{2B1B}-\x{2B1C}]|[\x{2B55}]|[\x{3030}]|[\x{303D}]|[\x{3297}-\x{3299}]|[\x{1F1E6}-\x{1F1FF}]|\x{0023}\x{20E3}|\x{0023}\x{FE0F}\x{20E3}|\x{002A}\x{20E3}|\x{002A}\x{FE0F}\x{20E3}|\x{0030}\x{20E3}|\x{0030}\x{FE0F}\x{20E3}|\x{0031}\x{20E3}|\x{0031}\x{FE0F}\x{20E3}|\x{0032}\x{20E3}|\x{0032}\x{FE0F}\x{20E3}|\x{0033}\x{20E3}|\x{0033}\x{FE0F}\x{20E3}|\x{0034}\x{20E3}|\x{0034}\x{FE0F}\x{20E3}|\x{0035}\x{20E3}|\x{0035}\x{FE0F}\x{20E3}|\x{0036}\x{20E3}|\x{0036}\x{FE0F}\x{20E3}|\x{0037}\x{20E3}|\x{0037}\x{FE0F}\x{20E3}|\x{0038}\x{20E3}|\x{0038}\x{FE0F}\x{20E3}|\x{0039}\x{20E3}|\x{0039}\x{FE0F}\x{20E3}';
+      
+
+      return !preg_match('/' . $ranges . '/mu', $input);
+    }
+}

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -115,6 +115,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method static Validator noneOf(Validatable ...$rule)
  * @method static Validator not(Validatable $rule)
  * @method static Validator notBlank()
+ * @method static Validator notEmoji()
  * @method static Validator notEmpty()
  * @method static Validator notOptional()
  * @method static Validator noWhitespace()

--- a/tests/integration/rules/notEmoji.phpt
+++ b/tests/integration/rules/notEmoji.phpt
@@ -1,0 +1,83 @@
+--CREDITS--
+Mazen Touati <mazen_touati@hotmail.com>
+--FILE--
+<?php
+require 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+use Respect\Validation\Exceptions\NotEmojiException;
+use Respect\Validation\Exceptions\AllOfException;
+
+$notEmojiValues = [
+    'Hello World, without emoji',
+    'مرحبا جميعا',
+    'こんにちは世界',
+];
+
+//Check not emoji values
+foreach ($notEmojiValues as $value) {
+  v::notEmoji()->assert($value);
+  v::notEmoji()->check($value);
+}
+
+$emojiValues = [
+    '🍕',
+    [
+      'field' => 'fullName',
+      'value' => 'this is a spark ⚡'
+    ],
+    '🌊🌊🌊🌊🌊🏄🌊🌊🌊🏖🌴',
+];
+
+//Check emoji values
+
+// check
+foreach ($emojiValues as $value) {
+  try {
+    if (is_array($value)) {
+      v::notEmoji()->setName($value['field'])->check($value['value']);
+    } else {
+      v::notEmoji()->check($value);
+    }
+  } catch (NotEmojiException $e) {
+    echo $e->getMessage().PHP_EOL;
+  }
+}
+
+// check negation
+foreach ($notEmojiValues as $value) {
+  try {
+    if (is_array($value)) {
+      v::not(v::notEmoji())->setName($value['field'])->check($value['value']);
+    } else {
+      v::not(v::notEmoji())->check($value);
+    }
+  } catch (NotEmojiException $e) {
+    echo $e->getMessage().PHP_EOL;
+  }
+}
+
+// assert
+foreach ($emojiValues as $value) {
+  try {
+    if (is_array($value)) {
+      v::notEmoji()->setName($value['field'])->assert($value['value']);
+    } else {
+      v::notEmoji()->assert($value);
+    }
+  } catch (AllOfException $e) {
+    echo $e->getFullMessage().PHP_EOL;
+  }
+}
+
+?>
+--EXPECT--
+"🍕" must not contain an Emoji
+fullName must not contain an Emoji
+"🌊🌊🌊🌊🌊🏄🌊🌊🌊🏖🌴" must not contain an Emoji
+"Hello World, without emoji" must contain an Emoji
+"مرحبا جميعا" must contain an Emoji
+"こんにちは世界" must contain an Emoji
+- "🍕" must not contain an Emoji
+- fullName must not contain an Emoji
+- "🌊🌊🌊🌊🌊🏄🌊🌊🌊🏖🌴" must not contain an Emoji

--- a/tests/unit/Rules/NotEmojiTest.php
+++ b/tests/unit/Rules/NotEmojiTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+namespace Respect\Validation\Rules;
+
+/**
+ * @group  rule
+ * @covers Respect\Validation\Rules\HelloWorld
+ */
+class NotEmojiTest extends RuleTestCase
+{
+    public function providerForValidInput()
+    {
+        $rule = new NotEmoji();
+        
+        return [
+          [$rule, 'Hello World'],
+          [$rule, '0123456789'],
+          [$rule, 'ABCDEFGHIKLMNOPQRSTVXYZabcdefghiklmnopqrstvxyz'],
+          [$rule, '&"\'(-_)@-*/+.'],
+          [$rule, 'çàéè⁊ǷÞÐÆ'],
+          [$rule, 'ضصثقفغعهخحجشسيبلاتنمكطئءؤرلاىةوزظذ'],
+          [$rule, 'ろぬふあうえおやゆよわ゛へちついすかんなにらせれせ゜たqとしはきくまのりもろむてさそひこみねるめ!'],
+        ];
+    }
+
+    public function providerForInvalidInput()
+    {
+        $rule = new NotEmoji();
+
+        return [
+            //Smileys & People
+            [$rule, '🤣'],
+              // with modifier
+              [$rule, '👉🏿'],
+              [$rule, '🎅🏾'],
+              [$rule, '🙍🏻‍♂'],
+
+            // Animals & Nature
+            [$rule, '🐵'],
+
+            // Food & Drink
+            [$rule, '🍎'],
+
+            // Travel & Places
+            [$rule, '⛰️'],
+
+            // Activities
+            [$rule, '🎈'],
+
+            // Objects
+            [$rule, '📢'],
+
+            // Symbols: symbols are cancer as they are not necessarly within a range; their unicodes are spread...
+            [$rule, '⚠️'],
+            [$rule, '⏺'],
+            [$rule, '✅'],
+
+            // Flags
+            [$rule, '🇹🇳'],
+            [$rule, '🏴󠁧󠁢󠁥󠁮󠁧󠁿'],
+            [$rule, '🏳‍🌈󠁧󠁢󠁥󠁮󠁧󠁿'],
+            [$rule, '🏴‍☠️󠁧󠁢󠁥󠁮󠁧󠁿'],
+
+            // Mixed with text
+            [$rule, 'this is a pizza 🍕'],
+        ];
+    }
+}

--- a/tests/unit/Rules/NotEmojiTest.php
+++ b/tests/unit/Rules/NotEmojiTest.php
@@ -18,7 +18,7 @@ use Respect\Validation\Test\RuleTestCase;
 /**
  * @group rule
  *
- * @covers \Respect\Validation\Rules\HelloWorld
+ * @covers \Respect\Validation\Rules\NotEmoji
  *
  * @author  Mazen Touati <mazen_touati@hotmail.com>
  */

--- a/tests/unit/Rules/NotEmojiTest.php
+++ b/tests/unit/Rules/NotEmojiTest.php
@@ -9,15 +9,25 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Respect\Validation\Rules;
 
+use Respect\Validation\Test\RuleTestCase;
+
 /**
- * @group  rule
- * @covers Respect\Validation\Rules\HelloWorld
+ * @group rule
+ *
+ * @covers \Respect\Validation\Rules\HelloWorld
+ *
+ * @author  Mazen Touati <mazen_touati@hotmail.com>
  */
-class NotEmojiTest extends RuleTestCase
+final class NotEmojiTest extends RuleTestCase
 {
-    public function providerForValidInput()
+    /**
+     * {@inheritdoc}
+     */
+    public function providerForValidInput(): array
     {
         $rule = new NotEmoji();
         
@@ -32,7 +42,10 @@ class NotEmojiTest extends RuleTestCase
         ];
     }
 
-    public function providerForInvalidInput()
+    /**
+     * {@inheritdoc}
+     */
+    public function providerForInvalidInput(): array
     {
         $rule = new NotEmoji();
 


### PR DESCRIPTION
Hey there,
This pull request bring a new validator as mentioned in this issue #1173 .

Checking the emoji is very tricky as their Unicode ranges are spread, so I used the official reference for the Unicode v11 to gather the emoji data. I created a script to scrap, organize and handle these information to generate an optimized Regex pattern that's able to catch the emoji.