### PR TITLE
Improve readability of integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,10 @@
         "psr-4": {
             "Respect\\Validation\\": "tests/unit/",
             "Respect\\Validation\\Test\\": "tests/library/"
-        }
+        },
+        "files": [
+            "tests/integration/lib/helpers.php"
+        ]
     },
     "scripts": {
         "docheader": "vendor/bin/docheader check library/ tests/",

--- a/tests/integration/assert-with-attributes.phpt
+++ b/tests/integration/assert-with-attributes.phpt
@@ -8,10 +8,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
+exceptionFullMessage(static function () {
     $array = [
         'mysql' => [
             'host' => 42,
@@ -48,9 +47,7 @@ try {
         )
         ->setName('the given data')
         ->assert($object);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 - All of the required rules must pass for the given data

--- a/tests/integration/assert-with-keys.phpt
+++ b/tests/integration/assert-with-keys.phpt
@@ -7,10 +7,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
+exceptionFullMessage(static function () {
     v::create()
         ->key(
             'mysql',
@@ -41,9 +40,7 @@ try {
                 'password' => 42,
             ],
         ]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 - All of the required rules must pass for the given data

--- a/tests/integration/get_full_message_should_include_all_validation_messages_in_a_chain.phpt
+++ b/tests/integration/get_full_message_should_include_all_validation_messages_in_a_chain.phpt
@@ -9,14 +9,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
-try {
-    Validator::stringType()->length(2, 15)->assert(0);
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage();
-}
+exceptionFullMessage(static fn() => Validator::stringType()->length(2, 15)->assert(0));
 ?>
 --EXPECT--
 - All of the required rules must pass for 0

--- a/tests/integration/get_messages.phpt
+++ b/tests/integration/get_messages.phpt
@@ -7,10 +7,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
+exceptionMessages(static function () {
     v::create()
         ->key(
             'mysql',
@@ -40,9 +39,7 @@ try {
                 'password' => 42,
             ],
         ]);
-} catch (NestedValidationException $exception) {
-    print_r($exception->getMessages());
-}
+});
 ?>
 --EXPECT--
 Array

--- a/tests/integration/get_messages_should_include_all_validation_messages_in_a_chain.phpt
+++ b/tests/integration/get_messages_should_include_all_validation_messages_in_a_chain.phpt
@@ -11,10 +11,9 @@ date_default_timezone_set('UTC');
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
-try {
+exceptionMessages(static function () {
     $input = [
         'username' => 'u',
         'birthdate' => 'Not a date',
@@ -27,9 +26,7 @@ try {
         ->key('password', Validator::notEmpty())
         ->key('email', Validator::email())
         ->assert($input);
-} catch (NestedValidationException $e) {
-    print_r($e->getMessages());
-}
+});
 ?>
 --EXPECT--
 Array

--- a/tests/integration/get_messages_with_replacements.phpt
+++ b/tests/integration/get_messages_with_replacements.phpt
@@ -8,41 +8,41 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::create()
-        ->key(
-            'mysql',
-            v::create()
-                ->key('host', v::stringType(), true)
-                ->key('user', v::stringType(), true)
-                ->key('password', v::stringType(), true)
-                ->key('schema', v::stringType(), true),
-            true
-        )
-        ->key(
-            'postgresql',
-            v::create()
-                ->key('host', v::stringType(), true)
-                ->key('user', v::stringType(), true)
-                ->key('password', v::stringType(), true)
-                ->key('schema', v::stringType(), true),
-            true
-        )
-        ->assert([
-            'mysql' => [
-                'host' => 42,
-                'schema' => 42,
-            ],
-            'postgresql' => [
-                'user' => 42,
-                'password' => 42,
-            ],
-        ]);
-} catch (NestedValidationException $exception) {
-    print_r($exception->getMessages([
+exceptionMessages(
+    static function () {
+        v::create()
+            ->key(
+                'mysql',
+                v::create()
+                    ->key('host', v::stringType(), true)
+                    ->key('user', v::stringType(), true)
+                    ->key('password', v::stringType(), true)
+                    ->key('schema', v::stringType(), true),
+                true
+            )
+            ->key(
+                'postgresql',
+                v::create()
+                    ->key('host', v::stringType(), true)
+                    ->key('user', v::stringType(), true)
+                    ->key('password', v::stringType(), true)
+                    ->key('schema', v::stringType(), true),
+                true
+            )
+            ->assert([
+                'mysql' => [
+                    'host' => 42,
+                    'schema' => 42,
+                ],
+                'postgresql' => [
+                    'user' => 42,
+                    'password' => 42,
+                ],
+            ]);
+    },
+    [
         'mysql' => [
             'user' => 'Value should be a MySQL username',
             'host' => '{{input}} should be a MySQL host',
@@ -50,8 +50,8 @@ try {
         'postgresql' => [
             'schema' => 'You must provide a valid PostgreSQL schema',
         ],
-    ]));
-}
+    ]
+);
 ?>
 --EXPECT--
 Array

--- a/tests/integration/issue-1033.phpt
+++ b/tests/integration/issue-1033.phpt
@@ -15,14 +15,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::each(v::equals(1))->assert(['A', 'B', 'B']);
-} catch (AllOfException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionFullMessage(static fn() => v::each(v::equals(1))->assert(['A', 'B', 'B']));
 ?>
 --EXPECT--
 - Each item in `{ "A", "B", "B" }` must be valid

--- a/tests/integration/issue-1244.phpt
+++ b/tests/integration/issue-1244.phpt
@@ -5,15 +5,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::key('firstname', v::notBlank()->setName('First Name'))->assert([]);
-} catch (NestedValidationException $e) {
-    print_r($e->getMessages());
-}
-
+exceptionMessages(static fn () => v::key('firstname', v::notBlank()->setName('First Name'))->assert([]));
 ?>
 --EXPECTF--
 Array

--- a/tests/integration/issue-1289.phpt
+++ b/tests/integration/issue-1289.phpt
@@ -10,8 +10,6 @@ default must be of type string
 
 declare(strict_types=1);
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Rules\ArrayType;
 use Respect\Validation\Rules\BoolType;
 use Respect\Validation\Rules\Each;
@@ -55,17 +53,8 @@ $input = [
         'children' => ['nope'],
     ],
 ];
-try {
-    $validator->check($input);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    $validator->assert($input);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage();
-}
+exceptionMessage(static fn() => $validator->check($input));
+exceptionFullMessage(static fn() => $validator->assert($input));
 ?>
 --EXPECT--
 default must be of type string

--- a/tests/integration/issue-1348.phpt
+++ b/tests/integration/issue-1348.phpt
@@ -7,17 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
 $cars = [
     ['manufacturer' => 'Honda', 'model' => 'Accord'],
     ['manufacturer' => 'Toyota', 'model' => 'Rav4'],
-    ['manufacturer' => 'Ford', 'model' => 'notarealcar'],
+    ['manufacturer' => 'Ford', 'model' => 'not real'],
     ['manufacturer' => 'Honda', 'model' => 'not valid'],
 ];
 
-try {
+exceptionMessages(static function () use ($cars) {
     Validator::arrayType()->each(
         Validator::oneOf(
             Validator::key('manufacturer', Validator::equals('Honda'))
@@ -28,19 +27,15 @@ try {
                 ->key('model', Validator::in(['F150', 'Bronco']))
         )
     )->assert($cars);
-} catch (NestedValidationException $e) {
-    var_dump($e->getMessages());
-}
-
-
+});
 ?>
 --EXPECT--
-array(1) {
-  ["each"]=>
-  array(2) {
-    ["validator.0"]=>
-    string(92) "All of the required rules must pass for `{ "manufacturer": "Ford", "model": "notarealcar" }`"
-    ["validator.1"]=>
-    string(91) "All of the required rules must pass for `{ "manufacturer": "Honda", "model": "not valid" }`"
-  }
-}
+Array
+(
+    [each] => Array
+        (
+            [validator.0] => All of the required rules must pass for `{ "manufacturer": "Ford", "model": "not real" }`
+            [validator.1] => All of the required rules must pass for `{ "manufacturer": "Honda", "model": "not valid" }`
+        )
+
+)

--- a/tests/integration/issue-179.phpt
+++ b/tests/integration/issue-179.phpt
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Validator as v;
 
 $config = [
@@ -23,11 +22,7 @@ $validator->key('user', v::stringType());
 $validator->key('password', v::stringType());
 $validator->key('schema', v::stringType());
 
-try {
-    $validator->assert($config);
-} catch (AllOfException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionFullMessage(static fn() => $validator->assert($config));
 ?>
 --EXPECT--
 - These rules must pass for Settings

--- a/tests/integration/issue-425.phpt
+++ b/tests/integration/issue-425.phpt
@@ -7,26 +7,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Validator as v;
 
 $validator = v::create()
     ->key('age', v::intType()->notEmpty()->noneOf(v::stringType()))
     ->key('reference', v::stringType()->notEmpty()->length(1, 50));
 
-try {
-    $validator->assert(['age' => 1]);
-} catch (AllOfException $e) {
-    echo $e->getFullMessage();
-}
-
-echo PHP_EOL;
-
-try {
-    $validator->assert(['reference' => 'QSF1234']);
-} catch (AllOfException $e) {
-    echo $e->getFullMessage();
-}
+exceptionFullMessage(static fn() => $validator->assert(['age' => 1]));
+exceptionFullMessage(static fn() => $validator->assert(['reference' => 'QSF1234']));
 ?>
 --EXPECT--
 - These rules must pass for `{ "age": 1 }`

--- a/tests/integration/issue-446.phpt
+++ b/tests/integration/issue-446.phpt
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
 $arr = [
@@ -15,14 +14,12 @@ $arr = [
     'email' => 'hello@hello.com',
 ];
 
-try {
+exceptionMessages(static function () use ($arr) {
     v::create()
         ->key('name', v::length(2, 32))
         ->key('email', v::email())
         ->assert($arr);
-} catch (NestedValidationException $e) {
-    print_r($e->getMessages());
-}
+});
 ?>
 --EXPECT--
 Array

--- a/tests/integration/issue-619.phpt
+++ b/tests/integration/issue-619.phpt
@@ -8,14 +8,11 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Rules\Instance;
 
-try {
+exceptionMessage(static function () {
     (new Instance('stdClass'))->setTemplate('invalid object')->assert('test');
-} catch (ValidationException $exception) {
-    print_r($exception->getMessage());
-}
+});
 ?>
 --EXPECT--
 invalid object

--- a/tests/integration/issue-727.phpt
+++ b/tests/integration/issue-727.phpt
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\PhoneException;
 use Respect\Validation\Validator as v;
 
 $work = new stdClass();
@@ -26,7 +25,7 @@ $phoneNumbers->work = $work;
 
 $validateThis = ['phoneNumbers' => $phoneNumbers];
 
-try {
+exceptionMessage(static function () use ($validateThis) {
     v::create()
         ->keyNested('phoneNumbers.personal.country', v::intType(), false)
         ->keyNested('phoneNumbers.personal.number', v::phone(), false)
@@ -35,9 +34,7 @@ try {
         ->keyNested('phoneNumbers.work.number', v::phone(), false)
         ->keyNested('phoneNumbers.work.primary', v::boolType(), false)
         ->check($validateThis);
-} catch (PhoneException $exception) {
-    echo $exception->getMessage();
-}
+});
 ?>
 --EXPECT--
 phoneNumbers.personal.number must be a valid telephone number

--- a/tests/integration/issue-739.phpt
+++ b/tests/integration/issue-739.phpt
@@ -7,14 +7,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::when(v::alwaysInvalid(), v::alwaysValid())->check('foo');
-} catch (ValidationException $exception) {
-    echo $exception->getMessage();
-}
+exceptionMessage(static fn() => v::when(v::alwaysInvalid(), v::alwaysValid())->check('foo'));
 ?>
 --EXPECT--
 "foo" is not valid

--- a/tests/integration/issue-796.phpt
+++ b/tests/integration/issue-796.phpt
@@ -8,10 +8,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
+exceptionFullMessage(static function () {
     v::create()
         ->key(
             'mysql',
@@ -46,9 +45,7 @@ try {
                 'schema' => 'schema',
             ],
         ]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 - All of the required rules must pass for the given data

--- a/tests/integration/issue-799.phpt
+++ b/tests/integration/issue-799.phpt
@@ -7,24 +7,21 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Test\Stubs\CountableStub;
 use Respect\Validation\Validator as v;
 
 $input = 'http://www.google.com/search?q=respect.github.com';
 
-try {
+exceptionMessage(static function () use ($input) {
     v::create()
         ->call(
             [new CountableStub(1), 'count'],
             v::arrayVal()->key('scheme', v::startsWith('https'))
         )
         ->assert($input);
-} catch (AllOfException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
+});
 
-try {
+exceptionMessage(static function () use ($input) {
     v::create()
         ->call(
             static function ($url) {
@@ -33,9 +30,7 @@ try {
             v::arrayVal()->key('scheme', v::startsWith('https'))
         )
         ->assert($input);
-} catch (AllOfException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 All of the required rules must pass for "http://www.google.com/search?q=respect.github.com"

--- a/tests/integration/issue-805.phpt
+++ b/tests/integration/issue-805.phpt
@@ -8,14 +8,11 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
+exceptionMessages(static function () {
     v::key('email', v::email()->setTemplate('WRONG EMAIL!!!!!!'))->assert(['email' => 'qwe']);
-} catch (NestedValidationException $exception) {
-    print_r($exception->getMessages());
-}
+});
 ?>
 --EXPECT--
 Array

--- a/tests/integration/keys_as_validator_names.phpt
+++ b/tests/integration/keys_as_validator_names.phpt
@@ -11,18 +11,15 @@ date_default_timezone_set('UTC');
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
-try {
+exceptionFullMessage(static function () {
     Validator::create()
         ->key('username', Validator::length(2, 32))
         ->key('birthdate', Validator::dateTime())
         ->setName('User Subscription Form')
         ->assert(['username' => '0', 'birthdate' => 'Whatever']);
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage();
-}
+});
 ?>
 --EXPECT--
 - All of the required rules must pass for User Subscription Form

--- a/tests/integration/lib/helpers.php
+++ b/tests/integration/lib/helpers.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+use Respect\Validation\Exceptions\NestedValidationException;
+use Respect\Validation\Exceptions\ValidationException;
+
+function exceptionMessage(callable $callable): void
+{
+    try {
+        $callable();
+    } catch (ValidationException $exception) {
+        echo $exception->getMessage() . PHP_EOL;
+    }
+}
+
+/**
+ * @param array<string, array<string, string>> $templates
+ */
+function exceptionMessages(callable $callable, array $templates = []): void
+{
+    try {
+        $callable();
+    } catch (NestedValidationException $exception) {
+        print_r($exception->getMessages($templates));
+    }
+}
+
+function exceptionFullMessage(callable $callable): void
+{
+    try {
+        $callable();
+    } catch (NestedValidationException $exception) {
+        echo $exception->getFullMessage() . PHP_EOL;
+    }
+}

--- a/tests/integration/not_with_recursion.phpt
+++ b/tests/integration/not_with_recursion.phpt
@@ -7,8 +7,6 @@ Henrique Moody <henriquemoody@gmail.com>
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
 $validator = v::not(
@@ -23,17 +21,8 @@ $validator = v::not(
     )
 );
 
-try {
-    $validator->check(2);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    $validator->assert(2);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => $validator->check(2));
+exceptionFullMessage(static fn() => $validator->assert(2));
 ?>
 --EXPECT--
 2 must not be positive

--- a/tests/integration/not_without_recursion.phpt
+++ b/tests/integration/not_without_recursion.phpt
@@ -9,17 +9,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator;
 
-try {
+exceptionMessage(static function () {
     $validator = Validator::not(
         Validator::intVal()->positive()
     );
     $validator->check(2);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 2 must not be positive

--- a/tests/integration/rules/allOf.phpt
+++ b/tests/integration/rules/allOf.phpt
@@ -8,34 +8,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
-use Respect\Validation\Exceptions\ConsonantException;
-use Respect\Validation\Exceptions\IntTypeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::not(v::allOf(v::intType(), v::positive()))->check(42);
-} catch (IntTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::allOf(v::stringType(), v::consonant())->check('Luke i\'m your father');
-} catch (ConsonantException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::allOf(v::stringType(), v::consonant())->assert(42);
-} catch (AllOfException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
+exceptionMessage(static fn() => v::not(v::allOf(v::intType(), v::positive()))->check(42));
+exceptionMessage(static fn() => v::allOf(v::stringType(), v::consonant())->check('Luke i\'m your father'));
+exceptionFullMessage(static fn() => v::allOf(v::stringType(), v::consonant())->assert(42));
+exceptionFullMessage(static function () {
     v::not(v::allOf(v::stringType(), v::length(10)))->assert('Frank Zappa is fantastic');
-} catch (AllOfException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 42 must not be of type integer

--- a/tests/integration/rules/alnum.phpt
+++ b/tests/integration/rules/alnum.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AlnumException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::alnum()->check('abc%1');
-} catch (AlnumException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::alnum(' ')->check('abc%2');
-} catch (AlnumException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alnum())->check('abcd3');
-} catch (AlnumException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alnum('% '))->check('abc%4');
-} catch (AlnumException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::alnum()->assert('abc^1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alnum())->assert('abcd2');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::alnum('* &%')->assert('abc^3');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alnum('^'))->assert('abc^4');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::alnum()->check('abc%1'));
+exceptionMessage(static fn() => v::alnum(' ')->check('abc%2'));
+exceptionMessage(static fn() => v::not(v::alnum())->check('abcd3'));
+exceptionMessage(static fn() => v::not(v::alnum('% '))->check('abc%4'));
+exceptionFullMessage(static fn() => v::alnum()->assert('abc^1'));
+exceptionFullMessage(static fn() => v::not(v::alnum())->assert('abcd2'));
+exceptionFullMessage(static fn() => v::alnum('* &%')->assert('abc^3'));
+exceptionFullMessage(static fn() => v::not(v::alnum('^'))->assert('abc^4'));
 ?>
 --EXPECT--
 "abc%1" must contain only letters (a-z) and digits (0-9)

--- a/tests/integration/rules/alpha.phpt
+++ b/tests/integration/rules/alpha.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AlphaException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::alpha()->check('aaa%a');
-} catch (AlphaException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::alpha(' ')->check('bbb%b');
-} catch (AlphaException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alpha())->check('ccccc');
-} catch (AlphaException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alpha('% '))->check('ddd%d');
-} catch (AlphaException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::alpha()->assert('eee^e');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alpha())->assert('fffff');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::alpha('* &%')->assert('ggg^g');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alpha('^'))->assert('hhh^h');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::alpha()->check('aaa%a'));
+exceptionMessage(static fn() => v::alpha(' ')->check('bbb%b'));
+exceptionMessage(static fn() => v::not(v::alpha())->check('ccccc'));
+exceptionMessage(static fn() => v::not(v::alpha('% '))->check('ddd%d'));
+exceptionFullMessage(static fn() => v::alpha()->assert('eee^e'));
+exceptionFullMessage(static fn() => v::not(v::alpha())->assert('fffff'));
+exceptionFullMessage(static fn() => v::alpha('* &%')->assert('ggg^g'));
+exceptionFullMessage(static fn() => v::not(v::alpha('^'))->assert('hhh^h'));
 ?>
 --EXPECT--
 "aaa%a" must contain only letters (a-z)

--- a/tests/integration/rules/alwaysInvalid.phpt
+++ b/tests/integration/rules/alwaysInvalid.phpt
@@ -7,21 +7,10 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AlwaysInvalidException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::alwaysInvalid()->check('whatever');
-} catch (AlwaysInvalidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::alwaysInvalid()->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::alwaysInvalid()->check('whatever'));
+exceptionFullMessage(static fn() => v::alwaysInvalid()->assert(''));
 ?>
 --EXPECT--
 "whatever" is always invalid

--- a/tests/integration/rules/alwaysValid.phpt
+++ b/tests/integration/rules/alwaysValid.phpt
@@ -7,22 +7,10 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AlwaysValidException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::not(v::alwaysValid())->check(true);
-} catch (AlwaysValidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::alwaysValid())->assert(true);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::not(v::alwaysValid())->check(true));
+exceptionFullMessage(static fn() => v::not(v::alwaysValid())->assert(true));
 ?>
 --EXPECT--
 `TRUE` is always invalid

--- a/tests/integration/rules/arrayType.phpt
+++ b/tests/integration/rules/arrayType.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ArrayTypeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::arrayType()->check('teste');
-} catch (ArrayTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::arrayType())->check([]);
-} catch (ArrayTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::arrayType()->assert(new ArrayObject());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::arrayType())->assert([1, 2, 3]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::arrayType()->check('teste'));
+exceptionMessage(static fn() => v::not(v::arrayType())->check([]));
+exceptionFullMessage(static fn() => v::arrayType()->assert(new ArrayObject()));
+exceptionFullMessage(static fn() => v::not(v::arrayType())->assert([1, 2, 3]));
 ?>
 --EXPECT--
 "teste" must be of type array

--- a/tests/integration/rules/arrayVal.phpt
+++ b/tests/integration/rules/arrayVal.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ArrayValException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::arrayVal()->check('Bla %123');
-} catch (ArrayValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::arrayVal())->check([42]);
-} catch (ArrayValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::arrayVal()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::arrayVal())->assert(new ArrayObject([2, 3]));
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::arrayVal()->check('Bla %123'));
+exceptionMessage(static fn() => v::not(v::arrayVal())->check([42]));
+exceptionFullMessage(static fn() => v::arrayVal()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::arrayVal())->assert(new ArrayObject([2, 3])));
 ?>
 --EXPECT--
 "Bla %123" must be an array value

--- a/tests/integration/rules/base.phpt
+++ b/tests/integration/rules/base.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\BaseException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::base(61)->check('Z01xSsg5675hic20dj');
-} catch (BaseException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::base(2)->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::base(2))->check('011010001');
-} catch (BaseException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::base(2))->assert('011010001');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::base(61)->check('Z01xSsg5675hic20dj'));
+exceptionFullMessage(static fn() => v::base(2)->assert(''));
+exceptionMessage(static fn() => v::not(v::base(2))->check('011010001'));
+exceptionFullMessage(static fn() => v::not(v::base(2))->assert('011010001'));
 ?>
 --EXPECT--
 "Z01xSsg5675hic20dj" must be a number in the base 61

--- a/tests/integration/rules/base64.phpt
+++ b/tests/integration/rules/base64.phpt
@@ -9,33 +9,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\Base64Exception;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::base64()->check('=c3VyZS4');
-} catch (Base64Exception $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::base64())->check('c3VyZS4=');
-} catch (Base64Exception $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::base64()->assert('=c3VyZS4');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::base64())->assert('c3VyZS4=');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::base64()->check('=c3VyZS4'));
+exceptionMessage(static fn() => v::not(v::base64())->check('c3VyZS4='));
+exceptionFullMessage(static fn() => v::base64()->assert('=c3VyZS4'));
+exceptionFullMessage(static fn() => v::not(v::base64())->assert('c3VyZS4='));
 ?>
 --EXPECT--
 "=c3VyZS4" must be Base64-encoded

--- a/tests/integration/rules/beetwen.phpt
+++ b/tests/integration/rules/beetwen.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\BetweenException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::between(1, 2)->check(0);
-} catch (BetweenException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::between('yesterday', 'tomorrow'))->check('today');
-} catch (BetweenException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::between('a', 'c')->assert('d');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::between(-INF, INF))->assert(0);
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::between(1, 2)->check(0));
+exceptionMessage(static fn() => v::not(v::between('yesterday', 'tomorrow'))->check('today'));
+exceptionFullMessage(static fn() => v::between('a', 'c')->assert('d'));
+exceptionFullMessage(static fn() => v::not(v::between(-INF, INF))->assert(0));
 ?>
 --EXPECT--
 0 must be between 1 and 2

