### PR TITLE
Auto-resolve exception namespaces

### DIFF
--- a/library/Factory.php
+++ b/library/Factory.php
@@ -23,8 +23,10 @@ use Respect\Validation\Message\Formatter;
 use Respect\Validation\Message\ParameterStringifier;
 use Respect\Validation\Message\Stringifier\KeepOriginalStringName;
 
+use function array_merge;
 use function lcfirst;
 use function sprintf;
+use function str_replace;
 use function trim;
 use function ucfirst;
 
@@ -157,7 +159,8 @@ final class Factory
         if ($validatable->getName() !== null) {
             $id = $params['name'] = $validatable->getName();
         }
-        foreach ($this->exceptionsNamespaces as $namespace) {
+        $exceptionNamespace = str_replace('\\Rules', '\\Exceptions', $reflection->getNamespaceName());
+        foreach (array_merge([$exceptionNamespace], $this->exceptionsNamespaces) as $namespace) {
             try {
                 /** @var class-string<ValidationException> $exceptionName */
                 $exceptionName = $namespace . '\\' . $ruleName . 'Exception';

--- a/tests/library/Rules/CustomRule.php
+++ b/tests/library/Rules/CustomRule.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Respect/Validation.
+ *
+ * (c) Alexandre Gomes Gaigalas <alexandre@gaigalas.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Rules;
+
+use Respect\Validation\Rules\AbstractRule;
+
+/**
+ * Example of a custom rule that does not have an exception.
+ *
+ * @author Casey McLaughlin <caseyamcl@gmail.com>
+ */
+final class CustomRule extends AbstractRule
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($input): bool
+    {
+        return false;
+    }
+}

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -18,6 +18,7 @@ use Respect\Validation\Exceptions\InvalidClassException;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Test\Exceptions\StubException;
 use Respect\Validation\Test\Rules\AbstractClass;
+use Respect\Validation\Test\Rules\CustomRule;
 use Respect\Validation\Test\Rules\Invalid;
 use Respect\Validation\Test\Rules\Stub;
 use Respect\Validation\Test\Rules\Valid;
@@ -226,5 +227,27 @@ final class FactoryTest extends TestCase
         self::assertSame($factory, Factory::getDefaultInstance());
 
         Factory::setDefaultInstance($defaultInstance);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAutoResolveExceptionIfNamespacePatternMatchesAndExceptionClassFound(): void
+    {
+        $this->expectException(StubException::class);
+
+        $rule = new Stub();
+        $rule->assert('test');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUseDefaultExceptionIfCustomExceptionNotFound(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $rule = new CustomRule();
+        $rule->assert('test');
     }
 }


### PR DESCRIPTION
After the refactoring on the Factory class [1], to throw exceptions of a
specific rule, it is necessary to add the exception namespace of that
rule. That change makes sense when someone wants to create rules from
the Validator class, but when using rules as classes, it's not as handy.

This commit will auto-resolve exception based on the rule namespace,
just as it used to be.

[1]: 1f217dda66feafac60e86351c6d808cd97f265b2