### PR TITLE
Rename "Consecutive" to "Circuit"

### DIFF
--- a/docs/02-feature-guide.md
+++ b/docs/02-feature-guide.md
@@ -43,7 +43,7 @@ Respect\Validation offers over 150 rules, many of which are designed to address 
 * Validating the **Length** of the input: [Length](rules/Length.md).
 * Validating the **Maximum** value in the input: [Max](rules/Max.md).
 * Validating the **Minimum** value in the input: [Min](rules/Min.md).
-* Handling **Special cases**: [Lazy](rules/Lazy.md), [Consecutive](rules/Consecutive.md), [Call](rules/Call.md).
+* Handling **Special cases**: [Lazy](rules/Lazy.md), [Circuit](rules/Circuit.md), [Call](rules/Call.md).
 
 ### Custom templates
 

--- a/docs/09-list-of-rules-by-category.md
+++ b/docs/09-list-of-rules-by-category.md
@@ -61,13 +61,11 @@
 
 - [AllOf](rules/AllOf.md)
 - [AnyOf](rules/AnyOf.md)
-- [Consecutive](rules/Consecutive.md)
 - [NoneOf](rules/NoneOf.md)
 - [OneOf](rules/OneOf.md)
 
 ## Conditions
 
-- [Consecutive](rules/Consecutive.md)
 - [Not](rules/Not.md)
 - [When](rules/When.md)
 
@@ -163,7 +161,6 @@
 - [AllOf](rules/AllOf.md)
 - [AnyOf](rules/AnyOf.md)
 - [Call](rules/Call.md)
-- [Consecutive](rules/Consecutive.md)
 - [Each](rules/Each.md)
 - [Key](rules/Key.md)
 - [KeySet](rules/KeySet.md)
@@ -314,7 +311,6 @@
 - [Charset](rules/Charset.md)
 - [Cnh](rules/Cnh.md)
 - [Cnpj](rules/Cnpj.md)
-- [Consecutive](rules/Consecutive.md)
 - [Consonant](rules/Consonant.md)
 - [Contains](rules/Contains.md)
 - [ContainsAny](rules/ContainsAny.md)

--- a/docs/rules/AllOf.md
+++ b/docs/rules/AllOf.md
@@ -46,7 +46,7 @@ v::allOf(v::intVal(), v::positive())->isValid(15); // true
 See also:
 
 - [AnyOf](AnyOf.md)
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)
 - [NoneOf](NoneOf.md)
 - [OneOf](OneOf.md)
 - [When](When.md)

--- a/docs/rules/AnyOf.md
+++ b/docs/rules/AnyOf.md
@@ -44,7 +44,7 @@ so `AnyOf()` returns true.
 See also:
 
 - [AllOf](AllOf.md)
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)
 - [ContainsAny](ContainsAny.md)
 - [NoneOf](NoneOf.md)
 - [OneOf](OneOf.md)

--- a/docs/rules/Circuit.md
+++ b/docs/rules/Circuit.md
@@ -1,8 +1,8 @@
-# Consecutive
+# Circuit
 
-- `Consecutive(Rule $rule1, Rule $rule2, Rule ...$rule)`
+- `Circuit(Rule $rule1, Rule $rule2, Rule ...$rule)`
 
-Validates the input against a series of rules until one fails.
+Validates the input against a series of rules until the first fails.
 
 This rule can be handy for getting the least error messages possible from a chain.
 