--- a/tests/integration/rules/beetwen_5.phpt
+++ b/tests/integration/rules/beetwen_5.phpt
@@ -8,14 +8,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::not(v::between('a', 'b'))->assert('a');
-} catch (AllOfException $e) {
-    echo $e->getFullMessage();
-}
+exceptionFullMessage(static fn() => v::not(v::between('a', 'b'))->assert('a'));
 ?>
 --EXPECT--
 - "a" must not be between "a" and "b"

--- a/tests/integration/rules/beetwen_6.phpt
+++ b/tests/integration/rules/beetwen_6.phpt
@@ -8,14 +8,9 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\AllOfException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::not(v::intType()->between(1, 42))->assert(41);
-} catch (AllOfException $e) {
-    echo $e->getFullMessage();
-}
+exceptionFullMessage(static fn() => v::not(v::intType()->between(1, 42))->assert(41));
 ?>
 --EXPECT--
 - 41 must not be between 1 and 42

--- a/tests/integration/rules/boolType.phpt
+++ b/tests/integration/rules/boolType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\BoolTypeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::boolType()->check('teste');
-} catch (BoolTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::boolType())->check(true);
-} catch (BoolTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::boolType()->assert([]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::boolType())->assert(false);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::boolType()->check('teste'));
+exceptionMessage(static fn() => v::not(v::boolType())->check(true));
+exceptionFullMessage(static fn() => v::boolType()->assert([]));
+exceptionFullMessage(static fn() => v::not(v::boolType())->assert(false));
 ?>
 --EXPECT--
 "teste" must be of type boolean

--- a/tests/integration/rules/boolVal.phpt
+++ b/tests/integration/rules/boolVal.phpt
@@ -9,33 +9,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\BoolValException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::boolVal()->check('ok');
-} catch (BoolValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::boolVal())->check('yes');
-} catch (BoolValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::boolVal()->assert('yep');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::boolVal())->assert('on');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::boolVal()->check('ok'));
+exceptionMessage(static fn() => v::not(v::boolVal())->check('yes'));
+exceptionFullMessage(static fn() => v::boolVal()->assert('yep'));
+exceptionFullMessage(static fn() => v::not(v::boolVal())->assert('on'));
 ?>
 --EXPECT--
 "ok" must be a boolean value

--- a/tests/integration/rules/bsn.phpt
+++ b/tests/integration/rules/bsn.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\BsnException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::bsn()->check('acb');
-} catch (BsnException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::bsn())->check('612890053');
-} catch (BsnException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::bsn()->assert('abc');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::bsn())->assert('612890053');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::bsn()->check('acb'));
+exceptionMessage(static fn() => v::not(v::bsn())->check('612890053'));
+exceptionFullMessage(static fn() => v::bsn()->assert('abc'));
+exceptionFullMessage(static fn() => v::not(v::bsn())->assert('612890053'));
 ?>
 --EXPECT--
 "acb" must be a BSN

--- a/tests/integration/rules/call.phpt
+++ b/tests/integration/rules/call.phpt
@@ -7,46 +7,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CallException;
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::call('trim', v::noWhitespace())->check(' two words ');
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::call('trim', v::stringType()))->check(' something ');
-} catch (CallException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::call('trim', v::alwaysValid())->check([]);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::call('strval', v::intType())->assert(1234);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::call('is_float', v::boolType()))->assert(1.2);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::call('array_walk', v::alwaysValid())->assert(INF);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::call('trim', v::noWhitespace())->check(' two words '));
+exceptionMessage(static fn() => v::not(v::call('trim', v::stringType()))->check(' something '));
+exceptionMessage(static fn() => v::call('trim', v::alwaysValid())->check([]));
+exceptionFullMessage(static fn() => v::call('strval', v::intType())->assert(1234));
+exceptionFullMessage(static fn() => v::not(v::call('is_float', v::boolType()))->assert(1.2));
+exceptionFullMessage(static fn() => v::call('array_walk', v::alwaysValid())->assert(INF));
 ?>
 --EXPECT--
 "two words" must not contain whitespace

--- a/tests/integration/rules/callableType.phpt
+++ b/tests/integration/rules/callableType.phpt
@@ -7,28 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CallableTypeException;
 use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::callableType()->check([]);
-} catch (CallableTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::callableType())->check('trim');
-} catch (CallableTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::callableType()->assert(true);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::callableType()->check([]));
+exceptionMessage(static fn() => v::not(v::callableType())->check('trim'));
+exceptionFullMessage(static fn() => v::callableType()->assert(true));
 try {
     v::not(v::callableType())->assert(static function (): void {
     });

--- a/tests/integration/rules/callback.phpt
+++ b/tests/integration/rules/callback.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CallbackException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::callback('is_string')->check([]);
-} catch (CallbackException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::callback('is_string'))->check('foo');
-} catch (CallbackException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::callback('is_string')->assert(true);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::callback('is_string'))->assert('foo');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::callback('is_string')->check([]));
+exceptionMessage(static fn() => v::not(v::callback('is_string'))->check('foo'));
+exceptionFullMessage(static fn() => v::callback('is_string')->assert(true));
+exceptionFullMessage(static fn() => v::not(v::callback('is_string'))->assert('foo'));
 ?>
 --EXPECT--
 `{ }` must be valid

--- a/tests/integration/rules/charset.phpt
+++ b/tests/integration/rules/charset.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CharsetException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::charset('ASCII')->check('açaí');
-} catch (CharsetException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::charset('UTF-8'))->check('açaí');
-} catch (CharsetException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::charset('ASCII')->assert('açaí');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::charset('UTF-8'))->assert('açaí');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::charset('ASCII')->check('açaí'));
+exceptionMessage(static fn() => v::not(v::charset('UTF-8'))->check('açaí'));
+exceptionFullMessage(static fn() => v::charset('ASCII')->assert('açaí'));
+exceptionFullMessage(static fn() => v::not(v::charset('UTF-8'))->assert('açaí'));
 ?>
 --EXPECT--
 "açaí" must be in the `{ "ASCII" }` charset

--- a/tests/integration/rules/cnh.phpt
+++ b/tests/integration/rules/cnh.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CnhException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::cnh()->check('batman');
-} catch (CnhException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::cnh())->check('02650306461');
-} catch (CnhException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::cnh()->assert('bruce wayne');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::cnh())->assert('02650306461');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::cnh()->check('batman'));
+exceptionMessage(static fn() => v::not(v::cnh())->check('02650306461'));
+exceptionFullMessage(static fn() => v::cnh()->assert('bruce wayne'));
+exceptionFullMessage(static fn() => v::not(v::cnh())->assert('02650306461'));
 ?>
 --EXPECT--
 "batman" must be a valid CNH number

--- a/tests/integration/rules/cnpj.phpt
+++ b/tests/integration/rules/cnpj.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CnpjException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::cnpj()->check('não cnpj');
-} catch (CnpjException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::cnpj())->check('65.150.175/0001-20');
-} catch (CnpjException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::cnpj()->assert('test');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::cnpj())->assert('65.150.175/0001-20');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::cnpj()->check('não cnpj'));
+exceptionMessage(static fn() => v::not(v::cnpj())->check('65.150.175/0001-20'));
+exceptionFullMessage(static fn() => v::cnpj()->assert('test'));
+exceptionFullMessage(static fn() => v::not(v::cnpj())->assert('65.150.175/0001-20'));
 ?>
 --EXPECT--
 "não cnpj" must be a valid CNPJ number

--- a/tests/integration/rules/cntrl.phpt
+++ b/tests/integration/rules/cntrl.phpt
@@ -7,58 +7,16 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ControlException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::control()->check('16-50');
-} catch (ControlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::control('16')->check('16-50');
-} catch (ControlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::control())->check("\n");
-} catch (ControlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::control('16'))->check("16\n");
-} catch (ControlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::control()->assert('Foo');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::control('Bar')->assert('Foo');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::control())->assert("\n");
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::control('Bar'))->assert("Bar\n");
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::control()->check('16-50'));
+exceptionMessage(static fn() => v::control('16')->check('16-50'));
+exceptionMessage(static fn() => v::not(v::control())->check("\n"));
+exceptionMessage(static fn() => v::not(v::control('16'))->check("16\n"));
+exceptionFullMessage(static fn() => v::control()->assert('Foo'));
+exceptionFullMessage(static fn() => v::control('Bar')->assert('Foo'));
+exceptionFullMessage(static fn() => v::not(v::control())->assert("\n"));
+exceptionFullMessage(static fn() => v::not(v::control('Bar'))->assert("Bar\n"));
 ?>
 --EXPECT--
 "16-50" must contain only control characters

--- a/tests/integration/rules/consonant.phpt
+++ b/tests/integration/rules/consonant.phpt
@@ -9,58 +9,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ConsonantException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::consonant()->check('aeiou');
-} catch (ConsonantException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::consonant('d')->check('daeiou');
-} catch (ConsonantException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::consonant())->check('bcd');
-} catch (ConsonantException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::consonant('a'))->check('abcd');
-} catch (ConsonantException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::consonant()->assert('aeiou');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::consonant('d')->assert('daeiou');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::consonant())->assert('bcd');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::consonant('a'))->assert('abcd');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::consonant()->check('aeiou'));
+exceptionMessage(static fn() => v::consonant('d')->check('daeiou'));
+exceptionMessage(static fn() => v::not(v::consonant())->check('bcd'));
+exceptionMessage(static fn() => v::not(v::consonant('a'))->check('abcd'));
+exceptionFullMessage(static fn() => v::consonant()->assert('aeiou'));
+exceptionFullMessage(static fn() => v::consonant('d')->assert('daeiou'));
+exceptionFullMessage(static fn() => v::not(v::consonant())->assert('bcd'));
+exceptionFullMessage(static fn() => v::not(v::consonant('a'))->assert('abcd'));
 ?>
 --EXPECT--
 "aeiou" must contain only consonants

