### PR TITLE
Fix: Lock 'symfony/polyfill-mbstring' Version at '^v1.27.0' in Drupal 10.1.x for Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.1 || ^8.2",
         "respect/stringifier": "^2.0.0",
-        "symfony/polyfill-mbstring": "^1.28"
+        "symfony/polyfill-mbstring": "^1.27"
     },
     "require-dev": {
         "egulias/email-validator": "^4.0",


### PR DESCRIPTION
hey dear maintainers 

Recently, the Respect/Validation library upgraded to using symfony/polyfill-mbstring 1.28.0. This presents a bit of issue for us, as we're still on Drupal 10.1.x, which works with symfony/polyfill-mbstring ~v1.27.0. Upgrading to Drupal 10.2.x (which plays well with ~v1.28.0) isn't in our cards just yet. So, we're hoping to keep our setup running smoothly with ~v1.27.0 of symfony/polyfill-mbstring for a little longer. 
