### PR TITLE
添加setDefault，用来设置默认值，当有些字段不需要可填可不填，或者该字段用于某个控制器的固定值时可使用->setDefault()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# [Respect\Validation 验证器](https://github.com/Respect/Validation) 汉化版
 # Respect\Validation
 
 [![Build Status](https://img.shields.io/travis/Respect/Validation/master.svg?style=flat-square)](http://travis-ci.org/Respect/Validation)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "respect/validation",
-    "description": "The most awesome validation engine ever created for PHP",
+    "name": "workerman/validation",
+    "description": "The most awesome validation engine ever created for PHP. Respect/Validation 汉化版本",
     "keywords": ["respect", "validation", "validator"],
     "type": "library",
     "homepage": "http://respect.github.io/Validation/",

--- a/library/Exceptions/AllOfException.php
+++ b/library/Exceptions/AllOfException.php
@@ -24,12 +24,12 @@ class AllOfException extends GroupedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NONE => '所有必需的规则都必须传递给 {{name}}',
-            self::SOME => '这些规则必须传递给 {{name}}',
+            self::NONE => '{{name}} 必需符合以下规则',
+            self::SOME => '{{name}} 必需符合以下规则',
         ],
         self::MODE_NEGATIVE => [
-            self::NONE => '这些规则都不能传递给 {{name}}',
-            self::SOME => '这些规则不能传递给 {{name}}',
+            self::NONE => '{{name}} 不能符合以下规则',
+            self::SOME => '{{name}} 不能符合以下规则',
         ],
     ];
 }

--- a/library/Exceptions/AllOfException.php
+++ b/library/Exceptions/AllOfException.php
@@ -24,12 +24,12 @@ class AllOfException extends GroupedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NONE => 'All of the required rules must pass for {{name}}',
-            self::SOME => 'These rules must pass for {{name}}',
+            self::NONE => '所有必需的规则都必须传递给 {{name}}',
+            self::SOME => '这些规则必须传递给 {{name}}',
         ],
         self::MODE_NEGATIVE => [
-            self::NONE => 'None of these rules must pass for {{name}}',
-            self::SOME => 'These rules must not pass for {{name}}',
+            self::NONE => '这些规则都不能传递给 {{name}}',
+            self::SOME => '这些规则不能传递给 {{name}}',
         ],
     ];
 }

--- a/library/Exceptions/AlnumException.php
+++ b/library/Exceptions/AlnumException.php
@@ -24,12 +24,12 @@ final class AlnumException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only letters (a-z) and digits (0-9)',
-            self::EXTRA => '{{name}} must contain only letters (a-z), digits (0-9) and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含字母（a-z）和数字（0-9）',
+            self::EXTRA => '{{name}} 只能包含字母（a-z）、数字（0-9）和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain letters (a-z) or digits (0-9)',
-            self::EXTRA => '{{name}} must not contain letters (a-z), digits (0-9) or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含字母（a-z）或数字（0-9）',
+            self::EXTRA => '{{name}} 不能包含字母（a-z）、数字（0-9）或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/AlphaException.php
+++ b/library/Exceptions/AlphaException.php
@@ -24,12 +24,12 @@ final class AlphaException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only letters (a-z)',
-            self::EXTRA => '{{name}} must contain only letters (a-z) and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含字母（a-z）',
+            self::EXTRA => '{{name}} 只能包含字母（a-z）和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain letters (a-z)',
-            self::EXTRA => '{{name}} must not contain letters (a-z) or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含字母（a-z）',
+            self::EXTRA => '{{name}} 不能包含字母（a-z）或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/AlwaysInvalidException.php
+++ b/library/Exceptions/AlwaysInvalidException.php
@@ -27,12 +27,12 @@ final class AlwaysInvalidException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} is always invalid',
-            self::SIMPLE => '{{name}} is not valid',
+            self::STANDARD => '{{name}} 始终无效',
+            self::SIMPLE => '{{name}} 无效',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} is always valid',
-            self::SIMPLE => '{{name}} is valid',
+            self::STANDARD => '{{name}} 始终有效',
+            self::SIMPLE => '{{name}} 有效',
         ],
     ];
 }

--- a/library/Exceptions/AlwaysValidException.php
+++ b/library/Exceptions/AlwaysValidException.php
@@ -25,10 +25,10 @@ final class AlwaysValidException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} is always valid',
+            self::STANDARD => '{{name}} 始终有效',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} is always invalid',
+            self::STANDARD => '{{name}} 始终无效',
         ],
     ];
 }

--- a/library/Exceptions/AnyOfException.php
+++ b/library/Exceptions/AnyOfException.php
@@ -24,10 +24,10 @@ final class AnyOfException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'At least one of these rules must pass for {{name}}',
+            self::STANDARD => '这些规则中至少有一个必须传递给 {{name}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'At least one of these rules must not pass for {{name}}',
+            self::STANDARD => '这些规则中至少有一个不能传递给 {{name}}',
         ],
     ];
 }

--- a/library/Exceptions/ArrayTypeException.php
+++ b/library/Exceptions/ArrayTypeException.php
@@ -26,10 +26,10 @@ final class ArrayTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be of type array',
+            self::STANDARD => '{{name}} 必须是array类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be of type array',
+            self::STANDARD => '{{name}} 不能是array类型',
         ],
     ];
 }

--- a/library/Exceptions/ArrayValException.php
+++ b/library/Exceptions/ArrayValException.php
@@ -25,10 +25,10 @@ final class ArrayValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an array value',
+            self::STANDARD => '{{name}} 必须是数组',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an array value',
+            self::STANDARD => '{{name}} 不能是数组',
         ],
     ];
 }

--- a/library/Exceptions/AttributeException.php
+++ b/library/Exceptions/AttributeException.php
@@ -30,12 +30,12 @@ final class AttributeException extends NestedValidationException implements NonO
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NOT_PRESENT => 'Attribute {{name}} must be present',
-            self::INVALID => 'Attribute {{name}} must be valid',
+            self::NOT_PRESENT => '属性 {{name}} 必须存在',
+            self::INVALID => '属性 {{name}} 必须有效',
         ],
         self::MODE_NEGATIVE => [
-            self::NOT_PRESENT => 'Attribute {{name}} must not be present',
-            self::INVALID => 'Attribute {{name}} must not validate',
+            self::NOT_PRESENT => '属性 {{name}} 不能存在',
+            self::INVALID => '属性 {{name}} 必须无效',
         ],
     ];
 

--- a/library/Exceptions/Base64Exception.php
+++ b/library/Exceptions/Base64Exception.php
@@ -25,10 +25,10 @@ final class Base64Exception extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be Base64-encoded',
+            self::STANDARD => '{{name}} 必须采用Base64编码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be Base64-encoded',
+            self::STANDARD => '{{name}} 不能是Base64编码',
         ],
     ];
 }

--- a/library/Exceptions/BaseException.php
+++ b/library/Exceptions/BaseException.php
@@ -25,10 +25,10 @@ final class BaseException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a number in the base {{base}}',
+            self::STANDARD => '{{name}} 必须是基于 {{base}} 中的数字',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a number in the base {{base}}',
+            self::STANDARD => '{{name}} 不能是基于 {{base}} 中的数字',
         ],
     ];
 }

--- a/library/Exceptions/BetweenException.php
+++ b/library/Exceptions/BetweenException.php
@@ -24,10 +24,10 @@ final class BetweenException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be between {{minValue}} and {{maxValue}}',
+            self::STANDARD => '{{name}} 必须介于 {{minValue}} 和 {{maxValue}} 之间',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be between {{minValue}} and {{maxValue}}',
+            self::STANDARD => '{{name}} 不能介于 {{minValue}} 和 {{maxValue}} 之间',
         ],
     ];
 }

--- a/library/Exceptions/BoolTypeException.php
+++ b/library/Exceptions/BoolTypeException.php
@@ -26,10 +26,10 @@ final class BoolTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be of type boolean',
+            self::STANDARD => '{{name}} 必须是boolean类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be of type boolean',
+            self::STANDARD => '{{name}} 不能是boolean类型',
         ],
     ];
 }

--- a/library/Exceptions/BoolValException.php
+++ b/library/Exceptions/BoolValException.php
@@ -25,10 +25,10 @@ final class BoolValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a boolean value',
+            self::STANDARD => '{{name}} 必须是布尔值',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a boolean value',
+            self::STANDARD => '{{name}} 不能是布尔值',
         ],
     ];
 }

--- a/library/Exceptions/BsnException.php
+++ b/library/Exceptions/BsnException.php
@@ -25,10 +25,10 @@ final class BsnException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a BSN',
+            self::STANDARD => '{{name}} 必须是BSN',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a BSN',
+            self::STANDARD => '{{name}} 不能是BSN',
         ],
     ];
 }

--- a/library/Exceptions/CallException.php
+++ b/library/Exceptions/CallException.php
@@ -24,10 +24,10 @@ final class CallException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{input}} must be valid when executed with {{callable}}',
+            self::STANDARD => '当使用 {{callable}} 时 {{input}} 必须有效',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{input}} must not be valid when executed with {{callable}}',
+            self::STANDARD => '当使用 {{callable}} 时 {{input}} 必须无效',
         ],
     ];
 }

--- a/library/Exceptions/CallableTypeException.php
+++ b/library/Exceptions/CallableTypeException.php
@@ -25,10 +25,10 @@ final class CallableTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be callable',
+            self::STANDARD => '{{name}} 必须是可调用的',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be callable',
+            self::STANDARD => '{{name}} 不能是可调用的',
         ],
     ];
 }

