### PR TITLE
Fixes #1244: Keys get the name of the associated validator

### DIFF
--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -26,14 +26,15 @@ abstract class AbstractRelated extends AbstractRule
 
     public function __construct($reference, Validatable $validator = null, $mandatory = true)
     {
-        $this->setName($reference);
-        if ($validator && !$validator->getName()) {
-            $validator->setName($reference);
-        }
-
         $this->reference = $reference;
         $this->validator = $validator;
         $this->mandatory = $mandatory;
+
+        if ($validator && $validator->getName()) {
+            $this->setName($validator->getName());
+        } else {
+            $this->setName($reference);
+        }
     }
 
     public function setName($name)

--- a/tests/integration/issue-1244.phpt
+++ b/tests/integration/issue-1244.phpt
@@ -1,0 +1,19 @@
+--FILE--
+<?php
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Validator as v;
+
+try {
+    v::key('firstname', v::notBlank()->setName('First Name'))->check([]);
+} catch (\Exception $e) {
+    print_r($e->getMessages());
+}
+
+?>
+--EXPECTF--
+Array
+(
+    [0] => Key First Name must be present
+)

--- a/tests/unit/Rules/AbstractRelatedTest.php
+++ b/tests/unit/Rules/AbstractRelatedTest.php
@@ -109,7 +109,7 @@ final class AbstractRelatedTest extends TestCase
             ->method('getName')
             ->will($this->returnValue(null));
         $ruleMock
-            ->expects($this->at(1))
+            ->expects($this->never())
             ->method('setName')
             ->with($reference);
 
@@ -161,7 +161,7 @@ final class AbstractRelatedTest extends TestCase
 
         $ruleMock = $this->createMock('Respect\\Validation\\Validatable');
         $ruleMock
-            ->expects($this->at(0))
+            ->expects($this->at(1))
             ->method('getName')
             ->will($this->returnValue('something else'));
         $ruleMock


### PR DESCRIPTION
Fixies #1244