### PR TITLE
Customize overwriting file and line in ValidationException

### DIFF
--- a/library/ValidatorDefaults.php
+++ b/library/ValidatorDefaults.php
@@ -22,6 +22,9 @@ final class ValidatorDefaults
 
     private static ?Translator $translator = null;
 
+    /** @var array<string> */
+    private static array $ignoredBacktracePaths = [__DIR__ . '/Validator.php'];
+
     public static function setFactory(Factory $factory): void
     {
         self::$factory = $factory;
@@ -62,5 +65,16 @@ final class ValidatorDefaults
         }
 
         return self::$translator;
+    }
+
+    /** @return array<string>*/
+    public static function getIgnoredBacktracePaths(): array
+    {
+        return self::$ignoredBacktracePaths;
+    }
+
+    public static function setIgnoredBacktracePaths(string ...$ignoredBacktracePaths): void
+    {
+        self::$ignoredBacktracePaths = $ignoredBacktracePaths;
     }
 }

--- a/tests/feature/ValidationExceptionStackTraceTest.php
+++ b/tests/feature/ValidationExceptionStackTraceTest.php
@@ -8,8 +8,9 @@
 declare(strict_types=1);
 
 use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Test\Stubs\MyValidator;
 
-test('Should overwrite stack trace when in Validator', function (): void {
+test('Should overwrite file and line in the Validator class', function (): void {
     try {
         v::intType()->assert('string');
     } catch (ValidationException $e) {
@@ -18,9 +19,47 @@ test('Should overwrite stack trace when in Validator', function (): void {
     }
 });
 
-test('Should not overwrite stack trace when created manually', function (): void {
+test('Should overwrite file and line via the ValidatorDefaults class', function (): void {
+    try {
+        MyValidator::assertIntType('string');
+    } catch (ValidationException $e) {
+        expect($e->getFile())->toBe(__FILE__);
+        expect($e->getLine())->toBe(__LINE__ - 3);
+    }
+});
+
+test('Should not overwrite file and line when created manually', function (): void {
     try {
         throw new ValidationException('message', 'fullMessage', ['id' => 'message']);
+    } catch (ValidationException $e) {
+        expect($e->getFile())->toBe(__FILE__);
+        expect($e->getLine())->toBe(__LINE__ - 3);
+    }
+});
+
+
+test('Should not overwrite file and line when file cannot be ever traced', function (): void {
+    try {
+        throw new ValidationException('message', 'fullMessage', ['id' => 'message'], ['/tmp/unknown']);
+    } catch (ValidationException $e) {
+        expect($e->getFile())->toBe(__FILE__);
+        expect($e->getLine())->toBe(__LINE__ - 3);
+    }
+});
+
+
+test('Should go not overwrite file and line when it runs out of choices', function (): void {
+    try {
+        $trace = array_unique(
+            array_filter(
+                array_map(
+                    fn($trace) => $trace['file'] ?? null,
+                    debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)
+                )
+            )
+        );
+        $trace[] = __FILE__;
+        throw new ValidationException('message', 'fullMessage', ['id' => 'message'], $trace);
     } catch (ValidationException $e) {
         expect($e->getFile())->toBe(__FILE__);
         expect($e->getLine())->toBe(__LINE__ - 3);

--- a/tests/library/Stubs/MyValidator.php
+++ b/tests/library/Stubs/MyValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Exceptions\ValidationException;
+use Respect\Validation\Validator;
+use Respect\Validation\ValidatorDefaults;
+
+final class MyValidator
+{
+    public static function assertIntType(mixed $input): void
+    {
+        $originalIgnoredBacktracePaths = ValidatorDefaults::getIgnoredBacktracePaths();
+        ValidatorDefaults::setIgnoredBacktracePaths(__FILE__, ...$originalIgnoredBacktracePaths);
+        try {
+            Validator::intType()->assert($input);
+        } catch (ValidationException $exception) {
+            // This is a workaround to avoid changing exceptions that are thrown in other places.
+            ValidatorDefaults::setIgnoredBacktracePaths(...$originalIgnoredBacktracePaths);
+            throw $exception;
+        }
+    }
+}


### PR DESCRIPTION
I've already changed the `ValidationException` so as not to let the file and line from the Validator.php [1]. However, one could go even further when creating more customizations on top of this library, and allowing to customize the line could be very useful.

What motivated me making this change because it will be handy when I get back to work on [Assertion][].

[1]: 75a9b8e94f9e74a6cf377e02b0b472eff0b1f2bd
[Assertion]: https://github.com/Respect/Assertion