### PR TITLE
Apply contribution guidelines to "Vatin" rule

### DIFF
--- a/tests/unit/Rules/VatinTest.php
+++ b/tests/unit/Rules/VatinTest.php
@@ -13,19 +13,56 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
-use Respect\Validation\Test\TestCase;
+use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Validatable;
+use stdClass;
 
 /**
- * @group  rule
+ * @group rule
+ *
  * @covers \Respect\Validation\Rules\Vatin
  *
- * @author Gabriel Caruso <carusogabriel34@gmail.com>
+ * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Tomasz Regdos <tomek@regdos.com>
  */
-final class VatinTest extends TestCase
+final class VatinTest extends RuleTestCase
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function providerForValidInput(): array
+    {
+        $countryCode = 'PL';
+        $rule = new Vatin($countryCode);
+
+        return [
+            [$rule, '1645865777'],
+            [$rule, '5581418257'],
+            [$rule, '1298727531'],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function providerForInvalidInput(): array
+    {
+        $countryCode = 'PL';
+        $rule = new Vatin($countryCode);
+
+        return [
+            [$rule, []],
+            [$rule, new stdClass()],
+            [$rule, '1645865778'],
+            [$rule, '164-586-57-77'],
+            [$rule, '164-58-65-777'],
+            [$rule, '5581418258'],
+            [$rule, '1298727532'],
+            [$rule, '1234567890'],
+        ];
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
As the "Vatin" rule is a "Plvatin" wrapper I considered using the same
unit tests from "PlVatin" to "Vatin".

I separated the exception test that was in the Vatin.php file into the Vatin.phpt file.