### PR TITLE
Refactor "Domain" rule

### DIFF
--- a/docs/rules/Domain.md
+++ b/docs/rules/Domain.md
@@ -3,7 +3,7 @@
 - `Domain()`
 - `Domain(bool $tldCheck)`
 
-Validates domain names.
+Validates whether the input is a valid domain name or not.
 
 ```php
 v::domain()->validate('google.com');

--- a/tests/integration/rules/domain.phpt
+++ b/tests/integration/rules/domain.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+Henrique Moody <henriquemoody@gmail.com>
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validator as v;
+
+try {
+    v::domain()->check('batman');
+} catch (ValidationException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    v::not(v::domain())->check('r--w.com');
+} catch (ValidationException $exception) {
+    echo $exception->getMessage().PHP_EOL;
+}
+
+try {
+    v::domain()->assert('p-éz-.kk');
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+
+try {
+    v::not(v::domain())->assert('github.com');
+} catch (NestedValidationException $exception) {
+    echo $exception->getFullMessage().PHP_EOL;
+}
+?>
+--EXPECT--
+"batman" must contain the value "."
+"r--w.com" must not be a valid domain
+- "p-éz-.kk" must be a valid domain
+  - "kk" must be a valid top-level domain name
+  - "p-éz-" must contain only letters (a-z), digits (0-9) and "-"
+  - "p-éz-" must not end with "-"
+- "github.com" must not be a valid domain

--- a/tests/unit/Rules/DomainTest.php
+++ b/tests/unit/Rules/DomainTest.php
@@ -13,14 +13,13 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
-use Respect\Validation\Test\TestCase;
-use Respect\Validation\Validator as v;
-use function sprintf;
-use function var_export;
+use Respect\Validation\Test\RuleTestCase;
+use Respect\Validation\Test\Stubs\ToStringStub;
+use stdClass;
 
 /**
- * @group  rule
- * @covers \Respect\Validation\Exceptions\DomainException
+ * @group rule
+ *
  * @covers \Respect\Validation\Rules\Domain
  *
  * @author Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
@@ -28,107 +27,45 @@ use function var_export;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Mehmet Tolga Avcioglu <mehmet@activecom.net>
  */
-final class DomainTest extends TestCase
+final class DomainTest extends RuleTestCase
 {
     /**
-     * @var Domain
+     * {@inheritDoc}
      */
-    protected $object;
-
-    protected function setUp(): void
-    {
-        $this->object = new Domain();
-    }
-
-    /**
-     * @dataProvider providerForDomain
-     *
-     * @test
-     *
-     * @param mixed $input
-     */
-    public function validDomainsShouldReturnTrue($input, bool $tldcheck = true): void
-    {
-        $this->object->tldCheck($tldcheck);
-        self::assertTrue($this->object->__invoke($input));
-        $this->object->assert($input);
-        $this->object->check($input);
-    }
-
-    /**
-     * @dataProvider providerForNotDomain
-     * @expectedException \Respect\Validation\Exceptions\ValidationException
-     *
-     * @test
-     *
-     * @param mixed $input
-     */
-    public function notDomain($input, bool $tldcheck = true): void
-    {
-        $this->object->tldCheck($tldcheck);
-        $this->object->check($input);
-    }
-
-    /**
-     * @dataProvider providerForNotDomain
-     * @expectedException \Respect\Validation\Exceptions\DomainException
-     *
-     * @test
-     *
-     * @param mixed $input
-     */
-    public function notDomainCheck($input, bool $tldcheck = true): void
-    {
-        $this->object->tldCheck($tldcheck);
-        $this->object->assert($input);
-    }
-
-    /**
-     * @return mixed[][]
-     */
-    public function providerForDomain(): array
+    public function providerForValidInput(): array
     {
         return [
-            ['111111111111domain.local', false],
-            ['111111111111.domain.local', false],
-            ['example.com'],
-            ['xn--bcher-kva.ch'],
-            ['mail.xn--bcher-kva.ch'],
-            ['example-hyphen.com'],
-            ['example--valid.com'],
-            ['std--a.com'],
-            ['r--w.com'],
+            [new Domain(false), '111111111111domain.local'],
+            [new Domain(false), '111111111111.domain.local'],
+            [new Domain(), 'example.com'],
+            [new Domain(), 'xn--bcher-kva.ch'],
+            [new Domain(), 'mail.xn--bcher-kva.ch'],
+            [new Domain(), 'example-hyphen.com'],
+            [new Domain(), 'example--valid.com'],
+            [new Domain(), 'std--a.com'],
+            [new Domain(), 'r--w.com'],
         ];
     }
 
     /**
-     * @return mixed[][]
+     * {@inheritDoc}
      */
-    public function providerForNotDomain(): array
+    public function providerForInvalidInput(): array
     {
         return [
-            [null],
-            [''],
-            ['2222222domain.local'],
-            ['-example-invalid.com'],
-            ['example.invalid.-com'],
-            ['xn--bcher--kva.ch'],
-            ['example.invalid-.com'],
-            ['1.2.3.256'],
-            ['1.2.3.4'],
+            [new Domain(), null],
+            [new Domain(), new stdClass()],
+            [new Domain(), []],
+            [new Domain(), new ToStringStub('google.com')],
+            [new Domain(), ''],
+            [new Domain(), 'no dots'],
+            [new Domain(), '2222222domain.local'],
+            [new Domain(), '-example-invalid.com'],
+            [new Domain(), 'example.invalid.-com'],
+            [new Domain(), 'xn--bcher--kva.ch'],
+            [new Domain(), 'example.invalid-.com'],
+            [new Domain(), '1.2.3.256'],
+            [new Domain(), '1.2.3.4'],
         ];
-    }
-
-    /**
-     * @dataProvider providerForDomain
-     *
-     * @test
-     */
-    public function builder(string $validDomain, bool $checkTLD = true): void
-    {
-        self::assertTrue(
-            v::domain($checkTLD)->validate($validDomain),
-            sprintf('Domain "%s" should be valid. (Check TLD: %s)', $validDomain, var_export($checkTLD, true))
-        );
     }
 }


### PR DESCRIPTION
The "Domain" rule duplicates a lot of its logic among the methods
"check()," "validate()," and "assert()." Such duplication makes it hard
to maintain and hard to understand.

Besides that:

- It triggers a PHP error when trying to validate a non-scalar value;

- It does not show the exceptions in the correct hierarchy;

- It allows to change the TLD validation after to object is created.

This commit will fix those issues and create better tests for the rule.