### PR TITLE
Removed Key Prefix

### DIFF
--- a/library/Exceptions/KeyException.php
+++ b/library/Exceptions/KeyException.php
@@ -30,12 +30,12 @@ final class KeyException extends NestedValidationException implements NonOmissib
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NOT_PRESENT => 'Key {{name}} must be present',
-            self::INVALID => 'Key {{name}} must be valid',
+            self::NOT_PRESENT => '{{name}} must be present',
+            self::INVALID => '{{name}} must be valid',
         ],
         self::MODE_NEGATIVE => [
-            self::NOT_PRESENT => 'Key {{name}} must not be present',
-            self::INVALID => 'Key {{name}} must not be valid',
+            self::NOT_PRESENT => '{{name}} must not be present',
+            self::INVALID => '{{name}} must not be valid',
         ],
     ];
 

--- a/tests/integration/assert-with-keys.phpt
+++ b/tests/integration/assert-with-keys.phpt
@@ -49,11 +49,11 @@ try {
 - All of the required rules must pass for the given data
   - All of the required rules must pass for mysql
     - host must be of type string
-    - Key user must be present
-    - Key password must be present
+    - user must be present
+    - password must be present
     - schema must be of type string
   - All of the required rules must pass for postgresql
-    - Key host must be present
+    - host must be present
     - user must be of type string
     - password must be of type string
-    - Key schema must be present
+    - schema must be present

--- a/tests/integration/get_messages.phpt
+++ b/tests/integration/get_messages.phpt
@@ -50,17 +50,17 @@ Array
     [mysql] => Array
         (
             [host] => host must be of type string
-            [user] => Key user must be present
-            [password] => Key password must be present
+            [user] => user must be present
+            [password] => password must be present
             [schema] => schema must be of type string
         )
 
     [postgresql] => Array
         (
-            [host] => Key host must be present
+            [host] => host must be present
             [user] => user must be of type string
             [password] => password must be of type string
-            [schema] => Key schema must be present
+            [schema] => schema must be present
         )
 
 )

--- a/tests/integration/get_messages_should_include_all_validation_messages_in_a_chain.phpt
+++ b/tests/integration/get_messages_should_include_all_validation_messages_in_a_chain.phpt
@@ -37,5 +37,5 @@ Array
     [username] => username must have a length between 2 and 32
     [birthdate] => birthdate must be a valid date/time
     [password] => password must not be empty
-    [email] => Key email must be present
+    [email] => email must be present
 )

--- a/tests/integration/get_messages_with_replacements.phpt
+++ b/tests/integration/get_messages_with_replacements.phpt
@@ -60,13 +60,13 @@ Array
         (
             [host] => 42 should be a MySQL host
             [user] => Value should be a MySQL username
-            [password] => Key password must be present
+            [password] => password must be present
             [schema] => schema must be of type string
         )
 
     [postgresql] => Array
         (
-            [host] => Key host must be present
+            [host] => host must be present
             [user] => user must be of type string
             [password] => password must be of type string
             [schema] => You must provide a valid PostgreSQL schema

--- a/tests/integration/issue-179.phpt
+++ b/tests/integration/issue-179.phpt
@@ -32,4 +32,4 @@ try {
 --EXPECT--
 - These rules must pass for Settings
   - host must be of type string
-  - Key user must be present
+  - user must be present

--- a/tests/integration/issue-425.phpt
+++ b/tests/integration/issue-425.phpt
@@ -30,6 +30,6 @@ try {
 ?>
 --EXPECT--
 - These rules must pass for `{ "age": 1 }`
-  - Key reference must be present
+  - reference must be present
 - These rules must pass for `{ "reference": "QSF1234" }`
-  - Key age must be present
+  - age must be present


### PR DESCRIPTION
Most Validation errors are sent to Users/Visitors or Clients and as such, they might not need to know it was a Key their inputs are being validated upon.

The PR can be rejected if it seems not a valid point or there's a way to change Rules\Key() errors.

Thanks