### PR TITLE
Create deprecated classes to keep backward compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Respect\\Validation\\": "library/"
+            "Respect\\Validation\\": ["library/", "deprecated/src/"]
         }
     },
     "autoload-dev": {
@@ -66,7 +66,7 @@
         ]
     },
     "scripts": {
-        "docheader": "vendor/bin/docheader check library/ tests/",
+        "docheader": "vendor/bin/docheader check library/ tests/ deprecated/",
         "phpcs": "vendor/bin/phpcs",
         "phpstan": "vendor/bin/phpstan analyze",
         "phpunit": "vendor/bin/phpunit",

--- a/deprecated/src/Rules/AbstractEnvelope.php
+++ b/deprecated/src/Rules/AbstractEnvelope.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Rules\Core\Envelope;
+
+/**
+ * @deprecated Use {@see Envelope} instead.
+ */
+abstract class AbstractEnvelope extends AbstractRule
+{
+}

--- a/deprecated/src/Rules/AbstractRule.php
+++ b/deprecated/src/Rules/AbstractRule.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use ReflectionClass;
+use Respect\Validation\Result;
+use Respect\Validation\Rule;
+use Respect\Validation\Validator;
+
+/**
+ * @deprecated Use {@see Simple} instead.
+ */
+abstract class AbstractRule implements Rule
+{
+    private ?string $name = null;
+
+    private ?string $template = null;
+
+    /**
+     * @deprecated Calling `validate()` directly is deprecated, please use the `Validator::isValid()` instead.
+     */
+    abstract public function validate($input): bool;
+
+    public function evaluate(mixed $input): Result
+    {
+        return new Result(
+            $this->validate($input),
+            $input,
+            $this,
+            $this->extractPropertiesValues(),
+            $this->template ?? '{{name}} must be valid',
+        );
+    }
+
+    /**
+     * @deprecated Calling `assert()` directly is deprecated, please use the `Validator::assert()` instead.
+     */
+    public function assert($input): void
+    {
+        Validator::create($this)->assert($input);
+    }
+
+    /**
+     * @deprecated Calling `check()` directly is deprecated, please use the `Validator::assert()` instead.
+     */
+    public function check($input): void
+    {
+        Validator::create($this)->assert($input);
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getTemplate(): ?string
+    {
+        return $this->template;
+    }
+
+    public function setTemplate(string $template): static
+    {
+        $this->template = $template;
+
+        return $this;
+    }
+
+    /** @return array<string, mixed> */
+    private function extractPropertiesValues(): array
+    {
+        $reflection ??= new ReflectionClass($this);
+        $values = [];
+        foreach ($reflection->getProperties() as $property) {
+            $propertyValue = $property->getValue($this);
+            if ($propertyValue === null) {
+                continue;
+            }
+
+            $values[$property->getName()] = $propertyValue;
+        }
+
+        return $values;
+    }
+}

--- a/deprecated/src/Rules/AbstractWrapper.php
+++ b/deprecated/src/Rules/AbstractWrapper.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use Respect\Validation\Rules\Core\Wrapper;
+
+/**
+ * @deprecated Use {@see Wrapper} instead.
+ */
+abstract class AbstractWrapper extends Wrapper
+{
+}

--- a/deprecated/src/Validatable.php
+++ b/deprecated/src/Validatable.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation;
+
+/**
+ * @deprecated Use {@see Rule} instead.
+ */
+interface Validatable extends Rule
+{
+}

--- a/deprecated/tests/abstract-rule.phpt
+++ b/deprecated/tests/abstract-rule.phpt
@@ -1,0 +1,22 @@
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+require 'vendor/autoload.php';
+
+use Respect\Validation\Rules\AbstractRule;
+
+class MyRule extends AbstractRule
+{
+    public function validate($input): bool
+    {
+        return false;
+    }
+}
+
+$myRule = new MyRule();
+$myRule->assert('anything');
+
+?>
+--EXPECT--

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,14 +11,30 @@
     <arg value="p" />
     <arg value="s" />
 
+    <file>deprecated/</file>
     <file>library/</file>
     <file>tests/</file>
 
     <rule ref="Respect" />
     <rule ref="Generic.Files.LineLength.TooLong">
         <exclude-pattern>tests/integration/</exclude-pattern>
+        <exclude-pattern>deprecated/tests/</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
         <exclude-pattern>tests/integration/</exclude-pattern>
+        <exclude-pattern>deprecated/tests/</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>deprecated/tests/</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>deprecated/tests/</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
+        <exclude-pattern>deprecated/tests/</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
+        <exclude-pattern>deprecated/tests/</exclude-pattern>
     </rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,5 +36,6 @@ parameters:
   level: 8
   treatPhpDocTypesAsCertain: false
   paths:
+    - deprecated/
     - library/
     - tests/


### PR DESCRIPTION
I'm not sure if I really want to go down that path. It will inflate the codebase quite a lot, and it will also be difficult to implement those.