--- a/library/Exceptions/CharsetException.php
+++ b/library/Exceptions/CharsetException.php
@@ -25,10 +25,10 @@ final class CharsetException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be in the {{charset}} charset',
+            self::STANDARD => '{{name}} 必须在 {{charset}} 字符集中',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be in the {{charset}} charset',
+            self::STANDARD => '{{name}} 不能在 {{charset}} 字符集中',
         ],
     ];
 }

--- a/library/Exceptions/CnhException.php
+++ b/library/Exceptions/CnhException.php
@@ -25,10 +25,10 @@ final class CnhException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid CNH number',
+            self::STANDARD => '{{name}} 必须是有效的CNH号码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid CNH number',
+            self::STANDARD => '{{name}} 不能是有效的CNH号码',
         ],
     ];
 }

--- a/library/Exceptions/CnpjException.php
+++ b/library/Exceptions/CnpjException.php
@@ -25,10 +25,10 @@ final class CnpjException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid CNPJ number',
+            self::STANDARD => '{{name}} 必须是有效的CNPJ编号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid CNPJ number',
+            self::STANDARD => '{{name}} 不能是有效的CNPJ编号',
         ],
     ];
 }

--- a/library/Exceptions/ConsonantException.php
+++ b/library/Exceptions/ConsonantException.php
@@ -25,12 +25,12 @@ final class ConsonantException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only consonants',
-            self::EXTRA => '{{name}} must contain only consonants and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含辅音',
+            self::EXTRA => '{{name}} 只能包含辅音和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain consonants',
-            self::EXTRA => '{{name}} must not contain consonants or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含辅音',
+            self::EXTRA => '{{name}} 不能包含辅音或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/ContainsAnyException.php
+++ b/library/Exceptions/ContainsAnyException.php
@@ -23,10 +23,10 @@ final class ContainsAnyException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain at least one of the values {{needles}}',
+            self::STANDARD => '{{name}} 必须包含至少一个值 {{needles}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain any of the values {{needles}}',
+            self::STANDARD => '{{name}} 不能包含任何值 {{needles}}',
         ],
     ];
 }

--- a/library/Exceptions/ContainsException.php
+++ b/library/Exceptions/ContainsException.php
@@ -25,10 +25,10 @@ final class ContainsException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain the value {{containsValue}}',
+            self::STANDARD => '{{name}} 必须包含值 {{containsValue}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain the value {{containsValue}}',
+            self::STANDARD => '{{name}} 不能包含值 {{containsValue}}',
         ],
     ];
 }

--- a/library/Exceptions/ControlException.php
+++ b/library/Exceptions/ControlException.php
@@ -25,12 +25,12 @@ final class ControlException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only control characters',
-            self::EXTRA => '{{name}} must contain only control characters and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含控制字符',
+            self::EXTRA => '{{name}} 只能包含控制字符和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain control characters',
-            self::EXTRA => '{{name}} must not contain control characters or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含控制字符',
+            self::EXTRA => '{{name}} 不能包含控制字符或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/CountableException.php
+++ b/library/Exceptions/CountableException.php
@@ -25,10 +25,10 @@ final class CountableException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be countable',
+            self::STANDARD => '{{name}} 必须是可数的',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be countable',
+            self::STANDARD => '{{name}} 不能是可数的',
         ],
     ];
 }

--- a/library/Exceptions/CountryCodeException.php
+++ b/library/Exceptions/CountryCodeException.php
@@ -25,10 +25,10 @@ final class CountryCodeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid country',
+            self::STANDARD => '{{name}} 必须是有效的国家/地区',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid country',
+            self::STANDARD => '{{name}} 不能是有效的国家/地区',
         ],
     ];
 }

--- a/library/Exceptions/CpfException.php
+++ b/library/Exceptions/CpfException.php
@@ -25,10 +25,10 @@ final class CpfException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid CPF number',
+            self::STANDARD => '{{name}} 必须是有效的CPF编号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid CPF number',
+            self::STANDARD => '{{name}} 不能是有效的CPF编号',
         ],
     ];
 }

--- a/library/Exceptions/CreditCardException.php
+++ b/library/Exceptions/CreditCardException.php
@@ -29,12 +29,12 @@ final class CreditCardException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid Credit Card number',
-            self::BRANDED => '{{name}} must be a valid {{brand}} Credit Card number',
+            self::STANDARD => '{{name}} 必须是有效的信用卡号',
+            self::BRANDED => '{{name}} 必须是有效的 {{brand}} 信用卡号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid Credit Card number',
-            self::BRANDED => '{{name}} must not be a valid {{brand}} Credit Card number',
+            self::STANDARD => '{{name}} 不能是有效的信用卡号',
+            self::BRANDED => '{{name}} 不能是有效的 {{brand}} 信用卡号',
         ],
     ];
 

--- a/library/Exceptions/CurrencyCodeException.php
+++ b/library/Exceptions/CurrencyCodeException.php
@@ -25,10 +25,10 @@ final class CurrencyCodeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid currency',
+            self::STANDARD => '{{name}} 必须是有效的货币',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid currency',
+            self::STANDARD => '{{name}} 不能是有效的货币',
         ],
     ];
 }

--- a/library/Exceptions/DateException.php
+++ b/library/Exceptions/DateException.php
@@ -24,10 +24,10 @@ final class DateException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid date in the format {{sample}}',
+            self::STANDARD => '{{name}} 必须是格式为 {{sample}} 的有效日期',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid date in the format {{sample}}',
+            self::STANDARD => '{{name}} 不能是格式为 {{sample}} 的日期',
         ],
     ];
 }

--- a/library/Exceptions/DateTimeException.php
+++ b/library/Exceptions/DateTimeException.php
@@ -26,12 +26,12 @@ final class DateTimeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid date/time',
-            self::FORMAT => '{{name}} must be a valid date/time in the format {{sample}}',
+            self::STANDARD => '{{name}} 必须是有效的日期/时间',
+            self::FORMAT => '{{name}} 必须是格式为 {{sample}} 的有效日期/时间',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid date/time',
-            self::FORMAT => '{{name}} must not be a valid date/time in the format {{sample}}',
+            self::STANDARD => '{{name}} 不能是有效的日期/时间',
+            self::FORMAT => '{{name}} 不能是格式为 {{sample}} 的有效日期/时间',
         ],
     ];
 

--- a/library/Exceptions/DigitException.php
+++ b/library/Exceptions/DigitException.php
@@ -24,12 +24,12 @@ final class DigitException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only digits (0-9)',
-            self::EXTRA => '{{name}} must contain only digits (0-9) and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含数字（0-9）',
+            self::EXTRA => '{{name}} 只能包含数字（0-9）和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain digits (0-9)',
-            self::EXTRA => '{{name}} must not contain digits (0-9) and {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含数字（0-9）',
+            self::EXTRA => '{{name}} 只能包含数字（0-9）和 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/DirectoryException.php
+++ b/library/Exceptions/DirectoryException.php
@@ -24,10 +24,10 @@ final class DirectoryException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a directory',
+            self::STANDARD => '{{name}} 必须是目录',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a directory',
+            self::STANDARD => '{{name}} 不能是目录',
         ],
     ];
 }

--- a/library/Exceptions/DomainException.php
+++ b/library/Exceptions/DomainException.php
@@ -24,10 +24,10 @@ final class DomainException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid domain',
+            self::STANDARD => '{{name}} 必须是有效域名',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid domain',
+            self::STANDARD => '{{name}} 不能是有效域名',
         ],
     ];
 }

--- a/library/Exceptions/EachException.php
+++ b/library/Exceptions/EachException.php
@@ -25,10 +25,10 @@ final class EachException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'Each item in {{name}} must be valid',
+            self::STANDARD => '{{name}} 中的每个项都必须有效',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'Each item in {{name}} must not validate',
+            self::STANDARD => '{{name}} 中的每个项都必须无效',
         ],
     ];
 }

--- a/library/Exceptions/EmailException.php
+++ b/library/Exceptions/EmailException.php
@@ -29,10 +29,10 @@ final class EmailException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be valid email',
+            self::STANDARD => '{{name}} 必须是有效的电子邮件',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an email',
+            self::STANDARD => '{{name}} 不能是电子邮件',
         ],
     ];
 }

--- a/library/Exceptions/EndsWithException.php
+++ b/library/Exceptions/EndsWithException.php
@@ -25,10 +25,10 @@ final class EndsWithException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must end with {{endValue}}',
+            self::STANDARD => '{{name}} 必须以 {{endValue}} 结尾',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not end with {{endValue}}',
+            self::STANDARD => '{{name}} 不能以 {{endValue}} 结尾',
         ],
     ];
 }

--- a/library/Exceptions/EqualsException.php
+++ b/library/Exceptions/EqualsException.php
@@ -25,10 +25,10 @@ final class EqualsException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must equal {{compareTo}}',
+            self::STANDARD => '{{name}} 必须等于 {{compareTo}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not equal {{compareTo}}',
+            self::STANDARD => '{{name}} 不能等于 {{compareTo}}',
         ],
     ];
 }

--- a/library/Exceptions/EquivalentException.php
+++ b/library/Exceptions/EquivalentException.php
@@ -23,10 +23,10 @@ final class EquivalentException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be equivalent to {{compareTo}}',
+            self::STANDARD => '{{name}} 必须与 {{compareTo}} 相等',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be equivalent to {{compareTo}}',
+            self::STANDARD => '{{name}} 不能与 {{compareTo}} 相等',
         ],
     ];
 }

