### PR TITLE
Overwrite file and line in ValidationException

### DIFF
--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -11,6 +11,8 @@ namespace Respect\Validation\Exceptions;
 
 use InvalidArgumentException;
 
+use function realpath;
+
 final class ValidationException extends InvalidArgumentException implements Exception
 {
     /** @param array<string, mixed> $messages */
@@ -19,6 +21,10 @@ final class ValidationException extends InvalidArgumentException implements Exce
         private readonly string $fullMessage,
         private readonly array $messages,
     ) {
+        if (realpath($this->file) === realpath(__DIR__ . '/../Validator.php')) {
+            $this->file = $this->getTrace()[0]['file'] ?? $this->file;
+            $this->line = $this->getTrace()[0]['line'] ?? $this->line;
+        }
         parent::__construct($message);
     }
 

--- a/tests/feature/ValidationExceptionStackTraceTest.php
+++ b/tests/feature/ValidationExceptionStackTraceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+use Respect\Validation\Exceptions\ValidationException;
+
+test('Should overwrite stack trace when in Validator', function (): void {
+    try {
+        v::intType()->assert('string');
+    } catch (ValidationException $e) {
+        expect($e->getFile())->toBe(__FILE__);
+        expect($e->getLine())->toBe(__LINE__ - 3);
+    }
+});
+
+test('Should not overwrite stack trace when created manually', function (): void {
+    try {
+        throw new ValidationException('message', 'fullMessage', ['id' => 'message']);
+    } catch (ValidationException $e) {
+        expect($e->getFile())->toBe(__FILE__);
+        expect($e->getLine())->toBe(__LINE__ - 3);
+    }
+});


### PR DESCRIPTION
Because of how PHP works, when we instantiate an Exception object, the `file` and `line` properties are the file and line where we created the object. That's a desirable behaviour, but there's no value for a user to know that we created an instance of `ValidationException` in the `Validator` class.

This commit will overwrite the file and line in the `ValidationException` to where the method `assert()` was called.

Note that when running `check()` it will still point to `Validator`, but I decided not to change it, as the method `check()` got deprecated.