### PR TITLE
Added regex in Postal Code for Cayman Islands.

### DIFF
--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -105,6 +105,7 @@ final class PostalCode extends AbstractEnvelope
         'KP' => '/^(\d{6})$/',
         'KR' => '/^(\d{5})$/',
         'KW' => '/^(\d{5})$/',
+		'KY' => '^KY\d-\d{4}$',
         'KZ' => '/^(\d{6})$/',
         'LA' => '/^(\d{5})$/',
         'LB' => '/^(\d{4}(\d{4})?)$/',


### PR DESCRIPTION
This is my first PR, so apologies if I did something wrong. User RCooler has opened issue #820 and this PR is a small addition in PostalCode.php containg regex for Cayman Islands (KY).