--- a/library/Exceptions/EvenException.php
+++ b/library/Exceptions/EvenException.php
@@ -27,10 +27,10 @@ final class EvenException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an even number',
+            self::STANDARD => '{{name}} 必须是偶数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an even number',
+            self::STANDARD => '{{name}} 不能是偶数',
         ],
     ];
 }

--- a/library/Exceptions/ExecutableException.php
+++ b/library/Exceptions/ExecutableException.php
@@ -24,10 +24,10 @@ final class ExecutableException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an executable file',
+            self::STANDARD => '{{name}} 必须是可执行文件',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an executable file',
+            self::STANDARD => '{{name}} 不能是可执行文件',
         ],
     ];
 }

--- a/library/Exceptions/ExistsException.php
+++ b/library/Exceptions/ExistsException.php
@@ -24,10 +24,10 @@ final class ExistsException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must exists',
+            self::STANDARD => '{{name}} 必须存在',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not exists',
+            self::STANDARD => '{{name}} 不能存在',
         ],
     ];
 }

--- a/library/Exceptions/ExtensionException.php
+++ b/library/Exceptions/ExtensionException.php
@@ -26,10 +26,10 @@ final class ExtensionException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must have {{extension}} extension',
+            self::STANDARD => '{{name}} 必须是 {{extension}} 后缀',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not have {{extension}} extension',
+            self::STANDARD => '{{name}} 不能是 {{extension}} 后缀',
         ],
     ];
 }

--- a/library/Exceptions/FactorException.php
+++ b/library/Exceptions/FactorException.php
@@ -25,10 +25,10 @@ final class FactorException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a factor of {{dividend}}',
+            self::STANDARD => '{{name}} 必须是 {{dividend}} 的因子',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a factor of {{dividend}}',
+            self::STANDARD => '{{name}} 不能是 {{dividend}} 的因子',
         ],
     ];
 }

--- a/library/Exceptions/FalseValException.php
+++ b/library/Exceptions/FalseValException.php
@@ -24,10 +24,10 @@ final class FalseValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} is not considered as "False"',
+            self::STANDARD => '{{name}} 不被视为 "False"',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} is considered as "False"',
+            self::STANDARD => '{{name}} 可视为 "False"',
         ],
     ];
 }

--- a/library/Exceptions/FibonacciException.php
+++ b/library/Exceptions/FibonacciException.php
@@ -25,10 +25,10 @@ final class FibonacciException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid Fibonacci number',
+            self::STANDARD => '{{name}} 必须是有效的斐波纳契数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid Fibonacci number',
+            self::STANDARD => '{{name}} 不能是有效的斐波纳契数',
         ],
     ];
 }

--- a/library/Exceptions/FileException.php
+++ b/library/Exceptions/FileException.php
@@ -24,10 +24,10 @@ final class FileException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a file',
+            self::STANDARD => '{{name}} 必须是文件',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a file',
+            self::STANDARD => '{{name}} 不能是文件',
         ],
     ];
 }

--- a/library/Exceptions/FiniteException.php
+++ b/library/Exceptions/FiniteException.php
@@ -24,10 +24,10 @@ final class FiniteException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a finite number',
+            self::STANDARD => '{{name}} 必须是有限数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a finite number',
+            self::STANDARD => '{{name}} 不能是有限数',
         ],
     ];
 }

--- a/library/Exceptions/FloatTypeException.php
+++ b/library/Exceptions/FloatTypeException.php
@@ -26,10 +26,10 @@ final class FloatTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be of type float',
+            self::STANDARD => '{{name}} 必须是float类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be of type float',
+            self::STANDARD => '{{name}} 不能是float类型',
         ],
     ];
 }

--- a/library/Exceptions/FloatValException.php
+++ b/library/Exceptions/FloatValException.php
@@ -25,10 +25,10 @@ final class FloatValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a float number',
+            self::STANDARD => '{{name}} 必须是浮点数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a float number',
+            self::STANDARD => '{{name}} 不能是浮点数',
         ],
     ];
 }

--- a/library/Exceptions/GraphException.php
+++ b/library/Exceptions/GraphException.php
@@ -25,12 +25,12 @@ final class GraphException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only graphical characters',
-            self::EXTRA => '{{name}} must contain only graphical characters and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含图形字符',
+            self::EXTRA => '{{name}} 只能包含图形字符和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain graphical characters',
-            self::EXTRA => '{{name}} must not contain graphical characters or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含图形字符',
+            self::EXTRA => '{{name}} 不能包含图形字符或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/GreaterThanException.php
+++ b/library/Exceptions/GreaterThanException.php
@@ -23,10 +23,10 @@ final class GreaterThanException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be greater than {{compareTo}}',
+            self::STANDARD => '{{name}} 必须大于 {{compareTo}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be greater than {{compareTo}}',
+            self::STANDARD => '{{name}} 不能大于 {{compareTo}}',
         ],
     ];
 }

--- a/library/Exceptions/GroupedValidationException.php
+++ b/library/Exceptions/GroupedValidationException.php
@@ -29,12 +29,12 @@ class GroupedValidationException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NONE => 'All of the required rules must pass for {{name}}',
-            self::SOME => 'These rules must pass for {{name}}',
+            self::NONE => '所有必需的规则都必须传递给 {{name}}',
+            self::SOME => '这些规则必须传递给 {{name}}',
         ],
         self::MODE_NEGATIVE => [
-            self::NONE => 'None of there rules must pass for {{name}}',
-            self::SOME => 'These rules must not pass for {{name}}',
+            self::NONE => '所有规则都不能传递给 {{name}}',
+            self::SOME => '这些规则不能传递给 {{name}}',
         ],
     ];
 

--- a/library/Exceptions/HexRgbColorException.php
+++ b/library/Exceptions/HexRgbColorException.php
@@ -24,10 +24,10 @@ final class HexRgbColorException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a hex RGB color',
+            self::STANDARD => '{{name}} 必须是十六进制RGB颜色',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a hex RGB color',
+            self::STANDARD => '{{name}} 不能是十六进制RGB颜色',
         ],
     ];
 }

--- a/library/Exceptions/IbanException.php
+++ b/library/Exceptions/IbanException.php
@@ -23,10 +23,10 @@ final class IbanException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid IBAN',
+            self::STANDARD => '{{name}} 必须是有效的IBAN',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid IBAN',
+            self::STANDARD => '{{name}} 不能是有效的IBAN',
         ],
     ];
 }

--- a/library/Exceptions/IdenticalException.php
+++ b/library/Exceptions/IdenticalException.php
@@ -23,10 +23,10 @@ final class IdenticalException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be identical as {{compareTo}}',
+            self::STANDARD => '{{name}} 必须与 {{compareTo}} 相同',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be identical as {{compareTo}}',
+            self::STANDARD => '{{name}} 不能与 {{compareTo}} 相同',
         ],
     ];
 }

--- a/library/Exceptions/ImageException.php
+++ b/library/Exceptions/ImageException.php
@@ -25,10 +25,10 @@ final class ImageException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid image',
+            self::STANDARD => '{{name}} 必须是有效的图像',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid image',
+            self::STANDARD => '{{name}} 不能是有效的图像',
         ],
     ];
 }

--- a/library/Exceptions/ImeiException.php
+++ b/library/Exceptions/ImeiException.php
@@ -25,10 +25,10 @@ final class ImeiException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid IMEI',
+            self::STANDARD => '{{name}} 必须是有效的IMEI',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid IMEI',
+            self::STANDARD => '{{name}} 不能是有效的IMEI',
         ],
     ];
 }

--- a/library/Exceptions/InException.php
+++ b/library/Exceptions/InException.php
@@ -25,10 +25,10 @@ final class InException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be in {{haystack}}',
+            self::STANDARD => '{{name}} 必须在 {{haystack}} 中',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be in {{haystack}}',
+            self::STANDARD => '{{name}} 不能在 {{haystack}} 中',
         ],
     ];
 }

--- a/library/Exceptions/InfiniteException.php
+++ b/library/Exceptions/InfiniteException.php
@@ -24,10 +24,10 @@ final class InfiniteException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an infinite number',
+            self::STANDARD => '{{name}} 必须是无穷大的数字',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an infinite number',
+            self::STANDARD => '{{name}} 不能是无穷大的数字',
         ],
     ];
 }

--- a/library/Exceptions/InstanceException.php
+++ b/library/Exceptions/InstanceException.php
@@ -25,10 +25,10 @@ final class InstanceException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an instance of {{instanceName}}',
+            self::STANDARD => '{{name}} 必须是 {{instanceName}} 的实例',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an instance of {{instanceName}}',
+            self::STANDARD => '{{name}} 不能是 {{instanceName}} 的实例',
         ],
     ];
 }

--- a/library/Exceptions/IntTypeException.php
+++ b/library/Exceptions/IntTypeException.php
@@ -25,10 +25,10 @@ final class IntTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be of type integer',
+            self::STANDARD => '{{name}} 必须是integer类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be of type integer',
+            self::STANDARD => '{{name}} 不能是integer类型',
         ],
     ];
 }

--- a/library/Exceptions/IntValException.php
+++ b/library/Exceptions/IntValException.php
@@ -25,10 +25,10 @@ final class IntValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an integer number',
+            self::STANDARD => '{{name}} 必须是整数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an integer number',
+            self::STANDARD => '{{name}} 不能是整数',
         ],
     ];
 }

