### PR TITLE
Fixing issue #1282

### DIFF
--- a/library/Rules/Call.php
+++ b/library/Rules/Call.php
@@ -61,9 +61,9 @@ final class Call extends AbstractRule
             throw $exception;
         } catch (Throwable $throwable) {
             throw $this->reportError($input);
+        } finally {
+            restore_error_handler();
         }
-
-        restore_error_handler();
     }
 
     /**
@@ -79,9 +79,9 @@ final class Call extends AbstractRule
             throw $exception;
         } catch (Throwable $throwable) {
             throw $this->reportError($input);
+        } finally {
+            restore_error_handler();
         }
-
-        restore_error_handler();
     }
 
     /**


### PR DESCRIPTION
Fix for: restore_error_handler() in Call validator is not invoked upon validation failure #1282