### PR TITLE
Always display the input

### DIFF
--- a/docs/rules/NotBlank.md
+++ b/docs/rules/NotBlank.md
@@ -30,13 +30,6 @@ It's similar to [NotEmpty](NotEmpty.md) but it's way more strict.
 
 ### `NotBlank::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-|------------|-----------------------------|
-| `default`  | The value must not be blank |
-| `inverted` | The value must be blank     |
-
-### `NotBlank::TEMPLATE_NAMED`
-
 | Mode       | Template                   |
 |------------|----------------------------|
 | `default`  | {{name}} must not be blank |

--- a/docs/rules/NotEmpty.md
+++ b/docs/rules/NotEmpty.md
@@ -39,13 +39,6 @@ v::stringType()->notEmpty()->isValid("\t \n \r");  //false
 
 ### `NotEmpty::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-|------------|-----------------------------|
-| `default`  | The value must not be empty |
-| `inverted` | The value must be empty     |
-
-### `NotEmpty::TEMPLATE_NAMED`
-
 | Mode       | Template                   |
 |------------|----------------------------|
 | `default`  | {{name}} must not be empty |

--- a/docs/rules/NotUndef.md
+++ b/docs/rules/NotUndef.md
@@ -33,13 +33,6 @@ v::notUndef()->isValid(new stdClass()); // true
 
 ### `NotUndef::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-|------------|-----------------------------|
-| `default`  | The value must be defined   |
-| `inverted` | The value must be undefined |
-
-### `NotUndef::TEMPLATE_NAMED`
-
 | Mode       | Template                   |
 |------------|----------------------------|
 | `default`  | {{name}} must be defined   |

--- a/library/Rules/NotBlank.php
+++ b/library/Rules/NotBlank.php
@@ -23,24 +23,14 @@ use function trim;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    'The value must not be blank',
-    'The value must be blank',
-    self::TEMPLATE_STANDARD,
-)]
-#[Template(
     '{{name}} must not be blank',
     '{{name}} must be blank',
-    self::TEMPLATE_NAMED,
 )]
 final class NotBlank extends Standard
 {
-    public const TEMPLATE_NAMED = '__named__';
-
     public function evaluate(mixed $input): Result
     {
-        $template = $input || $this->getName() ? self::TEMPLATE_NAMED : self::TEMPLATE_STANDARD;
-
-        return new Result($this->isBlank($input), $input, $this, [], $template);
+        return new Result($this->isBlank($input), $input, $this);
     }
 
     private function isBlank(mixed $input): bool

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -19,26 +19,17 @@ use function trim;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    'The value must not be empty',
-    'The value must be empty',
-    self::TEMPLATE_STANDARD,
-)]
-#[Template(
     '{{name}} must not be empty',
     '{{name}} must be empty',
-    self::TEMPLATE_NAMED,
 )]
 final class NotEmpty extends Standard
 {
-    public const TEMPLATE_NAMED = '__named__';
-
     public function evaluate(mixed $input): Result
     {
-        $template = $input || $this->getName() ? self::TEMPLATE_NAMED : self::TEMPLATE_STANDARD;
         if (is_string($input)) {
             $input = trim($input);
         }
 
-        return new Result(!empty($input), $input, $this, [], $template);
+        return new Result(!empty($input), $input, $this);
     }
 }

--- a/library/Rules/NotUndef.php
+++ b/library/Rules/NotUndef.php
@@ -17,29 +17,15 @@ use Respect\Validation\Rules\Core\Standard;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    'The value must be defined',
-    'The value must be undefined',
-    self::TEMPLATE_STANDARD,
-)]
-#[Template(
     '{{name}} must be defined',
     '{{name}} must be undefined',
-    self::TEMPLATE_NAMED,
 )]
 final class NotUndef extends Standard
 {
     use CanValidateUndefined;
 
-    public const TEMPLATE_NAMED = '__named__';
-
     public function evaluate(mixed $input): Result
     {
-        return new Result(
-            $this->isUndefined($input) === false,
-            $input,
-            $this,
-            [],
-            ($input || $this->getName() ? self::TEMPLATE_NAMED : self::TEMPLATE_STANDARD)
-        );
+        return new Result($this->isUndefined($input) === false, $input, $this);
     }
 }