--- a/library/Exceptions/IpException.php
+++ b/library/Exceptions/IpException.php
@@ -28,12 +28,12 @@ final class IpException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an IP address',
-            self::NETWORK_RANGE => '{{name}} must be an IP address in the {{range}} range',
+            self::STANDARD => '{{name}} 必须是IP地址',
+            self::NETWORK_RANGE => '{{name}} 必须是 {{range}} 范围内的IP地址',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an IP address',
-            self::NETWORK_RANGE => '{{name}} must not be an IP address in the {{range}} range',
+            self::STANDARD => '{{name}} 不能是IP地址',
+            self::NETWORK_RANGE => '{{name}} 不能是 {{range}} 范围内的IP地址',
         ],
     ];
 

--- a/library/Exceptions/IsbnException.php
+++ b/library/Exceptions/IsbnException.php
@@ -24,10 +24,10 @@ final class IsbnException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a ISBN',
+            self::STANDARD => '{{name}} 必须是ISBN',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a ISBN',
+            self::STANDARD => '{{name}} 不能是ISBN',
         ],
     ];
 }

--- a/library/Exceptions/IterableTypeException.php
+++ b/library/Exceptions/IterableTypeException.php
@@ -23,10 +23,10 @@ final class IterableTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be iterable',
+            self::STANDARD => '{{name}} 必须是可迭代的',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be iterable',
+            self::STANDARD => '{{name}} 不能是可迭代的',
         ],
     ];
 }

--- a/library/Exceptions/JsonException.php
+++ b/library/Exceptions/JsonException.php
@@ -25,10 +25,10 @@ final class JsonException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid JSON string',
+            self::STANDARD => '{{name}} 必须是有效的JSON字符串',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid JSON string',
+            self::STANDARD => '{{name}} 不能是有效的JSON字符串',
         ],
     ];
 }

--- a/library/Exceptions/KeyException.php
+++ b/library/Exceptions/KeyException.php
@@ -30,12 +30,12 @@ final class KeyException extends NestedValidationException implements NonOmissib
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NOT_PRESENT => 'Key {{name}} must be present',
-            self::INVALID => 'Key {{name}} must be valid',
+            self::NOT_PRESENT => '键 {{name}} 必须存在',
+            self::INVALID => '键 {{name}} 必须有效',
         ],
         self::MODE_NEGATIVE => [
-            self::NOT_PRESENT => 'Key {{name}} must not be present',
-            self::INVALID => 'Key {{name}} must not be valid',
+            self::NOT_PRESENT => '键 {{name}} 不能存在',
+            self::INVALID => '键 {{name}} 必须无效',
         ],
     ];
 

--- a/library/Exceptions/KeyNestedException.php
+++ b/library/Exceptions/KeyNestedException.php
@@ -30,12 +30,12 @@ final class KeyNestedException extends NestedValidationException implements NonO
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NOT_PRESENT => 'No items were found for key chain {{name}}',
-            self::INVALID => 'Key chain {{name}} is not valid',
+            self::NOT_PRESENT => '找不到密钥链 {{name}} 的项',
+            self::INVALID => '密钥链 {{name}} 无效',
         ],
         self::MODE_NEGATIVE => [
-            self::NOT_PRESENT => 'Items for key chain {{name}} must not be present',
-            self::INVALID => 'Key chain {{name}} must not be valid',
+            self::NOT_PRESENT => '密钥链 {{name}} 的项不存在',
+            self::INVALID => '密钥链 {{name}} 必须无效',
         ],
     ];
 

--- a/library/Exceptions/KeySetException.php
+++ b/library/Exceptions/KeySetException.php
@@ -27,14 +27,14 @@ final class KeySetException extends GroupedValidationException implements NonOmi
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::NONE => 'All of the required rules must pass for {{name}}',
-            self::SOME => 'These rules must pass for {{name}}',
-            self::STRUCTURE => 'Must have keys {{keys}}',
+            self::NONE => '所有必需的规则都必须传递给 {{name}}',
+            self::SOME => '这些规则必须传递给 {{name}}',
+            self::STRUCTURE => '必须有键 {{keys}}',
         ],
         self::MODE_NEGATIVE => [
-            self::NONE => 'None of these rules must pass for {{name}}',
-            self::SOME => 'These rules must not pass for {{name}}',
-            self::STRUCTURE => 'Must not have keys {{keys}}',
+            self::NONE => '这些规则都不能传递给 {{name}}',
+            self::SOME => '这些规则不能传递给 {{name}}',
+            self::STRUCTURE => '不能有键 {{keys}}',
         ],
     ];
 

--- a/library/Exceptions/KeyValueException.php
+++ b/library/Exceptions/KeyValueException.php
@@ -25,12 +25,12 @@ final class KeyValueException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'Key {{name}} must be present',
-            self::COMPONENT => '{{baseKey}} must be valid to validate {{comparedKey}}',
+            self::STANDARD => '键 {{name}} 必须存在',
+            self::COMPONENT => '{{baseKey}} 必须有效才能验证 {{comparedKey}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'Key {{name}} must not be present',
-            self::COMPONENT => '{{baseKey}} must not be valid to validate {{comparedKey}}',
+            self::STANDARD => '键 {{name}} 不能存在',
+            self::COMPONENT => '{{baseKey}} 必须无效才能验证 {{comparedKey}}',
         ],
     ];
 

--- a/library/Exceptions/LanguageCodeException.php
+++ b/library/Exceptions/LanguageCodeException.php
@@ -25,10 +25,10 @@ final class LanguageCodeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid ISO 639 {{set}} language code',
+            self::STANDARD => '{{name}} 必须是有效的 ISO 639 {{set}} 语言编码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid ISO 639 {{set}} language code',
+            self::STANDARD => '{{name}} 不能是有效的 ISO 639 {{set}} 语言编码',
         ],
     ];
 }

--- a/library/Exceptions/LeapDateException.php
+++ b/library/Exceptions/LeapDateException.php
@@ -24,10 +24,10 @@ final class LeapDateException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be leap date',
+            self::STANDARD => '{{name}} 必须是闰日',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be leap date',
+            self::STANDARD => '{{name}} 不能是闰日',
         ],
     ];
 }

--- a/library/Exceptions/LeapYearException.php
+++ b/library/Exceptions/LeapYearException.php
@@ -24,10 +24,10 @@ final class LeapYearException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a leap year',
+            self::STANDARD => '{{name}} 必须是闰年',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a leap year',
+            self::STANDARD => '{{name}} 不能是闰年',
         ],
     ];
 }

--- a/library/Exceptions/LengthException.php
+++ b/library/Exceptions/LengthException.php
@@ -33,20 +33,20 @@ final class LengthException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::BOTH => '{{name}} must have a length between {{minValue}} and {{maxValue}}',
-            self::LOWER => '{{name}} must have a length greater than {{minValue}}',
-            self::LOWER_INCLUSIVE => '{{name}} must have a length greater than or equal to {{minValue}}',
-            self::GREATER => '{{name}} must have a length lower than {{maxValue}}',
-            self::GREATER_INCLUSIVE => '{{name}} must have a length lower than or equal to {{maxValue}}',
-            self::EXACT => '{{name}} must have a length of {{maxValue}}',
+            self::BOTH => '{{name}} 长度必须在 {{minValue}} 与 {{maxValue}} 之间',
+            self::LOWER => '{{name}} 长度必须大于 {{minValue}}',
+            self::LOWER_INCLUSIVE => '{{name}} 的长度必须大于或等于 {{minValue}}',
+            self::GREATER => '{{name}} 长度必须小于 {{maxValue}}',
+            self::GREATER_INCLUSIVE => '{{name}} 长度必须小于或等于 {{maxValue}}',
+            self::EXACT => '{{name}} 长度必须是 {{maxValue}}',
         ],
         self::MODE_NEGATIVE => [
-            self::BOTH => '{{name}} must not have a length between {{minValue}} and {{maxValue}}',
-            self::LOWER => '{{name}} must not have a length greater than {{minValue}}',
-            self::LOWER_INCLUSIVE => '{{name}} must not have a length greater than or equal to {{minValue}}',
-            self::GREATER => '{{name}} must not have a length lower than {{maxValue}}',
-            self::GREATER_INCLUSIVE => '{{name}} must not have a length lower than or equal to {{maxValue}}',
-            self::EXACT => '{{name}} must not have a length of {{maxValue}}',
+            self::BOTH => '{{name}} 的长度不能介于 {{minValue}} 和 {{maxValue}} 之间',
+            self::LOWER => '{{name}} 长度不能大于 {{minValue}}',
+            self::LOWER_INCLUSIVE => '{{name}} 长度不能大于或等于 {{minValue}}',
+            self::GREATER => '{{name}} 长度不得小于 {{maxValue}}',
+            self::GREATER_INCLUSIVE => '{{name}} 长度不能小于或等于 {{maxValue}}',
+            self::EXACT => '{{name}} 长度不能是 {{maxValue}}',
         ],
     ];
 

--- a/library/Exceptions/LessThanException.php
+++ b/library/Exceptions/LessThanException.php
@@ -23,10 +23,10 @@ final class LessThanException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be less than {{compareTo}}',
+            self::STANDARD => '{{name}} 必须小于 {{compareTo}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be less than {{compareTo}}',
+            self::STANDARD => '{{name}} 不能小于 {{compareTo}}',
         ],
     ];
 }

--- a/library/Exceptions/LowercaseException.php
+++ b/library/Exceptions/LowercaseException.php
@@ -25,10 +25,10 @@ final class LowercaseException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be lowercase',
+            self::STANDARD => '{{name}} 必须是小写',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be lowercase',
+            self::STANDARD => '{{name}} 不能是小写',
         ],
     ];
 }

