### PR TITLE
Only define filter_var options when it is valid

### DIFF
--- a/library/Rules/FilterVar.php
+++ b/library/Rules/FilterVar.php
@@ -16,6 +16,8 @@ namespace Respect\Validation\Rules;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function in_array;
+use function is_array;
+use function is_int;
 
 use const FILTER_VALIDATE_BOOLEAN;
 use const FILTER_VALIDATE_DOMAIN;
@@ -57,6 +59,11 @@ final class FilterVar extends AbstractEnvelope
             throw new ComponentException('Cannot accept the given filter');
         }
 
-        parent::__construct(new Callback('filter_var', $filter, $options));
+        $arguments = [$filter];
+        if (is_array($options) || is_int($options)) {
+            $arguments[] = $options;
+        }
+
+        parent::__construct(new Callback('filter_var', ...$arguments));
     }
 }


### PR DESCRIPTION
The third argument of "filter_var" must be either an integer or an
array. On PHP 8 this "FilterVar" rule fails because we always pass that
argument, even if it is null.