--- a/tests/integration/rules/contains.phpt
+++ b/tests/integration/rules/contains.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ContainsException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::contains('foo')->check('bar');
-} catch (ContainsException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::contains('foo'))->check('fool');
-} catch (ContainsException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::contains('foo')->assert(['bar']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::contains('foo', true))->assert(['bar', 'foo']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::contains('foo')->check('bar'));
+exceptionMessage(static fn() => v::not(v::contains('foo'))->check('fool'));
+exceptionFullMessage(static fn() => v::contains('foo')->assert(['bar']));
+exceptionFullMessage(static fn() => v::not(v::contains('foo', true))->assert(['bar', 'foo']));
 ?>
 --EXPECT--
 "bar" must contain the value "foo"

--- a/tests/integration/rules/containsAny.phpt
+++ b/tests/integration/rules/containsAny.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ContainsAnyException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::containsAny(['foo', 'bar'])->check('baz');
-} catch (ContainsAnyException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::containsAny(['foo', 'bar']))->check('fool');
-} catch (ContainsAnyException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::containsAny(['foo', 'bar'])->assert(['baz']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::containsAny(['foo', 'bar'], true))->assert(['bar', 'foo']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::containsAny(['foo', 'bar'])->check('baz'));
+exceptionMessage(static fn() => v::not(v::containsAny(['foo', 'bar']))->check('fool'));
+exceptionFullMessage(static fn() => v::containsAny(['foo', 'bar'])->assert(['baz']));
+exceptionFullMessage(static fn() => v::not(v::containsAny(['foo', 'bar'], true))->assert(['bar', 'foo']));
 ?>
 --EXPECT--
 "baz" must contain at least one of the values `{ "foo", "bar" }`

--- a/tests/integration/rules/countable.phpt
+++ b/tests/integration/rules/countable.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CountableException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::countable()->check(1.0);
-} catch (CountableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::countable())->check([]);
-} catch (CountableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::countable()->assert('Not countable!');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::countable())->assert(new ArrayObject());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::countable()->check(1.0));
+exceptionMessage(static fn() => v::not(v::countable())->check([]));
+exceptionFullMessage(static fn() => v::countable()->assert('Not countable!'));
+exceptionFullMessage(static fn() => v::not(v::countable())->assert(new ArrayObject()));
 ?>
 --EXPECT--
 1.0 must be countable

--- a/tests/integration/rules/countryCode.phpt
+++ b/tests/integration/rules/countryCode.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CountryCodeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::countryCode()->check('1');
-} catch (CountryCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::countryCode())->check('BR');
-} catch (CountryCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::countryCode()->assert('1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::countryCode())->assert('BR');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::countryCode()->check('1'));
+exceptionMessage(static fn() => v::not(v::countryCode())->check('BR'));
+exceptionFullMessage(static fn() => v::countryCode()->assert('1'));
+exceptionFullMessage(static fn() => v::not(v::countryCode())->assert('BR'));
 ?>
 --EXPECT--
 "1" must be a valid country

--- a/tests/integration/rules/cpf.phpt
+++ b/tests/integration/rules/cpf.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CpfException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::cpf()->check('this thing');
-} catch (CpfException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::cpf())->check('276.865.775-11');
-} catch (CpfException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::cpf()->assert('your mother');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::cpf())->assert('61836182848');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::cpf()->check('this thing'));
+exceptionMessage(static fn() => v::not(v::cpf())->check('276.865.775-11'));
+exceptionFullMessage(static fn() => v::cpf()->assert('your mother'));
+exceptionFullMessage(static fn() => v::not(v::cpf())->assert('61836182848'));
 ?>
 --EXPECT--
 "this thing" must be a valid CPF number

--- a/tests/integration/rules/creditCard.phpt
+++ b/tests/integration/rules/creditCard.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CreditCardException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::creditCard('Discover')->check(3566002020360505);
-} catch (CreditCardException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::creditCard('Visa'))->check(4024007153361885);
-} catch (CreditCardException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::creditCard('MasterCard')->assert(3566002020360505);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::creditCard())->assert(5555444433331111);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::creditCard('Discover')->check(3566002020360505));
+exceptionMessage(static fn() => v::not(v::creditCard('Visa'))->check(4024007153361885));
+exceptionFullMessage(static fn() => v::creditCard('MasterCard')->assert(3566002020360505));
+exceptionFullMessage(static fn() => v::not(v::creditCard())->assert(5555444433331111));
 ?>
 --EXPECT--
 3566002020360505 must be a valid "Discover" Credit Card number

--- a/tests/integration/rules/currencyCode.phpt
+++ b/tests/integration/rules/currencyCode.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\CurrencyCodeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::currencyCode()->check('batman');
-} catch (CurrencyCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::currencyCode())->check('BRL');
-} catch (CurrencyCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::currencyCode()->assert('ppz');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::currencyCode())->assert('GBP');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::currencyCode()->check('batman'));
+exceptionMessage(static fn() => v::not(v::currencyCode())->check('BRL'));
+exceptionFullMessage(static fn() => v::currencyCode()->assert('ppz'));
+exceptionFullMessage(static fn() => v::not(v::currencyCode())->assert('GBP'));
 ?>
 --EXPECT--
 "batman" must be a valid currency

--- a/tests/integration/rules/date.phpt
+++ b/tests/integration/rules/date.phpt
@@ -7,35 +7,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\DateException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
 date_default_timezone_set('UTC');
 
-try {
-    v::date()->check('2018-01-29T08:32:54+00:00');
-} catch (DateException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::date())->check('2018-01-29');
-} catch (DateException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::date()->assert('2018-01-29T08:32:54+00:00');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::date('d/m/Y'))->assert('29/01/2018');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::date()->check('2018-01-29T08:32:54+00:00'));
+exceptionMessage(static fn() => v::not(v::date())->check('2018-01-29'));
+exceptionFullMessage(static fn() => v::date()->assert('2018-01-29T08:32:54+00:00'));
+exceptionFullMessage(static fn() => v::not(v::date('d/m/Y'))->assert('29/01/2018'));
 ?>
 --EXPECT--
 "2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"

--- a/tests/integration/rules/dateTime.phpt
+++ b/tests/integration/rules/dateTime.phpt
@@ -7,60 +7,18 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\DateTimeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
 date_default_timezone_set('UTC');
 
-try {
-    v::dateTime()->check('FooBarBazz');
-} catch (DateTimeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::dateTime('c')->check('06-12-1995');
-} catch (DateTimeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::dateTime()->assert('QuxQuuxx');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::dateTime('r')->assert(2018013030);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::dateTime())->check('4 days ago');
-} catch (DateTimeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::dateTime('Y-m-d'))->check('1988-09-09');
-} catch (DateTimeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::dateTime())->assert('+3 weeks');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::dateTime('d/m/y'))->assert('23/07/99');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::dateTime()->check('FooBarBazz'));
+exceptionMessage(static fn() => v::dateTime('c')->check('06-12-1995'));
+exceptionFullMessage(static fn() => v::dateTime()->assert('QuxQuuxx'));
+exceptionFullMessage(static fn() => v::dateTime('r')->assert(2018013030));
+exceptionMessage(static fn() => v::not(v::dateTime())->check('4 days ago'));
+exceptionMessage(static fn() => v::not(v::dateTime('Y-m-d'))->check('1988-09-09'));
+exceptionFullMessage(static fn() => v::not(v::dateTime())->assert('+3 weeks'));
+exceptionFullMessage(static fn() => v::not(v::dateTime('d/m/y'))->assert('23/07/99'));
 ?>
 --EXPECT--
 "FooBarBazz" must be a valid date/time

--- a/tests/integration/rules/decimal.phpt
+++ b/tests/integration/rules/decimal.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\DecimalException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::decimal(3)->check(0.1234);
-} catch (DecimalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::decimal(2)->assert(0.123);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::decimal(5))->check(0.12345);
-} catch (DecimalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::decimal(2))->assert(0.34);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::decimal(3)->check(0.1234));
+exceptionFullMessage(static fn() => v::decimal(2)->assert(0.123));
+exceptionMessage(static fn() => v::not(v::decimal(5))->check(0.12345));
+exceptionFullMessage(static fn() => v::not(v::decimal(2))->assert(0.34));
 ?>
 --EXPECT--
 0.1234 must have 3 decimals

--- a/tests/integration/rules/digit.phpt
+++ b/tests/integration/rules/digit.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\DigitException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::digit()->check('abc');
-} catch (DigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::digit('-')->check('a-b');
-} catch (DigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::digit())->check('123');
-} catch (DigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::digit('-'))->check('1-3');
-} catch (DigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::digit()->assert('abc');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::digit('-')->assert('a-b');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::digit())->assert('123');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::digit('-'))->assert('1-3');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::digit()->check('abc'));
+exceptionMessage(static fn() => v::digit('-')->check('a-b'));
+exceptionMessage(static fn() => v::not(v::digit())->check('123'));
+exceptionMessage(static fn() => v::not(v::digit('-'))->check('1-3'));
+exceptionFullMessage(static fn() => v::digit()->assert('abc'));
+exceptionFullMessage(static fn() => v::digit('-')->assert('a-b'));
+exceptionFullMessage(static fn() => v::not(v::digit())->assert('123'));
+exceptionFullMessage(static fn() => v::not(v::digit('-'))->assert('1-3'));
 ?>
 --EXPECT--
 "abc" must contain only digits (0-9)

--- a/tests/integration/rules/directory.phpt
+++ b/tests/integration/rules/directory.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\DirectoryException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::directory()->check('batman');
-} catch (DirectoryException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::directory())->check(dirname('/etc/'));
-} catch (DirectoryException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::directory()->assert('ppz');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::directory())->assert(dirname('/etc/'));
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::directory()->check('batman'));
+exceptionMessage(static fn() => v::not(v::directory())->check(dirname('/etc/')));
+exceptionFullMessage(static fn() => v::directory()->assert('ppz'));
+exceptionFullMessage(static fn() => v::not(v::directory())->assert(dirname('/etc/')));
 ?>
 --EXPECT--
 "batman" must be a directory

--- a/tests/integration/rules/domain.phpt
+++ b/tests/integration/rules/domain.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::domain()->check('batman');
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::domain())->check('r--w.com');
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::domain()->assert('p-éz-.kk');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::domain())->assert('github.com');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::domain()->check('batman'));
+exceptionMessage(static fn() => v::not(v::domain())->check('r--w.com'));
+exceptionFullMessage(static fn() => v::domain()->assert('p-éz-.kk'));
+exceptionFullMessage(static fn() => v::not(v::domain())->assert('github.com'));
 ?>
 --EXPECT--
 "batman" must contain the value "."

--- a/tests/integration/rules/each.phpt
+++ b/tests/integration/rules/each.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\EachException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::each(v::dateTime())->check(null);
-} catch (EachException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::each(v::dateTime()))->check(['2018-10-10']);
-} catch (EachException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::each(v::dateTime())->assert(null);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::each(v::dateTime()))->assert(['2018-10-10']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::each(v::dateTime())->check(null));
+exceptionMessage(static fn() => v::not(v::each(v::dateTime()))->check(['2018-10-10']));
+exceptionFullMessage(static fn() => v::each(v::dateTime())->assert(null));
+exceptionFullMessage(static fn() => v::not(v::each(v::dateTime()))->assert(['2018-10-10']));
 ?>
 --EXPECT--
 Each item in `NULL` must be valid

--- a/tests/integration/rules/email.phpt
+++ b/tests/integration/rules/email.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\EmailException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::email()->check('batman');
-} catch (EmailException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::email())->check('bruce.wayne@gothancity.com');
-} catch (EmailException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::email()->assert('bruce wayne');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::email())->assert('iambatman@gothancity.com');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::email()->check('batman'));
+exceptionMessage(static fn() => v::not(v::email())->check('bruce.wayne@gothancity.com'));
+exceptionFullMessage(static fn() => v::email()->assert('bruce wayne'));
+exceptionFullMessage(static fn() => v::not(v::email())->assert('iambatman@gothancity.com'));
 ?>
 --EXPECT--
 "batman" must be valid email

--- a/tests/integration/rules/endsWith.phpt
+++ b/tests/integration/rules/endsWith.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\EndsWithException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::endsWith('foo')->check('bar');
-} catch (EndsWithException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::endsWith('foo'))->check(['bar', 'foo']);
-} catch (EndsWithException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::endsWith('foo')->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::endsWith('foo'))->assert(['bar', 'foo']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::endsWith('foo')->check('bar'));
+exceptionMessage(static fn() => v::not(v::endsWith('foo'))->check(['bar', 'foo']));
+exceptionFullMessage(static fn() => v::endsWith('foo')->assert(''));
+exceptionFullMessage(static fn() => v::not(v::endsWith('foo'))->assert(['bar', 'foo']));
 ?>
 --EXPECT--
 "bar" must end with "foo"

--- a/tests/integration/rules/equals.phpt
+++ b/tests/integration/rules/equals.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\EqualsException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::equals(123)->check(321);
-} catch (EqualsException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::equals(321))->check(321);
-} catch (EqualsException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::equals(123)->assert(321);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::equals(321))->assert(321);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::equals(123)->check(321));
+exceptionMessage(static fn() => v::not(v::equals(321))->check(321));
+exceptionFullMessage(static fn() => v::equals(123)->assert(321));
+exceptionFullMessage(static fn() => v::not(v::equals(321))->assert(321));
 ?>
 --EXPECT--
 321 must equal 123

--- a/tests/integration/rules/equivalent.phpt
+++ b/tests/integration/rules/equivalent.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\EquivalentException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::equivalent(true)->check(false);
-} catch (EquivalentException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::equivalent('Something'))->check('someThing');
-} catch (EquivalentException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::equivalent(123)->assert('true');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::equivalent(true))->assert(1);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::equivalent(true)->check(false));
+exceptionMessage(static fn() => v::not(v::equivalent('Something'))->check('someThing'));
+exceptionFullMessage(static fn() => v::equivalent(123)->assert('true'));
+exceptionFullMessage(static fn() => v::not(v::equivalent(true))->assert(1));
 ?>
 --EXPECT--
 `FALSE` must be equivalent to `TRUE`

--- a/tests/integration/rules/even.phpt
+++ b/tests/integration/rules/even.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\EvenException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::even()->check(-1);
-} catch (EvenException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::even()->assert(5);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::even())->check(6);
-} catch (EvenException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::even())->assert(8);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::even()->check(-1));
+exceptionFullMessage(static fn() => v::even()->assert(5));
+exceptionMessage(static fn() => v::not(v::even())->check(6));
+exceptionFullMessage(static fn() => v::not(v::even())->assert(8));
 ?>
 --EXPECT--
 -1 must be an even number

--- a/tests/integration/rules/executable.phpt
+++ b/tests/integration/rules/executable.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ExecutableException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::executable()->check('bar');
-} catch (ExecutableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::executable())->check('tests/fixtures/executable');
-} catch (ExecutableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::executable()->assert('bar');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::executable())->assert('tests/fixtures/executable');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::executable()->check('bar'));
+exceptionMessage(static fn() => v::not(v::executable())->check('tests/fixtures/executable'));
+exceptionFullMessage(static fn() => v::executable()->assert('bar'));
+exceptionFullMessage(static fn() => v::not(v::executable())->assert('tests/fixtures/executable'));
 ?>
 --EXPECT--
 "bar" must be an executable file

--- a/tests/integration/rules/exists.phpt
+++ b/tests/integration/rules/exists.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ExistsException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::exists()->check('/path/of/a/non-existent/file');
-} catch (ExistsException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::exists())->check('tests/fixtures/valid-image.gif');
-} catch (ExistsException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::exists()->assert('/path/of/a/non-existent/file');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::exists())->assert('tests/fixtures/valid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::exists()->check('/path/of/a/non-existent/file'));
+exceptionMessage(static fn() => v::not(v::exists())->check('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::exists()->assert('/path/of/a/non-existent/file'));
+exceptionFullMessage(static fn() => v::not(v::exists())->assert('tests/fixtures/valid-image.png'));
 ?>
 --EXPECT--
 "/path/of/a/non-existent/file" must exist

--- a/tests/integration/rules/extension.phpt
+++ b/tests/integration/rules/extension.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ExtensionException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::extension('png')->check('filename.txt');
-} catch (ExtensionException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::extension('gif'))->check('filename.gif');
-} catch (ExtensionException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::extension('mp3')->assert('filename.wav');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::extension('png'))->assert('tests/fixtures/invalid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::extension('png')->check('filename.txt'));
+exceptionMessage(static fn() => v::not(v::extension('gif'))->check('filename.gif'));
+exceptionFullMessage(static fn() => v::extension('mp3')->assert('filename.wav'));
+exceptionFullMessage(static fn() => v::not(v::extension('png'))->assert('tests/fixtures/invalid-image.png'));
 ?>
 --EXPECT--
 "filename.txt" must have "png" extension

--- a/tests/integration/rules/factor.phpt
+++ b/tests/integration/rules/factor.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FactorException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::factor(3)->check(2);
-} catch (FactorException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::factor(0))->check(300);
-} catch (FactorException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::factor(5)->assert(3);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::factor(6))->assert(1);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::factor(3)->check(2));
+exceptionMessage(static fn() => v::not(v::factor(0))->check(300));
+exceptionFullMessage(static fn() => v::factor(5)->assert(3));
+exceptionFullMessage(static fn() => v::not(v::factor(6))->assert(1));
 ?>
 --EXPECT--
 2 must be a factor of 3