--- a/library/Exceptions/LuhnException.php
+++ b/library/Exceptions/LuhnException.php
@@ -25,10 +25,10 @@ final class LuhnException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid Luhn number',
+            self::STANDARD => '{{name}} 必须是有效的Luhn编号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid Luhn number',
+            self::STANDARD => '{{name}} 不能是有效的Luhn编号',
         ],
     ];
 }

--- a/library/Exceptions/MacAddressException.php
+++ b/library/Exceptions/MacAddressException.php
@@ -25,10 +25,10 @@ final class MacAddressException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid MAC address',
+            self::STANDARD => '{{name}} 必须是有效的MAC地址',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid MAC address',
+            self::STANDARD => '{{name}} 不能是有效的MAC地址',
         ],
     ];
 }

--- a/library/Exceptions/MaxAgeException.php
+++ b/library/Exceptions/MaxAgeException.php
@@ -24,10 +24,10 @@ final class MaxAgeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be {{age}} years or less',
+            self::STANDARD => '{{name}} 必须是 {{age}} 年或者更少',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be {{age}} years or less',
+            self::STANDARD => '{{name}} 不能是 {{age}} 年或者更少',
         ],
     ];
 }

--- a/library/Exceptions/MaxException.php
+++ b/library/Exceptions/MaxException.php
@@ -25,10 +25,10 @@ final class MaxException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be less than or equal to {{compareTo}}',
+            self::STANDARD => '{{name}} 必须小于或等于 {{compareTo}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be less than or equal to {{compareTo}}',
+            self::STANDARD => '{{name}} 不能小于或等于 {{compareTo}}',
         ],
     ];
 }

--- a/library/Exceptions/MimetypeException.php
+++ b/library/Exceptions/MimetypeException.php
@@ -26,10 +26,10 @@ final class MimetypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must have {{mimetype}} MIME type',
+            self::STANDARD => '{{name}} 必须具有 {{mimetype}} MIME类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not have {{mimetype}} MIME type',
+            self::STANDARD => '{{name}} 不能有 {{mimetype}} MIME类型',
         ],
     ];
 }

--- a/library/Exceptions/MinAgeException.php
+++ b/library/Exceptions/MinAgeException.php
@@ -25,10 +25,10 @@ final class MinAgeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be {{age}} years or more',
+            self::STANDARD => '{{name}} 必须是 {{age}} 必须是年或以上',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be {{age}} years or more',
+            self::STANDARD => '{{name}} 不能是 {{age}} 年或更长',
         ],
     ];
 }

--- a/library/Exceptions/MinException.php
+++ b/library/Exceptions/MinException.php
@@ -26,10 +26,10 @@ final class MinException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be greater than or equal to {{compareTo}}',
+            self::STANDARD => '{{name}} 必须大于或等于 {{compareTo}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be greater than or equal to {{compareTo}}',
+            self::STANDARD => '{{name}} 不能大于或等于 {{compareTo}}',
         ],
     ];
 }

--- a/library/Exceptions/MultipleException.php
+++ b/library/Exceptions/MultipleException.php
@@ -25,10 +25,10 @@ final class MultipleException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be multiple of {{multipleOf}}',
+            self::STANDARD => '{{name}} 必须是 {{multipleOf}} 的倍数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be multiple of {{multipleOf}}',
+            self::STANDARD => '{{name}} 不能是 {{multipleOf}} 的倍数',
         ],
     ];
 }

--- a/library/Exceptions/NegativeException.php
+++ b/library/Exceptions/NegativeException.php
@@ -25,10 +25,10 @@ final class NegativeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be negative',
+            self::STANDARD => '{{name}} 必须为负数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be negative',
+            self::STANDARD => '{{name}} 不能为负数',
         ],
     ];
 }

--- a/library/Exceptions/NestedValidationException.php
+++ b/library/Exceptions/NestedValidationException.php
@@ -22,7 +22,6 @@ use function count;
 use function current;
 use function implode;
 use function is_array;
-use function is_string;
 use function spl_object_hash;
 use function sprintf;
 use function str_repeat;
@@ -40,8 +39,6 @@ use const PHP_EOL;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jonathan Stewmon <jstewmon@rmn.com>
  * @author Wojciech Frącz <fraczwojciech@gmail.com>
- *
- * @implements IteratorAggregate<ValidationException>
  */
 class NestedValidationException extends ValidationException implements IteratorAggregate
 {
@@ -218,11 +215,11 @@ class NestedValidationException extends ValidationException implements IteratorA
     }
 
     /**
-     * @param string[]|string[][] $templates
+     * @param string[] $templates
      */
     private function renderMessage(ValidationException $exception, array $templates): string
     {
-        if (isset($templates[$exception->getId()]) && is_string($templates[$exception->getId()])) {
+        if (isset($templates[$exception->getId()])) {
             $exception->updateTemplate($templates[$exception->getId()]);
         }
 
@@ -230,10 +227,10 @@ class NestedValidationException extends ValidationException implements IteratorA
     }
 
     /**
-     * @param string[]|string[][] $templates
+     * @param string[] $templates
      * @param mixed ...$ids
      *
-     * @return string[]|string[][]
+     * @return string[]
      */
     private function findTemplates(array $templates, ...$ids): array
     {

--- a/library/Exceptions/NfeAccessKeyException.php
+++ b/library/Exceptions/NfeAccessKeyException.php
@@ -25,10 +25,10 @@ final class NfeAccessKeyException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid NFe access key',
+            self::STANDARD => '{{name}} 必须是有效的NFe访问密钥',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid NFe access key',
+            self::STANDARD => '{{name}} 不能是有效的NFe访问密钥',
         ],
     ];
 }

--- a/library/Exceptions/NifException.php
+++ b/library/Exceptions/NifException.php
@@ -24,10 +24,10 @@ final class NifException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a NIF',
+            self::STANDARD => '{{name}} 必须是NIF',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a NIF',
+            self::STANDARD => '{{name}} 不能是NIF',
         ],
     ];
 }

--- a/library/Exceptions/NipException.php
+++ b/library/Exceptions/NipException.php
@@ -24,10 +24,10 @@ final class NipException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid Polish VAT identification number',
+            self::STANDARD => '{{name}} 必须是有效的波兰增值税标识号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid Polish VAT identification number',
+            self::STANDARD => '{{name}} 不能是有效的波兰增值税标识号',
         ],
     ];
 }

--- a/library/Exceptions/NoException.php
+++ b/library/Exceptions/NoException.php
@@ -23,10 +23,10 @@ final class NoException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} is not considered as "No"',
+            self::STANDARD => '{{name}} 不被视为 "否"',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} is considered as "No"',
+            self::STANDARD => '{{name}} 被认为是 "否"',
         ],
     ];
 }

--- a/library/Exceptions/NoWhitespaceException.php
+++ b/library/Exceptions/NoWhitespaceException.php
@@ -25,10 +25,10 @@ final class NoWhitespaceException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must not contain whitespace',
+            self::STANDARD => '{{name}} 不能包含空格',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must contain whitespace',
+            self::STANDARD => '{{name}} 必须包含空格',
         ],
     ];
 }

--- a/library/Exceptions/NoneOfException.php
+++ b/library/Exceptions/NoneOfException.php
@@ -24,10 +24,10 @@ final class NoneOfException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'None of these rules must pass for {{name}}',
+            self::STANDARD => '这些规则都不能传递给 {{name}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'All of these rules must pass for {{name}}',
+            self::STANDARD => '所有这些规则都必须传递给 {{name}}',
         ],
     ];
 }

--- a/library/Exceptions/NotBlankException.php
+++ b/library/Exceptions/NotBlankException.php
@@ -26,12 +26,12 @@ final class NotBlankException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'The value must not be blank',
-            self::NAMED => '{{name}} must not be blank',
+            self::STANDARD => '值不能为空',
+            self::NAMED => '{{name}} 不能为空',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'The value must be blank',
-            self::NAMED => '{{name}} must be blank',
+            self::STANDARD => '值必须为空',
+            self::NAMED => '{{name}} 必须为空',
         ],
     ];
 

--- a/library/Exceptions/NotEmojiException.php
+++ b/library/Exceptions/NotEmojiException.php
@@ -23,10 +23,10 @@ final class NotEmojiException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must not contain an Emoji',
+            self::STANDARD => '{{name}} 不能包含表情符号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must contain an Emoji',
+            self::STANDARD => '{{name}} 必须包含表情符号',
         ],
     ];
 }

--- a/library/Exceptions/NotEmptyException.php
+++ b/library/Exceptions/NotEmptyException.php
@@ -27,12 +27,12 @@ final class NotEmptyException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'The value must not be empty',
-            self::NAMED => '{{name}} must not be empty',
+            self::STANDARD => '值不能为空',
+            self::NAMED => '{{name}} 不能为空',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'The value must be empty',
-            self::NAMED => '{{name}} must be empty',
+            self::STANDARD => '值必须为空',
+            self::NAMED => '{{name}} 必须为空',
         ],
     ];
 

--- a/library/Exceptions/NotOptionalException.php
+++ b/library/Exceptions/NotOptionalException.php
@@ -26,12 +26,12 @@ final class NotOptionalException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'The value must not be optional',
-            self::NAMED => '{{name}} must not be optional',
+            self::STANDARD => '该值不能是可选的',
+            self::NAMED => '{{name}} 不能是可选的',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'The value must be optional',
-            self::NAMED => '{{name}} must be optional',
+            self::STANDARD => '该值必须是可选的',
+            self::NAMED => '{{name}} 必须是可选的',
         ],
     ];
 

