### PR TITLE
Fix inconsistent behavior for leading zeros

### DIFF
--- a/docs/rules/IntVal.md
+++ b/docs/rules/IntVal.md
@@ -2,7 +2,7 @@
 
 - `IntVal()`
 
-Validates if the input is an integer.
+Validates if the input is an integer (allowing leading zeros).
 
 ```php
 v::intVal()->validate('10'); // true

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -16,7 +16,9 @@ namespace Respect\Validation\Rules;
 use function filter_var;
 use function is_bool;
 use function is_float;
-use const FILTER_FLAG_ALLOW_OCTAL;
+use function is_string;
+use function ltrim;
+use function strlen;
 use const FILTER_VALIDATE_INT;
 
 /**
@@ -39,6 +41,16 @@ final class IntVal extends AbstractRule
             return false;
         }
 
-        return filter_var($input, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_OCTAL) !== false;
+        if (is_string($input) && strlen($input) > 0) {
+            // allow leading zeros
+            $input = ltrim($input, '0');
+
+            if ($input === '') {
+                // input contained only zeros
+                return true;
+            }
+        }
+
+        return filter_var($input, FILTER_VALIDATE_INT) !== false;
     }
 }

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -41,7 +41,9 @@ final class IntValTest extends RuleTestCase
             [$rule, 123456],
             [$rule, PHP_INT_MAX],
             [$rule, '06'],
+            [$rule, '09'],
             [$rule, '0'],
+            [$rule, '00'],
         ];
     }
 


### PR DESCRIPTION
This is the pull request of #1253 for the 2.0 branch.

It corrects the fix introduced in #1061. The current behavior allows for leading zeros, but only if the integer can be interpreted as an octal, so that e.g. `06` and `07` validate but `09` and `00` do not.

The provided pull request restores the behavior (regarding leading zeros) as it was before [this change](https://github.com/Respect/Validation/commit/54d17abcee9c6e734691754c77641a5f51ecc608).
