### PR TITLE
Allow leading zeros when using "IntVal" rule

### DIFF
--- a/docs/rules/IntVal.md
+++ b/docs/rules/IntVal.md
@@ -2,12 +2,27 @@
 
 - `IntVal()`
 
-Validates if the input is an integer.
+Validates if the input is an integer, allowing leading zeros and other number bases.
 
 ```php
 v::intVal()->validate('10'); // true
+v::intVal()->validate('089'); // true
 v::intVal()->validate(10); // true
+v::intVal()->validate(0b101010); // true
+v::intVal()->validate(0x2a); // true
 ```
+
+This rule will consider as valid any input that PHP can convert to an integer,
+but that does not contain non-integer values. That way, one can safely use the
+value this rule validates, without having surprises.
+
+```php
+v::intVal()->validate(true); // false
+v::intVal()->validate('89a'); // false
+```
+
+Even though PHP can cast the values above as integers, this rule will not
+consider them as valid.
 
 ## Categorization
 
@@ -16,10 +31,11 @@ v::intVal()->validate(10); // true
 
 ## Changelog
 
-Version | Description
---------|-------------
-  1.0.0 | Renamed from `Int` to `IntVal`
-  0.3.9 | Created as `Int`
+Version  | Description
+---------|-------------
+  2.0.14 | Allow leading zeros
+  1.0.0  | Renamed from `Int` to `IntVal`
+  0.3.9  | Created as `Int`
 
 ***
 See also:

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -13,11 +13,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
-use function filter_var;
-use function is_bool;
-use function is_float;
-use const FILTER_FLAG_ALLOW_OCTAL;
-use const FILTER_VALIDATE_INT;
+use function ctype_digit;
+use function is_int;
 
 /**
  * Validates if the input is an integer.
@@ -35,10 +32,10 @@ final class IntVal extends AbstractRule
      */
     public function validate($input): bool
     {
-        if (is_float($input) || is_bool($input)) {
-            return false;
+        if (is_int($input)) {
+            return true;
         }
 
-        return filter_var($input, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_OCTAL) !== false;
+        return ctype_digit($input);
     }
 }

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use Respect\Validation\Test\RuleTestCase;
+use stdClass;
 use const PHP_INT_MAX;
 
 /**
@@ -41,7 +42,12 @@ final class IntValTest extends RuleTestCase
             [$rule, 123456],
             [$rule, PHP_INT_MAX],
             [$rule, '06'],
+            [$rule, '09'],
             [$rule, '0'],
+            [$rule, '00'],
+            [$rule, 0b101010],
+            [$rule, 0x2a],
+            [$rule, '089'],
         ];
     }
 
@@ -54,6 +60,8 @@ final class IntValTest extends RuleTestCase
 
         return [
             [$rule, ''],
+            [$rule, new stdClass()],
+            [$rule, []],
             [$rule, null],
             [$rule, 'a'],
             [$rule, '1.0'],
@@ -64,6 +72,7 @@ final class IntValTest extends RuleTestCase
             [$rule, 'Foo'],
             [$rule, '1.44'],
             [$rule, 1e-5],
+            [$rule, '089ab'],
         ];
     }
 }


### PR DESCRIPTION
There is some confusion about integer literals (as we type them into
source code) and integer values (the actual value they represent).

When casting the integer 08 (without quotes), PHP triggers an error as
integers starting with 0 should have base 8. However, when casting the
string '08' as an integer PHP returns the integer 8.

This commit will change the behavior of the "IntVal" rule, allowing it
to accept any integer type and any representation of an integer as a
string.