--- a/library/Exceptions/NullTypeException.php
+++ b/library/Exceptions/NullTypeException.php
@@ -26,10 +26,10 @@ final class NullTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be null',
+            self::STANDARD => '{{name}} 必须为 null',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be null',
+            self::STANDARD => '{{name}} 不能为 null',
         ],
     ];
 }

--- a/library/Exceptions/NullableException.php
+++ b/library/Exceptions/NullableException.php
@@ -26,12 +26,12 @@ final class NullableException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'The value must be nullable',
-            self::NAMED => '{{name}} must be nullable',
+            self::STANDARD => '值必须为nullable',
+            self::NAMED => '{{name}} 必须为nullable',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'The value must not be null',
-            self::NAMED => '{{name}} must not be null',
+            self::STANDARD => '值不能为null',
+            self::NAMED => '{{name}} 不能为null',
         ],
     ];
 

--- a/library/Exceptions/NumberException.php
+++ b/library/Exceptions/NumberException.php
@@ -25,10 +25,10 @@ final class NumberException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a number',
+            self::STANDARD => '{{name}} 必须是数字',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a number',
+            self::STANDARD => '{{name}} 不能为数字',
         ],
     ];
 }

--- a/library/Exceptions/NumericValException.php
+++ b/library/Exceptions/NumericValException.php
@@ -25,10 +25,10 @@ final class NumericValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be numeric',
+            self::STANDARD => '{{name}} 必须是数字',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be numeric',
+            self::STANDARD => '{{name}} 不能是数字',
         ],
     ];
 }

--- a/library/Exceptions/ObjectTypeException.php
+++ b/library/Exceptions/ObjectTypeException.php
@@ -26,10 +26,10 @@ final class ObjectTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be of type object',
+            self::STANDARD => '{{name}} 必须是object类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be of type object',
+            self::STANDARD => '{{name}} 不能是object类型',
         ],
     ];
 }

--- a/library/Exceptions/OddException.php
+++ b/library/Exceptions/OddException.php
@@ -25,10 +25,10 @@ final class OddException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an odd number',
+            self::STANDARD => '{{name}} 必须是奇数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an odd number',
+            self::STANDARD => '{{name}} 不能是奇数',
         ],
     ];
 }

--- a/library/Exceptions/OneOfException.php
+++ b/library/Exceptions/OneOfException.php
@@ -24,10 +24,10 @@ final class OneOfException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'Only one of these rules must pass for {{name}}',
+            self::STANDARD => '这些规则中只有一个必须传递给 {{name}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'Only one of these rules must not pass for {{name}}',
+            self::STANDARD => '这些规则中只有一个不能传递给 {{name}}',
         ],
     ];
 }

--- a/library/Exceptions/OptionalException.php
+++ b/library/Exceptions/OptionalException.php
@@ -25,12 +25,12 @@ final class OptionalException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => 'The value must be optional',
-            self::NAMED => '{{name}} must be optional',
+            self::STANDARD => '该值必须是可选的',
+            self::NAMED => '{{name}} 必须是可选的',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => 'The value must not be optional',
-            self::NAMED => '{{name}} must not be optional',
+            self::STANDARD => '该值不能是可选的',
+            self::NAMED => '{{name}} 不能是可选的',
         ],
     ];
 

--- a/library/Exceptions/PerfectSquareException.php
+++ b/library/Exceptions/PerfectSquareException.php
@@ -25,10 +25,10 @@ final class PerfectSquareException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid perfect square',
+            self::STANDARD => '{{name}} 必须是有效的完全正方形',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid perfect square',
+            self::STANDARD => '{{name}} 不能是有效的完全正方形',
         ],
     ];
 }

--- a/library/Exceptions/PeselException.php
+++ b/library/Exceptions/PeselException.php
@@ -25,10 +25,10 @@ final class PeselException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid PESEL',
+            self::STANDARD => '{{name}} 必须是有效的比索',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid PESEL',
+            self::STANDARD => '{{name}} 不能是有效的比索',
         ],
     ];
 }

--- a/library/Exceptions/PhoneException.php
+++ b/library/Exceptions/PhoneException.php
@@ -25,10 +25,10 @@ final class PhoneException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid telephone number',
+            self::STANDARD => '{{name}} 必须是有效的电话号码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid telephone number',
+            self::STANDARD => '{{name}} 不能是有效的电话号码',
         ],
     ];
 }

--- a/library/Exceptions/PhpLabelException.php
+++ b/library/Exceptions/PhpLabelException.php
@@ -25,10 +25,10 @@ final class PhpLabelException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid PHP label',
+            self::STANDARD => '{{name}} 必须是有效的PHP标签',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid PHP label',
+            self::STANDARD => '{{name}} 不能是有效的PHP标签',
         ],
     ];
 }

--- a/library/Exceptions/PisException.php
+++ b/library/Exceptions/PisException.php
@@ -25,10 +25,10 @@ final class PisException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid PIS number',
+            self::STANDARD => '{{name}} 必须是有效的PIS编号',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid PIS number',
+            self::STANDARD => '{{name}} 不能是有效的PIS编号',
         ],
     ];
 }

--- a/library/Exceptions/PolishIdCardException.php
+++ b/library/Exceptions/PolishIdCardException.php
@@ -23,10 +23,10 @@ final class PolishIdCardException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid Polish Identity Card number',
+            self::STANDARD => '{{name}} 必须是有效的波兰身份证号码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid Polish Identity Card number',
+            self::STANDARD => '{{name}} 不能是有效的波兰身份证号码r',
         ],
     ];
 }

--- a/library/Exceptions/PositiveException.php
+++ b/library/Exceptions/PositiveException.php
@@ -25,10 +25,10 @@ final class PositiveException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be positive',
+            self::STANDARD => '{{name}} 必须为正',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be positive',
+            self::STANDARD => '{{name}} 不能为正',
         ],
     ];
 }

--- a/library/Exceptions/PostalCodeException.php
+++ b/library/Exceptions/PostalCodeException.php
@@ -23,10 +23,10 @@ final class PostalCodeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid postal code on {{countryCode}}',
+            self::STANDARD => '{{name}} 必须是 {{countryCode}} 上的有效邮政编码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid postal code on {{countryCode}}',
+            self::STANDARD => '{{name}} 不能是 {{countryCode}} 上的有效邮政编码',
         ],
     ];
 }

--- a/library/Exceptions/PrimeNumberException.php
+++ b/library/Exceptions/PrimeNumberException.php
@@ -25,10 +25,10 @@ final class PrimeNumberException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid prime number',
+            self::STANDARD => '{{name}} 必须是有效的质数',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid prime number',
+            self::STANDARD => '{{name}} 不能是有效的质数',
         ],
     ];
 }

--- a/library/Exceptions/PrintableException.php
+++ b/library/Exceptions/PrintableException.php
@@ -28,12 +28,12 @@ final class PrintableException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only printable characters',
-            self::EXTRA => '{{name}} must contain only printable characters and "{{additionalChars}}"',
+            self::STANDARD => '{{name}} 只能包含可打印字符',
+            self::EXTRA => '{{name}} 只能包含可打印字符和 "{{additionalChars}}"',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain printable characters',
-            self::EXTRA => '{{name}} must not contain printable characters or "{{additionalChars}}"',
+            self::STANDARD => '{{name}} 不能包含可打印字符',
+            self::EXTRA => '{{name}} 不能包含可打印字符或 "{{additionalChars}}"',
         ],
     ];
 }

--- a/library/Exceptions/PunctException.php
+++ b/library/Exceptions/PunctException.php
@@ -25,12 +25,12 @@ final class PunctException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only punctuation characters',
-            self::EXTRA => '{{name}} must contain only punctuation characters and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含标点符号',
+            self::EXTRA => '{{name}} 只能包含标点符号和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain punctuation characters',
-            self::EXTRA => '{{name}} must not contain punctuation characters or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含标点符号',
+            self::EXTRA => '{{name}} 不能包含标点符号或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/ReadableException.php
+++ b/library/Exceptions/ReadableException.php
@@ -24,10 +24,10 @@ final class ReadableException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be readable',
+            self::STANDARD => '{{name}} 必须可读',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be readable',
+            self::STANDARD => '{{name}} 不能可读',
         ],
     ];
 }

--- a/library/Exceptions/RecursiveExceptionIterator.php
+++ b/library/Exceptions/RecursiveExceptionIterator.php
@@ -24,7 +24,7 @@ use UnexpectedValueException;
 final class RecursiveExceptionIterator implements RecursiveIterator, Countable
 {
     /**
-     * @var ArrayIterator<int, ValidationException>
+     * @var ArrayIterator|ValidationException[]
      */
     private $exceptions;
 
@@ -67,7 +67,7 @@ final class RecursiveExceptionIterator implements RecursiveIterator, Countable
 
     public function key(): int
     {
-        return (int) $this->exceptions->key();
+        return $this->exceptions->key();
     }
 
     public function next(): void

--- a/library/Exceptions/RegexException.php
+++ b/library/Exceptions/RegexException.php
@@ -25,10 +25,10 @@ final class RegexException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must validate against {{regex}}',
+            self::STANDARD => '{{name}} 对照 {{regex}} 进行验证',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not validate against {{regex}}',
+            self::STANDARD => '{{name}} 不能针对 {{regex}} 进行验证',
         ],
     ];
 }

