### PR TITLE
Allow `Min`, `Max`, and `Each` to wrap chained rules.

### DIFF
--- a/docs/rules/Max.md
+++ b/docs/rules/Max.md
@@ -24,12 +24,6 @@ empty, the validation will fail.
 
 ### `Max::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-|------------|-----------------------------|
-| `default`  | As the maximum of {{name}}, |
-| `inverted` | As the maximum of {{name}}, |
-
-### `Max::TEMPLATE_NAMED`
 
 | Mode       | Template       |
 |------------|----------------|

--- a/docs/rules/Min.md
+++ b/docs/rules/Min.md
@@ -24,13 +24,6 @@ empty, the validation will fail.
 
 ### `Min::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-|------------|-------------------------------|
-| `default`  | As the minimum from {{name}}, |
-| `inverted` | As the minimum from {{name}}, |
-
-### `Min::TEMPLATE_NAMED`
-
 | Mode       | Template         |
 |------------|------------------|
 | `default`  | The minimum from |

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -17,18 +17,30 @@ use Respect\Validation\Rules\Core\FilteredNonEmptyArray;
 use function max;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-#[Template('As the maximum of {{name}},', 'As the maximum of {{name}},')]
-#[Template('The maximum of', 'The maximum of', self::TEMPLATE_NAMED)]
+#[Template('The maximum of', 'The maximum of')]
 final class Max extends FilteredNonEmptyArray
 {
-    public const TEMPLATE_NAMED = '__named__';
 
     /** @param non-empty-array<mixed> $input */
     protected function evaluateNonEmptyArray(array $input): Result
     {
-        $result = $this->rule->evaluate(max($input))->withPrefixedId('max');
-        $template = $this->getName() === null ? self::TEMPLATE_STANDARD : self::TEMPLATE_NAMED;
+        $max = max($input);
 
-        return (new Result($result->isValid, $input, $this, [], $template, id: $result->id))->withSubsequent($result);
+        return $this->enrichResult($input, $this->rule->evaluate($max));
+    }
+
+    private function enrichResult(mixed $input, Result $result): Result
+    {
+        if (!$result->allowsSubsequent()) {
+            return $result
+                ->withInput($input)
+                ->withChildren(
+                    ...array_map(fn(Result $child) => $this->enrichResult($input, $child), $result->children)
+                );
+        }
+
+        return (new Result($result->isValid, $input, $this, id: $result->id))
+            ->withPrefixedId('max')
+            ->withSubsequent($result->withInput($input));
     }
 }

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -17,18 +17,29 @@ use Respect\Validation\Rules\Core\FilteredNonEmptyArray;
 use function min;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-#[Template('As the minimum from {{name}},', 'As the minimum from {{name}},')]
