### PR TITLE
Upgrade supported version of "egulias/email-validator"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-mbstring": "^1.2"
     },
     "require-dev": {
-        "egulias/email-validator": "^2.1",
+        "egulias/email-validator": "^3.0",
         "malukenho/docheader": "^0.1",
         "mikey179/vfsstream": "^1.6",
         "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
We could simply add version 3.0 instead of replacing it, but I would
like to stimulate people to keep their libraries up-to-date.

Fix #1332