--- a/library/Exceptions/ResourceTypeException.php
+++ b/library/Exceptions/ResourceTypeException.php
@@ -25,10 +25,10 @@ final class ResourceTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a resource',
+            self::STANDARD => '{{name}} 必须是资源',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a resource',
+            self::STANDARD => '{{name}} 不能是资源',
         ],
     ];
 }

--- a/library/Exceptions/RomanException.php
+++ b/library/Exceptions/RomanException.php
@@ -24,10 +24,10 @@ final class RomanException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid Roman numeral',
+            self::STANDARD => '{{name}} 必须是有效的罗马数字',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid Roman numeral',
+            self::STANDARD => '{{name}} 不能是有效的罗马数字',
         ],
     ];
 }

--- a/library/Exceptions/ScalarValException.php
+++ b/library/Exceptions/ScalarValException.php
@@ -23,10 +23,10 @@ final class ScalarValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a scalar value',
+            self::STANDARD => '{{name}} 必须是标量值',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a scalar value',
+            self::STANDARD => '{{name}} 不能是标量值',
         ],
     ];
 }

--- a/library/Exceptions/SfException.php
+++ b/library/Exceptions/SfException.php
@@ -24,10 +24,10 @@ final class SfException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be valid for {{constraint}}',
+            self::STANDARD => '{{name}} 必须对 {{constraint}} 有效',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be valid for {{constraint}}',
+            self::STANDARD => '{{name}} 不能对 {{constraint}} 有效',
         ],
     ];
 }

--- a/library/Exceptions/SizeException.php
+++ b/library/Exceptions/SizeException.php
@@ -29,14 +29,14 @@ final class SizeException extends NestedValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::BOTH => '{{name}} must be between {{minSize}} and {{maxSize}}',
-            self::LOWER => '{{name}} must be greater than {{minSize}}',
-            self::GREATER => '{{name}} must be lower than {{maxSize}}',
+            self::BOTH => '{{name}} 必须介于 {{minSize}} 和 {{maxSize}} 之间',
+            self::LOWER => '{{name}} 必须大于 {{minSize}}',
+            self::GREATER => '{{name}} 必须小于 {{maxSize}}',
         ],
         self::MODE_NEGATIVE => [
-            self::BOTH => '{{name}} must not be between {{minSize}} and {{maxSize}}',
-            self::LOWER => '{{name}} must not be greater than {{minSize}}',
-            self::GREATER => '{{name}} must not be lower than {{maxSize}}',
+            self::BOTH => '{{name}} 不能介于 {{minSize}} 和 {{maxSize}} 之间',
+            self::LOWER => '{{name}} 不能大于 {{minSize}}',
+            self::GREATER => '{{name}} 不能小于 {{maxSize}}',
         ],
     ];
 

--- a/library/Exceptions/SlugException.php
+++ b/library/Exceptions/SlugException.php
@@ -25,10 +25,10 @@ final class SlugException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid slug',
+            self::STANDARD => '{{name}} 必须是有效的 slug',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid slug',
+            self::STANDARD => '{{name}} 不能是有效的 slug',
         ],
     ];
 }

--- a/library/Exceptions/SortedException.php
+++ b/library/Exceptions/SortedException.php
@@ -29,12 +29,12 @@ final class SortedException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::ASCENDING => '{{name}} must be sorted in ascending order',
-            self::DESCENDING => '{{name}} must be sorted in descending order',
+            self::ASCENDING => '{{name}} 必须按升序排序',
+            self::DESCENDING => '{{name}} 必须按降序排序',
         ],
         self::MODE_NEGATIVE => [
-            self::ASCENDING => '{{name}} must not be sorted in ascending order',
-            self::DESCENDING => '{{name}} must not be sorted in descending order',
+            self::ASCENDING => '{{name}} 不能按升序排序',
+            self::DESCENDING => '{{name}} 不能按降序排序',
         ],
     ];
 

--- a/library/Exceptions/SpaceException.php
+++ b/library/Exceptions/SpaceException.php
@@ -24,12 +24,12 @@ final class SpaceException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only space characters',
-            self::EXTRA => '{{name}} must contain only space characters and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含空格字符',
+            self::EXTRA => '{{name}} 只能包含空格字符和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain space characters',
-            self::EXTRA => '{{name}} must not contain space characters or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含空格字符',
+            self::EXTRA => '{{name}} 不能包含空格字符或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/StartsWithException.php
+++ b/library/Exceptions/StartsWithException.php
@@ -24,10 +24,10 @@ final class StartsWithException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must start with {{startValue}}',
+            self::STANDARD => '{{name}} 必须以 {{startValue}} 开头',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not start with {{startValue}}',
+            self::STANDARD => '{{name}} 不能以 {{startValue}} 开头',
         ],
     ];
 }

--- a/library/Exceptions/StringTypeException.php
+++ b/library/Exceptions/StringTypeException.php
@@ -24,10 +24,10 @@ final class StringTypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be of type string',
+            self::STANDARD => '{{name}} 必须是string类型',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be of type string',
+            self::STANDARD => '{{name}} 不能是string类型',
         ],
     ];
 }

--- a/library/Exceptions/StringValException.php
+++ b/library/Exceptions/StringValException.php
@@ -24,10 +24,10 @@ final class StringValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a string',
+            self::STANDARD => '{{name}} 必须是字符串',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be string',
+            self::STANDARD => '{{name}} 不能是字符串',
         ],
     ];
 }

--- a/library/Exceptions/SubdivisionCodeException.php
+++ b/library/Exceptions/SubdivisionCodeException.php
@@ -23,10 +23,10 @@ class SubdivisionCodeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a subdivision code of {{countryName}}',
+            self::STANDARD => '{{name}} 必须是 {{countryName}} 的细分代码',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a subdivision code of {{countryName}}',
+            self::STANDARD => '{{name}} 不能是 {{countryName}} 的细分代码',
         ],
     ];
 }

--- a/library/Exceptions/SubsetException.php
+++ b/library/Exceptions/SubsetException.php
@@ -24,10 +24,10 @@ final class SubsetException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be subset of {{superset}}',
+            self::STANDARD => '{{name}} 必须是 {{superset}} 的子集',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be subset of {{superset}}',
+            self::STANDARD => '{{name}} 不能是 {{superset}} 的子集',
         ],
     ];
 }

--- a/library/Exceptions/SymbolicLinkException.php
+++ b/library/Exceptions/SymbolicLinkException.php
@@ -24,10 +24,10 @@ final class SymbolicLinkException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a symbolic link',
+            self::STANDARD => '{{name}} 必须是符号链接',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a symbolic link',
+            self::STANDARD => '{{name}} 不能是符号链接',
         ],
     ];
 }

--- a/library/Exceptions/TimeException.php
+++ b/library/Exceptions/TimeException.php
@@ -23,10 +23,10 @@ final class TimeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid time in the format {{sample}}',
+            self::STANDARD => '{{name}} 必须是格式为 {{sample}} 的有效时间',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid time in the format {{sample}}',
+            self::STANDARD => '{{name}} 不能是格式为 {{sample}} 的有效时间',
         ],
     ];
 }

--- a/library/Exceptions/TldException.php
+++ b/library/Exceptions/TldException.php
@@ -28,10 +28,10 @@ final class TldException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid top-level domain name',
+            self::STANDARD => '{{name}} 必须是有效的顶级域名',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid top-level domain name',
+            self::STANDARD => '{{name}} 不能是有效的顶级域名',
         ],
     ];
 }

--- a/library/Exceptions/TrueValException.php
+++ b/library/Exceptions/TrueValException.php
@@ -26,10 +26,10 @@ final class TrueValException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} is not considered as "True"',
+            self::STANDARD => '{{name}} 不被视为 "True"',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} is considered as "True"',
+            self::STANDARD => '{{name}} 被视为 "True"',
         ],
     ];
 }

--- a/library/Exceptions/TypeException.php
+++ b/library/Exceptions/TypeException.php
@@ -26,10 +26,10 @@ final class TypeException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be {{type}}',
+            self::STANDARD => '{{name}} 必须是 {{type}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be {{type}}',
+            self::STANDARD => '{{name}} 不能是 {{type}}',
         ],
     ];
 }

--- a/library/Exceptions/UniqueException.php
+++ b/library/Exceptions/UniqueException.php
@@ -27,10 +27,10 @@ final class UniqueException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must not contain duplicates',
+            self::STANDARD => '{{name}} 不能包含重复项',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must contain duplicates',
+            self::STANDARD => '{{name}} 必须包含重复项',
         ],
     ];
 }

--- a/library/Exceptions/UploadedException.php
+++ b/library/Exceptions/UploadedException.php
@@ -27,10 +27,10 @@ final class UploadedException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be an uploaded file',
+            self::STANDARD => '{{name}} 必须是上传的文件',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be an uploaded file',
+            self::STANDARD => '{{name}} 不能是上传的文件',
         ],
     ];
 }

--- a/library/Exceptions/UppercaseException.php
+++ b/library/Exceptions/UppercaseException.php
@@ -25,10 +25,10 @@ final class UppercaseException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be uppercase',
+            self::STANDARD => '{{name}} 必须大写',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be uppercase',
+            self::STANDARD => '{{name}} 不能大写',
         ],
     ];
 }

--- a/library/Exceptions/UrlException.php
+++ b/library/Exceptions/UrlException.php
@@ -23,10 +23,10 @@ final class UrlException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a URL',
+            self::STANDARD => '{{name}} 必须是URL',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a URL',
+            self::STANDARD => '{{name}} 不能是URL',
         ],
     ];
 }

