### PR TITLE
Call mbstring functions without getting encoding

### DIFF
--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -54,8 +54,6 @@ final class Charset extends AbstractRule
      */
     public function validate($input): bool
     {
-        $detectedEncoding = mb_detect_encoding($input, $this->charset, true);
-
-        return in_array($detectedEncoding, $this->charset, true);
+        return in_array(mb_detect_encoding($input, $this->charset, true), $this->charset, true);
     }
 }

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -16,7 +16,6 @@ namespace Respect\Validation\Rules;
 use function in_array;
 use function is_array;
 use function is_scalar;
-use function mb_detect_encoding;
 use function mb_stripos;
 use function mb_strpos;
 
@@ -74,11 +73,10 @@ final class Contains extends AbstractRule
             return false;
         }
 
-        $encoding = (string) mb_detect_encoding($haystack);
         if ($this->identical) {
-            return mb_strpos($haystack, $needle, 0, $encoding) !== false;
+            return mb_strpos($haystack, $needle) !== false;
         }
 
-        return mb_stripos($haystack, $needle, 0, $encoding) !== false;
+        return mb_stripos($haystack, $needle) !== false;
     }
 }

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -15,7 +15,6 @@ namespace Respect\Validation\Rules;
 
 use function end;
 use function is_array;
-use function mb_detect_encoding;
 use function mb_strlen;
 use function mb_strripos;
 use function mb_strrpos;
@@ -70,10 +69,7 @@ final class EndsWith extends AbstractRule
             return end($input) == $this->endValue;
         }
 
-        $encoding = (string) mb_detect_encoding($input);
-        $endPosition = mb_strlen($input, $encoding) - mb_strlen($this->endValue, $encoding);
-
-        return mb_strripos($input, $this->endValue, 0, $encoding) === $endPosition;
+        return mb_strripos($input, $this->endValue) === mb_strlen($input) - mb_strlen($this->endValue);
     }
 
     /**
@@ -85,9 +81,6 @@ final class EndsWith extends AbstractRule
             return end($input) === $this->endValue;
         }
 
-        $encoding = (string) mb_detect_encoding($input);
-        $endPosition = mb_strlen($input, $encoding) - mb_strlen($this->endValue, $encoding);
-
-        return mb_strrpos($input, $this->endValue, 0, $encoding) === $endPosition;
+        return mb_strrpos($input, $this->endValue) === mb_strlen($input) - mb_strlen($this->endValue);
     }
 }

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -15,7 +15,6 @@ namespace Respect\Validation\Rules;
 
 use function in_array;
 use function is_array;
-use function mb_detect_encoding;
 use function mb_stripos;
 use function mb_strpos;
 
@@ -74,9 +73,7 @@ final class In extends AbstractRule
             return $input == $this->haystack;
         }
 
-        $inputString = (string) $input;
-
-        return mb_stripos($this->haystack, $inputString, 0, (string) mb_detect_encoding($inputString)) !== false;
+        return mb_stripos($this->haystack, (string) $input) !== false;
     }
 
     /**
@@ -92,8 +89,6 @@ final class In extends AbstractRule
             return $input === $this->haystack;
         }
 
-        $inputString = (string) $input;
-
-        return mb_strpos($this->haystack, $inputString, 0, (string) mb_detect_encoding($inputString)) !== false;
+        return mb_strpos($this->haystack, (string) $input) !== false;
     }
 }

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -22,7 +22,6 @@ use function is_array;
 use function is_int;
 use function is_object;
 use function is_string;
-use function mb_detect_encoding;
 use function mb_strlen;
 use function sprintf;
 
@@ -89,7 +88,7 @@ final class Length extends AbstractRule
     private function extractLength($input): ?int
     {
         if (is_string($input)) {
-            return (int) mb_strlen($input, (string) mb_detect_encoding($input));
+            return (int) mb_strlen($input);
         }
 
         if (is_array($input) || $input instanceof CountableInterface) {

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use function is_string;
-use function mb_detect_encoding;
 use function mb_strtolower;
 
 /**
@@ -36,6 +35,6 @@ final class Lowercase extends AbstractRule
             return false;
         }
 
-        return $input === mb_strtolower($input, (string) mb_detect_encoding($input));
+        return $input === mb_strtolower($input);
     }
 }

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use function is_array;
-use function mb_detect_encoding;
 use function mb_stripos;
 use function mb_strpos;
 use function reset;
@@ -68,7 +67,7 @@ final class StartsWith extends AbstractRule
             return reset($input) == $this->startValue;
         }
 
-        return mb_stripos($input, $this->startValue, 0, (string) mb_detect_encoding($input)) === 0;
+        return mb_stripos($input, $this->startValue) === 0;
     }
 
     /**
@@ -80,6 +79,6 @@ final class StartsWith extends AbstractRule
             return reset($input) === $this->startValue;
         }
 
-        return mb_strpos($input, $this->startValue, 0, (string) mb_detect_encoding($input)) === 0;
+        return mb_strpos($input, $this->startValue) === 0;
     }
 }

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use function is_string;
-use function mb_detect_encoding;
 use function mb_strtoupper;
 
 /**
@@ -36,6 +35,6 @@ final class Uppercase extends AbstractRule
             return false;
         }
 
-        return $input === mb_strtoupper($input, (string) mb_detect_encoding($input));
+        return $input === mb_strtoupper($input);
     }
 }


### PR DESCRIPTION
The functions from the mbstring can deal find with strings without
forcing a specific encoding. However, sometimes "mb_detect_encoding()"
cannot identify the encoding therefore the functions that expect a valid
encoding will trigger a PHP error.

This commit will remove the unnecessary use of "mb_detect_encoding()."

Close #681