### PR TITLE
Create a stringifier for "quoted" values

### DIFF
--- a/library/Message/Placeholder/Quoted.php
+++ b/library/Message/Placeholder/Quoted.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Message\Placeholder;
+
+final class Quoted
+{
+    public function __construct(
+        private readonly string $value
+    ) {
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/library/Message/StandardRenderer.php
+++ b/library/Message/StandardRenderer.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Message;
 
 use ReflectionClass;
 use Respect\Stringifier\Stringifier;
+use Respect\Validation\Message\Placeholder\Quoted;
 use Respect\Validation\Mode;
 use Respect\Validation\Result;
 use Respect\Validation\Rule;
@@ -71,6 +72,10 @@ final class StandardRenderer implements Renderer
 
     private function placeholder(string $name, mixed $value, Translator $translator, ?string $modifier = null): string
     {
+        if ($modifier === 'quote' && is_string($value)) {
+            return $this->placeholder($name, new Quoted($value), $translator);
+        }
+
         if ($modifier === 'raw' && is_scalar($value)) {
             return is_bool($value) ? (string) (int) $value : (string) $value;
         }

--- a/library/Message/StandardStringifier.php
+++ b/library/Message/StandardStringifier.php
@@ -31,6 +31,7 @@ use Respect\Stringifier\Stringifiers\ObjectWithDebugInfoStringifier;
 use Respect\Stringifier\Stringifiers\ResourceStringifier;
 use Respect\Stringifier\Stringifiers\StringableObjectStringifier;
 use Respect\Stringifier\Stringifiers\ThrowableObjectStringifier;
+use Respect\Validation\Message\Stringifier\QuotedStringifier;
 
 final class StandardStringifier implements Stringifier
 {
@@ -86,6 +87,7 @@ final class StandardStringifier implements Stringifier
         $stringifier->prependStringifier(new ThrowableObjectStringifier($jsonEncodableStringifier, $quoter));
         $stringifier->prependStringifier(new DateTimeStringifier($quoter, DateTimeInterface::ATOM));
         $stringifier->prependStringifier(new IteratorObjectStringifier($stringifier, $quoter));
+        $stringifier->prependStringifier(new QuotedStringifier($quoter));
 
         return $stringifier;
     }

--- a/library/Message/Stringifier/QuotedStringifier.php
+++ b/library/Message/Stringifier/QuotedStringifier.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Respect\Validation\Message\Stringifier;
+
+use Respect\Stringifier\Quoter;
+use Respect\Stringifier\Stringifier;
+use Respect\Validation\Message\Placeholder\Quoted;
+
+final class QuotedStringifier implements Stringifier
+{
+    public function __construct(
+        private readonly Quoter $quoter
+    ) {
+    }
+
+    public function stringify(mixed $raw, int $depth): ?string
+    {
+        if (!$raw instanceof Quoted) {
+            return null;
+        }
+
+        return $this->quoter->quote($raw->getValue(), $depth);
+    }
+}

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -16,8 +16,8 @@ use Respect\Validation\Rules\Core\Standard;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an instance of `{{class|raw}}`',
-    '{{name}} must not be an instance of `{{class|raw}}`',
+    '{{name}} must be an instance of {{class|quote}}',
+    '{{name}} must not be an instance of {{class|quote}}',
 )]
 final class Instance extends Standard
 {

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -19,8 +19,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must match the pattern `{{regex|raw}}`',
-    '{{name}} must not match the pattern `{{regex|raw}}`',
+    '{{name}} must match the pattern {{regex|quote}}',
+    '{{name}} must not match the pattern {{regex|quote}}',
 )]
 final class Regex extends Standard
 {

--- a/tests/unit/Message/Stringifier/QuotedStringifierTest.php
+++ b/tests/unit/Message/Stringifier/QuotedStringifierTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Message\Stringifier;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Respect\Stringifier\Quoters\StandardQuoter;
+use Respect\Validation\Message\Placeholder\Quoted;
+use Respect\Validation\Test\TestCase;
+
+#[CoversClass(QuotedStringifier::class)]
+final class QuotedStringifierTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('providerForAnyValues')]
+    public function itShouldNotStringifyWhenValueIsNotAnInstanceOfQuoted(mixed $value): void
+    {
+        $quoter = new StandardQuoter(1);
+        $stringifier = new QuotedStringifier($quoter);
+
+        self::assertNull($stringifier->stringify($value, 0));
+    }
+
+    #[Test]
+    #[DataProvider('providerForStringTypes')]
+    public function itShouldStringifyWhenValueIsAnInstanceOfQuoted(string $value): void
+    {
+        $quoted = new Quoted($value);
+        $quoter = new StandardQuoter(1);
+        $stringifier = new QuotedStringifier($quoter);
+
+        $expected = $quoter->quote($quoted->getValue(), 0);
+        $actual = $stringifier->stringify($quoted, 0);
+
+        self::assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
The `StandardQuoter` adds backticks around strings, which indicates that it's not a simple string but a code. With this stringifier, we can add quotes to placeholders directly into templates.