### PR TITLE
Fix inconsistent behavior for leading zeros

### DIFF
--- a/docs/rules/IntVal.md
+++ b/docs/rules/IntVal.md
@@ -2,7 +2,7 @@
 
 - `v::intVal()`
 
-Validates if the input is an integer.
+Validates if the input is an integer (allowing leading zeros).
 
 ```php
 v::intVal()->validate('10'); // true

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -19,6 +19,16 @@ class IntVal extends AbstractRule
             return false;
         }
 
-        return false !== filter_var($input, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_OCTAL);
+        if (is_string($input) && strlen($input) > 0) {
+            // allow leading zeros
+            $input = ltrim($input, '0');
+
+            if ($input === '') {
+                // input contained only zeros
+                return true;
+            }
+        }
+
+        return false !== filter_var($input, FILTER_VALIDATE_INT);
     }
 }

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -55,7 +55,9 @@ class IntValTest extends TestCase
             [123456],
             [PHP_INT_MAX],
             ['06'],
-            ['0']
+            ['09'],
+            ['0'],
+            ['00'],
         ];
     }
 


### PR DESCRIPTION
This corrects the fix introduced in #1061. The current behavior allows for leading zeros, but only if the integer can be interpreted as an octal, so that e.g. `09` and `00` fail to validate.

The provided pull request restores the behavior (regarding leading zeros) as it was before [this change](https://github.com/Respect/Validation/commit/54d17abcee9c6e734691754c77641a5f51ecc608).
