### PR TITLE
Fix Email validator when egulias/email-validator was not installed

### DIFF
--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -64,9 +64,9 @@ final class Email extends AbstractRule
     private function createEmailValidator(): ?EmailValidator
     {
         if (class_exists(EmailValidator::class)) {
-            return null;
+            return new EmailValidator();
         }
 
-        return new EmailValidator();
+        return null;
     }
 }


### PR DESCRIPTION
`egulias/email-validator` is an optional dependency. Validation 2.0 broke the `Email` rule by trying to use the dependency when it was not available.