### PR TITLE
Create "ParameterStringifier"

### DIFF
--- a/docs/feature-guide.md
+++ b/docs/feature-guide.md
@@ -246,6 +246,26 @@ The example above uses `gettext()` but you can use any other callable value, lik
 After that, if you call `getMessage()`, `getMessages()`, or `getFullMessage()`,
 the message will be translated.
 
+## Message placeholder conversion
+
+Message in Validation usually have placeholders that are in between "{{" and
+"}}" characters. To replace those placeholders with the real parameters, we need
+to convert them to string.
+
+We use the `ParameterStringifier` to convert those parameters into a string.
+Our default implementation will convert all parameters with
+[Respect\Stringifier](https://github.com/Respect/Stringifier) unless the
+parameter is called `name` and it is already a string.
+
+It is possible to overwrite that behavior by creating a custom implementation of
+the `ParameterStringifier` and passing it to the `Factory`:
+
+```php
+Factory::setDefaultInstance(
+    (new Factory())->withParameterStringifier(new MyCustomStringifier())
+);
+```
+
 ## Custom rules
 
 You can also create and use your own rules. To do this, you will need to create

--- a/library/Factory.php
+++ b/library/Factory.php
@@ -19,6 +19,7 @@ use ReflectionObject;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Exceptions\InvalidClassException;
 use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Message\Formatter;
 use function lcfirst;
 use function sprintf;
 use function trim;
@@ -148,7 +149,7 @@ final class Factory
             }
         }
 
-        return new ValidationException($input, $id, $params, $this->translator);
+        return new ValidationException($input, $id, $params, new Formatter($this->translator));
     }
 
     /**
@@ -188,7 +189,7 @@ final class Factory
     ): ValidationException {
         /** @var ValidationException $exception */
         $exception = $this->createReflectionClass($exceptionName, ValidationException::class)
-            ->newInstance($input, $id, $params, $this->translator);
+            ->newInstance($input, $id, $params, new Formatter($this->translator));
         if (isset($params['template'])) {
             $exception->updateTemplate($params['template']);
         }

--- a/library/Message/Formatter.php
+++ b/library/Message/Formatter.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Message;
+
+use function call_user_func;
+use function is_string;
+use function preg_replace_callback;
+use function Respect\Stringifier\stringify;
+
+final class Formatter
+{
+    /**
+     * @var callable
+     */
+    private $translator;
+
+    public function __construct(callable $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param mixed $input
+     * @param mixed[] $parameters
+     */
+    public function format(string $template, $input, array $parameters): string
+    {
+        $parameters['name'] = $parameters['name'] ?? stringify($input);
+
+        return preg_replace_callback(
+            '/{{(\w+)}}/',
+            static function ($match) use ($parameters) {
+                if (!isset($parameters[$match[1]])) {
+                    return $match[0];
+                }
+
+                $value = $parameters[$match[1]];
+                if ($match[1] == 'name' && is_string($value)) {
+                    return $value;
+                }
+
+                return stringify($value);
+            },
+            call_user_func($this->translator, $template)
+        );
+    }
+}

--- a/library/Message/ParameterStringifier.php
+++ b/library/Message/ParameterStringifier.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Message;
+
+interface ParameterStringifier
+{
+    /**
+     * @param mixed $value
+     */
+    public function stringify(string $name, $value): string;
+}

--- a/library/Message/Stringifier/KeepOriginalStringName.php
+++ b/library/Message/Stringifier/KeepOriginalStringName.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the "LICENSE.md"
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Message\Stringifier;
+
+use Respect\Validation\Message\ParameterStringifier;
+use function is_string;
+use function Respect\Stringifier\stringify;
+
+final class KeepOriginalStringName implements ParameterStringifier
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function stringify(string $name, $value): string
+    {
+        if ($name === 'name' && is_string($value)) {
+            return $value;
+        }
+
+        return stringify($value);
+    }
+}

--- a/tests/library/RuleTestCase.php
+++ b/tests/library/RuleTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Test;
 
 use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Message\Formatter;
 use Respect\Validation\Validatable;
 use function realpath;
 use function sprintf;
@@ -99,7 +100,7 @@ abstract class RuleTestCase extends TestCase
                 'validatable',
                 'input',
                 [],
-                'trim'
+                new Formatter('strval')
             );
             $checkException->updateTemplate(sprintf('Exception for %s:check() method', $mockClassName));
             $validatableMocked
@@ -110,7 +111,7 @@ abstract class RuleTestCase extends TestCase
                 'validatable',
                 'input',
                 [],
-                'trim'
+                new Formatter('strval')
             );
             $assertException->updateTemplate(sprintf('Exception for %s:assert() method', $mockClassName));
             $validatableMocked

