### PR TITLE
Fix bug when `Multiple` is passed an invalid value

### DIFF
--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use function filter_var;
+
+use const FILTER_VALIDATE_INT;
+
 /**
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
@@ -31,6 +35,9 @@ final class Multiple extends AbstractRule
      */
     public function validate($input): bool
     {
+        if (filter_var($input, FILTER_VALIDATE_INT) === false) {
+            return false;
+        }
         if ($this->multipleOf == 0) {
             return $input == 0;
         }


### PR DESCRIPTION
If you are using `Multiple` to validate, and pass a value that is unsupported by the `%` operator, it will fail instead of creating a validation error. This fixes that bug.

Example of code the reproduces the bug:

```php
Respect\Validation\Validator::intType()->multiple(10)->assert('Hello!');
// TypeError: Unsupported operand types: string % int
```

I'm submitting against the 2.3 branch instead of main because that's the version I'm using, and the version I tested this change against. It looks like the library has undergone significant refactoring since 2.3, so this probably can't be merged as-is to main.

This uses the same method that was already in use in the `Even` rule. Probably a better way of doing things would be some kind of "short circuit" where, since `intType` fails, `multiple` is never used. But, I don't want to throw anything drastic your way since it looks like you're in the middle of a big refactor.