### PR TITLE
Changed regex for IL to allow 5 and 7 digits

### DIFF
--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -89,7 +89,7 @@ final class PostalCode extends AbstractEnvelope
         'HU' => '/^(\d{4})$/',
         'ID' => '/^(\d{5})$/',
         'IE' => '/^([AC-FHKNPRTV-Y][0-9]{2}|D6W) ?[0-9AC-FHKNPRTV-Y]{4}$/',
-        'IL' => '/^(\d{5})$/',
+        'IL' => '/^(\d{5}|\d{7})$/',
         'IM' => '/^((?:(?:[A-PR-UWYZ][A-HK-Y]\d[ABEHMNPRV-Y0-9]|[A-PR-UWYZ]\d[A-HJKPS-UW0-9])\s\d[ABD-HJLNP-UW-Z]{2})|GIR\s?0AA)$/',
         'IN' => '/^(\d{6})$/',
         'IQ' => '/^(\d{5})$/',


### PR DESCRIPTION
Changed regex for IL to allow 5 and 7 digits.
Reason: In 2013, after the introduction of the 7 digit codes, 5 digit codes were still being used widely.
https://en.wikipedia.org/wiki/List_of_postal_codes