--- a/tests/integration/rules/falseVal.phpt
+++ b/tests/integration/rules/falseVal.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FalseValException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::falseVal()->check(true);
-} catch (FalseValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::falseVal())->check('false');
-} catch (FalseValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::falseVal()->assert(1);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::falseVal())->assert(0);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::falseVal()->check(true));
+exceptionMessage(static fn() => v::not(v::falseVal())->check('false'));
+exceptionFullMessage(static fn() => v::falseVal()->assert(1));
+exceptionFullMessage(static fn() => v::not(v::falseVal())->assert(0));
 ?>
 --EXPECT--
 `TRUE` must evaluate to `false`

--- a/tests/integration/rules/fibonacci.phpt
+++ b/tests/integration/rules/fibonacci.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FibonacciException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::fibonacci()->check(4);
-} catch (FibonacciException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::fibonacci())->check(5);
-} catch (FibonacciException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::fibonacci()->assert(16);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::fibonacci())->assert(21);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::fibonacci()->check(4));
+exceptionMessage(static fn() => v::not(v::fibonacci())->check(5));
+exceptionFullMessage(static fn() => v::fibonacci()->assert(16));
+exceptionFullMessage(static fn() => v::not(v::fibonacci())->assert(21));
 ?>
 --EXPECT--
 4 must be a valid Fibonacci number

--- a/tests/integration/rules/file.phpt
+++ b/tests/integration/rules/file.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FileException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::file()->check('tests/fixtures/non-existent.sh');
-} catch (FileException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::file())->check('tests/fixtures/valid-image.png');
-} catch (FileException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::file()->assert('tests/fixtures/non-existent.sh');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::file())->assert('tests/fixtures/valid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::file()->check('tests/fixtures/non-existent.sh'));
+exceptionMessage(static fn() => v::not(v::file())->check('tests/fixtures/valid-image.png'));
+exceptionFullMessage(static fn() => v::file()->assert('tests/fixtures/non-existent.sh'));
+exceptionFullMessage(static fn() => v::not(v::file())->assert('tests/fixtures/valid-image.png'));
 ?>
 --EXPECT--
 "tests/fixtures/non-existent.sh" must be a file

--- a/tests/integration/rules/filterVar.phpt
+++ b/tests/integration/rules/filterVar.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FilterVarException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::filterVar(FILTER_VALIDATE_IP)->check(42);
-} catch (FilterVarException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::filterVar(FILTER_VALIDATE_BOOLEAN))->check('On');
-} catch (FilterVarException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::filterVar(FILTER_VALIDATE_EMAIL)->assert(1.5);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::filterVar(FILTER_VALIDATE_FLOAT))->assert(1.0);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::filterVar(FILTER_VALIDATE_IP)->check(42));
+exceptionMessage(static fn() => v::not(v::filterVar(FILTER_VALIDATE_BOOLEAN))->check('On'));
+exceptionFullMessage(static fn() => v::filterVar(FILTER_VALIDATE_EMAIL)->assert(1.5));
+exceptionFullMessage(static fn() => v::not(v::filterVar(FILTER_VALIDATE_FLOAT))->assert(1.0));
 ?>
 --EXPECT--
 42 must be valid

--- a/tests/integration/rules/finite.phpt
+++ b/tests/integration/rules/finite.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FiniteException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::finite()->check('');
-} catch (FiniteException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::finite())->check(10);
-} catch (FiniteException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::finite()->assert([12]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::finite())->assert('123456');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::finite()->check(''));
+exceptionMessage(static fn() => v::not(v::finite())->check(10));
+exceptionFullMessage(static fn() => v::finite()->assert([12]));
+exceptionFullMessage(static fn() => v::not(v::finite())->assert('123456'));
 ?>
 --EXPECT--
 "" must be a finite number

--- a/tests/integration/rules/floatType.phpt
+++ b/tests/integration/rules/floatType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FloatTypeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::floatType()->check('42.33');
-} catch (FloatTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::floatType())->check(INF);
-} catch (FloatTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::floatType()->assert(true);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::floatType())->assert(2.0);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::floatType()->check('42.33'));
+exceptionMessage(static fn() => v::not(v::floatType())->check(INF));
+exceptionFullMessage(static fn() => v::floatType()->assert(true));
+exceptionFullMessage(static fn() => v::not(v::floatType())->assert(2.0));
 ?>
 --EXPECT--
 "42.33" must be of type float

--- a/tests/integration/rules/floatval.phpt
+++ b/tests/integration/rules/floatval.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\FloatValException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::floatVal()->check('a');
-} catch (FloatValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::floatVal())->check(165.0);
-} catch (FloatValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::floatVal()->assert('a');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::floatVal())->assert('165.7');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::floatVal()->check('a'));
+exceptionMessage(static fn() => v::not(v::floatVal())->check(165.0));
+exceptionFullMessage(static fn() => v::floatVal()->assert('a'));
+exceptionFullMessage(static fn() => v::not(v::floatVal())->assert('165.7'));
 ?>
 --EXPECT--
 "a" must be a float number

--- a/tests/integration/rules/graph.phpt
+++ b/tests/integration/rules/graph.phpt
@@ -7,58 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\GraphException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::graph()->check("foo\nbar");
-} catch (GraphException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::graph('foo')->check("foo\nbar");
-} catch (GraphException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::graph())->check('foobar');
-} catch (GraphException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::graph("\n"))->check("foo\nbar");
-} catch (GraphException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::graph()->assert("foo\nbar");
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::graph('foo')->assert("foo\nbar");
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::graph())->assert('foobar');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::graph("\n"))->assert("foo\nbar");
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::graph()->check("foo\nbar"));
+exceptionMessage(static fn() => v::graph('foo')->check("foo\nbar"));
+exceptionMessage(static fn() => v::not(v::graph())->check('foobar'));
+exceptionMessage(static fn() => v::not(v::graph("\n"))->check("foo\nbar"));
+exceptionFullMessage(static fn() => v::graph()->assert("foo\nbar"));
+exceptionFullMessage(static fn() => v::graph('foo')->assert("foo\nbar"));
+exceptionFullMessage(static fn() => v::not(v::graph())->assert('foobar'));
+exceptionFullMessage(static fn() => v::not(v::graph("\n"))->assert("foo\nbar"));
 ?>
 --EXPECT--
 "foo\nbar" must contain only graphical characters

--- a/tests/integration/rules/greaterThan.phpt
+++ b/tests/integration/rules/greaterThan.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\GreaterThanException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::greaterThan(21)->check(12);
-} catch (GreaterThanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::greaterThan('yesterday'))->check('today');
-} catch (GreaterThanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::greaterThan('2018-09-09')->assert('1988-09-09');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::greaterThan('a'))->assert('ba');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::greaterThan(21)->check(12));
+exceptionMessage(static fn() => v::not(v::greaterThan('yesterday'))->check('today'));
+exceptionFullMessage(static fn() => v::greaterThan('2018-09-09')->assert('1988-09-09'));
+exceptionFullMessage(static fn() => v::not(v::greaterThan('a'))->assert('ba'));
 ?>
 --EXPECT--
 12 must be greater than 21

--- a/tests/integration/rules/hexRgbColor.phpt
+++ b/tests/integration/rules/hexRgbColor.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\HexRgbColorException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::hexRgbColor()->check('invalid');
-} catch (HexRgbColorException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::hexRgbColor())->check('#808080');
-} catch (HexRgbColorException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::hexRgbColor()->assert('invalid');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::hexRgbColor())->assert('#808080');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::hexRgbColor()->check('invalid'));
+exceptionMessage(static fn() => v::not(v::hexRgbColor())->check('#808080'));
+exceptionFullMessage(static fn() => v::hexRgbColor()->assert('invalid'));
+exceptionFullMessage(static fn() => v::not(v::hexRgbColor())->assert('#808080'));
 ?>
 --EXPECT--
 "invalid" must be a hex RGB color

--- a/tests/integration/rules/iban.phpt
+++ b/tests/integration/rules/iban.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IbanException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::iban()->check('SE35 5000 5880 7742');
-} catch (IbanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::iban())->check('GB82 WEST 1234 5698 7654 32');
-} catch (IbanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::iban()->assert('NOT AN IBAN');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::iban())->assert('HU93 1160 0006 0000 0000 1234 5676');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-?>
+exceptionMessage(static fn() => v::iban()->check('SE35 5000 5880 7742'));
+exceptionMessage(static fn() => v::not(v::iban())->check('GB82 WEST 1234 5698 7654 32'));
+exceptionFullMessage(static fn() => v::iban()->assert('NOT AN IBAN'));
+exceptionFullMessage(static fn() => v::not(v::iban())->assert('HU93 1160 0006 0000 0000 1234 5676'));?>
 --SKIPIF--
 <?php
 if (!extension_loaded('bcmath')) {

--- a/tests/integration/rules/identical.phpt
+++ b/tests/integration/rules/identical.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IdenticalException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::identical(123)->check(321);
-} catch (IdenticalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::identical(321))->check(321);
-} catch (IdenticalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::identical(123)->assert(321);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::identical(321))->assert(321);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::identical(123)->check(321));
+exceptionMessage(static fn() => v::not(v::identical(321))->check(321));
+exceptionFullMessage(static fn() => v::identical(123)->assert(321));
+exceptionFullMessage(static fn() => v::not(v::identical(321))->assert(321));
 ?>
 --EXPECT--
 321 must be identical as 123

--- a/tests/integration/rules/image.phpt
+++ b/tests/integration/rules/image.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ImageException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::image()->check('tests/fixtures/invalid-image.png');
-} catch (ImageException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::image())->check('tests/fixtures/valid-image.png');
-} catch (ImageException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::image()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::image())->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::image()->check('tests/fixtures/invalid-image.png'));
+exceptionMessage(static fn() => v::not(v::image())->check('tests/fixtures/valid-image.png'));
+exceptionFullMessage(static fn() => v::image()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::image())->assert('tests/fixtures/valid-image.gif'));
 ?>
 --EXPECT--
 "tests/fixtures/invalid-image.png" must be a valid image

--- a/tests/integration/rules/imei.phpt
+++ b/tests/integration/rules/imei.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ImeiException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::imei()->check('490154203237512');
-} catch (ImeiException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::imei())->check('350077523237513');
-} catch (ImeiException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::imei()->assert(null);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::imei())->assert('356938035643809');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::imei()->check('490154203237512'));
+exceptionMessage(static fn() => v::not(v::imei())->check('350077523237513'));
+exceptionFullMessage(static fn() => v::imei()->assert(null));
+exceptionFullMessage(static fn() => v::not(v::imei())->assert('356938035643809'));
 ?>
 --EXPECT--
 "490154203237512" must be a valid IMEI

--- a/tests/integration/rules/in.phpt
+++ b/tests/integration/rules/in.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\InException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::in([3, 2])->check(1);
-} catch (InException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::in('foobar'))->check('foo');
-} catch (InException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::in([2, '1', 3], true)->assert('2');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::in([2, '1', 3], true))->assert('1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::in([3, 2])->check(1));
+exceptionMessage(static fn() => v::not(v::in('foobar'))->check('foo'));
+exceptionFullMessage(static fn() => v::in([2, '1', 3], true)->assert('2'));
+exceptionFullMessage(static fn() => v::not(v::in([2, '1', 3], true))->assert('1'));
 ?>
 --EXPECT--
 1 must be in `{ 3, 2 }`

--- a/tests/integration/rules/infinite.phpt
+++ b/tests/integration/rules/infinite.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\InfiniteException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::infinite()->check(-9);
-} catch (InfiniteException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::infinite())->check(INF);
-} catch (InfiniteException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::infinite()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::infinite())->assert(INF * -1);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::infinite()->check(-9));
+exceptionMessage(static fn() => v::not(v::infinite())->check(INF));
+exceptionFullMessage(static fn() => v::infinite()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::infinite())->assert(INF * -1));
 ?>
 --EXPECT--
 -9 must be an infinite number

--- a/tests/integration/rules/instance.phpt
+++ b/tests/integration/rules/instance.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\InstanceException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::instance(DateTime::class)->check('');
-} catch (InstanceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::instance(Traversable::class))->check(new ArrayObject());
-} catch (InstanceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::instance(ArrayIterator::class)->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::instance(stdClass::class))->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::instance(DateTime::class)->check(''));
+exceptionMessage(static fn() => v::not(v::instance(Traversable::class))->check(new ArrayObject()));
+exceptionFullMessage(static fn() => v::instance(ArrayIterator::class)->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::instance(stdClass::class))->assert(new stdClass()));
 ?>
 --EXPECT--
 "" must be an instance of "DateTime"

--- a/tests/integration/rules/intType.phpt
+++ b/tests/integration/rules/intType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IntTypeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::intType()->check(new stdClass());
-} catch (IntTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::intType())->check(42);
-} catch (IntTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::intType()->assert(INF);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::intType())->assert(1234567890);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::intType()->check(new stdClass()));
+exceptionMessage(static fn() => v::not(v::intType())->check(42));
+exceptionFullMessage(static fn() => v::intType()->assert(INF));
+exceptionFullMessage(static fn() => v::not(v::intType())->assert(1234567890));
 ?>
 --EXPECT--
 `[object] (stdClass: { })` must be of type integer

--- a/tests/integration/rules/intVal.phpt
+++ b/tests/integration/rules/intVal.phpt
@@ -8,45 +8,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IntValException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::intVal()->check('42.33');
-} catch (IntValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::intVal())->check(2);
-} catch (IntValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::intVal()->assert('Foo');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::intVal())->assert(3);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::intVal())->assert(-42);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::intVal())->assert('-42');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::intVal()->check('42.33'));
+exceptionMessage(static fn() => v::not(v::intVal())->check(2));
+exceptionFullMessage(static fn() => v::intVal()->assert('Foo'));
+exceptionFullMessage(static fn() => v::not(v::intVal())->assert(3));
+exceptionFullMessage(static fn() => v::not(v::intVal())->assert(-42));
+exceptionFullMessage(static fn() => v::not(v::intVal())->assert('-42'));
 ?>
 --EXPECT--
 "42.33" must be an integer number

--- a/tests/integration/rules/ip.phpt
+++ b/tests/integration/rules/ip.phpt
@@ -8,58 +8,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IpException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::ip()->check('257.0.0.1');
-} catch (IpException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::ip())->check('127.0.0.1');
-} catch (IpException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::ip('127.0.1.*')->check('127.0.0.1');
-} catch (IpException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::ip('127.0.1.*'))->check('127.0.1.1');
-} catch (IpException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::ip()->assert('257.0.0.1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::ip())->assert('127.0.0.1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::ip('127.0.1.*')->assert('127.0.0.1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::ip('127.0.1.*'))->assert('127.0.1.1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-?>
+exceptionMessage(static fn() => v::ip()->check('257.0.0.1'));
+exceptionMessage(static fn() => v::not(v::ip())->check('127.0.0.1'));
+exceptionMessage(static fn() => v::ip('127.0.1.*')->check('127.0.0.1'));
+exceptionMessage(static fn() => v::not(v::ip('127.0.1.*'))->check('127.0.1.1'));
+exceptionFullMessage(static fn() => v::ip()->assert('257.0.0.1'));
+exceptionFullMessage(static fn() => v::not(v::ip())->assert('127.0.0.1'));
+exceptionFullMessage(static fn() => v::ip('127.0.1.*')->assert('127.0.0.1'));
+exceptionFullMessage(static fn() => v::not(v::ip('127.0.1.*'))->assert('127.0.1.1'));?>
 --SKIPIF--
 <?php
 if (!extension_loaded('bcmath')) {

--- a/tests/integration/rules/isbn.phpt
+++ b/tests/integration/rules/isbn.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IsbnException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::isbn()->check('ISBN-12: 978-0-596-52068-7');
-} catch (IsbnException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::isbn())->check('ISBN-13: 978-0-596-52068-7');
-} catch (IsbnException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::isbn()->assert('978 10 596 52068 7');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::isbn())->assert('978 0 596 52068 7');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::isbn()->check('ISBN-12: 978-0-596-52068-7'));
+exceptionMessage(static fn() => v::not(v::isbn())->check('ISBN-13: 978-0-596-52068-7'));
+exceptionFullMessage(static fn() => v::isbn()->assert('978 10 596 52068 7'));
+exceptionFullMessage(static fn() => v::not(v::isbn())->assert('978 0 596 52068 7'));
 ?>
 --EXPECT--
 "ISBN-12: 978-0-596-52068-7" must be a ISBN

--- a/tests/integration/rules/iterableType.phpt
+++ b/tests/integration/rules/iterableType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IterableTypeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::iterableType()->check(3);
-} catch (IterableTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::iterableType())->check([2, 3]);
-} catch (IterableTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::iterableType()->assert('String');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::iterableType())->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::iterableType()->check(3));
+exceptionMessage(static fn() => v::not(v::iterableType())->check([2, 3]));
+exceptionFullMessage(static fn() => v::iterableType()->assert('String'));
+exceptionFullMessage(static fn() => v::not(v::iterableType())->assert(new stdClass()));
 ?>
 --EXPECT--
 3 must be iterable

