### PR TITLE
Documentation: Fix parameter type of keySet

### DIFF
--- a/library/StaticValidator.php
+++ b/library/StaticValidator.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Respect\Validation;
 
 use finfo;
-use Respect\Validation\Rules\Key;
 
 interface StaticValidator
 {
@@ -201,7 +200,7 @@ interface StaticValidator
         bool $mandatory = true
     ): ChainedValidator;
 
-    public static function keySet(Key ...$rule): ChainedValidator;
+    public static function keySet(ChainedValidator ...$rule): ChainedValidator;
 
     public static function keyValue(string $comparedKey, string $ruleName, string $baseKey): ChainedValidator;
 


### PR DESCRIPTION
The documentation states that we should use Validator::keySet() in combination with Validator::key() but the return type of key() does not match the expected parameter type of keyset().

If I am not mistaken, the StaticValidator interface is only used as a mixin for IDEs and Static Code Analysis to determine whether the library is being used correctly, so this change should have no side effects.