### PR TITLE
Each::assert(): fix only the first error being reported when given a …

### DIFF
--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -55,7 +55,7 @@ final class Each extends AbstractRule
         $exceptions = [];
         foreach ($input as $value) {
             try {
-                $this->rule->check($value);
+                $this->rule->assert($value);
             } catch (ValidationException $exception) {
                 $exceptions[] = $exception;
             }


### PR DESCRIPTION
…composite rule

```yml
  lol:
    default: 2
    description: []
    children:
      - nope
```

```php
$validator = new Validator(
			(new Callback(function(array $input) : bool{
				$keyValidator = new Validator(new ArrayType(), new Each(new StringType()));
				$keyValidator->assert(array_keys($input));
				return true;
			}))->setName("permission keys"),
			new Each(new Validator(
				new Key("default", new OneOf(new StringType(), new BoolType()), false), //TODO: enumerate possible values
				new Key("description", new StringVal(), false),
				new Key("children", new ArrayType(), false)
			))
		);
		$validator->setName("permissions");
		try{
			$validator->assert($data);
		}catch(NestedValidationException $e){
			var_dump($e->getFullMessage());
		}
```

produced:
```
- default must be of type string
```
while it should produce something like:
```
- These rules must pass for `{ "default": 2, "description": { }, "children": { "nope" } }`
  - Only one of these rules must pass for default
    - default must be of type string
    - default must be of type boolean
  - description must be a string
```