--- a/tests/integration/rules/json.phpt
+++ b/tests/integration/rules/json.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\JsonException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::json()->check(false);
-} catch (JsonException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::json())->check('{"foo": "bar", "number":1}');
-} catch (JsonException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::json()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::json())->assert('{}');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::json()->check(false));
+exceptionMessage(static fn() => v::not(v::json())->check('{"foo": "bar", "number":1}'));
+exceptionFullMessage(static fn() => v::json()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::json())->assert('{}'));
 ?>
 --EXPECT--
 `FALSE` must be a valid JSON string

--- a/tests/integration/rules/keyValue.phpt
+++ b/tests/integration/rules/keyValue.phpt
@@ -10,69 +10,18 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::keyValue('foo', 'equals', 'bar')->check(['bar' => 42]);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'equals', 'bar')->check(['foo' => 42]);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'json', 'bar')->check(['foo' => 42, 'bar' => 43]);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'equals', 'bar')->check(['foo' => 1, 'bar' => 2]);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::keyValue('foo', 'equals', 'bar'))->check(['foo' => 1, 'bar' => 1]);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'equals', 'bar')->assert(['bar' => 42]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 42]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'json', 'bar')->assert(['foo' => 42, 'bar' => 43]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 1, 'bar' => 2]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::keyValue('foo', 'equals', 'bar'))->assert(['foo' => 1, 'bar' => 1]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::keyValue('foo', 'equals', 'bar')->check(['bar' => 42]));
+exceptionMessage(static fn() => v::keyValue('foo', 'equals', 'bar')->check(['foo' => 42]));
+exceptionMessage(static fn() => v::keyValue('foo', 'json', 'bar')->check(['foo' => 42, 'bar' => 43]));
+exceptionMessage(static fn() => v::keyValue('foo', 'equals', 'bar')->check(['foo' => 1, 'bar' => 2]));
+exceptionMessage(static fn() => v::not(v::keyValue('foo', 'equals', 'bar'))->check(['foo' => 1, 'bar' => 1]));
+exceptionFullMessage(static fn() => v::keyValue('foo', 'equals', 'bar')->assert(['bar' => 42]));
+exceptionFullMessage(static fn() => v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 42]));
+exceptionFullMessage(static fn() => v::keyValue('foo', 'json', 'bar')->assert(['foo' => 42, 'bar' => 43]));
+exceptionFullMessage(static fn() => v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 1, 'bar' => 2]));
+exceptionFullMessage(static fn() => v::not(v::keyValue('foo', 'equals', 'bar'))->assert(['foo' => 1, 'bar' => 1]));
 ?>
 --EXPECT--
 Key "foo" must be present

--- a/tests/integration/rules/languageCode.phpt
+++ b/tests/integration/rules/languageCode.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LanguageCodeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::languageCode()->check(null);
-} catch (LanguageCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::languageCode())->check('pt');
-} catch (LanguageCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::languageCode()->assert('por');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::languageCode())->assert('en');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::languageCode()->check(null));
+exceptionMessage(static fn() => v::not(v::languageCode())->check('pt'));
+exceptionFullMessage(static fn() => v::languageCode()->assert('por'));
+exceptionFullMessage(static fn() => v::not(v::languageCode())->assert('en'));
 ?>
 --EXPECT--
 `NULL` must be a valid ISO 639 "alpha-2" language code

--- a/tests/integration/rules/leapDate.phpt
+++ b/tests/integration/rules/leapDate.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LeapDateException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::leapDate('Y-m-d')->check('1989-02-29');
-} catch (LeapDateException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::leapDate('Y-m-d'))->check('1988-02-29');
-} catch (LeapDateException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::leapDate('Y-m-d')->assert('1990-02-29');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::leapDate('Y-m-d'))->assert('1992-02-29');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::leapDate('Y-m-d')->check('1989-02-29'));
+exceptionMessage(static fn() => v::not(v::leapDate('Y-m-d'))->check('1988-02-29'));
+exceptionFullMessage(static fn() => v::leapDate('Y-m-d')->assert('1990-02-29'));
+exceptionFullMessage(static fn() => v::not(v::leapDate('Y-m-d'))->assert('1992-02-29'));
 ?>
 --EXPECT--
 "1989-02-29" must be leap date

--- a/tests/integration/rules/leapYear.phpt
+++ b/tests/integration/rules/leapYear.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LeapYearException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::leapYear()->check('2009');
-} catch (LeapYearException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::leapYear())->check('2008');
-} catch (LeapYearException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::leapYear()->assert('2009-02-29');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::leapYear())->assert('2008');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::leapYear()->check('2009'));
+exceptionMessage(static fn() => v::not(v::leapYear())->check('2008'));
+exceptionFullMessage(static fn() => v::leapYear()->assert('2009-02-29'));
+exceptionFullMessage(static fn() => v::not(v::leapYear())->assert('2008'));
 ?>
 --EXPECT--
 "2009" must be a leap year

--- a/tests/integration/rules/length.phpt
+++ b/tests/integration/rules/length.phpt
@@ -8,129 +8,28 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LengthException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::length(0, 5, false)->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::length(0, 10)->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::length(15, null, false)->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::length(20)->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::length(5, 10)->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(0, 15))->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(0, 20, false))->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(10, null))->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(5, null, false))->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(5, 20))->check('phpsp.org.br');
-} catch (LengthException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::length(0, 5, false)->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::length(0, 10)->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::length(15, null, false)->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::length(20)->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::length(5, 10)->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(0, 15))->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(0, 20, false))->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(10, null))->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(5, null, false))->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::length(5, 20))->assert('phpsp.org.br');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::length(0, 5, false)->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::length(0, 10)->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::length(15, null, false)->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::length(20)->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::length(5, 10)->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::not(v::length(0, 15))->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::not(v::length(0, 20, false))->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::not(v::length(10, null))->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::not(v::length(5, null, false))->check('phpsp.org.br'));
+exceptionMessage(static fn() => v::not(v::length(5, 20))->check('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::length(0, 5, false)->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::length(0, 10)->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::length(15, null, false)->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::length(20)->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::length(5, 10)->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::not(v::length(0, 15))->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::not(v::length(0, 20, false))->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::not(v::length(10, null))->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::not(v::length(5, null, false))->assert('phpsp.org.br'));
+exceptionFullMessage(static fn() => v::not(v::length(5, 20))->assert('phpsp.org.br'));
 ?>
 --EXPECT--
 "phpsp.org.br" must have a length lower than 5

--- a/tests/integration/rules/lessThan.phpt
+++ b/tests/integration/rules/lessThan.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LessThanException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::lessThan(12)->check(21);
-} catch (LessThanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::lessThan('today'))->check('yesterday');
-} catch (LessThanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::lessThan('1988-09-09')->assert('2018-09-09');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::lessThan('b'))->assert('a');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::lessThan(12)->check(21));
+exceptionMessage(static fn() => v::not(v::lessThan('today'))->check('yesterday'));
+exceptionFullMessage(static fn() => v::lessThan('1988-09-09')->assert('2018-09-09'));
+exceptionFullMessage(static fn() => v::not(v::lessThan('b'))->assert('a'));
 ?>
 --EXPECT--
 21 must be less than 12

--- a/tests/integration/rules/lowercase.phpt
+++ b/tests/integration/rules/lowercase.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LowercaseException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::lowercase()->check('UPPERCASE');
-} catch (LowercaseException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::lowercase())->check('lowercase');
-} catch (LowercaseException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::lowercase()->assert('UPPERCASE');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::lowercase())->assert('lowercase');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::lowercase()->check('UPPERCASE'));
+exceptionMessage(static fn() => v::not(v::lowercase())->check('lowercase'));
+exceptionFullMessage(static fn() => v::lowercase()->assert('UPPERCASE'));
+exceptionFullMessage(static fn() => v::not(v::lowercase())->assert('lowercase'));
 ?>
 --EXPECT--
 "UPPERCASE" must be lowercase

--- a/tests/integration/rules/luhn.phpt
+++ b/tests/integration/rules/luhn.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\LuhnException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::luhn()->check('2222400041240021');
-} catch (LuhnException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::luhn())->check('2223000048400011');
-} catch (LuhnException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::luhn()->assert('340316193809334');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::luhn())->assert('6011000990139424');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::luhn()->check('2222400041240021'));
+exceptionMessage(static fn() => v::not(v::luhn())->check('2223000048400011'));
+exceptionFullMessage(static fn() => v::luhn()->assert('340316193809334'));
+exceptionFullMessage(static fn() => v::not(v::luhn())->assert('6011000990139424'));
 ?>
 --EXPECT--
 "2222400041240021" must be a valid Luhn number

--- a/tests/integration/rules/macAddress.phpt
+++ b/tests/integration/rules/macAddress.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\MacAddressException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::macAddress()->check('00-11222:33:44:55');
-} catch (MacAddressException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::macAddress())->check('00:11:22:33:44:55');
-} catch (MacAddressException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::macAddress()->assert('90-bc-nk:1a-dd-cc');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::macAddress())->assert('AF:0F:bd:12:44:ba');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::macAddress()->check('00-11222:33:44:55'));
+exceptionMessage(static fn() => v::not(v::macAddress())->check('00:11:22:33:44:55'));
+exceptionFullMessage(static fn() => v::macAddress()->assert('90-bc-nk:1a-dd-cc'));
+exceptionFullMessage(static fn() => v::not(v::macAddress())->assert('AF:0F:bd:12:44:ba'));
 ?>
 --EXPECT--
 "00-11222:33:44:55" must be a valid MAC address

--- a/tests/integration/rules/max.phpt
+++ b/tests/integration/rules/max.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\MaxException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::max(10)->check(11);
-} catch (MaxException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::max(10))->check(5);
-} catch (MaxException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::max('today')->assert('tomorrow');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::max('b'))->assert('a');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::max(10)->check(11));
+exceptionMessage(static fn() => v::not(v::max(10))->check(5));
+exceptionFullMessage(static fn() => v::max('today')->assert('tomorrow'));
+exceptionFullMessage(static fn() => v::not(v::max('b'))->assert('a'));
 ?>
 --EXPECT--
 11 must be less than or equal to 10

--- a/tests/integration/rules/maxAge.phpt
+++ b/tests/integration/rules/maxAge.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\MaxAgeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::maxAge(12)->check('50 years ago');
-} catch (MaxAgeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::maxAge(12))->check('11 years ago');
-} catch (MaxAgeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::maxAge(12, 'Y-m-d')->assert('1988-09-09');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::maxAge(12, 'Y-m-d'))->assert('2018-01-01');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::maxAge(12)->check('50 years ago'));
+exceptionMessage(static fn() => v::not(v::maxAge(12))->check('11 years ago'));
+exceptionFullMessage(static fn() => v::maxAge(12, 'Y-m-d')->assert('1988-09-09'));
+exceptionFullMessage(static fn() => v::not(v::maxAge(12, 'Y-m-d'))->assert('2018-01-01'));
 ?>
 --EXPECT--
 "50 years ago" must be 12 years or less

--- a/tests/integration/rules/mimetype.phpt
+++ b/tests/integration/rules/mimetype.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\MimetypeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::mimetype('image/png')->check('image.png');
-} catch (MimetypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::mimetype('image/png'))->check('tests/fixtures/valid-image.png');
-} catch (MimetypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::mimetype('image/png')->assert('tests/fixtures/invalid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::mimetype('image/png'))->assert('tests/fixtures/valid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::mimetype('image/png')->check('image.png'));
+exceptionMessage(static fn() => v::not(v::mimetype('image/png'))->check('tests/fixtures/valid-image.png'));
+exceptionFullMessage(static fn() => v::mimetype('image/png')->assert('tests/fixtures/invalid-image.png'));
+exceptionFullMessage(static fn() => v::not(v::mimetype('image/png'))->assert('tests/fixtures/valid-image.png'));
 ?>
 --EXPECT--
 "image.png" must have "image/png" MIME type

--- a/tests/integration/rules/min.phpt
+++ b/tests/integration/rules/min.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\MinException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::min(INF)->check(10);
-} catch (MinException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::min(5))->check(INF);
-} catch (MinException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::min('today')->assert('yesterday');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::min('a'))->assert('z');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::min(INF)->check(10));
+exceptionMessage(static fn() => v::not(v::min(5))->check(INF));
+exceptionFullMessage(static fn() => v::min('today')->assert('yesterday'));
+exceptionFullMessage(static fn() => v::not(v::min('a'))->assert('z'));
 ?>
 --EXPECT--
 10 must be greater than or equal to `INF`

--- a/tests/integration/rules/minAge.phpt
+++ b/tests/integration/rules/minAge.phpt
@@ -10,33 +10,12 @@ require 'vendor/autoload.php';
 
 date_default_timezone_set('UTC');
 
-use Respect\Validation\Exceptions\MinAgeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::minAge(18)->check('17 years ago');
-} catch (MinAgeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::minAge(18))->check('-30 years');
-} catch (MinAgeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::minAge(18)->assert('yesterday');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::minAge(18, 'd/m/Y')->assert('12/10/2010');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::minAge(18)->check('17 years ago'));
+exceptionMessage(static fn() => v::not(v::minAge(18))->check('-30 years'));
+exceptionFullMessage(static fn() => v::minAge(18)->assert('yesterday'));
+exceptionFullMessage(static fn() => v::minAge(18, 'd/m/Y')->assert('12/10/2010'));
 ?>
 --EXPECT--
 "17 years ago" must be 18 years or more

--- a/tests/integration/rules/multiple.phpt
+++ b/tests/integration/rules/multiple.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\MultipleException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::multiple(3)->check(22);
-} catch (MultipleException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::multiple(3))->check(9);
-} catch (MultipleException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::multiple(2)->assert(5);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::multiple(5))->assert(25);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::multiple(3)->check(22));
+exceptionMessage(static fn() => v::not(v::multiple(3))->check(9));
+exceptionFullMessage(static fn() => v::multiple(2)->assert(5));
+exceptionFullMessage(static fn() => v::not(v::multiple(5))->assert(25));
 ?>
 --EXPECT--
 22 must be multiple of 3

--- a/tests/integration/rules/negative.phpt
+++ b/tests/integration/rules/negative.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NegativeException;
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::negative()->check(16);
-} catch (NegativeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::negative())->check(-10);
-} catch (NegativeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::negative()->assert('a');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::negative())->assert('-144');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::negative()->check(16));
+exceptionMessage(static fn() => v::not(v::negative())->check(-10));
+exceptionFullMessage(static fn() => v::negative()->assert('a'));
+exceptionFullMessage(static fn() => v::not(v::negative())->assert('-144'));
 ?>
 --EXPECT--
 16 must be negative

--- a/tests/integration/rules/nfeAccessKey.phpt
+++ b/tests/integration/rules/nfeAccessKey.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NfeAccessKeyException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::nfeAccessKey()->check('31841136830118868211870485416765268625116906');
-} catch (NfeAccessKeyException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nfeAccessKey())->check('52060433009911002506550120000007800267301615');
-} catch (NfeAccessKeyException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nfeAccessKey())->assert('52060433009911002506550120000007800267301615');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::nfeAccessKey()->check('31841136830118868211870485416765268625116906'));
+exceptionMessage(static fn() => v::not(v::nfeAccessKey())->check('52060433009911002506550120000007800267301615'));
+exceptionFullMessage(static fn() => v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906'));
+exceptionFullMessage(static fn() => v::not(v::nfeAccessKey())->assert('52060433009911002506550120000007800267301615'));
 ?>
 --EXPECT--
 "31841136830118868211870485416765268625116906" must be a valid NFe access key

--- a/tests/integration/rules/nif.phpt
+++ b/tests/integration/rules/nif.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NifException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::nif()->check('06357771Q');
-} catch (NifException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nif())->check('71110316C');
-} catch (NifException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::nif()->assert('06357771Q');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nif())->assert('R1332622H');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::nif()->check('06357771Q'));
+exceptionMessage(static fn() => v::not(v::nif())->check('71110316C'));
+exceptionFullMessage(static fn() => v::nif()->assert('06357771Q'));
+exceptionFullMessage(static fn() => v::not(v::nif())->assert('R1332622H'));
 ?>
 --EXPECT--
 "06357771Q" must be a NIF

--- a/tests/integration/rules/nip.phpt
+++ b/tests/integration/rules/nip.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NipException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::nip()->check('1645865778');
-} catch (NipException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nip())->check('1645865777');
-} catch (NipException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::nip()->assert('1645865778');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nip())->assert('1645865777');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::nip()->check('1645865778'));
+exceptionMessage(static fn() => v::not(v::nip())->check('1645865777'));
+exceptionFullMessage(static fn() => v::nip()->assert('1645865778'));
+exceptionFullMessage(static fn() => v::not(v::nip())->assert('1645865777'));
 ?>
 --EXPECT--
 "1645865778" must be a valid Polish VAT identification number

