### PR TITLE
Update dateTime.phpt

### DIFF
--- a/tests/integration/rules/dateTime.phpt
+++ b/tests/integration/rules/dateTime.phpt
@@ -11,6 +11,8 @@ use Respect\Validation\Exceptions\DateTimeException;
 use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
+date_default_timezone_set('UTC');
+    
 try {
     v::dateTime()->check('FooBarBazz');
 } catch (DateTimeException $exception) {


### PR DESCRIPTION
Set default timezone explicitly to UTC so that tests do not fail in other time-zones.  This doesn't seem to affect other tests when I run `composer phpunit`