### PR TITLE
I think you meant to import the built-in `Error` class...

### DIFF
--- a/tests/unit/Rules/CallTest.php
+++ b/tests/unit/Rules/CallTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use Exception;
-use PHPUnit\Framework\Error\Error;
+use Error;
 use Respect\Validation\Exceptions\AlwaysInvalidException;
 use Respect\Validation\Exceptions\CallException;
 use Respect\Validation\Test\TestCase;


### PR DESCRIPTION
...rather than the `PHPUnit\Framework\Error\Error` class.  The tests succeed with the former and fail with the latter. (php v7.4.5)