### PR TITLE
bugfix for Irish postal codes

### DIFF
--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -81,7 +81,7 @@ class PostalCode extends Regex
         'HT' => '/^(?:HT)*(\d{4})$/',
         'HU' => '/^(\d{4})$/',
         'ID' => '/^(\d{5})$/',
-        'IE' => '/^[A-Z]\d{2}\s?([A-Z]|\d){4}$/',
+        'IE' => '/^([A-Z]\d{2}|D6W)\s?([A-Z]|\d){4}$/',
         'IL' => '/^(\d{5})$/',
         'IM' => '/^((?:(?:[A-PR-UWYZ][A-HK-Y]\d[ABEHMNPRV-Y0-9]|[A-PR-UWYZ]\d[A-HJKPS-UW0-9])\s\d[ABD-HJLNP-UW-Z]{2})|GIR\s?0AA)$/',
         'IN' => '/^(\d{6})$/',

--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -81,7 +81,7 @@ class PostalCode extends Regex
         'HT' => '/^(?:HT)*(\d{4})$/',
         'HU' => '/^(\d{4})$/',
         'ID' => '/^(\d{5})$/',
-        'IE' => '/^[A-Z]\d{2}$|^[A-Z]{3}[A-Z]{4}$/',
+        'IE' => '/^[A-Z]\d{2}\s?([A-Z]|\d){4}$/',
         'IL' => '/^(\d{5})$/',
         'IM' => '/^((?:(?:[A-PR-UWYZ][A-HK-Y]\d[ABEHMNPRV-Y0-9]|[A-PR-UWYZ]\d[A-HJKPS-UW0-9])\s\d[ABD-HJLNP-UW-Z]{2})|GIR\s?0AA)$/',
         'IN' => '/^(\d{6})$/',

--- a/tests/unit/Rules/PostalCodeTest.php
+++ b/tests/unit/Rules/PostalCodeTest.php
@@ -100,6 +100,7 @@ class PostalCodeTest extends TestCase
             ['PT', '3660606'],
             ['CO', '110231'],
             ['KR', '03187'],
+            ['IE', 'D14 YD91']
         ];
     }
 


### PR DESCRIPTION
Addresses Issue #1200 

Replaces the Regexp to only work for [Eircode postal codes](https://www.eircode.ie/what-is-eircode) in Ireland (IE). This is the official format since 2015. 

Prior to 2015 Dublin, and Cork, had independent formats, and the rest of the country had none. 

Struggled with the idea of combining previous regular expression with this one using an or (|), but settled on replacing it. 

Let me know.

 