--- a/tests/integration/rules/no.phpt
+++ b/tests/integration/rules/no.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NoException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::not(v::no())->check('No');
-} catch (NoException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::no()->check('Yes');
-} catch (NoException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::no())->assert('No');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::no()->assert('Yes');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::not(v::no())->check('No'));
+exceptionMessage(static fn() => v::no()->check('Yes'));
+exceptionFullMessage(static fn() => v::not(v::no())->assert('No'));
+exceptionFullMessage(static fn() => v::no()->assert('Yes'));
 ?>
 --EXPECT--
 "No" must not be similar to "No"

--- a/tests/integration/rules/noWhitespace.phpt
+++ b/tests/integration/rules/noWhitespace.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NoWhitespaceException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::noWhitespace()->check('w poiur');
-} catch (NoWhitespaceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::noWhitespace())->check('wpoiur');
-} catch (NoWhitespaceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::noWhitespace()->assert('w poiur');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::noWhitespace())->assert('wpoiur');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::noWhitespace()->check('w poiur'));
+exceptionMessage(static fn() => v::not(v::noWhitespace())->check('wpoiur'));
+exceptionFullMessage(static fn() => v::noWhitespace()->assert('w poiur'));
+exceptionFullMessage(static fn() => v::not(v::noWhitespace())->assert('wpoiur'));
 ?>
 --EXPECT--
 "w poiur" must not contain whitespace

--- a/tests/integration/rules/notBlank.phpt
+++ b/tests/integration/rules/notBlank.phpt
@@ -7,45 +7,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NotBlankException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::notBlank()->check(null);
-} catch (NotBlankException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notBlank()->setName('Field')->check(null);
-} catch (NotBlankException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notBlank())->check(1);
-} catch (NotBlankException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notBlank()->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::notBlank()->setName('Field')->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notBlank())->assert([1]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::notBlank()->check(null));
+exceptionMessage(static fn() => v::notBlank()->setName('Field')->check(null));
+exceptionMessage(static fn() => v::not(v::notBlank())->check(1));
+exceptionFullMessage(static fn() => v::notBlank()->assert(''));
+exceptionFullMessage(static fn() => v::notBlank()->setName('Field')->assert(''));
+exceptionFullMessage(static fn() => v::not(v::notBlank())->assert([1]));
 ?>
 --EXPECT--
 The value must not be blank

--- a/tests/integration/rules/notEmoji.phpt
+++ b/tests/integration/rules/notEmoji.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NotEmojiException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::notEmoji()->check('🍕');
-} catch (NotEmojiException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notEmoji())->check('AB');
-} catch (NotEmojiException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notEmoji()->assert('🏄');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notEmoji())->assert('YZ');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::notEmoji()->check('🍕'));
+exceptionMessage(static fn() => v::not(v::notEmoji())->check('AB'));
+exceptionFullMessage(static fn() => v::notEmoji()->assert('🏄'));
+exceptionFullMessage(static fn() => v::not(v::notEmoji())->assert('YZ'));
 ?>
 --EXPECT--
 "🍕" must not contain an Emoji

--- a/tests/integration/rules/notEmpty.phpt
+++ b/tests/integration/rules/notEmpty.phpt
@@ -8,46 +8,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NotEmptyException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::notEmpty()->check(null);
-} catch (NotEmptyException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notEmpty()->setName('Field')->check(null);
-} catch (NotEmptyException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notEmpty())->check(1);
-} catch (NotEmptyException $e) {
-    echo $e->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notEmpty()->assert('');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::notEmpty()->setName('Field')->assert('');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notEmpty())->assert([1]);
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::notEmpty()->check(null));
+exceptionMessage(static fn() => v::notEmpty()->setName('Field')->check(null));
+exceptionMessage(static fn() => v::not(v::notEmpty())->check(1));
+exceptionFullMessage(static fn() => v::notEmpty()->assert(''));
+exceptionFullMessage(static fn() => v::notEmpty()->setName('Field')->assert(''));
+exceptionFullMessage(static fn() => v::not(v::notEmpty())->assert([1]));
 ?>
 --EXPECT--
 The value must not be empty

--- a/tests/integration/rules/notOptional.phpt
+++ b/tests/integration/rules/notOptional.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NotOptionalException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::notOptional()->check(null);
-} catch (NotOptionalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notOptional())->check(0);
-} catch (NotOptionalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notOptional()->setName('Field')->check(null);
-} catch (NotOptionalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notOptional()->setName('Field'))->check([]);
-} catch (NotOptionalException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::notOptional()->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notOptional())->assert([]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::notOptional()->setName('Field')->assert('');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::notOptional()->setName('Field'))->assert([]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::notOptional()->check(null));
+exceptionMessage(static fn() => v::not(v::notOptional())->check(0));
+exceptionMessage(static fn() => v::notOptional()->setName('Field')->check(null));
+exceptionMessage(static fn() => v::not(v::notOptional()->setName('Field'))->check([]));
+exceptionFullMessage(static fn() => v::notOptional()->assert(''));
+exceptionFullMessage(static fn() => v::not(v::notOptional())->assert([]));
+exceptionFullMessage(static fn() => v::notOptional()->setName('Field')->assert(''));
+exceptionFullMessage(static fn() => v::not(v::notOptional()->setName('Field'))->assert([]));
 ?>
 --EXPECT--
 The value must not be optional

--- a/tests/integration/rules/nullType.phpt
+++ b/tests/integration/rules/nullType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NullTypeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::nullType()->check('');
-} catch (NullTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nullType())->check(null);
-} catch (NullTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::nullType()->assert(false);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::nullType())->assert(null);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::nullType()->check(''));
+exceptionMessage(static fn() => v::not(v::nullType())->check(null));
+exceptionFullMessage(static fn() => v::nullType()->assert(false));
+exceptionFullMessage(static fn() => v::not(v::nullType())->assert(null));
 ?>
 --EXPECT--
 "" must be null

--- a/tests/integration/rules/number.phpt
+++ b/tests/integration/rules/number.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NumberException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::number()->check(acos(1.01));
-} catch (NumberException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::number())->check(42);
-} catch (NumberException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::number()->assert(NAN);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::number())->assert(42);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::number()->check(acos(1.01)));
+exceptionMessage(static fn() => v::not(v::number())->check(42));
+exceptionFullMessage(static fn() => v::number()->assert(NAN));
+exceptionFullMessage(static fn() => v::not(v::number())->assert(42));
 ?>
 --EXPECT--
 `NaN` must be a number

--- a/tests/integration/rules/numericVal.phpt
+++ b/tests/integration/rules/numericVal.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\NumericValException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::numericVal()->check('a');
-} catch (NumericValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::numericVal())->check('1');
-} catch (NumericValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::numericVal()->assert('a');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::numericVal())->assert('1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::numericVal()->check('a'));
+exceptionMessage(static fn() => v::not(v::numericVal())->check('1'));
+exceptionFullMessage(static fn() => v::numericVal()->assert('a'));
+exceptionFullMessage(static fn() => v::not(v::numericVal())->assert('1'));
 ?>
 --EXPECT--
 "a" must be numeric

--- a/tests/integration/rules/objectType.phpt
+++ b/tests/integration/rules/objectType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ObjectTypeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::objectType()->check([]);
-} catch (ObjectTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::objectType())->check(new stdClass());
-} catch (ObjectTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::objectType()->assert('test');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::objectType())->assert(new ArrayObject());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::objectType()->check([]));
+exceptionMessage(static fn() => v::not(v::objectType())->check(new stdClass()));
+exceptionFullMessage(static fn() => v::objectType()->assert('test'));
+exceptionFullMessage(static fn() => v::not(v::objectType())->assert(new ArrayObject()));
 ?>
 --EXPECT--
 `{ }` must be of type object

--- a/tests/integration/rules/odd.phpt
+++ b/tests/integration/rules/odd.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\OddException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::odd()->check(2);
-} catch (OddException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::odd())->check(7);
-} catch (OddException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::odd()->assert(2);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::odd())->assert(9);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::odd()->check(2));
+exceptionMessage(static fn() => v::not(v::odd())->check(7));
+exceptionFullMessage(static fn() => v::odd()->assert(2));
+exceptionFullMessage(static fn() => v::not(v::odd())->assert(9));
 ?>
 --EXPECT--
 2 must be an odd number

--- a/tests/integration/rules/optional.phpt
+++ b/tests/integration/rules/optional.phpt
@@ -7,58 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::optional(v::alpha())->check(1234);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::optional(v::alpha())->setName('Name')->check(1234);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::optional(v::alpha()))->check('abcd');
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::optional(v::alpha()))->setName('Name')->check('abcd');
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::optional(v::alpha())->assert(1234);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::optional(v::alpha())->setName('Name')->assert(1234);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::optional(v::alpha()))->assert('abcd');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::optional(v::alpha()))->setName('Name')->assert('abcd');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::optional(v::alpha())->check(1234));
+exceptionMessage(static fn() => v::optional(v::alpha())->setName('Name')->check(1234));
+exceptionMessage(static fn() => v::not(v::optional(v::alpha()))->check('abcd'));
+exceptionMessage(static fn() => v::not(v::optional(v::alpha()))->setName('Name')->check('abcd'));
+exceptionFullMessage(static fn() => v::optional(v::alpha())->assert(1234));
+exceptionFullMessage(static fn() => v::optional(v::alpha())->setName('Name')->assert(1234));
+exceptionFullMessage(static fn() => v::not(v::optional(v::alpha()))->assert('abcd'));
+exceptionFullMessage(static fn() => v::not(v::optional(v::alpha()))->setName('Name')->assert('abcd'));
 ?>
 --EXPECT--
 1234 must contain only letters (a-z)

--- a/tests/integration/rules/perfectSquare.phpt
+++ b/tests/integration/rules/perfectSquare.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PerfectSquareException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::perfectSquare()->check(250);
-} catch (PerfectSquareException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::perfectSquare())->check(9);
-} catch (PerfectSquareException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::perfectSquare()->assert(7);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::perfectSquare())->assert(400);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::perfectSquare()->check(250));
+exceptionMessage(static fn() => v::not(v::perfectSquare())->check(9));
+exceptionFullMessage(static fn() => v::perfectSquare()->assert(7));
+exceptionFullMessage(static fn() => v::not(v::perfectSquare())->assert(400));
 ?>
 --EXPECT--
 250 must be a valid perfect square

--- a/tests/integration/rules/pesel.phpt
+++ b/tests/integration/rules/pesel.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PeselException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::pesel()->check('21120209251');
-} catch (PeselException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::pesel())->check('21120209256');
-} catch (PeselException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::pesel()->assert('21120209251');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::pesel())->assert('21120209256');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::pesel()->check('21120209251'));
+exceptionMessage(static fn() => v::not(v::pesel())->check('21120209256'));
+exceptionFullMessage(static fn() => v::pesel()->assert('21120209251'));
+exceptionFullMessage(static fn() => v::not(v::pesel())->assert('21120209256'));
 ?>
 --EXPECT--;
 "21120209251" must be a valid PESEL

--- a/tests/integration/rules/phone.phpt
+++ b/tests/integration/rules/phone.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PhoneException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::phone()->check('123');
-} catch (PhoneException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::phone())->check('+1 650 253 00 00');
-} catch (PhoneException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::phone()->assert('(555)5555 555');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::phone())->assert('+55 11 91111 1111');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::phone()->check('123'));
+exceptionMessage(static fn() => v::not(v::phone())->check('+1 650 253 00 00'));
+exceptionFullMessage(static fn() => v::phone()->assert('(555)5555 555'));
+exceptionFullMessage(static fn() => v::not(v::phone())->assert('+55 11 91111 1111'));
 ?>
 --EXPECT--
 "123" must be a valid telephone number

--- a/tests/integration/rules/phplabel.phpt
+++ b/tests/integration/rules/phplabel.phpt
@@ -10,33 +10,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PhpLabelException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::phpLabel()->check('f o o');
-} catch (PhpLabelException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::phpLabel())->check('correctOne');
-} catch (PhpLabelException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::phpLabel()->assert('0wner');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::phpLabel())->assert('Respect');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::phpLabel()->check('f o o'));
+exceptionMessage(static fn() => v::not(v::phpLabel())->check('correctOne'));
+exceptionFullMessage(static fn() => v::phpLabel()->assert('0wner'));
+exceptionFullMessage(static fn() => v::not(v::phpLabel())->assert('Respect'));
 ?>
 --EXPECT--
 "f o o" must be a valid PHP label

--- a/tests/integration/rules/pis.phpt
+++ b/tests/integration/rules/pis.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PisException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::pis()->check('this thing');
-} catch (PisException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::pis())->check('120.6671.406-4');
-} catch (PisException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::pis()->assert('your mother');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::pis())->assert('120.9378.174-5');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::pis()->check('this thing'));
+exceptionMessage(static fn() => v::not(v::pis())->check('120.6671.406-4'));
+exceptionFullMessage(static fn() => v::pis()->assert('your mother'));
+exceptionFullMessage(static fn() => v::not(v::pis())->assert('120.9378.174-5'));
 ?>
 --EXPECT--
 "this thing" must be a valid PIS number

--- a/tests/integration/rules/polishIdCard.phpt
+++ b/tests/integration/rules/polishIdCard.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PolishIdCardException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::polishIdCard()->check('AYE205411');
-} catch (PolishIdCardException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::polishIdCard())->check('AYE205410');
-} catch (PolishIdCardException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::polishIdCard()->assert('AYE205411');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::polishIdCard())->assert('AYE205410');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::polishIdCard()->check('AYE205411'));
+exceptionMessage(static fn() => v::not(v::polishIdCard())->check('AYE205410'));
+exceptionFullMessage(static fn() => v::polishIdCard()->assert('AYE205411'));
+exceptionFullMessage(static fn() => v::not(v::polishIdCard())->assert('AYE205410'));
 ?>
 --EXPECT--
 "AYE205411" must be a valid Polish Identity Card number

--- a/tests/integration/rules/positive.phpt
+++ b/tests/integration/rules/positive.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PositiveException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::positive()->check(-10);
-} catch (PositiveException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::positive())->check(16);
-} catch (PositiveException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::positive()->assert('a');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::positive())->assert('165');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::positive()->check(-10));
+exceptionMessage(static fn() => v::not(v::positive())->check(16));
+exceptionFullMessage(static fn() => v::positive()->assert('a'));
+exceptionFullMessage(static fn() => v::not(v::positive())->assert('165'));
 ?>
 --EXPECT--
 -10 must be positive

--- a/tests/integration/rules/postalCode.phpt
+++ b/tests/integration/rules/postalCode.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PostalCodeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::postalCode('BR')->check('1057BV');
-} catch (PostalCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::postalCode('NL'))->check('1057BV');
-} catch (PostalCodeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::postalCode('BR')->assert('1057BV');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::postalCode('NL'))->assert('1057BV');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::postalCode('BR')->check('1057BV'));
+exceptionMessage(static fn() => v::not(v::postalCode('NL'))->check('1057BV'));
+exceptionFullMessage(static fn() => v::postalCode('BR')->assert('1057BV'));
+exceptionFullMessage(static fn() => v::not(v::postalCode('NL'))->assert('1057BV'));
 ?>
 --EXPECT--
 "1057BV" must be a valid postal code on "BR"

--- a/tests/integration/rules/primeNumber.phpt
+++ b/tests/integration/rules/primeNumber.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PrimeNumberException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::primeNumber()->check(10);
-} catch (PrimeNumberException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::primeNumber())->check(3);
-} catch (PrimeNumberException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::primeNumber()->assert('Foo');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::primeNumber())->assert('+7');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::primeNumber()->check(10));
+exceptionMessage(static fn() => v::not(v::primeNumber())->check(3));
+exceptionFullMessage(static fn() => v::primeNumber()->assert('Foo'));
+exceptionFullMessage(static fn() => v::not(v::primeNumber())->assert('+7'));
 ?>
 --EXPECT--
 10 must be a valid prime number

--- a/tests/integration/rules/printable.phpt
+++ b/tests/integration/rules/printable.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PrintableException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::printable()->check('');
-} catch (PrintableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::printable())->check('abc');
-} catch (PrintableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::printable()->assert('foo' . chr(10) . 'bar');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::printable())->assert('$%asd');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::printable()->check(''));
+exceptionMessage(static fn() => v::not(v::printable())->check('abc'));
+exceptionFullMessage(static fn() => v::printable()->assert('foo' . chr(10) . 'bar'));
+exceptionFullMessage(static fn() => v::not(v::printable())->assert('$%asd'));
 ?>
 --EXPECT--
 "" must contain only printable characters