-#[Template('The minimum from', 'The minimum from', self::TEMPLATE_NAMED)]
+#[Template('The minimum from', 'The minimum from')]
 final class Min extends FilteredNonEmptyArray
 {
-    public const TEMPLATE_NAMED = '__named__';
-
     /** @param non-empty-array<mixed> $input */
     protected function evaluateNonEmptyArray(array $input): Result
     {
-        $result = $this->rule->evaluate(min($input))->withPrefixedId('min');
-        $template = $this->getName() === null ? self::TEMPLATE_STANDARD : self::TEMPLATE_NAMED;
+        $min = min($input);
 
-        return (new Result($result->isValid, $input, $this, [], $template, id: $result->id))->withSubsequent($result);
+        return $this->enrichResult($input, $this->rule->evaluate($min));
+    }
+
+    private function enrichResult(mixed $input, Result $result): Result
+    {
+        if (!$result->allowsSubsequent()) {
+            return $result
+                ->withInput($input)
+                ->withChildren(
+                    ...array_map(fn(Result $child) => $this->enrichResult($input, $child), $result->children)
+                );
+        }
+
+        return (new Result($result->isValid, $input, $this, id: $result->id))
+            ->withPrefixedId('min')
+            ->withSubsequent($result->withInput($input));
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,8 @@ use function PHPUnit\Framework\assertStringMatchesFormat;
 /** @param array<string, mixed> $messages */
 function expectAll(Closure $callback, string $message, string $fullMessage, array $messages): Closure
 {
+    // Normalize newlines in $fullMessage so OS differences don't cause false failures
+    $fullMessage = preg_replace('/\R/u', PHP_EOL, $fullMessage);
     return function () use ($callback, $message, $fullMessage, $messages): void {
         try {
             $callback->call($this);
@@ -30,6 +32,8 @@ function expectAll(Closure $callback, string $message, string $fullMessage, arra
 /** @param array<string, mixed> $messages */
 function expectAllToMatch(Closure $callback, string $message, string $fullMessage, array $messages): Closure
 {
+    // Normalize newlines in $fullMessage so OS differences don't cause false failures
+    $fullMessage = preg_replace('/\R/u', PHP_EOL, $fullMessage);
     return function () use ($callback, $message, $fullMessage, $messages): void {
         try {
             $callback();
@@ -60,6 +64,8 @@ function expectMessage(Closure $callback, string $message): Closure
 
 function expectFullMessage(Closure $callback, string $fullMessage): Closure
 {
+    // Normalize newlines in $fullMessage so OS differences don't cause false failures
+    $fullMessage = preg_replace('/\R/u', PHP_EOL, $fullMessage);
     return function () use ($callback, $fullMessage): void {
         try {
             $callback();

--- a/tests/feature/Rules/MaxTest.php
+++ b/tests/feature/Rules/MaxTest.php
@@ -23,16 +23,16 @@ test('Empty', expectAll(
 
 test('Default', expectAll(
     fn() => v::max(v::negative())->assert([1, 2, 3]),
-    'As the maximum of `[1, 2, 3]`, 3 must be a negative number',
-    '- As the maximum of `[1, 2, 3]`, 3 must be a negative number',
-    ['maxNegative' => 'As the maximum of `[1, 2, 3]`, 3 must be a negative number']
+    'The maximum of `[1, 2, 3]` must be a negative number',
+    '- The maximum of `[1, 2, 3]` must be a negative number',
+    ['maxNegative' => 'The maximum of `[1, 2, 3]` must be a negative number']
 ));
 
 test('Inverted', expectAll(
     fn() => v::not(v::max(v::negative()))->assert([-3, -2, -1]),
-    'As the maximum of `[-3, -2, -1]`, -1 must not be a negative number',
-    '- As the maximum of `[-3, -2, -1]`, -1 must not be a negative number',
-    ['notMaxNegative' => 'As the maximum of `[-3, -2, -1]`, -1 must not be a negative number']
+    'The maximum of `[-3, -2, -1]` must not be a negative number',
+    '- The maximum of `[-3, -2, -1]` must not be a negative number',
+    ['notMaxNegative' => 'The maximum of `[-3, -2, -1]` must not be a negative number']
 ));
 
 test('With wrapped name, default', expectAll(
@@ -68,4 +68,19 @@ test('With template, default', expectAll(
     'The maximum of the value is not what we expect',
     '- The maximum of the value is not what we expect',
     ['maxNegative' => 'The maximum of the value is not what we expect']
+));
+
+test('Chained wrapped rule', expectAll(
+    fn() => v::max(v::between(5, 7)->odd())->assert([1, 2, 3, 4]),
+    'The maximum of `[1, 2, 3, 4]` must be between 5 and 7',
+    <<<'FULL_MESSAGE'
+    - All of the required rules must pass for `[1, 2, 3, 4]`
+      - The maximum of `[1, 2, 3, 4]` must be between 5 and 7
+      - The maximum of `[1, 2, 3, 4]` must be an odd number
+    FULL_MESSAGE,
+    [
+        '__root__' => 'All of the required rules must pass for `[1, 2, 3, 4]`',
+        'maxBetween' => 'The maximum of `[1, 2, 3, 4]` must be between 5 and 7',
+        'maxOdd' => 'The maximum of `[1, 2, 3, 4]` must be an odd number',
+    ]
 ));

--- a/tests/feature/Rules/MinTest.php
+++ b/tests/feature/Rules/MinTest.php
@@ -9,16 +9,16 @@ declare(strict_types=1);
 
 test('Default', expectAll(
     fn() => v::min(v::equals(1))->assert([2, 3]),
-    'As the minimum from `[2, 3]`, 2 must be equal to 1',
-    '- As the minimum from `[2, 3]`, 2 must be equal to 1',
-    ['minEquals' => 'As the minimum from `[2, 3]`, 2 must be equal to 1']
+    'The minimum from `[2, 3]` must be equal to 1',
+    '- The minimum from `[2, 3]` must be equal to 1',
+    ['minEquals' => 'The minimum from `[2, 3]` must be equal to 1']
 ));
 
 test('Inverted', expectAll(
     fn() => v::not(v::min(v::equals(1)))->assert([1, 2, 3]),
-    'As the minimum from `[1, 2, 3]`, 1 must not be equal to 1',
-    '- As the minimum from `[1, 2, 3]`, 1 must not be equal to 1',
-    ['notMinEquals' => 'As the minimum from `[1, 2, 3]`, 1 must not be equal to 1']
+    'The minimum from `[1, 2, 3]` must not be equal to 1',
+    '- The minimum from `[1, 2, 3]` must not be equal to 1',
+    ['notMinEquals' => 'The minimum from `[1, 2, 3]` must not be equal to 1']
 ));
 
 test('With template', expectAll(
@@ -33,4 +33,19 @@ test('With name', expectAll(
     'The minimum from Options must be equal to 1',
     '- The minimum from Options must be equal to 1',
     ['minEquals' => 'The minimum from Options must be equal to 1']
+));
+
+test('Chained wrapped rule', expectAll(
+    fn() => v::min(v::between(5, 7)->odd())->assert([2, 3, 4]),
+    'The minimum from `[2, 3, 4]` must be between 5 and 7',
+    <<<'FULL_MESSAGE'
+    - All of the required rules must pass for `[2, 3, 4]`
+      - The minimum from `[2, 3, 4]` must be between 5 and 7
+      - The minimum from `[2, 3, 4]` must be an odd number
+    FULL_MESSAGE,
+    [
+        '__root__' => 'All of the required rules must pass for `[2, 3, 4]`',
+        'minBetween' => 'The minimum from `[2, 3, 4]` must be between 5 and 7',
+        'minOdd' => 'The minimum from `[2, 3, 4]` must be an odd number',
+    ]
 ));

--- a/tests/feature/Transformers/PrefixTest.php
+++ b/tests/feature/Transformers/PrefixTest.php
@@ -25,16 +25,16 @@ test('Length', expectAll(
 
 test('Max', expectAll(
     fn() => v::maxOdd()->assert([1, 2, 3, 4]),
-    'As the maximum of `[1, 2, 3, 4]`, 4 must be an odd number',
-    '- As the maximum of `[1, 2, 3, 4]`, 4 must be an odd number',
-    ['maxOdd' => 'As the maximum of `[1, 2, 3, 4]`, 4 must be an odd number']
+    'The maximum of `[1, 2, 3, 4]` must be an odd number',
+    '- The maximum of `[1, 2, 3, 4]` must be an odd number',
+    ['maxOdd' => 'The maximum of `[1, 2, 3, 4]` must be an odd number']
 ));
 
 test('Min', expectAll(
     fn() => v::minEven()->assert([1, 2, 3]),
-    'As the minimum from `[1, 2, 3]`, 1 must be an even number',
-    '- As the minimum from `[1, 2, 3]`, 1 must be an even number',
-    ['minEven' => 'As the minimum from `[1, 2, 3]`, 1 must be an even number']
+    'The minimum from `[1, 2, 3]` must be an even number',
+    '- The minimum from `[1, 2, 3]` must be an even number',
+    ['minEven' => 'The minimum from `[1, 2, 3]` must be an even number']
 ));
 
 test('Not', expectAll(


### PR DESCRIPTION
Following the pattern set in #1485, allow, the `Min`, `Max`, and `Each` rules to elegantly support chained rules with well-formatted validation messages.