--- a/library/Exceptions/UuidException.php
+++ b/library/Exceptions/UuidException.php
@@ -27,12 +27,12 @@ final class UuidException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid UUID',
-            self::VERSION => '{{name}} must be a valid UUID version {{version}}',
+            self::STANDARD => '{{name}} 必须是有效的UUID',
+            self::VERSION => '{{name}} 必须是有效的UUID版本 {{version}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid UUID',
-            self::VERSION => '{{name}} must not be a valid UUID version {{version}}',
+            self::STANDARD => '{{name}} 不能是有效的UUID',
+            self::VERSION => '{{name}} 不能是有效的UUID版本 {{version}}',
         ],
     ];
 

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -37,10 +37,10 @@ class ValidationException extends InvalidArgumentException implements Exception
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be valid',
+            self::STANDARD => '{{name}} 必须有效',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be valid',
+            self::STANDARD => '{{name}} 不能有效',
         ],
     ];
 

--- a/library/Exceptions/VersionException.php
+++ b/library/Exceptions/VersionException.php
@@ -24,10 +24,10 @@ final class VersionException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a version',
+            self::STANDARD => '{{name}} 必须是版本',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a version',
+            self::STANDARD => '{{name}} 不能是版本',
         ],
     ];
 }

--- a/library/Exceptions/VideoUrlException.php
+++ b/library/Exceptions/VideoUrlException.php
@@ -27,12 +27,12 @@ final class VideoUrlException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a valid video URL',
-            self::SERVICE => '{{name}} must be a valid {{service}} video URL',
+            self::STANDARD => '{{name}} 必须是有效的视频URL',
+            self::SERVICE => '{{name}} 必须是有效的 {{service}} 视频URL',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a valid video URL',
-            self::SERVICE => '{{name}} must not be a valid {{service}} video URL',
+            self::STANDARD => '{{name}} 不能是有效的视频URL',
+            self::SERVICE => '{{name}} 不能是有效的 {{service}} 视频URL',
         ],
     ];
 

--- a/library/Exceptions/VowelException.php
+++ b/library/Exceptions/VowelException.php
@@ -24,12 +24,12 @@ final class VowelException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must contain only vowels',
-            self::EXTRA => '{{name}} must contain only vowels and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含元音',
+            self::EXTRA => '{{name}} 只能包含元音和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain vowels',
-            self::EXTRA => '{{name}} must not contain vowels or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含元音',
+            self::EXTRA => '{{name}} 不能包含元音或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/WritableException.php
+++ b/library/Exceptions/WritableException.php
@@ -24,10 +24,10 @@ final class WritableException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be writable',
+            self::STANDARD => '{{name}} 必须是可写的',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be writable',
+            self::STANDARD => '{{name}} 不能是可写的',
         ],
     ];
 }

--- a/library/Exceptions/XdigitException.php
+++ b/library/Exceptions/XdigitException.php
@@ -24,12 +24,12 @@ final class XdigitException extends FilteredValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} contain only hexadecimal digits',
-            self::EXTRA => '{{name}} contain only hexadecimal digits and {{additionalChars}}',
+            self::STANDARD => '{{name}} 只能包含十六进制数字',
+            self::EXTRA => '{{name}} 只能包含十六进制数字和 {{additionalChars}}',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not contain hexadecimal digits',
-            self::EXTRA => '{{name}} must not contain hexadecimal digits or {{additionalChars}}',
+            self::STANDARD => '{{name}} 不能包含十六进制数字',
+            self::EXTRA => '{{name}} 不能包含十六进制数字或 {{additionalChars}}',
         ],
     ];
 }

--- a/library/Exceptions/YesException.php
+++ b/library/Exceptions/YesException.php
@@ -24,10 +24,10 @@ final class YesException extends ValidationException
      */
     protected $defaultTemplates = [
         self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} is not considered as "Yes"',
+            self::STANDARD => '{{name}} 不被认为是 "Yes"',
         ],
         self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} is considered as "Yes"',
+            self::STANDARD => '{{name}} 被认为是 "Yes"',
         ],
     ];
 }

--- a/library/Factory.php
+++ b/library/Factory.php
@@ -163,7 +163,7 @@ final class Factory
         $params = ['input' => $input] + $extraParams + $this->extractPropertiesValues($validatable, $reflection);
         $id = lcfirst($ruleName);
         if ($validatable->getName() !== null) {
-            $id = $params['name'] = $validatable->getName();
+            /*$id = */$params['name'] = $validatable->getName();
         }
         foreach ($this->exceptionsNamespaces as $namespace) {
             try {

--- a/library/Rules/AbstractComposite.php
+++ b/library/Rules/AbstractComposite.php
@@ -60,6 +60,18 @@ abstract class AbstractComposite extends AbstractRule
         return parent::setName($name);
     }
 
+    public function setDefault(string $name): Validatable
+    {
+        $parentDefault = $this->getDefault();
+        foreach ($this->rules as $rule) {
+            $ruleDefault = $rule->getDefault();
+            if ($ruleDefault && $parentDefault !== $ruleDefault) {
+                continue;
+            }
+            $rule->setDefault($name);
+        }
+        return parent::setDefault($name);
+    }
     /**
      * Append a rule into the stack of rules.
      *

--- a/library/Rules/AbstractComposite.php
+++ b/library/Rules/AbstractComposite.php
@@ -60,7 +60,7 @@ abstract class AbstractComposite extends AbstractRule
         return parent::setName($name);
     }
 
-    public function setDefault(string $name): Validatable
+    public function setDefault(string $default, bool $defaultType=false): Validatable
     {
         $parentDefault = $this->getDefault();
         foreach ($this->rules as $rule) {
@@ -68,9 +68,9 @@ abstract class AbstractComposite extends AbstractRule
             if ($ruleDefault && $parentDefault !== $ruleDefault) {
                 continue;
             }
-            $rule->setDefault($name);
+            $rule->setDefault($default, $defaultType);
         }
-        return parent::setDefault($name);
+        return parent::setDefault($default, $defaultType);
     }
     /**
      * Append a rule into the stack of rules.

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -30,6 +30,10 @@ abstract class AbstractRule implements Validatable
      */
     protected $default;
     /**
+     * @var bool|false
+     */
+    protected $defaultType;
+    /**
      * @var string|null
      */
     protected $name;
@@ -109,9 +113,17 @@ abstract class AbstractRule implements Validatable
     {
         return $this->default;
     }
-    public function setDefault(string $default): Validatable
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultType(): ?bool
+    {
+        return $this->defaultType;
+    }
+    public function setDefault(string $default, bool $defaultType=false): Validatable
     {
         $this->default = $default;
+        $this->defaultType = $defaultType;
         return $this;
     }
 }

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -28,6 +28,10 @@ abstract class AbstractRule implements Validatable
     /**
      * @var string|null
      */
+    protected $default;
+    /**
+     * @var string|null
+     */
     protected $name;
 
     /**
@@ -96,6 +100,18 @@ abstract class AbstractRule implements Validatable
     {
         $this->template = $template;
 
+        return $this;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefault(): ?string
+    {
+        return $this->default;
+    }
+    public function setDefault(string $default): Validatable
+    {
+        $this->default = $default;
         return $this;
     }
 }

--- a/library/Rules/FilterVar.php
+++ b/library/Rules/FilterVar.php
@@ -51,7 +51,7 @@ final class FilterVar extends AbstractEnvelope
      *
      * @throws ComponentException
      */
-    public function __construct(int $filter, $options = null)
+    public function __construct(int $filter, $options = [])
     {
         if (!in_array($filter, self::ALLOWED_FILTERS)) {
             throw new ComponentException('Cannot accept the given filter');

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -230,4 +230,22 @@ final class Validator extends AllOf
     {
         return new self();
     }
+
+    /**
+     * 按照规则检查输入，如果不符合规则则抛出异常
+     *
+     * @param array $input
+     * @param array $rules
+     * @return array
+     */
+    public static function input(array $input, array $rules)
+    {
+        $values = [];
+        foreach ($rules as $field => $rule) {
+            $value = $input[$field] ?? null;
+            $rule->check($value);
+            $values[$field] = $value;
+        }
+        return $values;
+    }
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -242,7 +242,7 @@ final class Validator extends AllOf
     {
         $values = [];
         foreach ($rules as $field => $rule) {
-            $value = $input[$field] ?? null;
+            $value = $input[$field] ?? $rule->default;
             $rule->check($value);
             $values[$field] = $value;
         }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -242,7 +242,7 @@ final class Validator extends AllOf
     {
         $values = [];
         foreach ($rules as $field => $rule) {
-            $value = $input[$field] ?? $rule->default;
+            $value = $rule->defaultType?$rule->default:($input[$field] ?? $rule->default);
             $rule->check($value);
             $values[$field] = $value;
         }


### PR DESCRIPTION
PR需求来源：https://www.workerman.net/q/11421

用法
$data = v::input($request->post(), [
            'app_id' => v::alnum()->length(1, 64)->setName('用户名')->setDefault("toadmin"),
            'app_id1' => v::alnum()->length(1, 64)->setName('用户名')->setDefault("toadmin",true),
            'xxx' => v::optional(v::length(5, 64))->setName('其它'),
            'xxx1' => v::length(5, 64)->setDefault('其它111')
        ]);
        
       使用setDefault后，同时可代替v::optional用于验证一些字段可填可不填字段中，同时可以使用setDefaule第二个参数为true即可设置为强制默认值，而不被前端传输的参数替换，比如app_id1，我需要固定为“toadmin”，而不被前端传输app_id1为touser而覆盖。

       而验证后的变量 $data 即可传输到service等层进行业务处理
