### PR TITLE
Rule/portuguese nif rule

### DIFF
--- a/docs/rules/PortugueseNif.md
+++ b/docs/rules/PortugueseNif.md
@@ -1,0 +1,19 @@
+# Portuguese NIF
+
+- `PortugueseNif()`
+
+Validates Portugal's fiscal identification number ([NIF](https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal)).
+
+```php
+v::portugueseNif()->validate('124885446'); // true
+v::portugueseNif()->validate('220005245'); // false
+```
+
+## Categorization
+
+- Identifications
+
+***
+See also:
+
+- [Nif](Nif.md)

--- a/library/Exceptions/PortugueseNifException.php
+++ b/library/Exceptions/PortugueseNifException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Exceptions;
+
+/**
+ * @author Gonçalo Andrade <goncalo.andrade95@gmail.com>
+ */
+final class PortugueseNifException extends ValidationException
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $defaultTemplates = [
+        self::MODE_DEFAULT => [
+            self::STANDARD => '{{name}} must be a Portuguese NIF',
+        ],
+        self::MODE_NEGATIVE => [
+            self::STANDARD => '{{name}} must not be a Portuguese NIF'
+        ]
+    ];
+}

--- a/library/Rules/PortugueseNif.php
+++ b/library/Rules/PortugueseNif.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use function array_keys;
+use function array_map;
+use function array_pop;
+use function array_sum;
+use function intval;
+use function is_numeric;
+use function is_string;
+use function str_split;
+use function strlen;
+
+/**
+ * Validates Portugal's fiscal identification number (NIF)
+ *
+ *
+ * @see https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal
+ *
+ * @author Gonçalo Andrade <goncalo.andrade95@gmail.com>
+ */
+final class PortugueseNif extends AbstractRule
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($input): bool
+    {
+        // Validate format and length
+        if (!is_string($input)) {
+            return false;
+        }
+
+        if (!is_numeric($input)) {
+            return false;
+        }
+
+        if (strlen($input) != 9) {
+            return false;
+        }
+
+        $digits = array_map(static fn (string $digit) => intval($digit), str_split($input));
+
+        // Validate first and second digits
+        switch ($digits[0]) {
+            case 4:
+                switch ($digits[1]) {
+                    case 5:
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            case 7:
+                switch ($digits[1]) {
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 4:
+                    case 5:
+                    case 7:
+                    case 8:
+                    case 9:
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            case 9:
+                switch ($digits[1]) {
+                    case 0:
+                    case 1:
+                    case 8:
+                    case 9:
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            default:
+                break;
+        }
+
+        // Validate check digit
+        $checkDigit = array_pop($digits);
+        $digitKeys = array_keys($digits);
+        $sumTerms = array_map(static fn (int $digit, int $position) => $digit * (9 - $position), $digits, $digitKeys);
+        $sum = array_sum($sumTerms);
+        $modulus = $sum % 11;
+
+        if ($modulus == 0 || $modulus == 1) {
+            return $checkDigit == 0;
+        }
+
+        return $checkDigit == 11 - $modulus;
+    }
+}

--- a/tests/unit/Rules/PortugueseNifTest.php
+++ b/tests/unit/Rules/PortugueseNifTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Test\RuleTestCase;
+use stdClass;
+
+use function stream_context_create;
+
+final class PortugueseNifTest extends RuleTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function providerForValidInput(): array
+    {
+        $rule = new PortugueseNif();
+
+        return [
+            [$rule, '124885446'],
+            [$rule, '296981079'],
+            [$rule, '372697216'],
+            [$rule, '452536910'],
+            [$rule, '547512104'],
+            [$rule, '600481093'],
+            [$rule, '709060548'],
+            [$rule, '748501746'],
+            [$rule, '755231872'],
+            [$rule, '712993010'],
+            [$rule, '726086193'],
+            [$rule, '774001437'],
+            [$rule, '787667560'],
+            [$rule, '796553823'],
+            [$rule, '839697350'],
+            [$rule, '909339260'],
+            [$rule, '912534087'],
+            [$rule, '982150148'],
+            [$rule, '990402509'],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function providerForInvalidInput(): array
+    {
+        $rule = new PortugueseNif();
+
+        return [
+            // Check digit is wrong
+            [$rule, '129468882'],
+            [$rule, '220005245'],
+            [$rule, '389684008'],
+            [$rule, '454438148'],
+            [$rule, '504116863'],
+            [$rule, '671236496'],
+            [$rule, '703830557'],
+            [$rule, '743373410'],
+            [$rule, '750701191'],
+            [$rule, '710147053'],
+            [$rule, '725277167'],
+            [$rule, '777722796'],
+            [$rule, '784431824'],
+            [$rule, '798137629'],
+            [$rule, '801391192'],
+            [$rule, '907147885'],
+            [$rule, '911864617'],
+            [$rule, '983401988'],
+            [$rule, '995934101'],
+
+            // Invalid formats
+            [$rule, 'ABC885446'],
+            [$rule, '29698107'],
+            [$rule, '3726972165'],
+
+            // Weird types
+            [$rule, []],
+            [$rule, true],
+            [$rule, 1],
+            [$rule, 0.5],
+            [$rule, null],
+            [$rule, new stdClass()],
+            [$rule, stream_context_create()],
+
+        ];
+    }
+}


### PR DESCRIPTION
Hi!

I work in a project where we use Respect/Validation. Something that we regularly have to check for is the validity of a Portuguese fiscal identification number (NIF). Since Validation does not, at this time, have such a validation rule, I decided to contribute one. I hope you find it useful.
I named the rule `PortugueseNif` because there is already a rule called `Nif`. I'm not sure this is the best name for it, so I ask for your input on this.

I tried to create this pull request in a way that follows Validation's contribution guidelines. However, if anything is not as you would expect, let me know and I'll try to fix it :)