### PR TITLE
Fix Decimal rule for float values > 10

### DIFF
--- a/library/Rules/Decimal.php
+++ b/library/Rules/Decimal.php
@@ -70,6 +70,6 @@ final class Decimal extends AbstractRule
             return $formatted;
         }
 
-        return preg_replace('/^(\d.\d)0*/', '$1', $formatted);
+        return preg_replace('/^(\d+\.\d)0*$/', '$1', $formatted);
     }
 }

--- a/tests/unit/Rules/DecimalTest.php
+++ b/tests/unit/Rules/DecimalTest.php
@@ -48,6 +48,10 @@ final class DecimalTest extends RuleTestCase
             [new Decimal(1), 1.1],
             [new Decimal(1), '1.3'],
             [new Decimal(1), 1.50],
+            [new Decimal(1), 10.0],
+            [new Decimal(2), 10.00],
+            [new Decimal(1), 10.50],
+            [new Decimal(2), 10.50],
             [new Decimal(3), '1.000'],
             [new Decimal(3), 123456789.001],
         ];


### PR DESCRIPTION
Today I faced unexpected behavior with the Decimal rule (decimals = 2) on the float value greater than 10. 
I believe the regexp that removes trailing `0` needs to be fixed.