### PR TITLE
Increase test coverage for some rules

### DIFF
--- a/tests/unit/Rules/CnpjTest.php
+++ b/tests/unit/Rules/CnpjTest.php
@@ -75,6 +75,7 @@ final class CnpjTest extends RuleTestCase
             [$rule, '123'],
             [$rule, '992999999999929384'],
             [$rule, '99-010-0.'],
+            [$rule, null],
         ];
     }
 }

--- a/tests/unit/Rules/SizeTest.php
+++ b/tests/unit/Rules/SizeTest.php
@@ -11,7 +11,9 @@ namespace Respect\Validation\Rules;
 
 use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Test\RuleTestCase;
 use SplFileInfo;
@@ -40,6 +42,14 @@ final class SizeTest extends RuleTestCase
             ->withContent(LargeFileContent::withMegabytes(2))
             ->at($root);
 
+        /** @var MockObject $psr7Stream1Mb */
+        $psr7Stream1Mb = $this->createMock(StreamInterface::class);
+        $psr7Stream1Mb->expects(self::once())->method('getSize')->willReturn(1024);
+
+        /** @var MockObject $psr7UploadedFileMb */
+        $psr7UploadedFileMb = $this->createMock(UploadedFileInterface::class);
+        $psr7UploadedFileMb->expects(self::once())->method('getSize')->willReturn(1024);
+
         return [
             'file with at least 1kb' => [new Size('1kb', null), $file2Kb->url()],
             'file with at least 2k' => [new Size('2kb', null), $file2Kb->url()],
@@ -52,6 +62,8 @@ final class SizeTest extends RuleTestCase
             'file with up to 3mb' => [new Size(null, '3mb'), $file2Mb->url()],
             'file between 1mb and 3mb' => [new Size('1mb', '3mb'), $file2Mb->url()],
             'SplFileInfo instance' => [new Size('1mb', '3mb'), new SplFileInfo($file2Mb->url())],
+            'PSR-7 stream' => [new Size('1kb', '2kb'), $psr7Stream1Mb],
+            'PSR-7 UploadedFile' => [new Size('1kb', '2kb'), $psr7UploadedFileMb],
         ];
     }
 
@@ -68,8 +80,13 @@ final class SizeTest extends RuleTestCase
             ->withContent(LargeFileContent::withMegabytes(2))
             ->at($root);
 
+        /** @var MockObject $psr7Stream1Mb */
         $psr7Stream1Mb = $this->createMock(StreamInterface::class);
         $psr7Stream1Mb->expects(self::once())->method('getSize')->willReturn(1024);
+
+        /** @var MockObject $psr7UploadedFileMb */
+        $psr7UploadedFileMb = $this->createMock(UploadedFileInterface::class);
+        $psr7UploadedFileMb->expects(self::once())->method('getSize')->willReturn(1024);
 
         return [
             'file with at least 3kb' => [new Size('3kb', null), $file2Kb->url()],
@@ -82,6 +99,7 @@ final class SizeTest extends RuleTestCase
             'SplFileInfo instancia' => [new Size('1pb', '3pb'), new SplFileInfo($file2Mb->url())],
             'parameter invalid' => [new Size('1pb', '3pb'), []],
             'PSR-7 stream' => [new Size('1MB', '1.1MB'), $psr7Stream1Mb],
+            'PSR-7 UploadedFile' => [new Size('1MB', '1.1MB'), $psr7UploadedFileMb],
         ];
     }
 

--- a/tests/unit/Rules/SortedTest.php
+++ b/tests/unit/Rules/SortedTest.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Rules;
 
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Test\RuleTestCase;
+use stdClass;
 
 /**
  * @group rules
@@ -55,6 +56,10 @@ final class SortedTest extends RuleTestCase
             'DESC string-sequence with ASC validation' => [new Sorted('ASC'), '321'],
             'ASC array-sequence with DESC validation' => [new Sorted('DESC'), [1, 2, 3]],
             'ASC string-sequence with DESC validation' => [new Sorted('DESC'), 'abc'],
+            'unsupported value (integer)' => [new Sorted('DESC'), 1 ],
+            'unsupported value (float)' => [new Sorted('DESC'), 1.2 ],
+            'unsupported value (bool)' => [new Sorted('DESC'), true ],
+            'unsupported value (object)' => [new Sorted('DESC'), new stdClass() ],
         ];
     }
 


### PR DESCRIPTION
- Add test for null value in the Cnpj rule.
- Add UploadedFileInterface object test for Size rule.
- Add test for invalid values in Sorted rule.