--- a/tests/integration/rules/punct.phpt
+++ b/tests/integration/rules/punct.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\PunctException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::punct()->check('a');
-} catch (PunctException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::punct('c')->check('b');
-} catch (PunctException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::punct())->check('.');
-} catch (PunctException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::punct('d'))->check('?');
-} catch (PunctException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::punct()->assert('e');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::punct('f')->assert('g');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::punct())->assert('!');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::punct('h'))->assert(';');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::punct()->check('a'));
+exceptionMessage(static fn() => v::punct('c')->check('b'));
+exceptionMessage(static fn() => v::not(v::punct())->check('.'));
+exceptionMessage(static fn() => v::not(v::punct('d'))->check('?'));
+exceptionFullMessage(static fn() => v::punct()->assert('e'));
+exceptionFullMessage(static fn() => v::punct('f')->assert('g'));
+exceptionFullMessage(static fn() => v::not(v::punct())->assert('!'));
+exceptionFullMessage(static fn() => v::not(v::punct('h'))->assert(';'));
 ?>
 --EXPECT--
 "a" must contain only punctuation characters

--- a/tests/integration/rules/readable.phpt
+++ b/tests/integration/rules/readable.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ReadableException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::readable()->check('tests/fixtures/invalid-image.jpg');
-} catch (ReadableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::readable())->check('tests/fixtures/valid-image.png');
-} catch (ReadableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::readable()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::readable())->assert('tests/fixtures/valid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::readable()->check('tests/fixtures/invalid-image.jpg'));
+exceptionMessage(static fn() => v::not(v::readable())->check('tests/fixtures/valid-image.png'));
+exceptionFullMessage(static fn() => v::readable()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::readable())->assert('tests/fixtures/valid-image.png'));
 ?>
 --EXPECT--
 "tests/fixtures/invalid-image.jpg" must be readable

--- a/tests/integration/rules/regex.phpt
+++ b/tests/integration/rules/regex.phpt
@@ -5,33 +5,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\RegexException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::regex('/^w+$/')->check('w poiur');
-} catch (RegexException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::regex('/^[a-z]+$/'))->check('wpoiur');
-} catch (RegexException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::regex('/^w+$/')->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::regex('/^[a-z]+$/i'))->assert('wPoiur');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::regex('/^w+$/')->check('w poiur'));
+exceptionMessage(static fn() => v::not(v::regex('/^[a-z]+$/'))->check('wpoiur'));
+exceptionFullMessage(static fn() => v::regex('/^w+$/')->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::regex('/^[a-z]+$/i'))->assert('wPoiur'));
 ?>
 --EXPECT--
 "w poiur" must validate against "/^w+$/"

--- a/tests/integration/rules/resourceType.phpt
+++ b/tests/integration/rules/resourceType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ResourceTypeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::resourceType()->check('test');
-} catch (ResourceTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::resourceType())->check(tmpfile());
-} catch (ResourceTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::resourceType()->assert([]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::resourceType())->assert(tmpfile());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::resourceType()->check('test'));
+exceptionMessage(static fn() => v::not(v::resourceType())->check(tmpfile()));
+exceptionFullMessage(static fn() => v::resourceType()->assert([]));
+exceptionFullMessage(static fn() => v::not(v::resourceType())->assert(tmpfile()));
 ?>
 --EXPECT--
 "test" must be a resource

--- a/tests/integration/rules/roman.phpt
+++ b/tests/integration/rules/roman.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\RomanException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::roman()->check(1234);
-} catch (RomanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::roman())->check('XL');
-} catch (RomanException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::roman()->assert('e2');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::roman())->assert('IV');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::roman()->check(1234));
+exceptionMessage(static fn() => v::not(v::roman())->check('XL'));
+exceptionFullMessage(static fn() => v::roman()->assert('e2'));
+exceptionFullMessage(static fn() => v::not(v::roman())->assert('IV'));
 ?>
 --EXPECT--
 1234 must be a valid Roman numeral

--- a/tests/integration/rules/scalarVal.phpt
+++ b/tests/integration/rules/scalarVal.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\ScalarValException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::scalarVal()->check([]);
-} catch (ScalarValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::scalarVal())->check(true);
-} catch (ScalarValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::scalarVal()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::scalarVal())->assert(42);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::scalarVal()->check([]));
+exceptionMessage(static fn() => v::not(v::scalarVal())->check(true));
+exceptionFullMessage(static fn() => v::scalarVal()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::scalarVal())->assert(42));
 ?>
 --EXPECT--
 `{ }` must be a scalar value

--- a/tests/integration/rules/size.phpt
+++ b/tests/integration/rules/size.phpt
@@ -7,81 +7,20 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\SizeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::size('1kb', '2kb')->check('tests/fixtures/valid-image.gif');
-} catch (SizeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::size('700kb', null)->check('tests/fixtures/valid-image.gif');
-} catch (SizeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::size(null, '1kb')->check('tests/fixtures/valid-image.gif');
-} catch (SizeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::size('500kb', '600kb'))->check('tests/fixtures/valid-image.gif');
-} catch (SizeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::size('500kb', null))->check('tests/fixtures/valid-image.gif');
-} catch (SizeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::size(null, '600kb'))->check('tests/fixtures/valid-image.gif');
-} catch (SizeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::size('1kb', '2kb')->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::size('700kb', null)->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::size(null, '1kb')->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::size('500kb', '600kb'))->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::size('500kb', null))->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::size(null, '600kb'))->assert('tests/fixtures/valid-image.gif');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::size('1kb', '2kb')->check('tests/fixtures/valid-image.gif'));
+exceptionMessage(static fn() => v::size('700kb', null)->check('tests/fixtures/valid-image.gif'));
+exceptionMessage(static fn() => v::size(null, '1kb')->check('tests/fixtures/valid-image.gif'));
+exceptionMessage(static fn() => v::not(v::size('500kb', '600kb'))->check('tests/fixtures/valid-image.gif'));
+exceptionMessage(static fn() => v::not(v::size('500kb', null))->check('tests/fixtures/valid-image.gif'));
+exceptionMessage(static fn() => v::not(v::size(null, '600kb'))->check('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::size('1kb', '2kb')->assert('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::size('700kb', null)->assert('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::size(null, '1kb')->assert('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::not(v::size('500kb', '600kb'))->assert('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::not(v::size('500kb', null))->assert('tests/fixtures/valid-image.gif'));
+exceptionFullMessage(static fn() => v::not(v::size(null, '600kb'))->assert('tests/fixtures/valid-image.gif'));
 ?>
 --EXPECT--
 "tests/fixtures/valid-image.gif" must be between "1kb" and "2kb"

--- a/tests/integration/rules/slug.phpt
+++ b/tests/integration/rules/slug.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\SlugException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::slug()->check('my-Slug');
-} catch (SlugException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::slug())->check('my-slug');
-} catch (SlugException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::slug()->assert('my-Slug');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::slug())->assert('my-slug');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::slug()->check('my-Slug'));
+exceptionMessage(static fn() => v::not(v::slug())->check('my-slug'));
+exceptionFullMessage(static fn() => v::slug()->assert('my-Slug'));
+exceptionFullMessage(static fn() => v::not(v::slug())->assert('my-slug'));
 ?>
 --EXPECT--
 "my-Slug" must be a valid slug

--- a/tests/integration/rules/sorted.phpt
+++ b/tests/integration/rules/sorted.phpt
@@ -8,57 +8,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\SortedException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::sorted('ASC')->check([1, 3, 2]);
-} catch (SortedException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::sorted('DESC')->check([1, 2, 3]);
-} catch (SortedException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::sorted('ASC'))->check([1, 2, 3]);
-} catch (SortedException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::sorted('DESC'))->check([3, 2, 1]);
-} catch (SortedException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::sorted('ASC')->assert([3, 2, 1]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::sorted('DESC')->assert([1, 2, 3]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::sorted('ASC'))->assert([1, 2, 3]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::sorted('DESC'))->assert([3, 2, 1]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::sorted('ASC')->check([1, 3, 2]));
+exceptionMessage(static fn() => v::sorted('DESC')->check([1, 2, 3]));
+exceptionMessage(static fn() => v::not(v::sorted('ASC'))->check([1, 2, 3]));
+exceptionMessage(static fn() => v::not(v::sorted('DESC'))->check([3, 2, 1]));
+exceptionFullMessage(static fn() => v::sorted('ASC')->assert([3, 2, 1]));
+exceptionFullMessage(static fn() => v::sorted('DESC')->assert([1, 2, 3]));
+exceptionFullMessage(static fn() => v::not(v::sorted('ASC'))->assert([1, 2, 3]));
+exceptionFullMessage(static fn() => v::not(v::sorted('DESC'))->assert([3, 2, 1]));
 ?>
 --EXPECT--
 `{ 1, 3, 2 }` must be sorted in ascending order

--- a/tests/integration/rules/space.phpt
+++ b/tests/integration/rules/space.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\SpaceException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::space()->check('ab');
-} catch (SpaceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::space('c')->check('cd');
-} catch (SpaceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::space())->check("\t");
-} catch (SpaceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::space('def'))->check("\r");
-} catch (SpaceException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::space()->assert('ef');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::space('e')->assert('gh');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::space())->assert("\n");
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::space('yk'))->assert(' k');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::space()->check('ab'));
+exceptionMessage(static fn() => v::space('c')->check('cd'));
+exceptionMessage(static fn() => v::not(v::space())->check("\t"));
+exceptionMessage(static fn() => v::not(v::space('def'))->check("\r"));
+exceptionFullMessage(static fn() => v::space()->assert('ef'));
+exceptionFullMessage(static fn() => v::space('e')->assert('gh'));
+exceptionFullMessage(static fn() => v::not(v::space())->assert("\n"));
+exceptionFullMessage(static fn() => v::not(v::space('yk'))->assert(' k'));
 ?>
 --EXPECT--
 "ab" must contain only space characters

--- a/tests/integration/rules/startsWith.phpt
+++ b/tests/integration/rules/startsWith.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\StartsWithException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::startsWith('b')->check(['a', 'b']);
-} catch (StartsWithException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::startsWith(1.1))->check([1.1, 2.2]);
-} catch (StartsWithException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::startsWith('3.3', true)->assert([3.3, 4.4]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::startsWith('c'))->assert(['c', 'd']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::startsWith('b')->check(['a', 'b']));
+exceptionMessage(static fn() => v::not(v::startsWith(1.1))->check([1.1, 2.2]));
+exceptionFullMessage(static fn() => v::startsWith('3.3', true)->assert([3.3, 4.4]));
+exceptionFullMessage(static fn() => v::not(v::startsWith('c'))->assert(['c', 'd']));
 ?>
 --EXPECT--
 `{ "a", "b" }` must start with "b"

--- a/tests/integration/rules/stringType.phpt
+++ b/tests/integration/rules/stringType.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\StringTypeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::stringType()->check(42);
-} catch (StringTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::stringType())->check('foo');
-} catch (StringTypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::stringType()->assert(true);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::stringType())->assert('bar');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::stringType()->check(42));
+exceptionMessage(static fn() => v::not(v::stringType())->check('foo'));
+exceptionFullMessage(static fn() => v::stringType()->assert(true));
+exceptionFullMessage(static fn() => v::not(v::stringType())->assert('bar'));
 ?>
 --EXPECT--
 42 must be of type string

--- a/tests/integration/rules/stringVal.phpt
+++ b/tests/integration/rules/stringVal.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\StringValException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::stringVal()->check([]);
-} catch (StringValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::stringVal())->check(true);
-} catch (StringValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::stringVal()->assert(new stdClass());
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::stringVal())->assert(42);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::stringVal()->check([]));
+exceptionMessage(static fn() => v::not(v::stringVal())->check(true));
+exceptionFullMessage(static fn() => v::stringVal()->assert(new stdClass()));
+exceptionFullMessage(static fn() => v::not(v::stringVal())->assert(42));
 ?>
 --EXPECT--
 `{ }` must be a string

--- a/tests/integration/rules/subset.phpt
+++ b/tests/integration/rules/subset.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\SubsetException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::subset([1, 2])->check([1, 2, 3]);
-} catch (SubsetException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::subset([1, 2, 3]))->check([1, 2]);
-} catch (SubsetException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::subset(['A', 'B'])->assert(['B', 'C']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::subset(['A']))->assert(['A']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::subset([1, 2])->check([1, 2, 3]));
+exceptionMessage(static fn() => v::not(v::subset([1, 2, 3]))->check([1, 2]));
+exceptionFullMessage(static fn() => v::subset(['A', 'B'])->assert(['B', 'C']));
+exceptionFullMessage(static fn() => v::not(v::subset(['A']))->assert(['A']));
 ?>
 --EXPECT--
 `{ 1, 2, 3 }` must be subset of `{ 1, 2 }`

--- a/tests/integration/rules/symbolicLink.phpt
+++ b/tests/integration/rules/symbolicLink.phpt
@@ -8,33 +8,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\SymbolicLinkException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::symbolicLink()->check('tests/fixtures/fake-filename');
-} catch (SymbolicLinkException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::symbolicLink())->check('tests/fixtures/symbolic-link');
-} catch (SymbolicLinkException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::symbolicLink()->assert('tests/fixtures/fake-filename');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::symbolicLink())->assert('tests/fixtures/symbolic-link');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::symbolicLink()->check('tests/fixtures/fake-filename'));
+exceptionMessage(static fn() => v::not(v::symbolicLink())->check('tests/fixtures/symbolic-link'));
+exceptionFullMessage(static fn() => v::symbolicLink()->assert('tests/fixtures/fake-filename'));
+exceptionFullMessage(static fn() => v::not(v::symbolicLink())->assert('tests/fixtures/symbolic-link'));
 ?>
 --EXPECT--
 "tests/fixtures/fake-filename" must be a symbolic link

--- a/tests/integration/rules/time.phpt
+++ b/tests/integration/rules/time.phpt
@@ -7,35 +7,14 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\TimeException;
 use Respect\Validation\Validator as v;
 
 date_default_timezone_set('UTC');
 
-try {
-    v::time()->check('2018-01-30');
-} catch (TimeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::time())->check('09:25:46');
-} catch (TimeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::time()->assert('2018-01-30');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::time('g:i A'))->assert('8:13 AM');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::time()->check('2018-01-30'));
+exceptionMessage(static fn() => v::not(v::time())->check('09:25:46'));
+exceptionFullMessage(static fn() => v::time()->assert('2018-01-30'));
+exceptionFullMessage(static fn() => v::not(v::time('g:i A'))->assert('8:13 AM'));
 ?>
 --EXPECT--
 "2018-01-30" must be a valid time in the format "23:59:59"

--- a/tests/integration/rules/tld.phpt
+++ b/tests/integration/rules/tld.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\TldException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::tld()->check('42');
-} catch (TldException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::tld())->check('com');
-} catch (TldException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::tld()->assert('1984');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::tld())->assert('com');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::tld()->check('42'));
+exceptionMessage(static fn() => v::not(v::tld())->check('com'));
+exceptionFullMessage(static fn() => v::tld()->assert('1984'));
+exceptionFullMessage(static fn() => v::not(v::tld())->assert('com'));
 ?>
 --EXPECT--
 "42" must be a valid top-level domain name

--- a/tests/integration/rules/trueVal.phpt
+++ b/tests/integration/rules/trueVal.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\TrueValException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::trueVal()->check(false);
-} catch (TrueValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::trueVal())->check(1);
-} catch (TrueValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::trueVal()->assert(0);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::trueVal())->assert('true');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::trueVal()->check(false));
+exceptionMessage(static fn() => v::not(v::trueVal())->check(1));
+exceptionFullMessage(static fn() => v::trueVal()->assert(0));
+exceptionFullMessage(static fn() => v::not(v::trueVal())->assert('true'));
 ?>
 --EXPECT--
 `FALSE` must evaluate to `true`

--- a/tests/integration/rules/type.phpt
+++ b/tests/integration/rules/type.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\TypeException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::type('integer')->check('42');
-} catch (TypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::type('string'))->check('foo');
-} catch (TypeException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::type('double')->assert(20);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::type('bool'))->assert(true);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::type('integer')->check('42'));
+exceptionMessage(static fn() => v::not(v::type('string'))->check('foo'));
+exceptionFullMessage(static fn() => v::type('double')->assert(20));
+exceptionFullMessage(static fn() => v::not(v::type('bool'))->assert(true));
 ?>
 --EXPECT--
 "42" must be "integer"

--- a/tests/integration/rules/unique.phpt
+++ b/tests/integration/rules/unique.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\UniqueException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::unique()->check([1, 2, 2, 3]);
-} catch (UniqueException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::unique())->check([1, 2, 3, 4]);
-} catch (UniqueException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::unique()->assert('test');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::unique())->assert(['a', 'b', 'c']);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::unique()->check([1, 2, 2, 3]));
+exceptionMessage(static fn() => v::not(v::unique())->check([1, 2, 3, 4]));
+exceptionFullMessage(static fn() => v::unique()->assert('test'));
+exceptionFullMessage(static fn() => v::not(v::unique())->assert(['a', 'b', 'c']));
 ?>
 --EXPECT--
 `{ 1, 2, 2, 3 }` must not contain duplicates

