### PR TITLE
Added PSR-7 UploadedFileInterface support for the size rule 

### DIFF
--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -26,6 +26,7 @@ use function sprintf;
  *
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @author Felipe Stival <v0idpwn@gmail.com>
  */
 final class Size extends AbstractRule
 {
@@ -66,7 +67,7 @@ final class Size extends AbstractRule
      */
     public function validate($input): bool
     {
-        if ($input instanceof SplFileInfo) {
+        if ($input instanceof SplFileInfo ||$input instanceof \Psr\Http\Message\UploadedFileInterface) {
             return $this->isValidSize($input->getSize());
         }
 

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -67,7 +67,7 @@ final class Size extends AbstractRule
      */
     public function validate($input): bool
     {
-        if ($input instanceof SplFileInfo ||$input instanceof \Psr\Http\Message\UploadedFileInterface) {
+        if ($input instanceof SplFileInfo || $input instanceof \Psr\Http\Message\UploadedFileInterface) {
             return $this->isValidSize($input->getSize());
         }
 


### PR DESCRIPTION
The PSR-7 UploadedFileInterface is used by many people (including frameworks), and the validation requires just an "or", because its Size function behaves the same as SplFileInfo. I think it is valid addition.
