### PR TITLE
Use `json_validate` in `Rules\Json` if available

### DIFF
--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -36,6 +36,10 @@ final class Json extends AbstractRule
             return false;
         }
 
+        if (function_exists('json_validate')) {
+            return json_validate($input);
+        }
+
         json_decode($input);
 
         return json_last_error() === JSON_ERROR_NONE;


### PR DESCRIPTION
[`json_validate` function](https://wiki.php.net/rfc/json_validate) [added in PHP 8.3](https://php.watch/versions/8.3/json_validate) validates a given string input to contain valid JSON without decoding it in memory.

This adds a function availability check to `Rules\Json`, and uses the new function instead of decoding the given input, followed by a last-error check.