--- a/tests/feature/Rules/EachTest.php
+++ b/tests/feature/Rules/EachTest.php
@@ -16,9 +16,9 @@ test('Non-iterable', expectAll(
 
 test('Empty', expectAll(
     fn() => v::each(v::intType())->assert([]),
-    'The value must not be empty',
-    '- The value must not be empty',
-    ['each' => 'The value must not be empty'],
+    '`[]` must not be empty',
+    '- `[]` must not be empty',
+    ['each' => '`[]` must not be empty'],
 ));
 
 test('Default', expectAll(

--- a/tests/feature/Rules/MaxTest.php
+++ b/tests/feature/Rules/MaxTest.php
@@ -16,9 +16,9 @@ test('Non-iterable', expectAll(
 
 test('Empty', expectAll(
     fn() => v::max(v::negative())->assert([]),
-    'The value must not be empty',
-    '- The value must not be empty',
-    ['max' => 'The value must not be empty'],
+    '`[]` must not be empty',
+    '- `[]` must not be empty',
+    ['max' => '`[]` must not be empty'],
 ));
 
 test('Default', expectAll(

--- a/tests/feature/Rules/NotBlankTest.php
+++ b/tests/feature/Rules/NotBlankTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 test('Scenario #1', expectMessage(
     fn() => v::notBlank()->assert(null),
-    'The value must not be blank',
+    '`null` must not be blank',
 ));
 
 test('Scenario #2', expectMessage(
@@ -24,7 +24,7 @@ test('Scenario #3', expectMessage(
 
 test('Scenario #4', expectFullMessage(
     fn() => v::notBlank()->assert(''),
-    '- The value must not be blank',
+    '- "" must not be blank',
 ));
 
 test('Scenario #5', expectFullMessage(

--- a/tests/feature/Rules/NotEmptyTest.php
+++ b/tests/feature/Rules/NotEmptyTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 test('Scenario #1', expectMessage(
     fn() => v::notEmpty()->assert(null),
-    'The value must not be empty',
+    '`null` must not be empty',
 ));
 
 test('Scenario #2', expectMessage(
@@ -24,7 +24,7 @@ test('Scenario #3', expectMessage(
 
 test('Scenario #4', expectFullMessage(
     fn() => v::notEmpty()->assert(''),
-    '- The value must not be empty',
+    '- "" must not be empty',
 ));
 
 test('Scenario #5', expectFullMessage(

--- a/tests/feature/Rules/NotUndefTest.php
+++ b/tests/feature/Rules/NotUndefTest.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 test('Scenario #1', expectMessage(
     fn() => v::notUndef()->assert(null),
-    'The value must be defined',
+    '`null` must be defined',
 ));
 
 test('Scenario #2', expectMessage(
     fn() => v::not(v::notUndef())->assert(0),
-    'The value must be undefined',
+    '0 must be undefined',
 ));
 
 test('Scenario #3', expectMessage(
@@ -29,12 +29,12 @@ test('Scenario #4', expectMessage(
 
 test('Scenario #5', expectFullMessage(
     fn() => v::notUndef()->assert(''),
-    '- The value must be defined',
+    '- "" must be defined',
 ));
 
 test('Scenario #6', expectFullMessage(
     fn() => v::not(v::notUndef())->assert([]),
-    '- The value must be undefined',
+    '- `[]` must be undefined',
 ));
 
 test('Scenario #7', expectFullMessage(

--- a/tests/feature/Rules/WhenTest.php
+++ b/tests/feature/Rules/WhenTest.php
@@ -16,9 +16,9 @@ test('When valid use "then"', expectAll(
 
 test('When invalid use "else"', expectAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert(''),
-    'The value must not be empty',
-    '- The value must not be empty',
-    ['notEmpty' => 'The value must not be empty'],
+    '"" must not be empty',
+    '- "" must not be empty',
+    ['notEmpty' => '"" must not be empty'],
 ));
 
 test('When valid use "then" using single template', expectAll(


### PR DESCRIPTION
The "NotBlank", "NotEmpty", and "NotUndef" rules do not display the input in all cases and instead displays the string "The value". The problem with that is that one doesn't see which value was passed, which is not so useful.

This commit will changes those rules to always display the input. If someone doesn't want the input to show, they can always set a name for the rule.