### PR TITLE
Allow validating domains with "FilterVar" rule

### DIFF
--- a/docs/rules/FilterVar.md
+++ b/docs/rules/FilterVar.md
@@ -10,6 +10,8 @@ v::filterVar(FILTER_VALIDATE_EMAIL)->validate('bob@example.com'); // true
 v::filterVar(FILTER_VALIDATE_URL)->validate('http://example.com'); // true
 v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://example.com'); // false
 v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://example.com/path'); // true
+v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->validate('webserver.local'); // true
+v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->validate('@local'); // false
 ```
 
 ## Categorization
@@ -18,9 +20,10 @@ v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://e
 
 ## Changelog
 
-Version | Description
---------|-------------
-  0.8.0 | Created
+Version  | Description
+---------|-------------
+  2.0.15 | Allow validating domains
+   0.8.0 | Created
 
 ***
 See also:

--- a/library/Rules/FilterVar.php
+++ b/library/Rules/FilterVar.php
@@ -18,6 +18,7 @@ use Respect\Validation\Exceptions\ComponentException;
 use function in_array;
 
 use const FILTER_VALIDATE_BOOLEAN;
+use const FILTER_VALIDATE_DOMAIN;
 use const FILTER_VALIDATE_EMAIL;
 use const FILTER_VALIDATE_FLOAT;
 use const FILTER_VALIDATE_INT;
@@ -34,6 +35,7 @@ final class FilterVar extends AbstractEnvelope
 {
     private const ALLOWED_FILTERS = [
         FILTER_VALIDATE_BOOLEAN,
+        FILTER_VALIDATE_DOMAIN,
         FILTER_VALIDATE_EMAIL,
         FILTER_VALIDATE_FLOAT,
         FILTER_VALIDATE_INT,

--- a/tests/unit/Rules/FilterVarTest.php
+++ b/tests/unit/Rules/FilterVarTest.php
@@ -15,9 +15,11 @@ namespace Respect\Validation\Rules;
 
 use Respect\Validation\Test\RuleTestCase;
 
+use const FILTER_FLAG_HOSTNAME;
 use const FILTER_FLAG_QUERY_REQUIRED;
 use const FILTER_SANITIZE_EMAIL;
 use const FILTER_VALIDATE_BOOLEAN;
+use const FILTER_VALIDATE_DOMAIN;
 use const FILTER_VALIDATE_EMAIL;
 use const FILTER_VALIDATE_FLOAT;
 use const FILTER_VALIDATE_INT;
@@ -56,6 +58,7 @@ final class FilterVarTest extends RuleTestCase
             [new FilterVar(FILTER_VALIDATE_FLOAT), 1.5],
             [new FilterVar(FILTER_VALIDATE_BOOLEAN), 'On'],
             [new FilterVar(FILTER_VALIDATE_URL, FILTER_FLAG_QUERY_REQUIRED), 'http://example.com?foo=bar'],
+            [new FilterVar(FILTER_VALIDATE_DOMAIN), 'example.com'],
         ];
     }
 
@@ -67,6 +70,8 @@ final class FilterVarTest extends RuleTestCase
         return [
             [new FilterVar(FILTER_VALIDATE_INT), 1.4],
             [new FilterVar(FILTER_VALIDATE_URL, FILTER_FLAG_QUERY_REQUIRED), 'http://example.com'],
+            [new FilterVar(FILTER_VALIDATE_DOMAIN), '.com'],
+            [new FilterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME), '@local'],
         ];
     }
 }


### PR DESCRIPTION
Even though using "filter_var()" to validate domains may is error-prone,
Validation should fully support "filter_var()" as long as the
"FilterVar" exists.

Closes #1257