### PR TITLE
Fix bug to validate "01234567890" input in CPF rule

### DIFF
--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -18,7 +18,7 @@ class Cpf extends AbstractRule
         // Code ported from jsfromhell.com
         $c = preg_replace('/\D/', '', $input);
 
-        if (strlen($c) != 11 || preg_match("/^{$c[0]}{11}$/", $c)) {
+        if (strlen($c) != 11 || preg_match("/^{$c[0]}{11}$/", $c) || $c === '01234567890') {
             return false;
         }
 

--- a/tests/unit/Rules/CpfTest.php
+++ b/tests/unit/Rules/CpfTest.php
@@ -108,6 +108,7 @@ class CpfTest extends TestCase
     public function providerInvalidUnformattedCpf()
     {
         return [
+            ['01234567890'],
             ['11111111111'],
             ['22222222222'],
             ['12345678900'],


### PR DESCRIPTION
I think "01234567890" input is not valid. I added a condition to fix it