--- a/tests/library/RuleTestCase.php
+++ b/tests/library/RuleTestCase.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Test;
 
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Message\Formatter;
+use Respect\Validation\Message\Stringifier\KeepOriginalStringName;
 use Respect\Validation\Validatable;
 use function realpath;
 use function sprintf;
@@ -100,7 +101,7 @@ abstract class RuleTestCase extends TestCase
                 'validatable',
                 'input',
                 [],
-                new Formatter('strval')
+                new Formatter('strval', new KeepOriginalStringName())
             );
             $checkException->updateTemplate(sprintf('Exception for %s:check() method', $mockClassName));
             $validatableMocked
@@ -111,7 +112,7 @@ abstract class RuleTestCase extends TestCase
                 'validatable',
                 'input',
                 [],
-                new Formatter('strval')
+                new Formatter('strval', new KeepOriginalStringName())
             );
             $assertException->updateTemplate(sprintf('Exception for %s:assert() method', $mockClassName));
             $validatableMocked

--- a/tests/unit/Exceptions/NestedValidationExceptionTest.php
+++ b/tests/unit/Exceptions/NestedValidationExceptionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Exceptions;
 
 use Respect\Validation\Message\Formatter;
+use Respect\Validation\Message\Stringifier\KeepOriginalStringName;
 use Respect\Validation\Test\TestCase;
 
 /**
@@ -30,8 +31,8 @@ final class NestedValidationExceptionTest extends TestCase
      */
     public function getChildrenShouldReturnExceptionAddedByAddRelated(): void
     {
-        $composite = new AttributeException('input', 'id', [], new Formatter('strval'));
-        $node = new IntValException('input', 'id', [], new Formatter('strval'));
+        $composite = new AttributeException('input', 'id', [], new Formatter('strval', new KeepOriginalStringName()));
+        $node = new IntValException('input', 'id', [], new Formatter('strval', new KeepOriginalStringName()));
         $composite->addChild($node);
         self::assertCount(1, $composite->getChildren());
         self::assertContainsOnly(IntValException::class, $composite->getChildren());
@@ -42,8 +43,8 @@ final class NestedValidationExceptionTest extends TestCase
      */
     public function addingTheSameInstanceShouldAddJustOneSingleReference(): void
     {
-        $composite = new AttributeException('input', 'id', [], new Formatter('strval'));
-        $node = new IntValException('input', 'id', [], new Formatter('strval'));
+        $composite = new AttributeException('input', 'id', [], new Formatter('strval', new KeepOriginalStringName()));
+        $node = new IntValException('input', 'id', [], new Formatter('strval', new KeepOriginalStringName()));
         $composite->addChild($node);
         $composite->addChild($node);
         $composite->addChild($node);

--- a/tests/unit/Exceptions/NestedValidationExceptionTest.php
+++ b/tests/unit/Exceptions/NestedValidationExceptionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
+use Respect\Validation\Message\Formatter;
 use Respect\Validation\Test\TestCase;
 
 /**
@@ -29,8 +30,8 @@ final class NestedValidationExceptionTest extends TestCase
      */
     public function getChildrenShouldReturnExceptionAddedByAddRelated(): void
     {
-        $composite = new AttributeException('input', 'id', [], 'trim');
-        $node = new IntValException('input', 'id', [], 'trim');
+        $composite = new AttributeException('input', 'id', [], new Formatter('strval'));
+        $node = new IntValException('input', 'id', [], new Formatter('strval'));
         $composite->addChild($node);
         self::assertCount(1, $composite->getChildren());
         self::assertContainsOnly(IntValException::class, $composite->getChildren());
@@ -41,8 +42,8 @@ final class NestedValidationExceptionTest extends TestCase
      */
     public function addingTheSameInstanceShouldAddJustOneSingleReference(): void
     {
-        $composite = new AttributeException('input', 'id', [], 'trim');
-        $node = new IntValException('input', 'id', [], 'trim');
+        $composite = new AttributeException('input', 'id', [], new Formatter('strval'));
+        $node = new IntValException('input', 'id', [], new Formatter('strval'));
         $composite->addChild($node);
         $composite->addChild($node);
         $composite->addChild($node);

--- a/tests/unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/unit/Exceptions/ValidationExceptionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Exceptions;
 
 use Respect\Validation\Message\Formatter;
+use Respect\Validation\Message\Stringifier\KeepOriginalStringName;
 use Respect\Validation\Test\TestCase;
 use function trim;
 
@@ -33,7 +34,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldImplementException(): void
     {
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
 
         self::assertInstanceOf(Exception::class, $sut);
     }
@@ -44,7 +45,7 @@ final class ValidationExceptionTest extends TestCase
     public function itShouldRetrieveId(): void
     {
         $id = 'my id';
-        $sut = new ValidationException('input', $id, [], new Formatter('strval'));
+        $sut = new ValidationException('input', $id, [], $this->createFormatter());
 
         self::assertSame($id, $sut->getId());
     }
@@ -56,7 +57,7 @@ final class ValidationExceptionTest extends TestCase
     {
         $params = ['foo' => true, 'bar' => 23];
 
-        $sut = new ValidationException('input', 'id', $params, new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', $params, $this->createFormatter());
 
         self::assertSame($params, $sut->getParams());
     }
@@ -69,7 +70,7 @@ final class ValidationExceptionTest extends TestCase
         $name = 'any name';
         $value = 'any value';
 
-        $sut = new ValidationException('input', 'id', [$name => $value], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [$name => $value], $this->createFormatter());
 
         self::assertSame($value, $sut->getParam($name));
     }
@@ -79,7 +80,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldReturnNullWhenParameterCanNotBeFound(): void
     {
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
 
         self::assertNull($sut->getParam('foo'));
     }
@@ -89,7 +90,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldHaveTemplateByDefault(): void
     {
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
 
         self::assertSame('"input" must be valid', $sut->getMessage());
     }
@@ -99,7 +100,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldUpdateMode(): void
     {
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
         $sut->updateMode(ValidationException::MODE_NEGATIVE);
 
         self::assertSame('"input" must not be valid', $sut->getMessage());
@@ -112,7 +113,7 @@ final class ValidationExceptionTest extends TestCase
     {
         $template = 'This is my new template';
 
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
         $sut->updateTemplate($template);
 
         self::assertEquals($template, $sut->getMessage());
@@ -123,7 +124,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldTellWhenHasAsCustomUpdateTemplate(): void
     {
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
 
         self::assertFalse($sut->hasCustomTemplate());
 
@@ -140,7 +141,7 @@ final class ValidationExceptionTest extends TestCase
         $template = ' This is my new template ';
         $expected = trim($template);
 
-        $sut = new ValidationException('input', 'id', [], new Formatter('trim'));
+        $sut = new ValidationException('input', 'id', [], new Formatter('trim', new KeepOriginalStringName()));
         $sut->updateTemplate($template);
 
         self::assertEquals($expected, $sut->getMessage());
@@ -151,7 +152,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldReplacePlaceholders(): void
     {
-        $sut = new ValidationException('foo', 'id', ['bar' => 1, 'baz' => 2], new Formatter('strval'));
+        $sut = new ValidationException('foo', 'id', ['bar' => 1, 'baz' => 2], $this->createFormatter());
         $sut->updateTemplate('{{name}} {{bar}} {{baz}}');
 
         self::assertEquals(
@@ -165,7 +166,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldKeepPlaceholdersThatCanNotReplace(): void
     {
-        $sut = new ValidationException('foo', 'id', ['foo' => 1], new Formatter('strval'));
+        $sut = new ValidationException('foo', 'id', ['foo' => 1], $this->createFormatter());
         $sut->updateTemplate('{{name}} {{foo}} {{bar}}');
 
         self::assertEquals(
@@ -179,7 +180,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldUpdateParams(): void
     {
-        $sut = new ValidationException('input', 'id', ['foo' => 1], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', ['foo' => 1], $this->createFormatter());
         $sut->updateTemplate('{{foo}}');
         $sut->updateParams(['foo' => 2]);
 
@@ -191,8 +192,13 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldConvertToString(): void
     {
-        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
+        $sut = new ValidationException('input', 'id', [], $this->createFormatter());
 
         self::assertSame('"input" must be valid', (string) $sut);
+    }
+
+    private function createFormatter(): Formatter
+    {
+        return new Formatter('strval', new KeepOriginalStringName());
     }
 }

--- a/tests/unit/Exceptions/ValidationExceptionTest.php
+++ b/tests/unit/Exceptions/ValidationExceptionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;
 
+use Respect\Validation\Message\Formatter;
 use Respect\Validation\Test\TestCase;
 use function trim;
 
@@ -32,7 +33,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldImplementException(): void
     {
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
 
         self::assertInstanceOf(Exception::class, $sut);
     }
@@ -43,7 +44,7 @@ final class ValidationExceptionTest extends TestCase
     public function itShouldRetrieveId(): void
     {
         $id = 'my id';
-        $sut = new ValidationException('input', $id, [], 'trim');
+        $sut = new ValidationException('input', $id, [], new Formatter('strval'));
 
         self::assertSame($id, $sut->getId());
     }
@@ -55,7 +56,7 @@ final class ValidationExceptionTest extends TestCase
     {
         $params = ['foo' => true, 'bar' => 23];
 
-        $sut = new ValidationException('input', 'id', $params, 'trim');
+        $sut = new ValidationException('input', 'id', $params, new Formatter('strval'));
 
         self::assertSame($params, $sut->getParams());
     }
@@ -68,7 +69,7 @@ final class ValidationExceptionTest extends TestCase
         $name = 'any name';
         $value = 'any value';
 
-        $sut = new ValidationException('input', 'id', [$name => $value], 'trim');
+        $sut = new ValidationException('input', 'id', [$name => $value], new Formatter('strval'));
 
         self::assertSame($value, $sut->getParam($name));
     }
@@ -78,7 +79,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldReturnNullWhenParameterCanNotBeFound(): void
     {
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
 
         self::assertNull($sut->getParam('foo'));
     }
@@ -88,7 +89,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldHaveTemplateByDefault(): void
     {
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
 
         self::assertSame('"input" must be valid', $sut->getMessage());
     }
@@ -98,7 +99,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldUpdateMode(): void
     {
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
         $sut->updateMode(ValidationException::MODE_NEGATIVE);
 
         self::assertSame('"input" must not be valid', $sut->getMessage());
@@ -111,7 +112,7 @@ final class ValidationExceptionTest extends TestCase
     {
         $template = 'This is my new template';
 
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
         $sut->updateTemplate($template);
 
         self::assertEquals($template, $sut->getMessage());
@@ -122,7 +123,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldTellWhenHasAsCustomUpdateTemplate(): void
     {
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
 
         self::assertFalse($sut->hasCustomTemplate());
 
@@ -134,12 +135,12 @@ final class ValidationExceptionTest extends TestCase
     /**
      * @test
      */
-    public function itShouldUseTranslator(): void
+    public function itShouldUseFormatter(): void
     {
         $template = ' This is my new template ';
         $expected = trim($template);
 
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('trim'));
         $sut->updateTemplate($template);
 
         self::assertEquals($expected, $sut->getMessage());
@@ -150,7 +151,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldReplacePlaceholders(): void
     {
-        $sut = new ValidationException('foo', 'id', ['bar' => 1, 'baz' => 2], 'trim');
+        $sut = new ValidationException('foo', 'id', ['bar' => 1, 'baz' => 2], new Formatter('strval'));
         $sut->updateTemplate('{{name}} {{bar}} {{baz}}');
 
         self::assertEquals(
@@ -164,7 +165,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldKeepPlaceholdersThatCanNotReplace(): void
     {
-        $sut = new ValidationException('foo', 'id', ['foo' => 1], 'trim');
+        $sut = new ValidationException('foo', 'id', ['foo' => 1], new Formatter('strval'));
         $sut->updateTemplate('{{name}} {{foo}} {{bar}}');
 
         self::assertEquals(
@@ -178,7 +179,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldUpdateParams(): void
     {
-        $sut = new ValidationException('input', 'id', ['foo' => 1], 'trim');
+        $sut = new ValidationException('input', 'id', ['foo' => 1], new Formatter('strval'));
         $sut->updateTemplate('{{foo}}');
         $sut->updateParams(['foo' => 2]);
 
@@ -190,7 +191,7 @@ final class ValidationExceptionTest extends TestCase
      */
     public function itShouldConvertToString(): void
     {
-        $sut = new ValidationException('input', 'id', [], 'trim');
+        $sut = new ValidationException('input', 'id', [], new Formatter('strval'));
 
         self::assertSame('"input" must be valid', (string) $sut);
     }

--- a/tests/unit/Rules/AbstractRuleTest.php
+++ b/tests/unit/Rules/AbstractRuleTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Message\Formatter;
 use Respect\Validation\Test\TestCase;
 
 /**
@@ -118,7 +119,9 @@ final class AbstractRuleTest extends TestCase
             ->expects(self::once())
             ->method('reportError')
             ->with($input)
-            ->will(self::throwException(new ValidationException($input, 'abstract', [], 'trim')));
+            ->will(self::throwException(
+                new ValidationException($input, 'abstract', [], new Formatter('strval'))
+            ));
 
         $abstractRuleMock->assert($input);
     }

--- a/tests/unit/Rules/AbstractRuleTest.php
+++ b/tests/unit/Rules/AbstractRuleTest.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Rules;
 
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Message\Formatter;
+use Respect\Validation\Message\Stringifier\KeepOriginalStringName;
 use Respect\Validation\Test\TestCase;
 
 /**
@@ -120,7 +121,7 @@ final class AbstractRuleTest extends TestCase
             ->method('reportError')
             ->with($input)
             ->will(self::throwException(
-                new ValidationException($input, 'abstract', [], new Formatter('strval'))
+                new ValidationException($input, 'abstract', [], new Formatter('strval', new KeepOriginalStringName()))
             ));
 
         $abstractRuleMock->assert($input);


### PR DESCRIPTION
I think the `Factory` and `ValidationException` are dealing with too many things. Perhaps I should re-think how to deal with it.

Both the Translator and the Stringifier are just dealing with the message. Perhaps if I create a single object that handles the message based on the default templates, mode, and chosen templates it would be better.

***
Close #1227