### PR TITLE
Fix Issues #1287  "OneOf" pass if only one inner validator passes

### DIFF
--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -33,7 +33,7 @@ final class OneOf extends AbstractComposite
         $exceptions = $this->getAllThrownExceptions($input);
         $numRules = count($validators);
         $numExceptions = count($exceptions);
-        if ($numExceptions !== $numRules - 1) {
+        if ($numExceptions >= $numRules) {
             /** @var OneOfException $oneOfException */
             $oneOfException = $this->reportError($input);
             $oneOfException->addChildren($exceptions);
@@ -56,7 +56,7 @@ final class OneOf extends AbstractComposite
             ++$rulesPassedCount;
         }
 
-        return $rulesPassedCount === 1;
+        return $rulesPassedCount > 0;
     }
 
     /**
@@ -76,7 +76,7 @@ final class OneOf extends AbstractComposite
             }
         }
 
-        if ($rulesPassedCount === 1) {
+        if ($rulesPassedCount > 0) {
             return;
         }
 

--- a/tests/unit/Rules/OneOfTest.php
+++ b/tests/unit/Rules/OneOfTest.php
@@ -83,8 +83,6 @@ final class OneOfTest extends TestCase
     }
 
     /**
-     * @expectedException \Respect\Validation\Exceptions\OneOfException
-     *
      * @test
      */
     public function invalidMultipleAssert(): void
@@ -99,14 +97,12 @@ final class OneOfTest extends TestCase
             return false;
         });
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertTrue($rule->validate('any'));
 
         $rule->assert('any');
     }
 
     /**
-     * @expectedException \Respect\Validation\Exceptions\CallbackException
-     *
      * @test
      */
     public function invalidMultipleCheck(): void
@@ -122,14 +118,12 @@ final class OneOfTest extends TestCase
         });
 
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertTrue($rule->validate('any'));
 
         $rule->check('any');
     }
 
     /**
-     * @expectedException \Respect\Validation\Exceptions\OneOfException
-     *
      * @test
      */
     public function invalidMultipleCheckAllValid(): void
@@ -145,7 +139,7 @@ final class OneOfTest extends TestCase
         });
 
         $rule = new OneOf($valid1, $valid2, $valid3);
-        self::assertFalse($rule->validate('any'));
+        self::assertTrue($rule->validate('any'));
 
         $rule->check('any');
     }


### PR DESCRIPTION
$num       = 1;
$validator = v::oneOf(v::equals(1));
var_dump($validator->validate($num));//true
$validator = v::oneOf(v::intVal());
var_dump($validator->validate($num));//true
$validator = v::oneOf(v::equals(1), v::intVal());
var_dump($validator->validate($num));//false 