### PR TITLE
Ip rule: Fix check whether start and end address have been set

### DIFF
--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -105,7 +105,7 @@ final class Ip extends AbstractRule
 
     private function createRange(): ?string
     {
-        if ($this->endAddress && $this->endAddress) {
+        if ($this->startAddress && $this->endAddress) {
             return $this->startAddress . '-' . $this->endAddress;
         }
 


### PR DESCRIPTION
Fixes the following phpstan error (output abbreviated for clearity):
```sh
Run vendor/bin/phpstan analyze
Note: Using configuration file /home/runner/work/Validation/Validation/phpstan.neon.dist.

 ------ ---------------------------------- 
  Line   library/Rules/Ip.php              
 ------ ---------------------------------- 
  108    Right side of && is always true.  
 ------ ---------------------------------- 
```
I did not add a new test because due to the way the two variables are initialized, there is actually no possibility for `startAddress` to be `null` and `endAddress` to be set simultaneously.