--- a/tests/integration/rules/uploaded.phpt
+++ b/tests/integration/rules/uploaded.phpt
@@ -7,38 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\UploadedException;
 use Respect\Validation\Validator as v;
 
 uopz_set_return('is_uploaded_file', false);
-try {
-    v::uploaded()->check('filename');
-} catch (UploadedException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::uploaded()->check('filename'));
 uopz_set_return('is_uploaded_file', true);
-try {
-    v::not(v::uploaded())->check('filename');
-} catch (UploadedException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::not(v::uploaded())->check('filename'));
 uopz_set_return('is_uploaded_file', false);
-try {
-    v::uploaded()->assert('filename');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionFullMessage(static fn() => v::uploaded()->assert('filename'));
 uopz_set_return('is_uploaded_file', true);
-try {
-    v::not(v::uploaded())->assert('filename');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-?>
+exceptionFullMessage(static fn() => v::not(v::uploaded())->assert('filename'));?>
 --SKIPIF--
 <?php
 if (!extension_loaded('uopz')) {

--- a/tests/integration/rules/uppercase.phpt
+++ b/tests/integration/rules/uppercase.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\UppercaseException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::uppercase()->check('lowercase');
-} catch (UppercaseException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::uppercase()->assert('lowercase');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::uppercase())->check('UPPERCASE');
-} catch (UppercaseException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::uppercase())->assert('UPPERCASE');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::uppercase()->check('lowercase'));
+exceptionFullMessage(static fn() => v::uppercase()->assert('lowercase'));
+exceptionMessage(static fn() => v::not(v::uppercase())->check('UPPERCASE'));
+exceptionFullMessage(static fn() => v::not(v::uppercase())->assert('UPPERCASE'));
 ?>
 --EXPECT--
 "lowercase" must be uppercase

--- a/tests/integration/rules/url.phpt
+++ b/tests/integration/rules/url.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\UrlException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::url()->check('example.com');
-} catch (UrlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::url())->check('http://example.com');
-} catch (UrlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::url()->assert('example.com');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::url())->assert('http://example.com');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::url()->check('example.com'));
+exceptionMessage(static fn() => v::not(v::url())->check('http://example.com'));
+exceptionFullMessage(static fn() => v::url()->assert('example.com'));
+exceptionFullMessage(static fn() => v::not(v::url())->assert('http://example.com'));
 ?>
 --EXPECT--
 "example.com" must be a URL

--- a/tests/integration/rules/uuid.phpt
+++ b/tests/integration/rules/uuid.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\UuidException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::uuid()->check('g71a18f4-3a13-11e7-a919-92ebcb67fe33');
-} catch (UuidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::uuid(1)->check('e0b5ffb9-9caf-2a34-9673-8fc91db78be6');
-} catch (UuidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::uuid())->check('fb3a7909-8034-59f5-8f38-21adbc168db7');
-} catch (UuidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::uuid(3))->check('11a38b9a-b3da-360f-9353-a5a725514269');
-} catch (UuidException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::uuid()->assert('g71a18f4-3a13-11e7-a919-92ebcb67fe33');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::uuid(4)->assert('a71a18f4-3a13-11e7-a919-92ebcb67fe33');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::uuid())->assert('e0b5ffb9-9caf-4a34-9673-8fc91db78be6');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::uuid(5))->assert('c4a760a8-dbcf-5254-a0d9-6a4474bd1b62');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::uuid()->check('g71a18f4-3a13-11e7-a919-92ebcb67fe33'));
+exceptionMessage(static fn() => v::uuid(1)->check('e0b5ffb9-9caf-2a34-9673-8fc91db78be6'));
+exceptionMessage(static fn() => v::not(v::uuid())->check('fb3a7909-8034-59f5-8f38-21adbc168db7'));
+exceptionMessage(static fn() => v::not(v::uuid(3))->check('11a38b9a-b3da-360f-9353-a5a725514269'));
+exceptionFullMessage(static fn() => v::uuid()->assert('g71a18f4-3a13-11e7-a919-92ebcb67fe33'));
+exceptionFullMessage(static fn() => v::uuid(4)->assert('a71a18f4-3a13-11e7-a919-92ebcb67fe33'));
+exceptionFullMessage(static fn() => v::not(v::uuid())->assert('e0b5ffb9-9caf-4a34-9673-8fc91db78be6'));
+exceptionFullMessage(static fn() => v::not(v::uuid(5))->assert('c4a760a8-dbcf-5254-a0d9-6a4474bd1b62'));
 ?>
 --EXPECT--
 "g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID

--- a/tests/integration/rules/version.phpt
+++ b/tests/integration/rules/version.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\VersionException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::version()->check('1.3.7--');
-} catch (VersionException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::version())->check('1.0.0-alpha');
-} catch (VersionException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::version()->assert('1.2.3.4-beta');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::version())->assert('1.3.7-rc.1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::version()->check('1.3.7--'));
+exceptionMessage(static fn() => v::not(v::version())->check('1.0.0-alpha'));
+exceptionFullMessage(static fn() => v::version()->assert('1.2.3.4-beta'));
+exceptionFullMessage(static fn() => v::not(v::version())->assert('1.3.7-rc.1'));
 ?>
 --EXPECT--
 "1.3.7--" must be a version

--- a/tests/integration/rules/videoUrl.phpt
+++ b/tests/integration/rules/videoUrl.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\VideoUrlException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::videoUrl()->check('example.com');
-} catch (VideoUrlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::videoUrl('YouTube')->check('example.com');
-} catch (VideoUrlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::videoUrl())->check('https://player.vimeo.com/video/7178746722');
-} catch (VideoUrlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::videoUrl('YouTube'))->check('https://www.youtube.com/embed/netHLn9TScY');
-} catch (VideoUrlException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::videoUrl()->assert('example.com');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::videoUrl('Vimeo')->assert('example.com');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::videoUrl())->assert('https://youtu.be/netHLn9TScY');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::videoUrl('Vimeo'))->assert('https://vimeo.com/71787467');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::videoUrl()->check('example.com'));
+exceptionMessage(static fn() => v::videoUrl('YouTube')->check('example.com'));
+exceptionMessage(static fn() => v::not(v::videoUrl())->check('https://player.vimeo.com/video/7178746722'));
+exceptionMessage(static fn() => v::not(v::videoUrl('YouTube'))->check('https://www.youtube.com/embed/netHLn9TScY'));
+exceptionFullMessage(static fn() => v::videoUrl()->assert('example.com'));
+exceptionFullMessage(static fn() => v::videoUrl('Vimeo')->assert('example.com'));
+exceptionFullMessage(static fn() => v::not(v::videoUrl())->assert('https://youtu.be/netHLn9TScY'));
+exceptionFullMessage(static fn() => v::not(v::videoUrl('Vimeo'))->assert('https://vimeo.com/71787467'));
 ?>
 --EXPECT--
 "example.com" must be a valid video URL

--- a/tests/integration/rules/vowel.phpt
+++ b/tests/integration/rules/vowel.phpt
@@ -7,58 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\VowelException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::vowel()->check('b');
-} catch (VowelException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::vowel('c')->check('d');
-} catch (VowelException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::vowel())->check('a');
-} catch (VowelException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::vowel('f'))->check('e');
-} catch (VowelException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::vowel()->assert('g');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::vowel('h')->assert('j');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::vowel())->assert('i');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::vowel('k'))->assert('o');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::vowel()->check('b'));
+exceptionMessage(static fn() => v::vowel('c')->check('d'));
+exceptionMessage(static fn() => v::not(v::vowel())->check('a'));
+exceptionMessage(static fn() => v::not(v::vowel('f'))->check('e'));
+exceptionFullMessage(static fn() => v::vowel()->assert('g'));
+exceptionFullMessage(static fn() => v::vowel('h')->assert('j'));
+exceptionFullMessage(static fn() => v::not(v::vowel())->assert('i'));
+exceptionFullMessage(static fn() => v::not(v::vowel('k'))->assert('o'));
 ?>
 --EXPECT--
 "b" must contain only vowels

--- a/tests/integration/rules/when.phpt
+++ b/tests/integration/rules/when.phpt
@@ -7,58 +7,18 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\IntValException;
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\WhenException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::when(v::alwaysValid(), v::intVal())->check('abc');
-} catch (IntValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::when(v::alwaysInvalid(), v::alwaysValid(), v::intVal())->check('def');
-} catch (IntValException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::when(v::alwaysValid(), v::stringVal()))->check('ghi');
-} catch (WhenException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::when(v::alwaysInvalid(), v::alwaysValid(), v::stringVal()))->check('jkl');
-} catch (WhenException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::when(v::alwaysValid(), v::intVal())->assert('mno');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::when(v::alwaysInvalid(), v::alwaysValid(), v::intVal())->assert('pqr');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::when(v::alwaysValid(), v::stringVal()))->assert('stu');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
+exceptionMessage(static fn() => v::when(v::alwaysValid(), v::intVal())->check('abc'));
+exceptionMessage(static fn() => v::when(v::alwaysInvalid(), v::alwaysValid(), v::intVal())->check('def'));
+exceptionMessage(static fn() => v::not(v::when(v::alwaysValid(), v::stringVal()))->check('ghi'));
+exceptionMessage(static fn() => v::not(v::when(v::alwaysInvalid(), v::alwaysValid(), v::stringVal()))->check('jkl'));
+exceptionFullMessage(static fn() => v::when(v::alwaysValid(), v::intVal())->assert('mno'));
+exceptionFullMessage(static fn() => v::when(v::alwaysInvalid(), v::alwaysValid(), v::intVal())->assert('pqr'));
+exceptionFullMessage(static fn() => v::not(v::when(v::alwaysValid(), v::stringVal()))->assert('stu'));
+exceptionFullMessage(static function () {
     v::not(v::when(v::alwaysInvalid(), v::alwaysValid(), v::stringVal()))->assert('vwx');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+});
 ?>
 --EXPECT--
 "abc" must be an integer number

--- a/tests/integration/rules/writable.phpt
+++ b/tests/integration/rules/writable.phpt
@@ -7,34 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\WritableException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::writable()->check('/path/of/a/valid/writable/file.txt');
-} catch (WritableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::writable())->check('tests/fixtures/valid-image.png');
-} catch (WritableException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::writable()->assert([]);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::writable())->assert('tests/fixtures/invalid-image.png');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
+exceptionMessage(static fn() => v::writable()->check('/path/of/a/valid/writable/file.txt'));
+exceptionMessage(static fn() => v::not(v::writable())->check('tests/fixtures/valid-image.png'));
+exceptionFullMessage(static fn() => v::writable()->assert([]));
+exceptionFullMessage(static fn() => v::not(v::writable())->assert('tests/fixtures/invalid-image.png'));
 ?>
 --EXPECT--
 "/path/of/a/valid/writable/file.txt" must be writable

--- a/tests/integration/rules/xdigit.phpt
+++ b/tests/integration/rules/xdigit.phpt
@@ -7,57 +7,16 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\XdigitException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::xdigit()->check('aaa%a');
-} catch (XdigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::xdigit(' ')->check('bbb%b');
-} catch (XdigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::xdigit())->check('ccccc');
-} catch (XdigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::xdigit('% '))->check('ddd%d');
-} catch (XdigitException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::xdigit()->assert('eee^e');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::xdigit())->assert('fffff');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::xdigit('* &%')->assert('000^0');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::xdigit('^'))->assert('111^1');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::xdigit()->check('aaa%a'));
+exceptionMessage(static fn() => v::xdigit(' ')->check('bbb%b'));
+exceptionMessage(static fn() => v::not(v::xdigit())->check('ccccc'));
+exceptionMessage(static fn() => v::not(v::xdigit('% '))->check('ddd%d'));
+exceptionFullMessage(static fn() => v::xdigit()->assert('eee^e'));
+exceptionFullMessage(static fn() => v::not(v::xdigit())->assert('fffff'));
+exceptionFullMessage(static fn() => v::xdigit('* &%')->assert('000^0'));
+exceptionFullMessage(static fn() => v::not(v::xdigit('^'))->assert('111^1'));
 ?>
 --EXPECT--
 "aaa%a" contain only hexadecimal digits

--- a/tests/integration/rules/yes.phpt
+++ b/tests/integration/rules/yes.phpt
@@ -7,33 +7,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
-use Respect\Validation\Exceptions\YesException;
 use Respect\Validation\Validator as v;
 
-try {
-    v::not(v::yes())->check('Yes');
-} catch (YesException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::yes()->check('si');
-} catch (YesException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
-
-try {
-    v::not(v::yes())->assert('Yes');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
-
-try {
-    v::yes()->assert('si');
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::not(v::yes())->check('Yes'));
+exceptionMessage(static fn() => v::yes()->check('si'));
+exceptionFullMessage(static fn() => v::not(v::yes())->assert('Yes'));
+exceptionFullMessage(static fn() => v::yes()->assert('si'));
 ?>
 --EXPECT--
 "Yes" must not be similar to "Yes"

--- a/tests/integration/set_template_with_multiple_validators_should_use_template_as_full_message.phpt
+++ b/tests/integration/set_template_with_multiple_validators_should_use_template_as_full_message.phpt
@@ -9,14 +9,11 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
-try {
+exceptionFullMessage(static function () {
     Validator::callback('is_string')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
-} catch (NestedValidationException $e) {
-    echo $e->getFullMessage();
-}
+});
 ?>
 --EXPECT--
 - "something" is not tasty

--- a/tests/integration/set_template_with_multiple_validators_should_use_template_as_main_message.phpt
+++ b/tests/integration/set_template_with_multiple_validators_should_use_template_as_main_message.phpt
@@ -9,14 +9,11 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
-try {
+exceptionMessage(static function () {
     Validator::callback('is_int')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
-} catch (NestedValidationException $e) {
-    echo $e->getMessage();
-}
+});
 ?>
 --EXPECT--
 "something" is not tasty

--- a/tests/integration/set_template_with_single_validator_should_use_template_as_main_message.phpt
+++ b/tests/integration/set_template_with_single_validator_should_use_template_as_main_message.phpt
@@ -9,23 +9,12 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Validator;
 
 $rule = Validator::callback('is_int')->setTemplate('{{name}} is not tasty');
-try {
-    $rule->assert('something');
-} catch (NestedValidationException $e) {
-    echo $e->getMessage();
-}
 
-echo PHP_EOL;
-
-try {
-    $rule->check('something');
-} catch (NestedValidationException $e) {
-    echo $e->getMessage();
-}
+exceptionMessage(static fn() => $rule->assert('something'));
+exceptionMessage(static fn() => $rule->check('something'));
 ?>
 --EXPECT--
 "something" is not tasty

--- a/tests/integration/should_not_overwrite_defined_names.phpt
+++ b/tests/integration/should_not_overwrite_defined_names.phpt
@@ -7,30 +7,17 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validator as v;
 
 $input = ['email' => 'not an email'];
 
-try {
-    v::key('email', v::email()->setName('Email'))->setName('Foo')->check($input);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::key('email', v::email()->setName('Email'))->setName('Foo')->check($input));
 
-try {
-    // This is a trick thing: the call to `setName()` here seems to be the one
-    // from the `Key` rule but it's actually from the `Validator`.
-    v::key('email', v::email())->setName('Email')->check($input);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
+// This is a trick thing: the call to `setName()` here seems to be the one
+// from the `Key` rule but it's actually from the `Validator`.
+exceptionMessage(static fn() => v::key('email', v::email())->setName('Email')->check($input));
 
-try {
-    v::key('email', v::email())->check($input);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage() . PHP_EOL;
-}
+exceptionMessage(static fn() => v::key('email', v::email())->check($input));
 ?>
 --EXPECT--
 Email must be valid email

--- a/tests/integration/translator-assert.phpt
+++ b/tests/integration/translator-assert.phpt
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Factory;
 use Respect\Validation\Validator;
 
@@ -25,11 +24,7 @@ Factory::setDefaultInstance(
         })
 );
 
-try {
-    Validator::stringType()->length(2, 15)->assert(0);
-} catch (NestedValidationException $exception) {
-    echo $exception->getFullMessage();
-}
+exceptionFullMessage(static fn() => Validator::stringType()->length(2, 15)->assert(0));
 ?>
 --EXPECT--
 - Todas as regras requeridas devem passar para 0

--- a/tests/integration/translator-check.phpt
+++ b/tests/integration/translator-check.phpt
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 require 'vendor/autoload.php';
 
-use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Factory;
 use Respect\Validation\Validator;
 
@@ -20,11 +19,7 @@ Factory::setDefaultInstance(
         })
 );
 
-try {
-    Validator::stringType()->length(2, 15)->check(0);
-} catch (ValidationException $exception) {
-    echo $exception->getMessage();
-}
+exceptionMessage(static fn() => Validator::stringType()->length(2, 15)->check(0));
 ?>
 --EXPECT--
 0 deve ser do tipo string


### PR DESCRIPTION
The integration tests use the same pattern to test exception messages. With my changes, we won't validate which exception we throw in those tests, but matching the message is enough. I created three functions to replace most of those tests.