### PR TITLE
Optimize OneOf and NoneOf rules

### DIFF
--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -28,16 +28,16 @@ final class NoneOf extends AbstractComposite
      */
     public function assert($input): void
     {
-        $exceptions = $this->getAllThrownExceptions($input);
-        $numRules = count($this->getRules());
-        $numExceptions = count($exceptions);
-        if ($numRules !== $numExceptions) {
-            /** @var NoneOfException $noneOfException */
-            $noneOfException = $this->reportError($input);
-            $noneOfException->addChildren($exceptions);
-
-            throw $noneOfException;
+        if ($this->validate($input)) {
+            return;
         }
+        $exceptions = $this->getAllThrownExceptions($input);
+
+        /** @var NoneOfException $noneOfException */
+        $noneOfException = $this->reportError($input);
+        $noneOfException->addChildren($exceptions);
+
+        throw $noneOfException;
     }
 
     /**

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -30,17 +30,16 @@ final class OneOf extends AbstractComposite
      */
     public function assert($input): void
     {
-        $validators = $this->getRules();
-        $exceptions = $this->getAllThrownExceptions($input);
-        $numRules = count($validators);
-        $numExceptions = count($exceptions);
-        if ($numExceptions !== $numRules - 1) {
-            /** @var OneOfException $oneOfException */
-            $oneOfException = $this->reportError($input);
-            $oneOfException->addChildren($exceptions);
-
-            throw $oneOfException;
+        if ($this->validate($input)) {
+            return;
         }
+
+        $exceptions = $this->getAllThrownExceptions($input);
+        /** @var OneOfException $oneOfException */
+        $oneOfException = $this->reportError($input);
+        $oneOfException->addChildren($exceptions);
+
+        throw $oneOfException;
     }
 
     /**


### PR DESCRIPTION
Even when OneOf and NoneOf are valid they create exceptions. Exception are very costly in terms of time and memory, they can be 10x slower than plain validation.