### PR TITLE
Rename `withPrefixedId` to `withPrefix`

### DIFF
--- a/library/Result.php
+++ b/library/Result.php
@@ -80,7 +80,7 @@ final class Result
     ): Result {
         if ($adjacent->allowsAdjacent()) {
             return (new Result($adjacent->isValid, $input, $rule, $parameters, $template, id: $adjacent->id))
-                ->withPrefixedId($prefix)
+                ->withPrefix($prefix)
                 ->withAdjacent($adjacent->withInput($input));
         }
 
@@ -111,7 +111,7 @@ final class Result
         return $this->clone(id: $id, unchangeableId: true);
     }
 
-    public function withPrefixedId(string $prefix): self
+    public function withPrefix(string $prefix): self
     {
         if ($this->id === $this->name || $this->unchangeableId) {
             return $this;

--- a/library/Rules/Not.php
+++ b/library/Rules/Not.php
@@ -18,6 +18,6 @@ final class Not extends Wrapper
 {
     public function evaluate(mixed $input): Result
     {
-        return $this->rule->evaluate($input)->withInvertedMode()->withPrefixedId('not');
+        return $this->rule->evaluate($input)->withInvertedMode()->withPrefix('not');
     }
 }

--- a/library/Rules/NullOr.php
+++ b/library/Rules/NullOr.php
@@ -41,7 +41,7 @@ final class NullOr extends Wrapper
     {
         if ($result->allowsAdjacent()) {
             return $result
-                ->withPrefixedId('nullOr')
+                ->withPrefix('nullOr')
                 ->withAdjacent(new Result($result->isValid, $result->input, $this));
         }
 

--- a/library/Rules/UndefOr.php
+++ b/library/Rules/UndefOr.php
@@ -44,7 +44,7 @@ final class UndefOr extends Wrapper
     {
         if ($result->allowsAdjacent()) {
             return $result
-                ->withPrefixedId('undefOr')
+                ->withPrefix('undefOr')
                 ->withAdjacent(new Result($result->isValid, $result->input, $this));
         }
 

--- a/tests/unit/Rules/NotTest.php
+++ b/tests/unit/Rules/NotTest.php
@@ -28,7 +28,7 @@ final class NotTest extends RuleTestCase
 
         self::assertEquals(
             $rule->evaluate('input'),
-            $wrapped->evaluate('input')->withPrefixedId('not')->withInvertedMode()
+            $wrapped->evaluate('input')->withPrefix('not')->withInvertedMode()
         );
     }
 


### PR DESCRIPTION
That makes the name shorter and it has the same meaning.