@@ -10,7 +10,7 @@ This rule can be helpful in combinations with [Lazy](Lazy.md). An excellent exam
 country code and a subdivision code.
 
 ```php
-v::consecutive(
+v::circuit(
     v::key('countryCode', v::countryCode()),
     v::lazy(static fn($input) => v::key('subdivisionCode', v::subdivisionCode($input['countryCode']))),
 )->isValid($_POST);
@@ -22,11 +22,7 @@ would then have to write `v::key('countryCode', v::countryCode())` twice in your
 
 ## Templates
 
-## Template placeholders
-
-| Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+This rule does not have any templates, because it will always return the result of the first rule that fails. When all the validation rules pass, it will return the result of the last rule of the circuit.
 
 ## Categorization
 

--- a/docs/rules/Lazy.md
+++ b/docs/rules/Lazy.md
@@ -47,4 +47,4 @@ See also:
 
 - [Call](Call.md)
 - [CallableType](CallableType.md)
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)

--- a/docs/rules/NoneOf.md
+++ b/docs/rules/NoneOf.md
@@ -45,7 +45,7 @@ See also:
 
 - [AllOf](AllOf.md)
 - [AnyOf](AnyOf.md)
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)
 - [Not](Not.md)
 - [OneOf](OneOf.md)
 - [When](When.md)

--- a/docs/rules/OneOf.md
+++ b/docs/rules/OneOf.md
@@ -46,6 +46,6 @@ See also:
 
 - [AllOf](AllOf.md)
 - [AnyOf](AnyOf.md)
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)
 - [NoneOf](NoneOf.md)
 - [When](When.md)

--- a/docs/rules/SubdivisionCode.md
+++ b/docs/rules/SubdivisionCode.md
@@ -44,7 +44,7 @@ v::subdivisionCode('US')->isValid('CA'); // true
 ***
 See also:
 
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)
 - [CountryCode](CountryCode.md)
 - [CurrencyCode](CurrencyCode.md)
 - [Nip](Nip.md)

--- a/docs/rules/When.md
+++ b/docs/rules/When.md
@@ -46,6 +46,6 @@ See also:
 - [AllOf](AllOf.md)
 - [AlwaysInvalid](AlwaysInvalid.md)
 - [AnyOf](AnyOf.md)
-- [Consecutive](Consecutive.md)
+- [Circuit](Circuit.md)
 - [NoneOf](NoneOf.md)
 - [OneOf](OneOf.md)

--- a/library/Mixins/Builder.php
+++ b/library/Mixins/Builder.php
@@ -65,11 +65,11 @@ interface Builder extends
 
     public static function charset(string $charset, string ...$charsets): Chain;
 
+    public static function circuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public static function cnh(): Chain;
 
     public static function cnpj(): Chain;
-
-    public static function consecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function consonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/Chain.php
+++ b/library/Mixins/Chain.php
@@ -70,11 +70,11 @@ interface Chain extends
 
     public function charset(string $charset, string ...$charsets): Chain;
 
+    public function circuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public function cnh(): Chain;
 
     public function cnpj(): Chain;
-
-    public function consecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function consonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/KeyBuilder.php
+++ b/library/Mixins/KeyBuilder.php
@@ -56,11 +56,11 @@ interface KeyBuilder
 
     public static function keyCharset(int|string $key, string $charset, string ...$charsets): Chain;
 
+    public static function keyCircuit(int|string $key, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public static function keyCnh(int|string $key): Chain;
 
     public static function keyCnpj(int|string $key): Chain;
-
-    public static function keyConsecutive(int|string $key, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function keyConsonant(int|string $key, string ...$additionalChars): Chain;
 

--- a/library/Mixins/KeyChain.php
+++ b/library/Mixins/KeyChain.php
@@ -56,11 +56,11 @@ interface KeyChain
 
     public function keyCharset(int|string $key, string $charset, string ...$charsets): Chain;
 
+    public function keyCircuit(int|string $key, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public function keyCnh(int|string $key): Chain;
 
     public function keyCnpj(int|string $key): Chain;
-
-    public function keyConsecutive(int|string $key, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function keyConsonant(int|string $key, string ...$additionalChars): Chain;
 

--- a/library/Mixins/NotBuilder.php
+++ b/library/Mixins/NotBuilder.php
@@ -55,11 +55,11 @@ interface NotBuilder
 
     public static function notCharset(string $charset, string ...$charsets): Chain;
 
+    public static function notCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public static function notCnh(): Chain;
 
     public static function notCnpj(): Chain;
-
-    public static function notConsecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function notConsonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/NotChain.php
+++ b/library/Mixins/NotChain.php
@@ -55,11 +55,11 @@ interface NotChain
 
     public function notCharset(string $charset, string ...$charsets): Chain;
 
+    public function notCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public function notCnh(): Chain;
 
     public function notCnpj(): Chain;
-
-    public function notConsecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function notConsonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/NullOrBuilder.php
+++ b/library/Mixins/NullOrBuilder.php
@@ -57,11 +57,11 @@ interface NullOrBuilder
 
     public static function nullOrCharset(string $charset, string ...$charsets): Chain;
 
+    public static function nullOrCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public static function nullOrCnh(): Chain;
 
     public static function nullOrCnpj(): Chain;
-
-    public static function nullOrConsecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function nullOrConsonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/NullOrChain.php
+++ b/library/Mixins/NullOrChain.php
@@ -57,11 +57,11 @@ interface NullOrChain
 
     public function nullOrCharset(string $charset, string ...$charsets): Chain;
 
+    public function nullOrCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public function nullOrCnh(): Chain;
 
     public function nullOrCnpj(): Chain;
-
-    public function nullOrConsecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function nullOrConsonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/PropertyBuilder.php
+++ b/library/Mixins/PropertyBuilder.php
@@ -56,11 +56,11 @@ interface PropertyBuilder
 
     public static function propertyCharset(string $propertyName, string $charset, string ...$charsets): Chain;
 
+    public static function propertyCircuit(string $propertyName, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public static function propertyCnh(string $propertyName): Chain;
 
     public static function propertyCnpj(string $propertyName): Chain;
-
-    public static function propertyConsecutive(string $propertyName, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function propertyConsonant(string $propertyName, string ...$additionalChars): Chain;
 

--- a/library/Mixins/PropertyChain.php
+++ b/library/Mixins/PropertyChain.php
@@ -56,11 +56,11 @@ interface PropertyChain
 
     public function propertyCharset(string $propertyName, string $charset, string ...$charsets): Chain;
 
+    public function propertyCircuit(string $propertyName, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public function propertyCnh(string $propertyName): Chain;
 
     public function propertyCnpj(string $propertyName): Chain;
-
-    public function propertyConsecutive(string $propertyName, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function propertyConsonant(string $propertyName, string ...$additionalChars): Chain;
 

--- a/library/Mixins/UndefOrBuilder.php
+++ b/library/Mixins/UndefOrBuilder.php
@@ -55,11 +55,11 @@ interface UndefOrBuilder
 
     public static function undefOrCharset(string $charset, string ...$charsets): Chain;
 
+    public static function undefOrCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public static function undefOrCnh(): Chain;
 
     public static function undefOrCnpj(): Chain;
-
-    public static function undefOrConsecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function undefOrConsonant(string ...$additionalChars): Chain;
 

--- a/library/Mixins/UndefOrChain.php
+++ b/library/Mixins/UndefOrChain.php
@@ -55,11 +55,11 @@ interface UndefOrChain
 
     public function undefOrCharset(string $charset, string ...$charsets): Chain;
 
+    public function undefOrCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
     public function undefOrCnh(): Chain;
 
     public function undefOrCnpj(): Chain;
-
-    public function undefOrConsecutive(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function undefOrConsonant(string ...$additionalChars): Chain;
 

--- a/library/Rules/Circuit.php
+++ b/library/Rules/Circuit.php
@@ -15,7 +15,7 @@ use Respect\Validation\Rules\Core\Binder;
 use Respect\Validation\Rules\Core\Composite;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
-final class Consecutive extends Composite
+final class Circuit extends Composite
 {
     public function evaluate(mixed $input): Result
     {

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -58,9 +58,9 @@ final class Domain extends Standard
         return new Result($this->partsRule->evaluate($parts)->isValid, $input, $this);
     }
 
-    private function createGenericRule(): Consecutive
+    private function createGenericRule(): Circuit
     {
-        return new Consecutive(
+        return new Circuit(
             new StringType(),
             new NoWhitespace(),
             new Contains('.'),
@@ -74,13 +74,13 @@ final class Domain extends Standard
             return new Tld();
         }
 
-        return new Consecutive(new Not(new StartsWith('-')), new Length(new GreaterThanOrEqual(2)));
+        return new Circuit(new Not(new StartsWith('-')), new Length(new GreaterThanOrEqual(2)));
     }
 
     private function createPartsRule(): Rule
     {
         return new Each(
-            new Consecutive(
+            new Circuit(
                 new Alnum('-'),
                 new Not(new StartsWith('-')),
                 new AnyOf(

--- a/library/Transformers/DeprecatedKeyValue.php
+++ b/library/Transformers/DeprecatedKeyValue.php
@@ -42,7 +42,7 @@ final class DeprecatedKeyValue implements Transformer
 
         [$comparedKey, $ruleName, $baseKey] = $ruleSpec->arguments;
 
-        return new RuleSpec('consecutive', [
+        return new RuleSpec('circuit', [
             new KeyExists($comparedKey),
             new KeyExists($baseKey),
             new Lazy(

--- a/tests/feature/Rules/CircuitTest.php
+++ b/tests/feature/Rules/CircuitTest.php
@@ -8,81 +8,81 @@
 declare(strict_types=1);
 
 test('Default', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::trueVal())->assert(false),
+    fn() => v::circuit(v::alwaysValid(), v::trueVal())->assert(false),
     '`false` must evaluate to `true`',
     '- `false` must evaluate to `true`',
     ['trueVal' => '`false` must evaluate to `true`']
 ));
 
 test('Inverted', expectAll(
-    fn() => v::not(v::consecutive(v::alwaysValid(), v::trueVal()))->assert(true),
+    fn() => v::not(v::circuit(v::alwaysValid(), v::trueVal()))->assert(true),
     '`true` must not evaluate to `true`',
     '- `true` must not evaluate to `true`',
     ['notTrueVal' => '`true` must not evaluate to `true`']
 ));
 
 test('Default with inverted failing rule', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::not(v::trueVal()))->assert(true),
+    fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal()))->assert(true),
     '`true` must not evaluate to `true`',
     '- `true` must not evaluate to `true`',
     ['notTrueVal' => '`true` must not evaluate to `true`']
 ));
 
 test('With wrapped name, default', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::trueVal()->setName('Wrapped'))->setName('Wrapper')->assert(false),
+    fn() => v::circuit(v::alwaysValid(), v::trueVal()->setName('Wrapped'))->setName('Wrapper')->assert(false),
     'Wrapped must evaluate to `true`',
     '- Wrapped must evaluate to `true`',
     ['trueVal' => 'Wrapped must evaluate to `true`']
 ));
 
 test('With wrapper name, default', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::trueVal())->setName('Wrapper')->assert(false),
+    fn() => v::circuit(v::alwaysValid(), v::trueVal())->setName('Wrapper')->assert(false),
     'Wrapper must evaluate to `true`',
     '- Wrapper must evaluate to `true`',
     ['trueVal' => 'Wrapper must evaluate to `true`']
 ));
 
 test('With the name set in the wrapped rule of an inverted failing rule', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::not(v::trueVal()->setName('Wrapped'))->setName('Not'))->setName('Wrapper')->assert(true),
+    fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal()->setName('Wrapped'))->setName('Not'))->setName('Wrapper')->assert(true),
     'Wrapped must not evaluate to `true`',
     '- Wrapped must not evaluate to `true`',
     ['notTrueVal' => 'Wrapped must not evaluate to `true`']
 ));
 
 test('With the name set in an inverted failing rule', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::not(v::trueVal())->setName('Not'))->setName('Wrapper')->assert(true),
+    fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal())->setName('Not'))->setName('Wrapper')->assert(true),
     'Not must not evaluate to `true`',
     '- Not must not evaluate to `true`',
     ['notTrueVal' => 'Not must not evaluate to `true`']
 ));
 
-test('With the name set in the "consecutive" that has an inverted failing rule', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::not(v::trueVal()))->setName('Wrapper')->assert(true),
+test('With the name set in the "circuit" that has an inverted failing rule', expectAll(
+    fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal()))->setName('Wrapper')->assert(true),
     'Wrapper must not evaluate to `true`',
     '- Wrapper must not evaluate to `true`',
     ['notTrueVal' => 'Wrapper must not evaluate to `true`']
 ));
 
 test('With template', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::trueVal())
-        ->setTemplate('Consecutive cool cats cunningly continuous cookies')
+    fn() => v::circuit(v::alwaysValid(), v::trueVal())
+        ->setTemplate('Circuit cool cats cunningly continuous cookies')
         ->assert(false),
-    'Consecutive cool cats cunningly continuous cookies',
-    '- Consecutive cool cats cunningly continuous cookies',
-    ['trueVal' => 'Consecutive cool cats cunningly continuous cookies']
+    'Circuit cool cats cunningly continuous cookies',
+    '- Circuit cool cats cunningly continuous cookies',
+    ['trueVal' => 'Circuit cool cats cunningly continuous cookies']
 ));
 
 test('With multiple templates', expectAll(
-    fn() => v::consecutive(v::alwaysValid(), v::trueVal())
-        ->setTemplates(['trueVal' => 'Clever clowns craft consecutive clever clocks'])
+    fn() => v::circuit(v::alwaysValid(), v::trueVal())
+        ->setTemplates(['trueVal' => 'Clever clowns craft circuit clever clocks'])
         ->assert(false),
-    'Clever clowns craft consecutive clever clocks',
-    '- Clever clowns craft consecutive clever clocks',
-    ['trueVal' => 'Clever clowns craft consecutive clever clocks']
+    'Clever clowns craft circuit clever clocks',
+    '- Clever clowns craft circuit clever clocks',
+    ['trueVal' => 'Clever clowns craft circuit clever clocks']
 ));
 
 test('Real example', expectAll(
-    fn() => v::consecutive(
+    fn() => v::circuit(
         v::key('countyCode', v::countryCode()),
         v::lazy(fn($input) => v::key('subdivisionCode', v::subdivisionCode($input['countyCode'])))
     )->assert(['countyCode' => 'BR', 'subdivisionCode' => 'CA']),

--- a/tests/unit/Rules/CircuitTest.php
+++ b/tests/unit/Rules/CircuitTest.php
@@ -19,21 +19,21 @@ use Respect\Validation\Test\TestCase;
 use function rand;
 
 #[Group('rule')]
-#[CoversClass(Consecutive::class)]
-final class ConsecutiveTest extends TestCase
+#[CoversClass(Circuit::class)]
+final class CircuitTest extends TestCase
 {
     #[Test]
     #[DataProvider('providerForAnyValues')]
     public function itShouldValidateInputWhenAllRulesValidatesTheInput(mixed $input): void
     {
-        self::assertValidInput(new Consecutive(Stub::pass(1), Stub::pass(1)), $input);
+        self::assertValidInput(new Circuit(Stub::pass(1), Stub::pass(1)), $input);
     }
 
     #[Test]
     #[DataProvider('providerForFailingRules')]
     public function itShouldExecuteRulesInSequenceUntilOneFails(Stub ...$stub): void
     {
-        $rule = new Consecutive(...$stub);
+        $rule = new Circuit(...$stub);
 
         self::assertInvalidInput($rule, rand());
     }
@@ -43,7 +43,7 @@ final class ConsecutiveTest extends TestCase
     {
         $input = rand();
 
-        $rule = new Consecutive(Stub::fail(1), Stub::daze());
+        $rule = new Circuit(Stub::fail(1), Stub::daze());
 
         $actual = $rule->evaluate($input);
         $expected = Stub::fail(1)->evaluate($input);


### PR DESCRIPTION
The "Consecutive" rule is now renamed to "Circuit" to better reflect its behavior of stopping at the first failure. I also favour this name because it's much shorter.