### PR TITLE
Prepare library for the next major version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
 
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ create a validator that validates if a string is equal to "Hello World".
 
 The rule itself needs to implement the `Validatable` interface but, it is
 convenient to just extend the `AbstractRule` class.
-Doing that, you'll only need to declare one method: `validate($input)`.
+Doing that, you'll only need to declare one method: `isValid(mixed $input): bool`.
 This method must return `true` or `false`.
 
 If your validator class is `HelloWorld`, it will be available as `v::helloWorld()`
@@ -62,17 +62,16 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Respect\Validation\Rules\Core\Simple;
+
 /**
  * Explain in one sentence what this rule does.
  *
  * @author Your Name <youremail@yourdomain.tld>
  */
-final class HelloWorld extends AbstractRule
+final class HelloWorld extends Simple
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function validate($input): bool
+    public function isValid(mixed $input): bool
     {
         return $input === 'Hello World';
     }
@@ -90,8 +89,8 @@ are able to use any methods of it. By extending `RuleTestCase` you should
 implement two methods that should return a [data provider][] with the rule as
 first item of the arrays:
 
-- `providerForValidInput`: Will test when `validate()` should return `true`
-- `providerForInvalidInput`: Will test when `validate()` should return `false`
+- `providerForValidInput`: Will test when `isValid()` should return `true`
+- `providerForInvalidInput`: Will test when `isValid()` should return `false`
 
 ```php
 <?php

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,44 +79,6 @@ final class HelloWorld extends AbstractRule
 }
 ```
 
-### Creating the rule exception
-
-Just that and we're done with the rule code. The Exception requires you to
-declare messages used by `assert()` and `check()`. Messages are declared in
-affirmative and negative moods, so if anyone calls `v::not(v::helloWorld())` the
-library will show the appropriate message.
-
-```php
-<?php
-
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
-declare(strict_types=1);
-
-namespace Respect\Validation\Exceptions;
-
-/**
- * @author Your Name <youremail@yourdomain.tld>
- */
-final class HelloWorldException extends ValidationException
-{
-    /**
-     * {@inheritDoc}
-     */
-    protected $defaultTemplates = [
-        self::MODE_DEFAULT => [
-            self::STANDARD => '{{name}} must be a Hello World',
-        ],
-        self::MODE_NEGATIVE => [
-            self::STANDARD => '{{name}} must not be a Hello World',
-        ]
-    ];
-}
-```
-
 ### Creating unit tests
 
 Finally, we need to test if everything is running smooth. We have `RuleTestCase`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The most awesome validation engine ever created for PHP.
 
-- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->validate($input)`.
+- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->isValid($input)`.
 - [Granularity control](docs/02-feature-guide.md#validation-methods) for advanced reporting.
 - [More than 150](docs/08-list-of-rules-by-category.md) (fully tested) validation rules.
 - [A concrete API](docs/05-concrete-api.md) for non fluent usage.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 94%    # the required coverage value
+        threshold: 1%  # the leniency in hitting the target

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.1 || ^8.2",
+        "php": ">=8.1",
         "respect/stringifier": "^0.2.0",
         "symfony/polyfill-mbstring": "^1.2"
     },

--- a/docs/02-feature-guide.md
+++ b/docs/02-feature-guide.md
@@ -15,7 +15,7 @@ The Hello World validator is something like this:
 
 ```php
 $number = 123;
-v::numericVal()->validate($number); // true
+v::numericVal()->isValid($number); // true
 ```
 
 ## Chained validation
@@ -25,7 +25,7 @@ containing numbers and letters, no whitespace and length between 1 and 15.
 
 ```php
 $usernameValidator = v::alnum()->noWhitespace()->length(1, 15);
-$usernameValidator->validate('alganet'); // true
+$usernameValidator->isValid('alganet'); // true
 ```
 
 ## Validating object attributes
@@ -44,7 +44,7 @@ Is possible to validate its attributes in a single chain:
 $userValidator = v::attribute('name', v::stringType()->length(1, 32))
                   ->attribute('birthdate', v::date()->minAge(18));
 
-$userValidator->validate($user); // true
+$userValidator->isValid($user); // true
 ```
 
 Validating array keys is also possible using `v::key()`
@@ -78,7 +78,7 @@ v::key(
         ->key('field2', v::stringType())
         ->key('field3', v::boolType())
     )
-    ->assert($data); // You can also use check() or validate()
+    ->assert($data); // You can also use check() or isValid()
 ```
 
 ## Input optional
@@ -93,11 +93,11 @@ For that reason all rules are mandatory now but if you want to treat a value as
 optional you can use `v::optional()` rule:
 
 ```php
-v::alpha()->validate(''); // false input required
-v::alpha()->validate(null); // false input required
+v::alpha()->isValid(''); // false input required
+v::alpha()->isValid(null); // false input required
 
-v::optional(v::alpha())->validate(''); // true
-v::optional(v::alpha())->validate(null); // true
+v::optional(v::alpha())->isValid(''); // true
+v::optional(v::alpha())->isValid(null); // true
 ```
 
 By _optional_ we consider `null` or an empty string (`''`).
@@ -109,7 +109,7 @@ See more on [Optional](rules/Optional.md).
 You can use the `v::not()` to negate any rule:
 
 ```php
-v::not(v::intVal())->validate(10); // false, input must not be integer
+v::not(v::intVal())->isValid(10); // false, input must not be integer
 ```
 
 ## Validator reuse
@@ -117,9 +117,9 @@ v::not(v::intVal())->validate(10); // false, input must not be integer
 Once created, you can reuse your validator anywhere. Remember `$usernameValidator`?
 
 ```php
-$usernameValidator->validate('respect');            //true
-$usernameValidator->validate('alexandre gaigalas'); // false
-$usernameValidator->validate('#$%');                //false
+$usernameValidator->isValid('respect');            //true
+$usernameValidator->isValid('alexandre gaigalas'); // false
+$usernameValidator->isValid('#$%');                //false
 ```
 
 ## Exception types
@@ -144,7 +144,7 @@ $usernameValidator->validate('#$%');                //false
 ## Informative exceptions
 
 When something goes wrong, Validation can tell you exactly what's going on. For this,
-we use the `assert()` method instead of `validate()`:
+we use the `assert()` method instead of `isValid()`:
 
 ```php
 use Respect\Validation\Exceptions\NestedValidationException;
@@ -239,7 +239,7 @@ v::dateTime('Y-m-d')->between('1980-02-02', 'now')->setName('Member Since');
 
 ## Validation methods
 
-We've seen `validate()` that returns true or false and `assert()` that throws a complete
+We've seen `isValid()` that returns true or false and `assert()` that throws a complete
 validation report. There is also a `check()` method that returns an Exception
 only with the first error found:
 

--- a/docs/05-concrete-api.md
+++ b/docs/05-concrete-api.md
@@ -8,7 +8,7 @@ or magic methods. We'll use a traditional dependency injection approach.
 use Respect\Validation\Validator as v;
 
 $usernameValidator = v::alnum()->noWhitespace()->length(1, 15);
-$usernameValidator->validate('alganet'); // true
+$usernameValidator->isValid('alganet'); // true
 ```
 
 If you `var_dump($usernameValidator)`, you'll see a composite of objects with
@@ -18,13 +18,14 @@ the chain only builds the structure. You can build it by yourself:
 
 ```php
 use Respect\Validation\Rules;
+use Respect\Validation\Validator;
 
-$usernameValidator = new Rules\AllOf(
+$usernameValidator = Validator::create(
     new Rules\Alnum(),
     new Rules\NoWhitespace(),
     new Rules\Length(1, 15)
 );
-$usernameValidator->validate('alganet'); // true
+$usernameValidator->isValid('alganet'); // true
 ```
 
 This is still a very lean API. You can use it in any dependency injection
@@ -32,14 +33,16 @@ container or test it in the way you want. Nesting is still possible:
 
 ```php
 use Respect\Validation\Rules;
+use Respect\Validation\Validator;
 
-$usernameValidator = new Rules\AllOf(
+$usernameValidator = Validator::create(
     new Rules\Alnum(),
     new Rules\NoWhitespace(),
     new Rules\Length(1, 15)
 );
-$userValidator = new Rules\Key('name', $usernameValidator);
-$userValidator->validate(['name' => 'alganet']); // true
+
+$userValidator = Validator::create(new Rules\Key('name', $usernameValidator));
+$userValidator->isValid(['name' => 'alganet']); // true
 ```
 
 ## How It Works?
@@ -63,7 +66,7 @@ something complex and returns for you.
 
 > I really don't like static calls, can I avoid it?
 
-Yes. Just use `$validator = new Validator();` each time you want a new validator,
+Yes. Just use `$validator = Validator::create();` each time you want a new validator,
 and continue from there.
 
 > Do you have a static method for each rule?

--- a/docs/06-custom-rules.md
+++ b/docs/06-custom-rules.md
@@ -10,11 +10,11 @@ validate method will be executed. Here's how the class should look:
 ```php
 namespace My\Validation\Rules;
 
-use Respect\Validation\Rules\AbstractRule;
+use Respect\Validation\Rules\Core\Simple;
 
-final class Something extends AbstractRule
+final class Something extends Simple
 {
-    public function validate($input): bool
+    public function isValid(mixed $input): bool
     {
         // Do something here with the $input and return a boolean value
     }

--- a/docs/07-comparable-values.md
+++ b/docs/07-comparable-values.md
@@ -16,15 +16,15 @@ that can be parsed by PHP
 Below you can see some examples:
 
 ```php
-v::min(100)->validate($collection); // true if it has at least 100 items
+v::min(100)->isValid($collection); // true if it has at least 100 items
 
 v::dateTime()
     ->between(new DateTime('yesterday'), new DateTime('tomorrow'))
-    ->validate(new DateTime('now')); // true
+    ->isValid(new DateTime('now')); // true
 
-v::numericVal()->max(10)->validate(5); // true
+v::numericVal()->max(10)->isValid(5); // true
 
-v::stringVal()->between('a', 'f')->validate('d'); // true
+v::stringVal()->between('a', 'f')->isValid('d'); // true
 
-v::dateTime()->between('yesterday', 'tomorrow')->validate('now'); // true
+v::dateTime()->between('yesterday', 'tomorrow')->isValid('now'); // true
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 The most awesome validation engine ever created for PHP.
 
-- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->validate($input)`.
+- Complex rules made simple: `v::numericVal()->positive()->between(1, 255)->isValid($input)`.
 - [Granularity control](02-feature-guide.md#validation-methods) for advanced reporting.
 - [More than 150](08-list-of-rules-by-category.md) (fully tested) validation rules.
 - [A concrete API](05-concrete-api.md) for non fluent usage.

--- a/docs/rules/AllOf.md
+++ b/docs/rules/AllOf.md
@@ -5,7 +5,7 @@
 Will validate if all inner validators validates.
 
 ```php
-v::allOf(v::intVal(), v::positive())->validate(15); // true
+v::allOf(v::intVal(), v::positive())->isValid(15); // true
 ```
 
 ## Categorization

--- a/docs/rules/Alnum.md
+++ b/docs/rules/Alnum.md
@@ -9,18 +9,18 @@ Alphanumeric is a combination of alphabetic (a-z and A-Z) and numeric (0-9)
 characters.
 
 ```php
-v::alnum()->validate('foo 123'); // false
-v::alnum(' ')->validate('foo 123'); // true
-v::alnum()->validate('100%'); // false
-v::alnum('%')->validate('100%'); // true
-v::alnum('%', ',')->validate('10,5%'); // true
+v::alnum()->isValid('foo 123'); // false
+v::alnum(' ')->isValid('foo 123'); // true
+v::alnum()->isValid('100%'); // false
+v::alnum('%')->isValid('100%'); // true
+v::alnum('%', ',')->isValid('10,5%'); // true
 ```
 
 You can restrict case using the [Lowercase](Lowercase.md) and
 [Uppercase](Uppercase.md) rules.
 
 ```php
-v::alnum()->uppercase()->validate('example'); // false
+v::alnum()->uppercase()->isValid('example'); // false
 ```
 
 Message template for this validator includes `{{additionalChars}}` as the string

--- a/docs/rules/Alpha.md
+++ b/docs/rules/Alpha.md
@@ -7,18 +7,18 @@ Validates whether the input contains only alphabetic characters. This is similar
 to [Alnum](Alnum.md), but it does not allow numbers.
 
 ```php
-v::alpha()->validate('some name'); // false
-v::alpha(' ')->validate('some name'); // true
-v::alpha()->validate('Cedric-Fabian'); // false
-v::alpha('-')->validate('Cedric-Fabian'); // true
-v::alpha('-', '\'')->validate('\'s-Gravenhage'); // true
+v::alpha()->isValid('some name'); // false
+v::alpha(' ')->isValid('some name'); // true
+v::alpha()->isValid('Cedric-Fabian'); // false
+v::alpha('-')->isValid('Cedric-Fabian'); // true
+v::alpha('-', '\'')->isValid('\'s-Gravenhage'); // true
 ```
 
 You can restrict case using the [Lowercase](Lowercase.md) and
 [Uppercase](Uppercase.md) rules.
 
 ```php
-v::alpha()->uppercase()->validate('example'); // false
+v::alpha()->uppercase()->isValid('example'); // false
 ```
 
 ## Categorization

--- a/docs/rules/AlwaysInvalid.md
+++ b/docs/rules/AlwaysInvalid.md
@@ -5,7 +5,7 @@
 Validates any input as invalid.
 
 ```php
-v::alwaysInvalid()->validate('whatever'); // false
+v::alwaysInvalid()->isValid('whatever'); // false
 ```
 
 ## Categorization

--- a/docs/rules/AlwaysValid.md
+++ b/docs/rules/AlwaysValid.md
@@ -5,7 +5,7 @@
 Validates any input as valid.
 
 ```php
-v::alwaysValid()->validate('whatever'); // true
+v::alwaysValid()->isValid('whatever'); // true
 ```
 
 ## Categorization

--- a/docs/rules/AnyOf.md
+++ b/docs/rules/AnyOf.md
@@ -5,7 +5,7 @@
 This is a group validator that acts as an OR operator.
 
 ```php
-v::anyOf(v::intVal(), v::floatVal())->validate(15.5); // true
+v::anyOf(v::intVal(), v::floatVal())->isValid(15.5); // true
 ```
 
 In the sample above, `IntVal()` doesn't validates, but `FloatVal()` validates,

--- a/docs/rules/ArrayType.md
+++ b/docs/rules/ArrayType.md
@@ -5,9 +5,9 @@
 Validates whether the type of an input is array.
 
 ```php
-v::arrayType()->validate([]); // true
-v::arrayType()->validate([1, 2, 3]); // true
-v::arrayType()->validate(new ArrayObject()); // false
+v::arrayType()->isValid([]); // true
+v::arrayType()->isValid([1, 2, 3]); // true
+v::arrayType()->isValid(new ArrayObject()); // false
 ```
 
 ## Categorization

--- a/docs/rules/ArrayVal.md
+++ b/docs/rules/ArrayVal.md
@@ -6,9 +6,9 @@ Validates if the input is an array or if the input can be used as an array
 (instance of `ArrayAccess` or `SimpleXMLElement`).
 
 ```php
-v::arrayVal()->validate([]); // true
-v::arrayVal()->validate(new ArrayObject); // true
-v::arrayVal()->validate(new SimpleXMLElement('<xml></xml>')); // true
+v::arrayVal()->isValid([]); // true
+v::arrayVal()->isValid(new ArrayObject); // true
+v::arrayVal()->isValid(new SimpleXMLElement('<xml></xml>')); // true
 ```
 
 ## Categorization

--- a/docs/rules/Attribute.md
+++ b/docs/rules/Attribute.md
@@ -10,19 +10,19 @@ Validates an object attribute, even private ones.
 $obj = new stdClass;
 $obj->foo = 'bar';
 
-v::attribute('foo')->validate($obj); // true
+v::attribute('foo')->isValid($obj); // true
 ```
 
 You can also validate the attribute itself:
 
 ```php
-v::attribute('foo', v::equals('bar'))->validate($obj); // true
+v::attribute('foo', v::equals('bar'))->isValid($obj); // true
 ```
 
 Third parameter makes the attribute presence optional:
 
 ```php
-v::attribute('lorem', v::stringType(), false)->validate($obj); // true
+v::attribute('lorem', v::stringType(), false)->isValid($obj); // true
 ```
 
 The name of this validator is automatically set to the attribute name.

--- a/docs/rules/Base.md
+++ b/docs/rules/Base.md
@@ -5,11 +5,11 @@
 Validate numbers in any base, even with non regular bases.
 
 ```php
-v::base(2)->validate('011010001'); // true
-v::base(3)->validate('0120122001'); // true
-v::base(8)->validate('01234567520'); // true
-v::base(16)->validate('012a34f5675c20d'); // true
-v::base(2)->validate('0120122001'); // false
+v::base(2)->isValid('011010001'); // true
+v::base(3)->isValid('0120122001'); // true
+v::base(8)->isValid('01234567520'); // true
+v::base(16)->isValid('012a34f5675c20d'); // true
+v::base(2)->isValid('0120122001'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Base64.md
+++ b/docs/rules/Base64.md
@@ -5,8 +5,8 @@
 Validate if a string is Base64-encoded.
 
 ```php
-v::base64()->validate('cmVzcGVjdCE='); // true
-v::base64()->validate('respect!'); // false
+v::base64()->isValid('cmVzcGVjdCE='); // true
+v::base64()->isValid('respect!'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Between.md
+++ b/docs/rules/Between.md
@@ -5,9 +5,9 @@
 Validates whether the input is between two other values.
 
 ```php
-v::intVal()->between(10, 20)->validate(10); // true
-v::intVal()->between(10, 20)->validate(15); // true
-v::intVal()->between(10, 20)->validate(20); // true
+v::intVal()->between(10, 20)->isValid(10); // true
+v::intVal()->between(10, 20)->isValid(15); // true
+v::intVal()->between(10, 20)->isValid(20); // true
 ```
 
 Validation makes comparison easier, check out our supported

--- a/docs/rules/BoolType.md
+++ b/docs/rules/BoolType.md
@@ -5,8 +5,8 @@
 Validates whether the type of the input is [boolean](http://php.net/types.boolean).
 
 ```php
-v::boolType()->validate(true); // true
-v::boolType()->validate(false); // true
+v::boolType()->isValid(true); // true
+v::boolType()->isValid(false); // true
 ```
 
 ## Categorization

--- a/docs/rules/BoolVal.md
+++ b/docs/rules/BoolVal.md
@@ -5,12 +5,12 @@
 Validates if the input results in a boolean value:
 
 ```php
-v::boolVal()->validate('on'); // true
-v::boolVal()->validate('off'); // true
-v::boolVal()->validate('yes'); // true
-v::boolVal()->validate('no'); // true
-v::boolVal()->validate(1); // true
-v::boolVal()->validate(0); // true
+v::boolVal()->isValid('on'); // true
+v::boolVal()->isValid('off'); // true
+v::boolVal()->isValid('yes'); // true
+v::boolVal()->isValid('no'); // true
+v::boolVal()->isValid(1); // true
+v::boolVal()->isValid(0); // true
 ```
 
 ## Categorization

--- a/docs/rules/Bsn.md
+++ b/docs/rules/Bsn.md
@@ -5,7 +5,7 @@
 Validates a Dutch citizen service number ([BSN](https://nl.wikipedia.org/wiki/Burgerservicenummer)).
 
 ```php
-v::bsn()->validate('612890053'); // true
+v::bsn()->isValid('612890053'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Call.md
+++ b/docs/rules/Call.md
@@ -37,7 +37,7 @@ v::call(
         ->key('host',   v::domain())
         ->key('path',   v::stringType())
         ->key('query',  v::notEmpty())
-)->validate($url);
+)->isValid($url);
 ```
 
 ## Categorization

--- a/docs/rules/CallableType.md
+++ b/docs/rules/CallableType.md
@@ -5,9 +5,9 @@
 Validates whether the pseudo-type of the input is [callable](http://php.net/types.callable).
 
 ```php
-v::callableType()->validate(function () {}); // true
-v::callableType()->validate('trim'); // true
-v::callableType()->validate([new DateTime(), 'format']); // true
+v::callableType()->isValid(function () {}); // true
+v::callableType()->isValid('trim'); // true
+v::callableType()->isValid([new DateTime(), 'format']); // true
 ```
 
 ## Categorization

--- a/docs/rules/Callback.md
+++ b/docs/rules/Callback.md
@@ -9,7 +9,7 @@ v::callback(
     function (int $input): bool {
         return $input + ($input / 2) == 15;
     }
-)->validate(10); // true
+)->isValid(10); // true
 ```
 
 ## Categorization

--- a/docs/rules/Charset.md
+++ b/docs/rules/Charset.md
@@ -5,9 +5,9 @@
 Validates if a string is in a specific charset.
 
 ```php
-v::charset('ASCII')->validate('açúcar'); // false
-v::charset('ASCII')->validate('sugar');  //true
-v::charset('ISO-8859-1', 'EUC-JP')->validate('日本国'); // true
+v::charset('ASCII')->isValid('açúcar'); // false
+v::charset('ASCII')->isValid('sugar');  //true
+v::charset('ISO-8859-1', 'EUC-JP')->isValid('日本国'); // true
 ```
 
 The array format is a logic OR, not AND.

--- a/docs/rules/Cnh.md
+++ b/docs/rules/Cnh.md
@@ -5,7 +5,7 @@
 Validates a Brazilian driver's license.
 
 ```php
-v::cnh()->validate('02650306461'); // true
+v::cnh()->isValid('02650306461'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Consonant.md
+++ b/docs/rules/Consonant.md
@@ -6,7 +6,7 @@
 Validates if the input contains only consonants.
 
 ```php
-v::consonant()->validate('xkcd'); // true
+v::consonant()->isValid('xkcd'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Contains.md
+++ b/docs/rules/Contains.md
@@ -8,13 +8,13 @@ Validates if the input contains some value.
 For strings:
 
 ```php
-v::contains('ipsum')->validate('lorem ipsum'); // true
+v::contains('ipsum')->isValid('lorem ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::contains('ipsum')->validate(['ipsum', 'lorem']); // true
+v::contains('ipsum')->isValid(['ipsum', 'lorem']); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/ContainsAny.md
+++ b/docs/rules/ContainsAny.md
@@ -8,13 +8,13 @@ Validates if the input contains at least one of defined values
 For strings (comparing is case insensitive):
 
 ```php
-v::containsAny(['lorem', 'dolor'])->validate('lorem ipsum'); // true
+v::containsAny(['lorem', 'dolor'])->isValid('lorem ipsum'); // true
 ```
 
 For arrays (comparing is case sensitive to respect "contains" behavior):
 
 ```php
-v::containsAny(['lorem', 'dolor'])->validate(['ipsum', 'lorem']); // true
+v::containsAny(['lorem', 'dolor'])->isValid(['ipsum', 'lorem']); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/Control.md
+++ b/docs/rules/Control.md
@@ -7,7 +7,7 @@ Validates if all of the characters in the provided string, are control
 characters.
 
 ```php
-v::control()->validate("\n\r\t"); // true
+v::control()->isValid("\n\r\t"); // true
 ```
 
 ## Categorization

--- a/docs/rules/Countable.md
+++ b/docs/rules/Countable.md
@@ -6,9 +6,9 @@ Validates if the input is countable, in other words, if you're allowed to use
 [count()](http://php.net/count) function on it.
 
 ```php
-v::countable()->validate([]); // true
-v::countable()->validate(new ArrayObject()); // true
-v::countable()->validate('string'); // false
+v::countable()->isValid([]); // true
+v::countable()->isValid(new ArrayObject()); // true
+v::countable()->isValid('string'); // false
 ```
 
 ## Categorization

--- a/docs/rules/CountryCode.md
+++ b/docs/rules/CountryCode.md
@@ -6,11 +6,11 @@
 Validates whether the input is a country code in [ISO 3166-1][] standard.
 
 ```php
-v::countryCode()->validate('BR'); // true
+v::countryCode()->isValid('BR'); // true
 
-v::countryCode('alpha-2')->validate('NL'); // true
-v::countryCode('alpha-3')->validate('USA'); // true
-v::countryCode('numeric')->validate('504'); // true
+v::countryCode('alpha-2')->isValid('NL'); // true
+v::countryCode('alpha-3')->isValid('USA'); // true
+v::countryCode('numeric')->isValid('504'); // true
 ```
 
 This rule supports the three sets of country codes:

--- a/docs/rules/Cpf.md
+++ b/docs/rules/Cpf.md
@@ -5,20 +5,20 @@
 Validates a Brazillian CPF number.
 
 ```php
-v::cpf()->validate('11598647644'); // true
+v::cpf()->isValid('11598647644'); // true
 ```
 
 It ignores any non-digit char:
 
 ```php
-v::cpf()->validate('693.319.118-40'); // true
+v::cpf()->isValid('693.319.118-40'); // true
 ```
 
 If you need to validate digits only, add `->digit()` to
 the chain:
 
 ```php
-v::digit()->cpf()->validate('11598647644'); // true
+v::digit()->cpf()->isValid('11598647644'); // true
 ```
 
 ## Categorization

--- a/docs/rules/CreditCard.md
+++ b/docs/rules/CreditCard.md
@@ -6,17 +6,17 @@
 Validates a credit card number.
 
 ```php
-v::creditCard()->validate('5376 7473 9720 8720'); // true
-v::creditCard()->validate('5376-7473-9720-8720'); // true
-v::creditCard()->validate('5376.7473.9720.8720'); // true
+v::creditCard()->isValid('5376 7473 9720 8720'); // true
+v::creditCard()->isValid('5376-7473-9720-8720'); // true
+v::creditCard()->isValid('5376.7473.9720.8720'); // true
 
-v::creditCard('American_Express')->validate('340316193809364'); // true
-v::creditCard('Diners_Club')->validate('30351042633884'); // true
-v::creditCard('Discover')->validate('6011000990139424'); // true
-v::creditCard('JCB')->validate('3566002020360505'); // true
-v::creditCard('Mastercard')->validate('5376747397208720'); // true
-v::creditCard('Visa')->validate('4024007153361885'); // true
-v::creaditCard('RuPay')->validate('6062973831636410') // true
+v::creditCard('American_Express')->isValid('340316193809364'); // true
+v::creditCard('Diners_Club')->isValid('30351042633884'); // true
+v::creditCard('Discover')->isValid('6011000990139424'); // true
+v::creditCard('JCB')->isValid('3566002020360505'); // true
+v::creditCard('Mastercard')->isValid('5376747397208720'); // true
+v::creditCard('Visa')->isValid('4024007153361885'); // true
+v::creaditCard('RuPay')->isValid('6062973831636410') // true
 ```
 
 The current supported brands are:
@@ -33,7 +33,7 @@ It ignores any non-numeric characters, use [Digit](Digit.md),
 [NoWhitespace](NoWhitespace.md), or [Regex](Regex.md) when appropriate.
 
 ```php
-v::digit()->creditCard()->validate('5376747397208720'); // true
+v::digit()->creditCard()->isValid('5376747397208720'); // true
 ```
 
 ## Categorization

--- a/docs/rules/CurrencyCode.md
+++ b/docs/rules/CurrencyCode.md
@@ -5,7 +5,7 @@
 Validates an [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code like GBP or EUR.
 
 ```php
-v::currencyCode()->validate('GBP'); // true
+v::currencyCode()->isValid('GBP'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Date.md
+++ b/docs/rules/Date.md
@@ -22,12 +22,12 @@ Format  | Description                                                           
 When a `$format` is not given its default value is `Y-m-d`.
 
 ```php
-v::date()->validate('2017-12-31'); // true
-v::date()->validate('2020-02-29'); // true
-v::date()->validate('2019-02-29'); // false
-v::date('m/d/y')->validate('12/31/17'); // true
-v::date('F jS, Y')->validate('May 1st, 2017'); // true
-v::date('Ydm')->validate(20173112); // true
+v::date()->isValid('2017-12-31'); // true
+v::date()->isValid('2020-02-29'); // true
+v::date()->isValid('2019-02-29'); // false
+v::date('m/d/y')->isValid('12/31/17'); // true
+v::date('F jS, Y')->isValid('May 1st, 2017'); // true
+v::date('Ydm')->isValid(20173112); // true
 ```
 
 ## Categorization

--- a/docs/rules/DateTime.md
+++ b/docs/rules/DateTime.md
@@ -10,26 +10,26 @@ The `$format` argument should be in accordance to [DateTime::format()][]. See mo
 When a `$format` is not given its default value is `Y-m-d H:i:s`.
 
 ```php
-v::dateTime()->validate('2009-01-01'); // true
+v::dateTime()->isValid('2009-01-01'); // true
 ```
 
 Also accepts [strtotime()](http://php.net/strtotime) values:
 
 ```php
-v::dateTime()->validate('now'); // true
+v::dateTime()->isValid('now'); // true
 ```
 
 And `DateTimeInterface` instances:
 
 ```php
-v::dateTime()->validate(new DateTime()); // true
-v::dateTime()->validate(new DateTimeImmutable()); // true
+v::dateTime()->isValid(new DateTime()); // true
+v::dateTime()->isValid(new DateTimeImmutable()); // true
 ```
 
 You can pass a format when validating strings:
 
 ```php
-v::dateTime('Y-m-d')->validate('01-01-2009'); // false
+v::dateTime('Y-m-d')->isValid('01-01-2009'); // false
 ```
 
 Format has no effect when validating DateTime instances.
@@ -50,9 +50,9 @@ you desire, and you may want to use [Callback](Callback.md) to create a custom v
 $input = '2014-04-12T23:20:50.052Z';
 
 v::callback(fn($input) => is_string($input) && DateTime::createFromFormat(DateTime::RFC3339_EXTENDED, $input))
-    ->validate($input); // true
+    ->isValid($input); // true
 
-v::dateTime(DateTime::RFC3339_EXTENDED)->validate($input); // false
+v::dateTime(DateTime::RFC3339_EXTENDED)->isValid($input); // false
 ```
 
 ## Categorization

--- a/docs/rules/Decimal.md
+++ b/docs/rules/Decimal.md
@@ -5,9 +5,9 @@
 Validates whether the input matches the expected number of decimals.
 
 ```php
-v::decimals(2)->validate('27990.50'); // true
-v::decimals(1)->validate('27990.50'); // false
-v::decimal(1)->validate(1.5); // true
+v::decimals(2)->isValid('27990.50'); // true
+v::decimals(1)->isValid('27990.50'); // false
+v::decimal(1)->isValid(1.5); // true
 
 ```
 
@@ -17,7 +17,7 @@ When validating float types, it is not possible to determine the amount of
 ending zeros and because of that, validations like the ones below will pass.
 
 ```php
-v::decimal(1)->validate(1.50); // true
+v::decimal(1)->isValid(1.50); // true
 ```
 
 ## Categorization

--- a/docs/rules/Digit.md
+++ b/docs/rules/Digit.md
@@ -6,10 +6,10 @@
 Validates whether the input contains only digits.
 
 ```php
-v::digit()->validate('020 612 1851'); // false
-v::digit(' ')->validate('020 612 1851'); // true
-v::digit()->validate('172.655.537-21'); // false
-v::digit('.', '-')->validate('172.655.537-21'); // true
+v::digit()->isValid('020 612 1851'); // false
+v::digit(' ')->isValid('020 612 1851'); // true
+v::digit()->isValid('172.655.537-21'); // false
+v::digit('.', '-')->isValid('172.655.537-21'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Directory.md
+++ b/docs/rules/Directory.md
@@ -5,15 +5,15 @@
 Validates if the given path is a directory.
 
 ```php
-v::directory()->validate(__DIR__); // true
-v::directory()->validate(__FILE__); // false
+v::directory()->isValid(__DIR__); // true
+v::directory()->isValid(__FILE__); // false
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
 
 ```php
-v::directory()->validate(new SplFileInfo('library/'));
-v::directory()->validate(dir('/'));
+v::directory()->isValid(new SplFileInfo('library/'));
+v::directory()->isValid(dir('/'));
 ```
 
 ## Categorization

--- a/docs/rules/Domain.md
+++ b/docs/rules/Domain.md
@@ -6,14 +6,14 @@
 Validates whether the input is a valid domain name or not.
 
 ```php
-v::domain()->validate('google.com');
+v::domain()->isValid('google.com');
 ```
 
 You can skip *top level domain* (TLD) checks to validate internal
 domain names:
 
 ```php
-v::domain(false)->validate('dev.machine.local');
+v::domain(false)->isValid('dev.machine.local');
 ```
 
 This is a composite validator, it validates several rules

--- a/docs/rules/Each.md
+++ b/docs/rules/Each.md
@@ -11,13 +11,13 @@ $releaseDates = [
     'relational' => '2011-02-05',
 ];
 
-v::each(v::dateTime())->validate($releaseDates); // true
+v::each(v::dateTime())->isValid($releaseDates); // true
 ```
 
 You can also validate array keys combining this rule with [Call](Call.md):
 
 ```php
-v::call('array_keys', v::each(v::stringType()))->validate($releaseDates); // true
+v::call('array_keys', v::each(v::stringType()))->isValid($releaseDates); // true
 ```
 
 This rule will not validate values that are not iterable, to have a more detailed
@@ -27,8 +27,8 @@ If the input is empty this rule will consider the value as valid, you use
 [NotEmpty](NotEmpty.md) if convenient:
 
 ```php
-v::each(v::dateTime())->validate([]); // true
-v::notEmpty()->each(v::dateTime())->validate([]); // false
+v::each(v::dateTime())->isValid([]); // true
+v::notEmpty()->each(v::dateTime())->isValid([]); // false
 ```
 
 ## Categorization

--- a/docs/rules/Email.md
+++ b/docs/rules/Email.md
@@ -5,7 +5,7 @@
 Validates an email address.
 
 ```php
-v::email()->validate('alganet@gmail.com'); // true
+v::email()->isValid('alganet@gmail.com'); // true
 ```
 
 ## Categorization

--- a/docs/rules/EndsWith.md
+++ b/docs/rules/EndsWith.md
@@ -9,13 +9,13 @@ only if the value is at the end of the input.
 For strings:
 
 ```php
-v::endsWith('ipsum')->validate('lorem ipsum'); // true
+v::endsWith('ipsum')->isValid('lorem ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::endsWith('ipsum')->validate(['lorem', 'ipsum']); // true
+v::endsWith('ipsum')->isValid(['lorem', 'ipsum']); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/Equals.md
+++ b/docs/rules/Equals.md
@@ -5,7 +5,7 @@
 Validates if the input is equal to some value.
 
 ```php
-v::equals('alganet')->validate('alganet'); // true
+v::equals('alganet')->isValid('alganet'); // true
 ```
 
 Message template for this validator includes `{{compareTo}}`.

--- a/docs/rules/Equivalent.md
+++ b/docs/rules/Equivalent.md
@@ -5,9 +5,9 @@
 Validates if the input is equivalent to some value.
 
 ```php
-v::equivalent(1)->validate(true); // true
-v::equivalent('Something')->validate('someThing'); // true
-v::equivalent(new ArrayObject([1, 2, 3, 4, 5]))->validate(new ArrayObject([1, 2, 3, 4, 5])); // true
+v::equivalent(1)->isValid(true); // true
+v::equivalent('Something')->isValid('someThing'); // true
+v::equivalent(new ArrayObject([1, 2, 3, 4, 5]))->isValid(new ArrayObject([1, 2, 3, 4, 5])); // true
 ```
 
 This rule is very similar to [Equals](Equals.md) but it does not make case-sensitive

--- a/docs/rules/Even.md
+++ b/docs/rules/Even.md
@@ -5,7 +5,7 @@
 Validates whether the input is an even number or not.
 
 ```php
-v::intVal()->even()->validate(2); // true
+v::intVal()->even()->isValid(2); // true
 ```
 
 Using `int()` before `even()` is a best practice.

--- a/docs/rules/Executable.md
+++ b/docs/rules/Executable.md
@@ -5,7 +5,7 @@
 Validates if a file is an executable.
 
 ```php
-v::executable()->validate('script.sh'); // true
+v::executable()->isValid('script.sh'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Exists.md
+++ b/docs/rules/Exists.md
@@ -5,14 +5,14 @@
 Validates files or directories.
 
 ```php
-v::exists()->validate(__FILE__); // true
-v::exists()->validate(__DIR__); // true
+v::exists()->isValid(__FILE__); // true
+v::exists()->isValid(__DIR__); // true
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
 
 ```php
-v::exists()->validate(new SplFileInfo('file.txt'));
+v::exists()->isValid(new SplFileInfo('file.txt'));
 ```
 
 ## Categorization

--- a/docs/rules/Extension.md
+++ b/docs/rules/Extension.md
@@ -5,7 +5,7 @@
 Validates if the file extension matches the expected one:
 
 ```php
-v::extension('png')->validate('image.png'); // true
+v::extension('png')->isValid('image.png'); // true
 ```
 
 This rule is case-sensitive.

--- a/docs/rules/Factor.md
+++ b/docs/rules/Factor.md
@@ -5,9 +5,9 @@
 Validates if the input is a factor of the defined dividend.
 
 ```php
-v::factor(0)->validate(5); // true
-v::factor(4)->validate(2); // true
-v::factor(4)->validate(3); // false
+v::factor(0)->isValid(5); // true
+v::factor(4)->isValid(2); // true
+v::factor(4)->isValid(3); // false
 ```
 
 ## Categorization

--- a/docs/rules/FalseVal.md
+++ b/docs/rules/FalseVal.md
@@ -5,14 +5,14 @@
 Validates if a value is considered as `false`.
 
 ```php
-v::falseVal()->validate(false); // true
-v::falseVal()->validate(0); // true
-v::falseVal()->validate('0'); // true
-v::falseVal()->validate('false'); // true
-v::falseVal()->validate('off'); // true
-v::falseVal()->validate('no'); // true
-v::falseVal()->validate('0.5'); // false
-v::falseVal()->validate('2'); // false
+v::falseVal()->isValid(false); // true
+v::falseVal()->isValid(0); // true
+v::falseVal()->isValid('0'); // true
+v::falseVal()->isValid('false'); // true
+v::falseVal()->isValid('off'); // true
+v::falseVal()->isValid('no'); // true
+v::falseVal()->isValid('0.5'); // false
+v::falseVal()->isValid('2'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Fibonacci.md
+++ b/docs/rules/Fibonacci.md
@@ -5,9 +5,9 @@
 Validates whether the input follows the Fibonacci integer sequence.
 
 ```php
-v::fibonacci()->validate(1); // true
-v::fibonacci()->validate('34'); // true
-v::fibonacci()->validate(6); // false
+v::fibonacci()->isValid(1); // true
+v::fibonacci()->isValid('34'); // true
+v::fibonacci()->isValid(6); // false
 ```
 
 ## Categorization

--- a/docs/rules/File.md
+++ b/docs/rules/File.md
@@ -5,14 +5,14 @@
 Validates whether file input is as a regular filename.
 
 ```php
-v::file()->validate(__FILE__); // true
-v::file()->validate(__DIR__); // false
+v::file()->isValid(__FILE__); // true
+v::file()->isValid(__DIR__); // false
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
 
 ```php
-v::file()->validate(new SplFileInfo('file.txt'));
+v::file()->isValid(new SplFileInfo('file.txt'));
 ```
 
 ## Categorization

--- a/docs/rules/FilterVar.md
+++ b/docs/rules/FilterVar.md
@@ -6,12 +6,12 @@
 Validates the input with the PHP's [filter_var()](http://php.net/filter_var) function.
 
 ```php
-v::filterVar(FILTER_VALIDATE_EMAIL)->validate('bob@example.com'); // true
-v::filterVar(FILTER_VALIDATE_URL)->validate('http://example.com'); // true
-v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://example.com'); // false
-v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->validate('http://example.com/path'); // true
-v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->validate('webserver.local'); // true
-v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->validate('@local'); // false
+v::filterVar(FILTER_VALIDATE_EMAIL)->isValid('bob@example.com'); // true
+v::filterVar(FILTER_VALIDATE_URL)->isValid('http://example.com'); // true
+v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->isValid('http://example.com'); // false
+v::filterVar(FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED)->isValid('http://example.com/path'); // true
+v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->isValid('webserver.local'); // true
+v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->isValid('@local'); // false
 ```
 
 ## Categorization
@@ -22,7 +22,7 @@ v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->validate('@local'); 
 
 Version  | Description
 ---------|-------------
-  2.3.0  | `v::filterVar(FILTER_VALIDATE_INT)->validate(0)` is no longer false
+  2.3.0  | `v::filterVar(FILTER_VALIDATE_INT)->isValid(0)` is no longer false
   2.0.15 | Allow validating domains
    0.8.0 | Created
 

--- a/docs/rules/Finite.md
+++ b/docs/rules/Finite.md
@@ -5,8 +5,8 @@
 Validates if the input is a finite number.
 
 ```php
-v::finite()->validate('10'); // true
-v::finite()->validate(10); // true
+v::finite()->isValid('10'); // true
+v::finite()->isValid(10); // true
 ```
 
 ## Categorization

--- a/docs/rules/FloatType.md
+++ b/docs/rules/FloatType.md
@@ -5,9 +5,9 @@
 Validates whether the type of the input is [float](http://php.net/types.float).
 
 ```php
-v::floatType()->validate(1.5); // true
-v::floatType()->validate('1.5'); // false
-v::floatType()->validate(0e5); // true
+v::floatType()->isValid(1.5); // true
+v::floatType()->isValid('1.5'); // false
+v::floatType()->isValid(0e5); // true
 ```
 
 ## Categorization

--- a/docs/rules/FloatVal.md
+++ b/docs/rules/FloatVal.md
@@ -5,8 +5,8 @@
 Validate whether the input value is float.
 
 ```php
-v::floatVal()->validate(1.5); // true
-v::floatVal()->validate('1e5'); // true
+v::floatVal()->isValid(1.5); // true
+v::floatVal()->isValid('1e5'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Graph.md
+++ b/docs/rules/Graph.md
@@ -7,7 +7,7 @@ Validates if all characters in the input are printable and actually creates
 visible output (no white space).
 
 ```php
-v::graph()->validate('LKM@#$%4;'); // true
+v::graph()->isValid('LKM@#$%4;'); // true
 ```
 
 ## Categorization

--- a/docs/rules/GreaterThan.md
+++ b/docs/rules/GreaterThan.md
@@ -5,8 +5,8 @@
 Validates whether the input is greater than a value.
 
 ```php
-v::greaterThan(10)->validate(11); // true
-v::greaterThan(10)->validate(9); // false
+v::greaterThan(10)->isValid(11); // true
+v::greaterThan(10)->isValid(9); // false
 ```
 
 Validation makes comparison easier, check out our supported

--- a/docs/rules/HexRgbColor.md
+++ b/docs/rules/HexRgbColor.md
@@ -5,10 +5,10 @@
 Validates whether the input is a hex RGB color or not.
 
 ```php
-v::hexRgbColor()->validate('#FFFAAA'); // true
-v::hexRgbColor()->validate('#ff6600'); // true
-v::hexRgbColor()->validate('123123'); // true
-v::hexRgbColor()->validate('FCD'); // true
+v::hexRgbColor()->isValid('#FFFAAA'); // true
+v::hexRgbColor()->isValid('#ff6600'); // true
+v::hexRgbColor()->isValid('123123'); // true
+v::hexRgbColor()->isValid('FCD'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Iban.md
+++ b/docs/rules/Iban.md
@@ -6,12 +6,12 @@ Validates whether the input is a valid [IBAN][] (International Bank Account
 Number) or not.
 
 ```php
-v::iban()->validate('SE35 5000 0000 0549 1000 0003'); // true
-v::iban()->validate('ch9300762011623852957'); // true
+v::iban()->isValid('SE35 5000 0000 0549 1000 0003'); // true
+v::iban()->isValid('ch9300762011623852957'); // true
 
-v::iban()->validate('ZZ32 5000 5880 7742'); // false
-v::iban()->validate(123456789); // false
-v::iban()->validate(''); // false
+v::iban()->isValid('ZZ32 5000 5880 7742'); // false
+v::iban()->isValid(123456789); // false
+v::iban()->isValid(''); // false
 ```
 
 ## Categorization

--- a/docs/rules/Identical.md
+++ b/docs/rules/Identical.md
@@ -5,8 +5,8 @@
 Validates if the input is identical to some value.
 
 ```php
-v::identical(42)->validate(42); // true
-v::identical(42)->validate('42'); // false
+v::identical(42)->isValid(42); // true
+v::identical(42)->isValid('42'); // false
 ```
 
 Message template for this validator includes `{{compareTo}}`.

--- a/docs/rules/Image.md
+++ b/docs/rules/Image.md
@@ -6,9 +6,9 @@
 Validates if the file is a valid image by checking its MIME type.
 
 ```php
-v::image()->validate('image.gif'); // true
-v::image()->validate('image.jpg'); // true
-v::image()->validate('image.png'); // true
+v::image()->isValid('image.gif'); // true
+v::image()->isValid('image.jpg'); // true
+v::image()->isValid('image.png'); // true
 ```
 
 All the validations above must return `false` if the input is not a valid file

--- a/docs/rules/Imei.md
+++ b/docs/rules/Imei.md
@@ -5,8 +5,8 @@
 Validates is the input is a valid [IMEI][].
 
 ```php
-v::imei()->validate('35-209900-176148-1'); // true
-v::imei()->validate('490154203237518'); // true
+v::imei()->isValid('35-209900-176148-1'); // true
+v::imei()->isValid('490154203237518'); // true
 ```
 
 ## Categorization

--- a/docs/rules/In.md
+++ b/docs/rules/In.md
@@ -8,13 +8,13 @@ Validates if the input is contained in a specific haystack.
 For strings:
 
 ```php
-v::in('lorem ipsum')->validate('ipsum'); // true
+v::in('lorem ipsum')->isValid('ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::in(['lorem', 'ipsum'])->validate('lorem'); // true
+v::in(['lorem', 'ipsum'])->isValid('lorem'); // true
 ```
 
 A second parameter may be passed for identical comparison instead

--- a/docs/rules/Infinite.md
+++ b/docs/rules/Infinite.md
@@ -5,7 +5,7 @@
 Validates if the input is an infinite number.
 
 ```php
-v::infinite()->validate(INF); // true
+v::infinite()->isValid(INF); // true
 ```
 
 ## Categorization

--- a/docs/rules/Instance.md
+++ b/docs/rules/Instance.md
@@ -5,8 +5,8 @@
 Validates if the input is an instance of the given class or interface.
 
 ```php
-v::instance('DateTime')->validate(new DateTime); // true
-v::instance('Traversable')->validate(new ArrayObject); // true
+v::instance('DateTime')->isValid(new DateTime); // true
+v::instance('Traversable')->isValid(new ArrayObject); // true
 ```
 
 Message template for this validator includes `{{instanceName}}`.

--- a/docs/rules/IntType.md
+++ b/docs/rules/IntType.md
@@ -5,8 +5,8 @@
 Validates whether the type of the input is [integer](http://php.net/types.integer).
 
 ```php
-v::intType()->validate(42); // true
-v::intType()->validate('10'); // false
+v::intType()->isValid(42); // true
+v::intType()->isValid('10'); // false
 ```
 
 ## Categorization

--- a/docs/rules/IntVal.md
+++ b/docs/rules/IntVal.md
@@ -5,11 +5,11 @@
 Validates if the input is an integer, allowing leading zeros and other number bases.
 
 ```php
-v::intVal()->validate('10'); // true
-v::intVal()->validate('089'); // true
-v::intVal()->validate(10); // true
-v::intVal()->validate(0b101010); // true
-v::intVal()->validate(0x2a); // true
+v::intVal()->isValid('10'); // true
+v::intVal()->isValid('089'); // true
+v::intVal()->isValid(10); // true
+v::intVal()->isValid(0b101010); // true
+v::intVal()->isValid(0x2a); // true
 ```
 
 This rule will consider as valid any input that PHP can convert to an integer,
@@ -17,8 +17,8 @@ but that does not contain non-integer values. That way, one can safely use the
 value this rule validates, without having surprises.
 
 ```php
-v::intVal()->validate(true); // false
-v::intVal()->validate('89a'); // false
+v::intVal()->isValid(true); // false
+v::intVal()->isValid('89a'); // false
 ```
 
 Even though PHP can cast the values above as integers, this rule will not

--- a/docs/rules/Ip.md
+++ b/docs/rules/Ip.md
@@ -9,28 +9,28 @@ Validates whether the input is a valid IP address.
 This validator uses the native [filter_var()][] PHP function.
 
 ```php
-v::ip()->validate('127.0.0.1'); // true
-v::ip('220.78.168.0/21')->validate('220.78.173.2'); // true
-v::ip('220.78.168.0/21')->validate('220.78.176.2'); // false
+v::ip()->isValid('127.0.0.1'); // true
+v::ip('220.78.168.0/21')->isValid('220.78.173.2'); // true
+v::ip('220.78.168.0/21')->isValid('220.78.176.2'); // false
 ```
 
 Validating ranges:
 
 ```php
-v::ip('127.0.0.1-127.0.0.5')->validate('127.0.0.2'); // true
-v::ip('127.0.0.1-127.0.0.5')->validate('127.0.0.10'); // false
+v::ip('127.0.0.1-127.0.0.5')->isValid('127.0.0.2'); // true
+v::ip('127.0.0.1-127.0.0.5')->isValid('127.0.0.10'); // false
 ```
 
 You can pass a parameter with [filter_var()][] flags for IP.
 
 ```php
-v::ip('*', FILTER_FLAG_NO_PRIV_RANGE)->validate('192.168.0.1'); // false
+v::ip('*', FILTER_FLAG_NO_PRIV_RANGE)->isValid('192.168.0.1'); // false
 ```
 
 If you want to validate IPv6 you can do as follow:
 
 ```php
-v::ip('*', FILTER_FLAG_IPV6)->validate('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'); // true
+v::ip('*', FILTER_FLAG_IPV6)->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Isbn.md
+++ b/docs/rules/Isbn.md
@@ -5,10 +5,10 @@
 Validates whether the input is a valid [ISBN][] or not.
 
 ```php
-v::isbn()->validate('ISBN-13: 978-0-596-52068-7'); // true
-v::isbn()->validate('978 0 596 52068 7'); // true
-v::isbn()->validate('ISBN-12: 978-0-596-52068-7'); // false
-v::isbn()->validate('978 10 596 52068 7'); // false
+v::isbn()->isValid('ISBN-13: 978-0-596-52068-7'); // true
+v::isbn()->isValid('978 0 596 52068 7'); // true
+v::isbn()->isValid('ISBN-12: 978-0-596-52068-7'); // false
+v::isbn()->isValid('978 10 596 52068 7'); // false
 ```
 
 ## Categorization

--- a/docs/rules/IterableType.md
+++ b/docs/rules/IterableType.md
@@ -7,10 +7,10 @@ if you're able to iterate over it with [foreach](http://php.net/foreach) languag
 construct.
 
 ```php
-v::iterableType()->validate([]); // true
-v::iterableType()->validate(new ArrayObject()); // true
-v::iterableType()->validate(new stdClass()); // true
-v::iterableType()->validate('string'); // false
+v::iterableType()->isValid([]); // true
+v::iterableType()->isValid(new ArrayObject()); // true
+v::iterableType()->isValid(new stdClass()); // true
+v::iterableType()->isValid('string'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Json.md
+++ b/docs/rules/Json.md
@@ -5,7 +5,7 @@
 Validates if the given input is a valid JSON.
 
 ```php
-v::json()->validate('{"foo":"bar"}'); // true
+v::json()->isValid('{"foo":"bar"}'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Key.md
+++ b/docs/rules/Key.md
@@ -11,19 +11,19 @@ $dict = [
     'foo' => 'bar'
 ];
 
-v::key('foo')->validate($dict); // true
+v::key('foo')->isValid($dict); // true
 ```
 
 You can also validate the key value itself:
 
 ```php
-v::key('foo', v::equals('bar'))->validate($dict); // true
+v::key('foo', v::equals('bar'))->isValid($dict); // true
 ```
 
 Third parameter makes the key presence optional:
 
 ```php
-v::key('lorem', v::stringType(), false)->validate($dict); // true
+v::key('lorem', v::stringType(), false)->isValid($dict); // true
 ```
 
 The name of this validator is automatically set to the key name.

--- a/docs/rules/KeyNested.md
+++ b/docs/rules/KeyNested.md
@@ -15,7 +15,7 @@ $array = [
     ],
 ];
 
-v::keyNested('foo.bar')->validate($array); // true
+v::keyNested('foo.bar')->isValid($array); // true
 ```
 
 Validating object properties:
@@ -25,7 +25,7 @@ $object = new stdClass();
 $object->foo = new stdClass();
 $object->foo->bar = 42;
 
-v::keyNested('foo.bar')->validate($object); // true
+v::keyNested('foo.bar')->isValid($object); // true
 ```
 
 This rule was inspired by [Yii2 ArrayHelper][].

--- a/docs/rules/KeySet.md
+++ b/docs/rules/KeySet.md
@@ -9,7 +9,7 @@ $dict = ['foo' => 42];
 
 v::keySet(
     v::key('foo', v::intVal())
-)->validate($dict); // true
+)->isValid($dict); // true
 ```
 
 Extra keys are not allowed:
@@ -18,7 +18,7 @@ $dict = ['foo' => 42, 'bar' => 'String'];
 
 v::keySet(
     v::key('foo', v::intVal())
-)->validate($dict); // false
+)->isValid($dict); // false
 ```
 
 Missing required keys are not allowed:
@@ -29,7 +29,7 @@ v::keySet(
     v::key('foo', v::intVal()),
     v::key('bar', v::stringType()),
     v::key('baz', v::boolType())
-)->validate($dict); // false
+)->isValid($dict); // false
 ```
 
 Missing non-required keys are allowed:
@@ -40,7 +40,7 @@ v::keySet(
     v::key('foo', v::intVal()),
     v::key('bar', v::stringType()),
     v::key('baz', v::boolType(), false)
-)->validate($dict); // true
+)->isValid($dict); // true
 ```
 
 It is not possible to negate `keySet()` rules with `not()`.

--- a/docs/rules/KeyValue.md
+++ b/docs/rules/KeyValue.md
@@ -10,8 +10,8 @@ another key value and that may cause some ugly code since you need the input
 before the validation, making some checking manually:
 
 ```php
-v::key('password', v::notEmpty())->validate($_POST);
-v::key('password_confirmation', v::equals($_POST['password'] ?? null))->validate($_POST);
+v::key('password', v::notEmpty())->isValid($_POST);
+v::key('password_confirmation', v::equals($_POST['password'] ?? null))->isValid($_POST);
 ```
 
 The problem with the above code is because you do not know if `password` is a
@@ -22,7 +22,7 @@ The `keyValue()` rule makes this job easier by creating a rule named on
 `$ruleName` passing `$baseKey` as the first argument of this rule, see an example:
 
 ```php
-v::keyValue('password_confirmation', 'equals', 'password')->validate($_POST);
+v::keyValue('password_confirmation', 'equals', 'password')->isValid($_POST);
 ```
 
 The above code will result on `true` if _`$_POST['password_confirmation']` is
@@ -31,7 +31,7 @@ The above code will result on `true` if _`$_POST['password_confirmation']` is
 See another example:
 
 ```php
-v::keyValue('state', 'subdivisionCode', 'country')->validate($_POST);
+v::keyValue('state', 'subdivisionCode', 'country')->isValid($_POST);
 ```
 
 The above code will result on `true` if _`$_POST['state']` is a

--- a/docs/rules/LanguageCode.md
+++ b/docs/rules/LanguageCode.md
@@ -6,11 +6,11 @@
 Validates whether the input is language code based on ISO 639.
 
 ```php
-v::languageCode()->validate('pt'); // true
-v::languageCode()->validate('en'); // true
-v::languageCode()->validate('it'); // true
-v::languageCode('alpha-3')->validate('ita'); // true
-v::languageCode('alpha-3')->validate('eng'); // true
+v::languageCode()->isValid('pt'); // true
+v::languageCode()->isValid('en'); // true
+v::languageCode()->isValid('it'); // true
+v::languageCode('alpha-3')->isValid('ita'); // true
+v::languageCode('alpha-3')->isValid('eng'); // true
 ```
 
 You can choose between `alpha-2` and `alpha-3`; `alpha-2` is set by default set.

--- a/docs/rules/LeapDate.md
+++ b/docs/rules/LeapDate.md
@@ -5,7 +5,7 @@
 Validates if a date is leap.
 
 ```php
-v::leapDate('Y-m-d')->validate('1988-02-29'); // true
+v::leapDate('Y-m-d')->isValid('1988-02-29'); // true
 ```
 
 This validator accepts DateTime instances as well. The $format

--- a/docs/rules/LeapYear.md
+++ b/docs/rules/LeapYear.md
@@ -5,7 +5,7 @@
 Validates if a year is leap.
 
 ```php
-v::leapYear()->validate('1988'); // true
+v::leapYear()->isValid('1988'); // true
 ```
 
 This validator accepts DateTime instances as well.

--- a/docs/rules/Length.md
+++ b/docs/rules/Length.md
@@ -10,32 +10,32 @@ Validates the length of the given input.
 Most simple example:
 
 ```php
-v::stringType()->length(1, 5)->validate('abc'); // true
+v::stringType()->length(1, 5)->isValid('abc'); // true
 ```
 
 You can also validate only minimum length:
 
 ```php
-v::stringType()->length(5, null)->validate('abcdef'); // true
+v::stringType()->length(5, null)->isValid('abcdef'); // true
 ```
 
 Only maximum length:
 
 ```php
-v::stringType()->length(null, 5)->validate('abc'); // true
+v::stringType()->length(null, 5)->isValid('abc'); // true
 ```
 
 The type as the first validator in a chain is a good practice,
 since length accepts many types:
 
 ```php
-v::arrayVal()->length(1, 5)->validate(['foo', 'bar']); // true
+v::arrayVal()->length(1, 5)->isValid(['foo', 'bar']); // true
 ```
 
 A third parameter may be passed to validate the passed values inclusive:
 
 ```php
-v::stringType()->length(1, 5, true)->validate('a'); // true
+v::stringType()->length(1, 5, true)->isValid('a'); // true
 ```
 
 Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.

--- a/docs/rules/LessThan.md
+++ b/docs/rules/LessThan.md
@@ -5,8 +5,8 @@
 Validates whether the input is less than a value.
 
 ```php
-v::lessThan(10)->validate(9); // true
-v::lessThan(10)->validate(10); // false
+v::lessThan(10)->isValid(9); // true
+v::lessThan(10)->isValid(10); // false
 ```
 
 Validation makes comparison easier, check out our supported

--- a/docs/rules/Lowercase.md
+++ b/docs/rules/Lowercase.md
@@ -5,7 +5,7 @@
 Validates whether the characters in the input are lowercase.
 
 ```php
-v::stringType()->lowercase()->validate('xkcd'); // true
+v::stringType()->lowercase()->isValid('xkcd'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Luhn.md
+++ b/docs/rules/Luhn.md
@@ -5,8 +5,8 @@
 Validate whether a given input is a [Luhn][] number.
 
 ```php
-v::luhn()->validate('2222400041240011'); // true
-v::luhn()->validate('respect!'); // false
+v::luhn()->isValid('2222400041240011'); // true
+v::luhn()->isValid('respect!'); // false
 ```
 
 ## Categorization

--- a/docs/rules/MacAddress.md
+++ b/docs/rules/MacAddress.md
@@ -5,8 +5,8 @@
 Validates whether the input is a valid MAC address.
 
 ```php
-v::macAddress()->validate('00:11:22:33:44:55'); // true
-v::macAddress()->validate('af-AA-22-33-44-55'); // true
+v::macAddress()->isValid('00:11:22:33:44:55'); // true
+v::macAddress()->isValid('af-AA-22-33-44-55'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Max.md
+++ b/docs/rules/Max.md
@@ -5,9 +5,9 @@
 Validates whether the input is less than or equal to a value.
 
 ```php
-v::max(10)->validate(9); // true
-v::max(10)->validate(10); // true
-v::max(10)->validate(11); // false
+v::max(10)->isValid(9); // true
+v::max(10)->isValid(10); // true
+v::max(10)->isValid(11); // false
 ```
 
 Validation makes comparison easier, check out our supported

--- a/docs/rules/MaxAge.md
+++ b/docs/rules/MaxAge.md
@@ -8,11 +8,11 @@ accordance to PHP's [date()][] function. When `$format` is not  given this rule
 accepts [Supported Date and Time Formats][] by PHP (see [strtotime()][]).
 
 ```php
-v::maxAge(12)->validate('12 years ago'); // true
-v::maxAge(12, 'Y-m-d')->validate('2013-07-31'); // true
+v::maxAge(12)->isValid('12 years ago'); // true
+v::maxAge(12, 'Y-m-d')->isValid('2013-07-31'); // true
 
-v::maxAge(12)->validate('13 years ago'); // false
-v::maxAge(18, 'Y-m-d')->validate('1988-09-09'); // false
+v::maxAge(12)->isValid('13 years ago'); // false
+v::maxAge(18, 'Y-m-d')->isValid('1988-09-09'); // false
 ```
 
 Using [Date](Date.md) before is a best-practice.

--- a/docs/rules/Mimetype.md
+++ b/docs/rules/Mimetype.md
@@ -5,8 +5,8 @@
 Validates if the input is a file and if its MIME type matches the expected one.
 
 ```php
-v::mimetype('image/png')->validate('image.png'); // true
-v::mimetype('image/jpeg')->validate('image.jpg'); // true
+v::mimetype('image/png')->isValid('image.png'); // true
+v::mimetype('image/jpeg')->isValid('image.jpg'); // true
 ```
 
 This rule is case-sensitive and requires [fileinfo](http://php.net/fileinfo) PHP extension.

--- a/docs/rules/Min.md
+++ b/docs/rules/Min.md
@@ -5,9 +5,9 @@
 Validates whether the input is greater than or equal to a value.
 
 ```php
-v::intVal()->min(10)->validate(9); // false
-v::intVal()->min(10)->validate(10); // true
-v::intVal()->min(10)->validate(11); // true
+v::intVal()->min(10)->isValid(9); // false
+v::intVal()->min(10)->isValid(10); // true
+v::intVal()->min(10)->isValid(11); // true
 ```
 
 Validation makes comparison easier, check out our supported

--- a/docs/rules/MinAge.md
+++ b/docs/rules/MinAge.md
@@ -8,11 +8,11 @@ accordance to PHP's [date()][] function. When `$format` is not  given this rule
 accepts [Supported Date and Time Formats][] by PHP (see [strtotime()][]).
 
 ```php
-v::minAge(18)->validate('18 years ago'); // true
-v::minAge(18, 'Y-m-d')->validate('1987-01-01'); // true
+v::minAge(18)->isValid('18 years ago'); // true
+v::minAge(18, 'Y-m-d')->isValid('1987-01-01'); // true
 
-v::minAge(18)->validate('17 years ago'); // false
-v::minAge(18, 'Y-m-d')->validate('2010-09-07'); // false
+v::minAge(18)->isValid('17 years ago'); // false
+v::minAge(18, 'Y-m-d')->isValid('2010-09-07'); // false
 ```
 
 Using [Date](Date.md) before is a best-practice.

--- a/docs/rules/Multiple.md
+++ b/docs/rules/Multiple.md
@@ -5,7 +5,7 @@
 Validates if the input is a multiple of the given parameter
 
 ```php
-v::intVal()->multiple(3)->validate(9); // true
+v::intVal()->multiple(3)->isValid(9); // true
 ```
 
 ## Categorization

--- a/docs/rules/Negative.md
+++ b/docs/rules/Negative.md
@@ -5,7 +5,7 @@
 Validates whether the input is a negative number.
 
 ```php
-v::numericVal()->negative()->validate(-15); // true
+v::numericVal()->negative()->isValid(-15); // true
 ```
 
 ## Categorization

--- a/docs/rules/NfeAccessKey.md
+++ b/docs/rules/NfeAccessKey.md
@@ -5,7 +5,7 @@
 Validates the access key of the Brazilian electronic invoice (NFe).
 
 ```php
-v::nfeAccessKey()->validate('31841136830118868211870485416765268625116906'); // true
+v::nfeAccessKey()->isValid('31841136830118868211870485416765268625116906'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Nif.md
+++ b/docs/rules/Nif.md
@@ -5,8 +5,8 @@
 Validates Spain's fiscal identification number ([NIF](https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal)).
 
 ```php
-v::nif()->validate('49294492H'); // true
-v::nif()->validate('P6437358A'); // false
+v::nif()->isValid('49294492H'); // true
+v::nif()->isValid('P6437358A'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Nip.md
+++ b/docs/rules/Nip.md
@@ -5,11 +5,11 @@
 Validates whether the input is a Polish VAT identification number (NIP).
 
 ```php
-v::nip()->validate('1645865777'); // true
-v::nip()->validate('1645865778'); // false
-v::nip()->validate('1234567890'); // false
-v::nip()->validate('164-586-57-77'); // false
-v::nip()->validate('164-58-65-777'); // false
+v::nip()->isValid('1645865777'); // true
+v::nip()->isValid('1645865778'); // false
+v::nip()->isValid('1234567890'); // false
+v::nip()->isValid('164-586-57-77'); // false
+v::nip()->isValid('164-58-65-777'); // false
 ```
 
 ## Categorization

--- a/docs/rules/No.md
+++ b/docs/rules/No.md
@@ -6,12 +6,12 @@
 Validates if value is considered as "No".
 
 ```php
-v::no()->validate('N'); // true
-v::no()->validate('Nay'); // true
-v::no()->validate('Nix'); // true
-v::no()->validate('No'); // true
-v::no()->validate('Nope'); // true
-v::no()->validate('Not'); // true
+v::no()->isValid('N'); // true
+v::no()->isValid('Nay'); // true
+v::no()->isValid('Nix'); // true
+v::no()->isValid('No'); // true
+v::no()->isValid('Nope'); // true
+v::no()->isValid('Not'); // true
 ```
 
 This rule is case insensitive.
@@ -21,13 +21,13 @@ constant, meaning that it will validate the input using your current location:
 
 ```php
 setlocale(LC_ALL, 'ru_RU');
-v::no(true)->validate('нет'); // true
+v::no(true)->isValid('нет'); // true
 ```
 
 Be careful when using `$locale` as `TRUE` because the it's very permissive:
 
 ```php
-v::no(true)->validate('Never gonna give you up 🎵'); // true
+v::no(true)->isValid('Never gonna give you up 🎵'); // true
 ```
 
 Besides that, with `$locale` as  `TRUE` it will consider any character starting
@@ -35,7 +35,7 @@ with "N" as valid:
 
 ```php
 setlocale(LC_ALL, 'es_ES');
-v::no(true)->validate('Yes'); // true
+v::no(true)->isValid('Yes'); // true
 ```
 
 ## Categorization

--- a/docs/rules/NoWhitespace.md
+++ b/docs/rules/NoWhitespace.md
@@ -5,8 +5,8 @@
 Validates if a string contains no whitespace (spaces, tabs and line breaks);
 
 ```php
-v::noWhitespace()->validate('foo bar');  //false
-v::noWhitespace()->validate("foo\nbar"); // false
+v::noWhitespace()->isValid('foo bar');  //false
+v::noWhitespace()->isValid("foo\nbar"); // false
 ```
 
 This is most useful when chaining with other validators such as `Alnum()`

--- a/docs/rules/NoneOf.md
+++ b/docs/rules/NoneOf.md
@@ -8,7 +8,7 @@ Validates if NONE of the given validators validate:
 v::noneOf(
     v::intVal(),
     v::floatVal()
-)->validate('foo'); // true
+)->isValid('foo'); // true
 ```
 
 In the sample above, 'foo' isn't a integer nor a float, so noneOf returns true.

--- a/docs/rules/Not.md
+++ b/docs/rules/Not.md
@@ -5,7 +5,7 @@
 Negates any rule.
 
 ```php
-v::not(v::ip())->validate('foo'); // true
+v::not(v::ip())->isValid('foo'); // true
 ```
 
 In the sample above, validator returns true because 'foo' isn't an IP Address.
@@ -13,7 +13,7 @@ In the sample above, validator returns true because 'foo' isn't an IP Address.
 You can negate complex, grouped or chained validators as well:
 
 ```php
-v::not(v::intVal()->positive())->validate(-1.5); // true
+v::not(v::intVal()->positive())->isValid(-1.5); // true
 ```
 
 Each other validation has custom messages for negated rules.

--- a/docs/rules/NotBlank.md
+++ b/docs/rules/NotBlank.md
@@ -6,22 +6,22 @@ Validates if the given input is not a blank value (`null`, zeros, empty strings
 or empty arrays, recursively).
 
 ```php
-v::notBlank()->validate(null); // false
-v::notBlank()->validate(''); // false
-v::notBlank()->validate([]); // false
-v::notBlank()->validate(' '); // false
-v::notBlank()->validate(0); // false
-v::notBlank()->validate('0'); // false
-v::notBlank()->validate(0); // false
-v::notBlank()->validate('0.0'); // false
-v::notBlank()->validate(false); // false
-v::notBlank()->validate(['']); // false
-v::notBlank()->validate([' ']); // false
-v::notBlank()->validate([0]); // false
-v::notBlank()->validate(['0']); // false
-v::notBlank()->validate([false]); // false
-v::notBlank()->validate([[''], [0]]); // false
-v::notBlank()->validate(new stdClass()); // false
+v::notBlank()->isValid(null); // false
+v::notBlank()->isValid(''); // false
+v::notBlank()->isValid([]); // false
+v::notBlank()->isValid(' '); // false
+v::notBlank()->isValid(0); // false
+v::notBlank()->isValid('0'); // false
+v::notBlank()->isValid(0); // false
+v::notBlank()->isValid('0.0'); // false
+v::notBlank()->isValid(false); // false
+v::notBlank()->isValid(['']); // false
+v::notBlank()->isValid([' ']); // false
+v::notBlank()->isValid([0]); // false
+v::notBlank()->isValid(['0']); // false
+v::notBlank()->isValid([false]); // false
+v::notBlank()->isValid([[''], [0]]); // false
+v::notBlank()->isValid(new stdClass()); // false
 ```
 
 It's similar to [NotEmpty](NotEmpty.md) but it's way more strict.

--- a/docs/rules/NotEmoji.md
+++ b/docs/rules/NotEmoji.md
@@ -5,12 +5,12 @@
 Validates if the input does not contain an emoji.
 
 ```php
-v::notEmoji()->validate('Hello World, without emoji'); // true
-v::notEmoji()->validate('🍕'); // false
-v::notEmoji()->validate('🎈'); // false
-v::notEmoji()->validate('⚡'); // false
-v::notEmoji()->validate('this is a spark ⚡'); // false
-v::notEmoji()->validate('🌊🌊🌊🌊🌊🏄🌊🌊🌊🏖🌴'); // false
+v::notEmoji()->isValid('Hello World, without emoji'); // true
+v::notEmoji()->isValid('🍕'); // false
+v::notEmoji()->isValid('🎈'); // false
+v::notEmoji()->isValid('⚡'); // false
+v::notEmoji()->isValid('this is a spark ⚡'); // false
+v::notEmoji()->isValid('🌊🌊🌊🌊🌊🏄🌊🌊🌊🏖🌴'); // false
 ```
 
 Please consider that the performance of this validator is linear which

--- a/docs/rules/NotEmpty.md
+++ b/docs/rules/NotEmpty.md
@@ -7,32 +7,32 @@ into account, use `noWhitespace()` if no spaces or linebreaks and other
 whitespace anywhere in the input is desired.
 
 ```php
-v::stringType()->notEmpty()->validate(''); // false
+v::stringType()->notEmpty()->isValid(''); // false
 ```
 
 Null values are empty:
 
 ```php
-v::notEmpty()->validate(null); // false
+v::notEmpty()->isValid(null); // false
 ```
 
 Numbers:
 
 ```php
-v::intVal()->notEmpty()->validate(0); // false
+v::intVal()->notEmpty()->isValid(0); // false
 ```
 
 Empty arrays:
 
 ```php
-v::arrayVal()->notEmpty()->validate([]); // false
+v::arrayVal()->notEmpty()->isValid([]); // false
 ```
 
 Whitespace:
 
 ```php
-v::stringType()->notEmpty()->validate('        ');  //false
-v::stringType()->notEmpty()->validate("\t \n \r");  //false
+v::stringType()->notEmpty()->isValid('        ');  //false
+v::stringType()->notEmpty()->isValid("\t \n \r");  //false
 ```
 
 ## Categorization

--- a/docs/rules/NotOptional.md
+++ b/docs/rules/NotOptional.md
@@ -6,27 +6,27 @@ Validates if the given input is not optional. By _optional_ we consider `null`
 or an empty string (`''`).
 
 ```php
-v::notOptional()->validate(''); // false
-v::notOptional()->validate(null); // false
+v::notOptional()->isValid(''); // false
+v::notOptional()->isValid(null); // false
 ```
 
 Other values:
 
 ```php
-v::notOptional()->validate([]); // true
-v::notOptional()->validate(' '); // true
-v::notOptional()->validate(0); // true
-v::notOptional()->validate('0'); // true
-v::notOptional()->validate(0); // true
-v::notOptional()->validate('0.0'); // true
-v::notOptional()->validate(false); // true
-v::notOptional()->validate(['']); // true
-v::notOptional()->validate([' ']); // true
-v::notOptional()->validate([0]); // true
-v::notOptional()->validate(['0']); // true
-v::notOptional()->validate([false]); // true
-v::notOptional()->validate([[''), [0]]); // true
-v::notOptional()->validate(new stdClass()); // true
+v::notOptional()->isValid([]); // true
+v::notOptional()->isValid(' '); // true
+v::notOptional()->isValid(0); // true
+v::notOptional()->isValid('0'); // true
+v::notOptional()->isValid(0); // true
+v::notOptional()->isValid('0.0'); // true
+v::notOptional()->isValid(false); // true
+v::notOptional()->isValid(['']); // true
+v::notOptional()->isValid([' ']); // true
+v::notOptional()->isValid([0]); // true
+v::notOptional()->isValid(['0']); // true
+v::notOptional()->isValid([false]); // true
+v::notOptional()->isValid([[''), [0]]); // true
+v::notOptional()->isValid(new stdClass()); // true
 ```
 
 ## Categorization

--- a/docs/rules/NullType.md
+++ b/docs/rules/NullType.md
@@ -5,7 +5,7 @@
 Validates whether the input is [null](http://php.net/types.null).
 
 ```php
-v::nullType()->validate(null); // true
+v::nullType()->isValid(null); // true
 ```
 
 ## Categorization

--- a/docs/rules/Nullable.md
+++ b/docs/rules/Nullable.md
@@ -5,9 +5,9 @@
 Validates the given input with a defined rule when input is not NULL.
 
 ```php
-v::nullable(v::email())->validate(null); // true
-v::nullable(v::email())->validate('example@example.com'); // true
-v::nullable(v::email())->validate('not an email'); // false
+v::nullable(v::email())->isValid(null); // true
+v::nullable(v::email())->isValid('example@example.com'); // true
+v::nullable(v::email())->isValid('not an email'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Number.md
+++ b/docs/rules/Number.md
@@ -5,8 +5,8 @@
 Validates if the input is a number.
 
 ```php
-v::number()->validate(42); // true
-v::number()->validate(acos(8)); // false
+v::number()->isValid(42); // true
+v::number()->isValid(acos(8)); // false
 ```
 
 > "In computing, NaN, standing for not a number, is a numeric data type value

--- a/docs/rules/NumericVal.md
+++ b/docs/rules/NumericVal.md
@@ -5,8 +5,8 @@
 Validates whether the input is numeric.
 
 ```php
-v::numericVal()->validate(-12); // true
-v::numericVal()->validate('135.0'); // true
+v::numericVal()->isValid(-12); // true
+v::numericVal()->isValid('135.0'); // true
 ```
 
 This rule doesn't validate if the input is a valid number, for that

--- a/docs/rules/ObjectType.md
+++ b/docs/rules/ObjectType.md
@@ -5,7 +5,7 @@
 Validates whether the input is an [object](http://php.net/types.object).
 
 ```php
-v::objectType()->validate(new stdClass); // true
+v::objectType()->isValid(new stdClass); // true
 ```
 
 ## Categorization

--- a/docs/rules/Odd.md
+++ b/docs/rules/Odd.md
@@ -5,8 +5,8 @@
 Validates whether the input is an odd number or not.
 
 ```php
-v::odd()->validate(0); // false
-v::odd()->validate(3); // true
+v::odd()->isValid(0); // false
+v::odd()->isValid(3); // true
 ```
 
 Using `intVal()` before `odd()` is a best practice.

--- a/docs/rules/OneOf.md
+++ b/docs/rules/OneOf.md
@@ -5,10 +5,10 @@
 Will validate if exactly one inner validator passes.
 
 ```php
-v::oneOf(v::digit(), v::alpha())->validate('AB'); // true
-v::oneOf(v::digit(), v::alpha())->validate('12'); // true
-v::oneOf(v::digit(), v::alpha())->validate('AB12'); // false
-v::oneOf(v::digit(), v::alpha())->validate('*'); // false
+v::oneOf(v::digit(), v::alpha())->isValid('AB'); // true
+v::oneOf(v::digit(), v::alpha())->isValid('12'); // true
+v::oneOf(v::digit(), v::alpha())->isValid('AB12'); // false
+v::oneOf(v::digit(), v::alpha())->isValid('*'); // false
 ```
 
 The chains above validate if the input is either a digit or an alphabetic

--- a/docs/rules/Optional.md
+++ b/docs/rules/Optional.md
@@ -6,8 +6,8 @@ Validates if the given input is optional or not. By _optional_ we consider `null
 or an empty string (`''`).
 
 ```php
-v::optional(v::alpha())->validate(''); // true
-v::optional(v::digit())->validate(null); // true
+v::optional(v::alpha())->isValid(''); // true
+v::optional(v::digit())->isValid(null); // true
 ```
 
 ## Categorization

--- a/docs/rules/PerfectSquare.md
+++ b/docs/rules/PerfectSquare.md
@@ -5,8 +5,8 @@
 Validates whether the input is a perfect square.
 
 ```php
-v::perfectSquare()->validate(25); // true (5*5)
-v::perfectSquare()->validate(9); // true (3*3)
+v::perfectSquare()->isValid(25); // true (5*5)
+v::perfectSquare()->isValid(9); // true (3*3)
 ```
 
 ## Categorization

--- a/docs/rules/Pesel.md
+++ b/docs/rules/Pesel.md
@@ -5,10 +5,10 @@
 Validates PESEL (Polish human identification number).
 
 ```php
-v::pesel()->validate('21120209256'); // true
-v::pesel()->validate('97072704800'); // true
-v::pesel()->validate('97072704801'); // false
-v::pesel()->validate('PESEL123456'); // false
+v::pesel()->isValid('21120209256'); // true
+v::pesel()->isValid('97072704800'); // true
+v::pesel()->isValid('97072704801'); // false
+v::pesel()->isValid('PESEL123456'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Phone.md
+++ b/docs/rules/Phone.md
@@ -6,9 +6,9 @@
 Validates whether the input is a valid phone number.
 
 ```php
-v::phone()->validate('+1 650 253 00 00'); // true
-v::phone('BR')->validate('+55 11 91111 1111'); // true
-v::phone('BR')->validate('11 91111 1111'); // false
+v::phone()->isValid('+1 650 253 00 00'); // true
+v::phone('BR')->isValid('+55 11 91111 1111'); // true
+v::phone('BR')->isValid('11 91111 1111'); // false
 ```
 
 ## Note

--- a/docs/rules/PhpLabel.md
+++ b/docs/rules/PhpLabel.md
@@ -9,9 +9,9 @@ Reference:
 http://php.net/manual/en/language.variables.basics.php
 
 ```php
-v::phpLabel()->validate('person'); //true
-v::phpLabel()->validate('foo'); //true
-v::phpLabel()->validate('4ccess'); //false
+v::phpLabel()->isValid('person'); //true
+v::phpLabel()->isValid('foo'); //true
+v::phpLabel()->isValid('4ccess'); //false
 ```
 
 ## Categorization

--- a/docs/rules/Pis.md
+++ b/docs/rules/Pis.md
@@ -5,11 +5,11 @@
 Validates a Brazilian PIS/NIS number ignoring any non-digit char.
 
 ```php
-v::pis()->validate('120.0340.678-8'); // true
-v::pis()->validate('120.03406788'); // true
-v::pis()->validate('120.0340.6788'); // true
-v::pis()->validate('1.2.0.0.3.4.0.6.7.8.8'); // true
-v::pis()->validate('12003406788'); // true
+v::pis()->isValid('120.0340.678-8'); // true
+v::pis()->isValid('120.03406788'); // true
+v::pis()->isValid('120.0340.6788'); // true
+v::pis()->isValid('1.2.0.0.3.4.0.6.7.8.8'); // true
+v::pis()->isValid('12003406788'); // true
 ```
 
 ## Categorization

--- a/docs/rules/PolishIdCard.md
+++ b/docs/rules/PolishIdCard.md
@@ -5,10 +5,10 @@
 Validates whether the input is a Polish identity card (Dowód Osobisty).
 
 ```php
-v::polishIdCard()->validate('AYW036733'); // true
-v::polishIdCard()->validate('APH505567'); // true
-v::polishIdCard()->validate('APH 505567'); // false
-v::polishIdCard()->validate('AYW036731'); // false
+v::polishIdCard()->isValid('AYW036733'); // true
+v::polishIdCard()->isValid('APH505567'); // true
+v::polishIdCard()->isValid('APH 505567'); // false
+v::polishIdCard()->isValid('AYW036731'); // false
 ```
 
 ## Categorization

--- a/docs/rules/PortugueseNif.md
+++ b/docs/rules/PortugueseNif.md
@@ -5,8 +5,8 @@
 Validates Portugal's fiscal identification number ([NIF](https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal)).
 
 ```php
-v::portugueseNif()->validate('124885446'); // true
-v::portugueseNif()->validate('220005245'); // false
+v::portugueseNif()->isValid('124885446'); // true
+v::portugueseNif()->isValid('220005245'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Positive.md
+++ b/docs/rules/Positive.md
@@ -5,9 +5,9 @@
 Validates whether the input is a positive number.
 
 ```php
-v::positive()->validate(1); // true
-v::positive()->validate(0); // false
-v::positive()->validate(-15); // false
+v::positive()->isValid(1); // true
+v::positive()->isValid(0); // false
+v::positive()->isValid(-15); // false
 ```
 
 ## Categorization

--- a/docs/rules/PostalCode.md
+++ b/docs/rules/PostalCode.md
@@ -5,19 +5,19 @@
 Validates whether the input is a valid postal code or not.
 
 ```php
-v::postalCode('BR')->validate('02179000'); // true
-v::postalCode('BR')->validate('02179-000'); // true
-v::postalCode('US')->validate('02179-000'); // false
-v::postalCode('US')->validate('55372'); // true
-v::postalCode('PL')->validate('99-300'); // true
+v::postalCode('BR')->isValid('02179000'); // true
+v::postalCode('BR')->isValid('02179-000'); // true
+v::postalCode('US')->isValid('02179-000'); // false
+v::postalCode('US')->isValid('55372'); // true
+v::postalCode('PL')->isValid('99-300'); // true
 ```
 
 By default, `PostalCode` won't validate the format (puncts, spaces), unless you pass `$formatted = true`:
 
 
 ```php
-v::postalCode('BR', true)->validate('02179000'); // false
-v::postalCode('BR', true)->validate('02179-000'); // true
+v::postalCode('BR', true)->isValid('02179000'); // false
+v::postalCode('BR', true)->isValid('02179-000'); // true
 ```
 
 Message template for this validator includes `{{countryCode}}`.

--- a/docs/rules/PrimeNumber.md
+++ b/docs/rules/PrimeNumber.md
@@ -5,7 +5,7 @@
 Validates a prime number
 
 ```php
-v::primeNumber()->validate(7); // true
+v::primeNumber()->isValid(7); // true
 ```
 
 ## Categorization

--- a/docs/rules/Printable.md
+++ b/docs/rules/Printable.md
@@ -6,7 +6,7 @@
 Similar to `Graph` but accepts whitespace.
 
 ```php
-v::printable()->validate('LMKA0$% _123'); // true
+v::printable()->isValid('LMKA0$% _123'); // true
 ```
 
 ## Categorization

--- a/docs/rules/PublicDomainSuffix.md
+++ b/docs/rules/PublicDomainSuffix.md
@@ -5,17 +5,17 @@
 Validates whether the input is a public ICANN domain suffix.
 
 ```php
-v::publicDomainSuffix->validate('co.uk'); // true
-v::publicDomainSuffix->validate('CO.UK'); // true
-v::publicDomainSuffix->validate('nom.br'); // true
-v::publicDomainSuffix->validate('invalid.com'); // false
+v::publicDomainSuffix->isValid('co.uk'); // true
+v::publicDomainSuffix->isValid('CO.UK'); // true
+v::publicDomainSuffix->isValid('nom.br'); // true
+v::publicDomainSuffix->isValid('invalid.com'); // false
 ```
 
 This rule will not match top level domains such as `tk`. 
 If you want to match either, use a combination with `Tld`:
 
 ```php
-v::oneOf(v::tld(), v::publicDomainSuffix())->validate('tk'); // true
+v::oneOf(v::tld(), v::publicDomainSuffix())->isValid('tk'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Punct.md
+++ b/docs/rules/Punct.md
@@ -6,7 +6,7 @@
 Validates whether the input composed by only punctuation characters.
 
 ```php
-v::punct()->validate('&,.;[]'); // true
+v::punct()->isValid('&,.;[]'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Readable.md
+++ b/docs/rules/Readable.md
@@ -5,7 +5,7 @@
 Validates if the given data is a file exists and is readable.
 
 ```php
-v::readable()->validate('file.txt'); // true
+v::readable()->isValid('file.txt'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Regex.md
+++ b/docs/rules/Regex.md
@@ -5,7 +5,7 @@
 Validates whether the input matches a defined regular expression.
 
 ```php
-v::regex('/[a-z]/')->validate('a'); // true
+v::regex('/[a-z]/')->isValid('a'); // true
 ```
 
 Message template for this validator includes `{{regex}}`.

--- a/docs/rules/ResourceType.md
+++ b/docs/rules/ResourceType.md
@@ -5,7 +5,7 @@
 Validates whether the input is a [resource](http://php.net/types.resource).
 
 ```php
-v::resourceType()->validate(fopen('/path/to/file.txt', 'w')); // true
+v::resourceType()->isValid(fopen('/path/to/file.txt', 'w')); // true
 ```
 
 ## Categorization

--- a/docs/rules/Roman.md
+++ b/docs/rules/Roman.md
@@ -5,7 +5,7 @@
 Validates if the input is a Roman numeral.
 
 ```php
-v::roman()->validate('IV'); // true
+v::roman()->isValid('IV'); // true
 ```
 
 ## Categorization

--- a/docs/rules/ScalarVal.md
+++ b/docs/rules/ScalarVal.md
@@ -5,8 +5,8 @@
 Validates whether the input is a scalar value or not.
 
 ```php
-v::scalarVal()->validate([]); // false
-v::scalarVal()->validate(135.0); // true
+v::scalarVal()->isValid([]); // false
+v::scalarVal()->isValid(135.0); // true
 ```
 
 ## Categorization

--- a/docs/rules/Size.md
+++ b/docs/rules/Size.md
@@ -7,9 +7,9 @@
 Validates whether the input is a file that is of a certain size or not.
 
 ```php
-v::size('1KB')->validate($filename); // Must have at least 1KB size
-v::size('1MB', '2MB')->validate($filename); // Must have the size between 1MB and 2MB
-v::size(null, '1GB')->validate($filename); // Must not be greater than 1GB
+v::size('1KB')->isValid($filename); // Must have at least 1KB size
+v::size('1MB', '2MB')->isValid($filename); // Must have the size between 1MB and 2MB
+v::size(null, '1GB')->isValid($filename); // Must not be greater than 1GB
 ```
 
 Sizes are not case-sensitive and the accepted values are:
@@ -27,7 +27,7 @@ Sizes are not case-sensitive and the accepted values are:
 This validator will consider `SplFileInfo` instances, like:
 
 ```php
-v::size('1.5mb')->validate(new SplFileInfo($filename)); // Will return true or false
+v::size('1.5mb')->isValid(new SplFileInfo($filename)); // Will return true or false
 ```
 
 Message template for this validator includes `{{minSize}}` and `{{maxSize}}`.

--- a/docs/rules/Slug.md
+++ b/docs/rules/Slug.md
@@ -5,9 +5,9 @@
 Validates whether the input is a valid slug.
 
 ```php
-v::slug()->validate('my-wordpress-title'); // true
-v::slug()->validate('my-wordpress--title'); // false
-v::slug()->validate('my-wordpress-title-'); // false
+v::slug()->isValid('my-wordpress-title'); // true
+v::slug()->isValid('my-wordpress--title'); // false
+v::slug()->isValid('my-wordpress-title-'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Sorted.md
+++ b/docs/rules/Sorted.md
@@ -5,11 +5,11 @@
 Validates whether the input is sorted in a certain order or not.
 
 ```php
-v::sorted('ASC')->validate([1, 2, 3]); // true
-v::sorted('ASC')->validate('ABC'); // true
-v::sorted('DESC')->validate([3, 2, 1]); // true
-v::sorted('ASC')->validate([]); // true
-v::sorted('ASC')->validate([1]); // true
+v::sorted('ASC')->isValid([1, 2, 3]); // true
+v::sorted('ASC')->isValid('ABC'); // true
+v::sorted('DESC')->isValid([3, 2, 1]); // true
+v::sorted('ASC')->isValid([]); // true
+v::sorted('ASC')->isValid([1]); // true
 ```
 
 You can also combine [Call](Call.md) to create custom validations:
@@ -20,15 +20,15 @@ v::call(
             return array_column($input, 'key');
         },
         v::sorted('ASC')
-    )->validate([
+    )->isValid([
         ['key' => 1],
         ['key' => 5],
         ['key' => 9],
     ]); // true
 
-v::call('strval', v::sorted('DESC'))->validate(4321); // true
+v::call('strval', v::sorted('DESC'))->isValid(4321); // true
 
-v::call('iterator_to_array', v::sorted())->validate(new ArrayIterator([1, 7, 4])); // false
+v::call('iterator_to_array', v::sorted())->isValid(new ArrayIterator([1, 7, 4])); // false
 ```
 
 ## Categorization

--- a/docs/rules/Space.md
+++ b/docs/rules/Space.md
@@ -6,7 +6,7 @@
 Validates whether the input contains only whitespaces characters.
 
 ```php
-v::space()->validate('    '); // true
+v::space()->isValid('    '); // true
 ```
 
 ## Categorization

--- a/docs/rules/StartsWith.md
+++ b/docs/rules/StartsWith.md
@@ -11,13 +11,13 @@ if the value is at the beginning of the input.
 For strings:
 
 ```php
-v::startsWith('lorem')->validate('lorem ipsum'); // true
+v::startsWith('lorem')->isValid('lorem ipsum'); // true
 ```
 
 For arrays:
 
 ```php
-v::startsWith('lorem')->validate(['lorem', 'ipsum']); // true
+v::startsWith('lorem')->isValid(['lorem', 'ipsum']); // true
 ```
 
 `true` may be passed as a parameter to indicate identical comparison

--- a/docs/rules/StringType.md
+++ b/docs/rules/StringType.md
@@ -5,7 +5,7 @@
 Validates whether the type of an input is string or not.
 
 ```php
-v::stringType()->validate('hi'); // true
+v::stringType()->isValid('hi'); // true
 ```
 
 ## Categorization

--- a/docs/rules/StringVal.md
+++ b/docs/rules/StringVal.md
@@ -5,13 +5,13 @@
 Validates whether the input can be used as a string.
 
 ```php
-v::stringVal()->validate('6'); // true
-v::stringVal()->validate('String'); // true
-v::stringVal()->validate(1.0); // true
-v::stringVal()->validate(42); // true
-v::stringVal()->validate(false); // true
-v::stringVal()->validate(true); // true
-v::stringVal()->validate(new ClassWithToString()); // true if ClassWithToString implements `__toString`
+v::stringVal()->isValid('6'); // true
+v::stringVal()->isValid('String'); // true
+v::stringVal()->isValid(1.0); // true
+v::stringVal()->isValid(42); // true
+v::stringVal()->isValid(false); // true
+v::stringVal()->isValid(true); // true
+v::stringVal()->isValid(new ClassWithToString()); // true if ClassWithToString implements `__toString`
 ```
 
 ## Categorization

--- a/docs/rules/SubdivisionCode.md
+++ b/docs/rules/SubdivisionCode.md
@@ -7,8 +7,8 @@ Validates subdivision country codes according to [ISO 3166-2][].
 The `$countryCode` must be a country in [ISO 3166-1 alpha-2][] format.
 
 ```php
-v::subdivisionCode('BR')->validate('SP'); // true
-v::subdivisionCode('US')->validate('CA'); // true
+v::subdivisionCode('BR')->isValid('SP'); // true
+v::subdivisionCode('US')->isValid('CA'); // true
 ```
 
 This rules uses data from [iso-codes][].

--- a/docs/rules/Subset.md
+++ b/docs/rules/Subset.md
@@ -5,8 +5,8 @@
 Validates whether the input is a subset of a given value.
 
 ```php
-v::subset([1, 2, 3])->validate([1, 2]); // true
-v::subset([1, 2])->validate([1, 2, 3]); // false
+v::subset([1, 2, 3])->isValid([1, 2]); // true
+v::subset([1, 2])->isValid([1, 2, 3]); // false
 ```
 
 ## Categorization

--- a/docs/rules/SymbolicLink.md
+++ b/docs/rules/SymbolicLink.md
@@ -5,9 +5,9 @@
 Validates if the given input is a symbolic link.
 
 ```php
-v::symbolicLink()->validate('/path/of/valid/symbolic/link'); // true
-v::symbolicLink()->validate(new SplFileInfo('/path/of/valid/symbolic/link)); // true
-v::symbolicLink()->validate(new SplFileObject('/path/of/valid/symbolic/link')); // true
+v::symbolicLink()->isValid('/path/of/valid/symbolic/link'); // true
+v::symbolicLink()->isValid(new SplFileInfo('/path/of/valid/symbolic/link)); // true
+v::symbolicLink()->isValid(new SplFileObject('/path/of/valid/symbolic/link')); // true
 ```
 
 ## Categorization

--- a/docs/rules/Time.md
+++ b/docs/rules/Time.md
@@ -23,15 +23,15 @@ Format  | Description                                        | Values
 When a `$format` is not given its default value is `H:i:s`.
 
 ```php
-v::time()->validate('00:00:00'); // true
-v::time()->validate('23:20:59'); // true
-v::time('H:i')->validate('23:59'); // true
-v::time('g:i A')->validate('8:13 AM'); // true
-v::time('His')->validate(232059); // true
+v::time()->isValid('00:00:00'); // true
+v::time()->isValid('23:20:59'); // true
+v::time('H:i')->isValid('23:59'); // true
+v::time('g:i A')->isValid('8:13 AM'); // true
+v::time('His')->isValid(232059); // true
 
-v::time()->validate('24:00:00'); // false
-v::time()->validate(new DateTime()); // false
-v::time()->validate(new DateTimeImmutable()); // false
+v::time()->isValid('24:00:00'); // false
+v::time()->isValid(new DateTime()); // false
+v::time()->isValid(new DateTimeImmutable()); // false
 ```
 
 ## Categorization

--- a/docs/rules/Tld.md
+++ b/docs/rules/Tld.md
@@ -5,10 +5,10 @@
 Validates whether the input is a top-level domain.
 
 ```php
-v::tld()->validate('com'); // true
-v::tld()->validate('ly'); // true
-v::tld()->validate('org'); // true
-v::tld()->validate('COM'); // true
+v::tld()->isValid('com'); // true
+v::tld()->isValid('ly'); // true
+v::tld()->isValid('org'); // true
+v::tld()->isValid('COM'); // true
 ```
 
 ## Categorization

--- a/docs/rules/TrueVal.md
+++ b/docs/rules/TrueVal.md
@@ -5,14 +5,14 @@
 Validates if a value is considered as `true`.
 
 ```php
-v::trueVal()->validate(true); // true
-v::trueVal()->validate(1); // true
-v::trueVal()->validate('1'); // true
-v::trueVal()->validate('true'); // true
-v::trueVal()->validate('on'); // true
-v::trueVal()->validate('yes'); // true
-v::trueVal()->validate('0.5'); // false
-v::trueVal()->validate('2'); // false
+v::trueVal()->isValid(true); // true
+v::trueVal()->isValid(1); // true
+v::trueVal()->isValid('1'); // true
+v::trueVal()->isValid('true'); // true
+v::trueVal()->isValid('on'); // true
+v::trueVal()->isValid('yes'); // true
+v::trueVal()->isValid('0.5'); // false
+v::trueVal()->isValid('2'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Type.md
+++ b/docs/rules/Type.md
@@ -5,9 +5,9 @@
 Validates the type of input.
 
 ```php
-v::type('bool')->validate(true); // true
-v::type('callable')->validate(function (){}); // true
-v::type('object')->validate(new stdClass()); // true
+v::type('bool')->isValid(true); // true
+v::type('callable')->isValid(function (){}); // true
+v::type('object')->isValid(new stdClass()); // true
 ```
 
 ## Categorization

--- a/docs/rules/Unique.md
+++ b/docs/rules/Unique.md
@@ -5,10 +5,10 @@
 Validates whether the input array contains only unique values.
 
 ```php
-v::unique()->validate([]); // true
-v::unique()->validate([1, 2, 3]); // true
-v::unique()->validate([1, 2, 2, 3]); // false
-v::unique()->validate([1, 2, 3, 1]); // false
+v::unique()->isValid([]); // true
+v::unique()->isValid([1, 2, 3]); // true
+v::unique()->isValid([1, 2, 2, 3]); // false
+v::unique()->isValid([1, 2, 3, 1]); // false
 ```
 
 ## Categorization

--- a/docs/rules/Uploaded.md
+++ b/docs/rules/Uploaded.md
@@ -5,7 +5,7 @@
 Validates if the given data is a file that was uploaded via HTTP POST.
 
 ```php
-v::uploaded()->validate('/path/of/an/uploaded/file'); // true
+v::uploaded()->isValid('/path/of/an/uploaded/file'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Uppercase.md
+++ b/docs/rules/Uppercase.md
@@ -5,7 +5,7 @@
 Validates whether the characters in the input are uppercase.
 
 ```php
-v::uppercase()->validate('W3C'); // true
+v::uppercase()->isValid('W3C'); // true
 ```
 
 This rule does not validate if the input a numeric value, so `123` and `%` will
@@ -13,9 +13,9 @@ be valid. Please add more validations to the chain if you want to refine your
 validation.
 
 ```php
-v::not(v::numericVal())->uppercase()->validate('42'); // false
-v::alnum()->uppercase()->validate('#$%!'); // false
-v::not(v::numericVal())->alnum()->uppercase()->validate('W3C'); // true
+v::not(v::numericVal())->uppercase()->isValid('42'); // false
+v::alnum()->uppercase()->isValid('#$%!'); // false
+v::not(v::numericVal())->alnum()->uppercase()->isValid('W3C'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Url.md
+++ b/docs/rules/Url.md
@@ -5,11 +5,11 @@
 Validates whether the input is a URL.
 
 ```php
-v::url()->validate('http://example.com'); // true
-v::url()->validate('https://www.youtube.com/watch?v=6FOUqQt3Kg0'); // true
-v::url()->validate('ldap://[::1]'); // true
-v::url()->validate('mailto:john.doe@example.com'); // true
-v::url()->validate('news:new.example.com'); // true
+v::url()->isValid('http://example.com'); // true
+v::url()->isValid('https://www.youtube.com/watch?v=6FOUqQt3Kg0'); // true
+v::url()->isValid('ldap://[::1]'); // true
+v::url()->isValid('mailto:john.doe@example.com'); // true
+v::url()->isValid('news:new.example.com'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Uuid.md
+++ b/docs/rules/Uuid.md
@@ -7,10 +7,10 @@ Validates whether the input is a valid UUID. It also supports validation of
 specific versions 1, 3, 4 and 5.
 
 ```php
-v::uuid()->validate('Hello World!'); // false
-v::uuid()->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
-v::uuid(1)->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // false
-v::uuid(4)->validate('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid()->isValid('Hello World!'); // false
+v::uuid()->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid(1)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // false
+v::uuid(4)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Version.md
+++ b/docs/rules/Version.md
@@ -5,7 +5,7 @@
 Validates version numbers using Semantic Versioning.
 
 ```php
-v::version()->validate('1.0.0');
+v::version()->isValid('1.0.0');
 ```
 
 ## Categorization

--- a/docs/rules/VideoUrl.md
+++ b/docs/rules/VideoUrl.md
@@ -6,23 +6,23 @@
 Validates if the input is a video URL value.
 
 ```php
-v::videoUrl()->validate('https://player.vimeo.com/video/71787467'); // true
-v::videoUrl()->validate('https://vimeo.com/71787467'); // true
-v::videoUrl()->validate('https://www.youtube.com/embed/netHLn9TScY'); // true
-v::videoUrl()->validate('https://www.youtube.com/watch?v=netHLn9TScY'); // true
-v::videoUrl()->validate('https://youtu.be/netHLn9TScY'); // true
-v::videoUrl()->validate('https://www.twitch.tv/videos/320689092'); // true
-v::videoUrl()->validate('https://clips.twitch.tv/BitterLazyMangetoutHumbleLife'); // true
+v::videoUrl()->isValid('https://player.vimeo.com/video/71787467'); // true
+v::videoUrl()->isValid('https://vimeo.com/71787467'); // true
+v::videoUrl()->isValid('https://www.youtube.com/embed/netHLn9TScY'); // true
+v::videoUrl()->isValid('https://www.youtube.com/watch?v=netHLn9TScY'); // true
+v::videoUrl()->isValid('https://youtu.be/netHLn9TScY'); // true
+v::videoUrl()->isValid('https://www.twitch.tv/videos/320689092'); // true
+v::videoUrl()->isValid('https://clips.twitch.tv/BitterLazyMangetoutHumbleLife'); // true
 
-v::videoUrl('youtube')->validate('https://www.youtube.com/watch?v=netHLn9TScY'); // true
-v::videoUrl('vimeo')->validate('https://vimeo.com/71787467'); // true
-v::videoUrl('twitch')->validate('https://www.twitch.tv/videos/320689092'); // true
-v::videoUrl('twitch')->validate('https://clips.twitch.tv/BitterLazyMangetoutHumbleLife'); // true
+v::videoUrl('youtube')->isValid('https://www.youtube.com/watch?v=netHLn9TScY'); // true
+v::videoUrl('vimeo')->isValid('https://vimeo.com/71787467'); // true
+v::videoUrl('twitch')->isValid('https://www.twitch.tv/videos/320689092'); // true
+v::videoUrl('twitch')->isValid('https://clips.twitch.tv/BitterLazyMangetoutHumbleLife'); // true
 
-v::videoUrl()->validate('https://youtube.com'); // false
-v::videoUrl('youtube')->validate('https://vimeo.com/71787467'); // false
-v::videoUrl('twitch')->validate('https://clips.twitch.tv/videos/90210'); // false
-v::videoUrl('twitch')->validate('https://twitch.tv/TakeTeaAndNoTea'); // false
+v::videoUrl()->isValid('https://youtube.com'); // false
+v::videoUrl('youtube')->isValid('https://vimeo.com/71787467'); // false
+v::videoUrl('twitch')->isValid('https://clips.twitch.tv/videos/90210'); // false
+v::videoUrl('twitch')->isValid('https://twitch.tv/TakeTeaAndNoTea'); // false
 ```
 
 The services accepted are:

--- a/docs/rules/Vowel.md
+++ b/docs/rules/Vowel.md
@@ -6,7 +6,7 @@
 Validates whether the input contains only vowels.
 
 ```php
-v::vowel()->validate('aei'); // true
+v::vowel()->isValid('aei'); // true
 ```
 
 ## Categorization

--- a/docs/rules/When.md
+++ b/docs/rules/When.md
@@ -9,11 +9,11 @@ When the `$if` validates, returns validation for `$then`.
 When the `$if` doesn't validate, returns validation for `$else`, if defined.
 
 ```php
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate(1); // true
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate('not empty'); // true
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid(1); // true
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid('not empty'); // true
 
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate(-1); // false
-v::when(v::intVal(), v::positive(), v::notEmpty())->validate(''); // false
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid(-1); // false
+v::when(v::intVal(), v::positive(), v::notEmpty())->isValid(''); // false
 ```
 
 In the sample above, if `$input` is an integer, then it must be positive.

--- a/docs/rules/Writable.md
+++ b/docs/rules/Writable.md
@@ -5,7 +5,7 @@
 Validates if the given input is writable file.
 
 ```php
-v::writable()->validate('file.txt'); // true
+v::writable()->isValid('file.txt'); // true
 ```
 
 ## Categorization

--- a/docs/rules/Xdigit.md
+++ b/docs/rules/Xdigit.md
@@ -6,13 +6,13 @@
 Validates whether the input is an hexadecimal number or not.
 
 ```php
-v::xdigit()->validate('abc123'); // true
+v::xdigit()->isValid('abc123'); // true
 ```
 
 Notice, however, that it doesn't accept strings starting with 0x:
 
 ```php
-v::xdigit()->validate('0x1f'); // false
+v::xdigit()->isValid('0x1f'); // false
 ```
 
 ## Categorization

--- a/docs/rules/Yes.md
+++ b/docs/rules/Yes.md
@@ -6,11 +6,11 @@
 Validates if the input considered as "Yes".
 
 ```php
-v::yes()->validate('Y'); // true
-v::yes()->validate('Yea'); // true
-v::yes()->validate('Yeah'); // true
-v::yes()->validate('Yep'); // true
-v::yes()->validate('Yes'); // true
+v::yes()->isValid('Y'); // true
+v::yes()->isValid('Yea'); // true
+v::yes()->isValid('Yeah'); // true
+v::yes()->isValid('Yep'); // true
+v::yes()->isValid('Yes'); // true
 ```
 
 This rule is case insensitive.
@@ -20,13 +20,13 @@ constant, meaning that it will validate the input using your current location:
 
 ```php
 setlocale(LC_ALL, 'pt_BR');
-v::yes(true)->validate('Sim'); // true
+v::yes(true)->isValid('Sim'); // true
 ```
 
 Be careful when using `$locale` as `TRUE` because the it's very permissive:
 
 ```php
-v::yes(true)->validate('Yydoesnotmatter'); // true
+v::yes(true)->isValid('Yydoesnotmatter'); // true
 ```
 
 Besides that, with `$locale` as  `TRUE` it will consider any character starting
@@ -34,7 +34,7 @@ with "Y" as valid:
 
 ```php
 setlocale(LC_ALL, 'ru_RU');
-v::yes(true)->validate('Yes'); // true
+v::yes(true)->isValid('Yes'); // true
 ```
 
 ## Categorization

--- a/library/Exceptions/AllOfException.php
+++ b/library/Exceptions/AllOfException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see NestedValidationException} instead.
  */
 class AllOfException extends GroupedValidationException
 {

--- a/library/Exceptions/AlnumException.php
+++ b/library/Exceptions/AlnumException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class AlnumException extends FilteredValidationException
 {

--- a/library/Exceptions/AlphaException.php
+++ b/library/Exceptions/AlphaException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class AlphaException extends FilteredValidationException
 {

--- a/library/Exceptions/AlwaysInvalidException.php
+++ b/library/Exceptions/AlwaysInvalidException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class AlwaysInvalidException extends ValidationException
 {

--- a/library/Exceptions/AlwaysValidException.php
+++ b/library/Exceptions/AlwaysValidException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class AlwaysValidException extends ValidationException
 {

--- a/library/Exceptions/AnyOfException.php
+++ b/library/Exceptions/AnyOfException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class AnyOfException extends NestedValidationException
 {

--- a/library/Exceptions/ArrayTypeException.php
+++ b/library/Exceptions/ArrayTypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author João Torquato <joao.otl@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ArrayTypeException extends ValidationException
 {

--- a/library/Exceptions/ArrayValException.php
+++ b/library/Exceptions/ArrayValException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ArrayValException extends ValidationException
 {

--- a/library/Exceptions/AttributeException.php
+++ b/library/Exceptions/AttributeException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class AttributeException extends NestedValidationException implements NonOmissibleException
 {

--- a/library/Exceptions/Base64Exception.php
+++ b/library/Exceptions/Base64Exception.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jens Segers <segers.jens@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class Base64Exception extends ValidationException
 {

--- a/library/Exceptions/BaseException.php
+++ b/library/Exceptions/BaseException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Carlos André Ferrari <caferrari@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class BaseException extends ValidationException
 {

--- a/library/Exceptions/BetweenException.php
+++ b/library/Exceptions/BetweenException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class BetweenException extends NestedValidationException
 {

--- a/library/Exceptions/BoolTypeException.php
+++ b/library/Exceptions/BoolTypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Devin Torres <devin@devintorres.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class BoolTypeException extends ValidationException
 {

--- a/library/Exceptions/BoolValException.php
+++ b/library/Exceptions/BoolValException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class BoolValException extends ValidationException
 {

--- a/library/Exceptions/BsnException.php
+++ b/library/Exceptions/BsnException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ronald Drenth <ronalddrenth@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class BsnException extends ValidationException
 {

--- a/library/Exceptions/CallException.php
+++ b/library/Exceptions/CallException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CallException extends NestedValidationException
 {

--- a/library/Exceptions/CallableTypeException.php
+++ b/library/Exceptions/CallableTypeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * Exception class for CallableType rule.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CallableTypeException extends ValidationException
 {

--- a/library/Exceptions/CallbackException.php
+++ b/library/Exceptions/CallbackException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CallbackException extends NestedValidationException
 {

--- a/library/Exceptions/CharsetException.php
+++ b/library/Exceptions/CharsetException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CharsetException extends ValidationException
 {

--- a/library/Exceptions/CnhException.php
+++ b/library/Exceptions/CnhException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Kinn Coelho Julião <kinncj@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CnhException extends ValidationException
 {

--- a/library/Exceptions/CnpjException.php
+++ b/library/Exceptions/CnpjException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Leonn Leite <leonnleite@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CnpjException extends ValidationException
 {

--- a/library/Exceptions/ConsonantException.php
+++ b/library/Exceptions/ConsonantException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Kleber Hamada Sato <kleberhs007@yahoo.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ConsonantException extends FilteredValidationException
 {

--- a/library/Exceptions/ContainsAnyException.php
+++ b/library/Exceptions/ContainsAnyException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Kirill Dlussky <kirill@dlussky.ru>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ContainsAnyException extends ValidationException
 {

--- a/library/Exceptions/ContainsException.php
+++ b/library/Exceptions/ContainsException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ContainsException extends ValidationException
 {

--- a/library/Exceptions/ControlException.php
+++ b/library/Exceptions/ControlException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ControlException extends FilteredValidationException
 {

--- a/library/Exceptions/CountableException.php
+++ b/library/Exceptions/CountableException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author João Torquato <joao.otl@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CountableException extends ValidationException
 {

--- a/library/Exceptions/CountryCodeException.php
+++ b/library/Exceptions/CountryCodeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CountryCodeException extends ValidationException
 {

--- a/library/Exceptions/CpfException.php
+++ b/library/Exceptions/CpfException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jair Henrique <jair.henrique@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CpfException extends ValidationException
 {

--- a/library/Exceptions/CreditCardException.php
+++ b/library/Exceptions/CreditCardException.php
@@ -15,6 +15,7 @@ use Respect\Validation\Rules\CreditCard;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CreditCardException extends ValidationException
 {

--- a/library/Exceptions/CurrencyCodeException.php
+++ b/library/Exceptions/CurrencyCodeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Justin Hook <justinhook88@yahoo.co.uk>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class CurrencyCodeException extends ValidationException
 {

--- a/library/Exceptions/DateException.php
+++ b/library/Exceptions/DateException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Bruno Luiz da Silva <contato@brunoluiz.net>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class DateException extends ValidationException
 {

--- a/library/Exceptions/DateTimeException.php
+++ b/library/Exceptions/DateTimeException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class DateTimeException extends ValidationException
 {

--- a/library/Exceptions/DecimalException.php
+++ b/library/Exceptions/DecimalException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class DecimalException extends ValidationException
 {

--- a/library/Exceptions/DigitException.php
+++ b/library/Exceptions/DigitException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class DigitException extends FilteredValidationException
 {

--- a/library/Exceptions/DirectoryException.php
+++ b/library/Exceptions/DirectoryException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class DirectoryException extends ValidationException
 {

--- a/library/Exceptions/DomainException.php
+++ b/library/Exceptions/DomainException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class DomainException extends NestedValidationException
 {

--- a/library/Exceptions/EachException.php
+++ b/library/Exceptions/EachException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class EachException extends NestedValidationException
 {

--- a/library/Exceptions/EmailException.php
+++ b/library/Exceptions/EmailException.php
@@ -17,6 +17,7 @@ namespace Respect\Validation\Exceptions;
  * @author Eduardo Gulias Davis <me@egulias.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class EmailException extends ValidationException
 {

--- a/library/Exceptions/EndsWithException.php
+++ b/library/Exceptions/EndsWithException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class EndsWithException extends ValidationException
 {

--- a/library/Exceptions/EqualsException.php
+++ b/library/Exceptions/EqualsException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ian Nisbet <ian@glutenite.co.uk>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class EqualsException extends ValidationException
 {

--- a/library/Exceptions/EquivalentException.php
+++ b/library/Exceptions/EquivalentException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class EquivalentException extends ValidationException
 {

--- a/library/Exceptions/EvenException.php
+++ b/library/Exceptions/EvenException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class EvenException extends ValidationException
 {

--- a/library/Exceptions/ExecutableException.php
+++ b/library/Exceptions/ExecutableException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ExecutableException extends ValidationException
 {

--- a/library/Exceptions/ExistsException.php
+++ b/library/Exceptions/ExistsException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ExistsException extends ValidationException
 {

--- a/library/Exceptions/ExtensionException.php
+++ b/library/Exceptions/ExtensionException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ExtensionException extends ValidationException
 {

--- a/library/Exceptions/FactorException.php
+++ b/library/Exceptions/FactorException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author David Meister <thedavidmeister@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FactorException extends ValidationException
 {

--- a/library/Exceptions/FalseValException.php
+++ b/library/Exceptions/FalseValException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FalseValException extends ValidationException
 {

--- a/library/Exceptions/FibonacciException.php
+++ b/library/Exceptions/FibonacciException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Samuel Heinzmann <samuel.heinzmann@swisscom.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FibonacciException extends ValidationException
 {

--- a/library/Exceptions/FileException.php
+++ b/library/Exceptions/FileException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FileException extends ValidationException
 {

--- a/library/Exceptions/FilterVarException.php
+++ b/library/Exceptions/FilterVarException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FilterVarException extends ValidationException
 {

--- a/library/Exceptions/FiniteException.php
+++ b/library/Exceptions/FiniteException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FiniteException extends ValidationException
 {

--- a/library/Exceptions/FloatTypeException.php
+++ b/library/Exceptions/FloatTypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Reginaldo Junior <76regi@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FloatTypeException extends ValidationException
 {

--- a/library/Exceptions/FloatValException.php
+++ b/library/Exceptions/FloatValException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class FloatValException extends ValidationException
 {

--- a/library/Exceptions/GraphException.php
+++ b/library/Exceptions/GraphException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class GraphException extends FilteredValidationException
 {

--- a/library/Exceptions/GreaterThanException.php
+++ b/library/Exceptions/GreaterThanException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class GreaterThanException extends ValidationException
 {

--- a/library/Exceptions/HexRgbColorException.php
+++ b/library/Exceptions/HexRgbColorException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Davide Pastore <pasdavide@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class HexRgbColorException extends ValidationException
 {

--- a/library/Exceptions/IbanException.php
+++ b/library/Exceptions/IbanException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Mazen Touati <mazen_touati@hotmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IbanException extends ValidationException
 {

--- a/library/Exceptions/IdenticalException.php
+++ b/library/Exceptions/IdenticalException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IdenticalException extends ValidationException
 {

--- a/library/Exceptions/ImageException.php
+++ b/library/Exceptions/ImageException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Guilherme Siani <guilherme@siani.com.br>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ImageException extends ValidationException
 {

--- a/library/Exceptions/ImeiException.php
+++ b/library/Exceptions/ImeiException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Diego Oliveira <contato@diegoholiveira.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ImeiException extends ValidationException
 {

--- a/library/Exceptions/InException.php
+++ b/library/Exceptions/InException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class InException extends ValidationException
 {

--- a/library/Exceptions/InfiniteException.php
+++ b/library/Exceptions/InfiniteException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class InfiniteException extends ValidationException
 {

--- a/library/Exceptions/InstanceException.php
+++ b/library/Exceptions/InstanceException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class InstanceException extends ValidationException
 {

--- a/library/Exceptions/IntTypeException.php
+++ b/library/Exceptions/IntTypeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * Exception class for IntType rule.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IntTypeException extends ValidationException
 {

--- a/library/Exceptions/IntValException.php
+++ b/library/Exceptions/IntValException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IntValException extends ValidationException
 {

--- a/library/Exceptions/InvalidClassException.php
+++ b/library/Exceptions/InvalidClassException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @since 2.0.0
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class InvalidClassException extends ComponentException
 {

--- a/library/Exceptions/IpException.php
+++ b/library/Exceptions/IpException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IpException extends ValidationException
 {

--- a/library/Exceptions/IsbnException.php
+++ b/library/Exceptions/IsbnException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Moritz Fromm <moritzgitfromm@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IsbnException extends ValidationException
 {

--- a/library/Exceptions/IterableTypeException.php
+++ b/library/Exceptions/IterableTypeException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class IterableTypeException extends ValidationException
 {

--- a/library/Exceptions/JsonException.php
+++ b/library/Exceptions/JsonException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class JsonException extends ValidationException
 {

--- a/library/Exceptions/KeyException.php
+++ b/library/Exceptions/KeyException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class KeyException extends NestedValidationException implements NonOmissibleException
 {

--- a/library/Exceptions/KeyNestedException.php
+++ b/library/Exceptions/KeyNestedException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ivan Zinovyev <vanyazin@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class KeyNestedException extends NestedValidationException implements NonOmissibleException
 {

--- a/library/Exceptions/KeySetException.php
+++ b/library/Exceptions/KeySetException.php
@@ -13,6 +13,7 @@ use function count;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class KeySetException extends GroupedValidationException implements NonOmissibleException
 {

--- a/library/Exceptions/KeyValueException.php
+++ b/library/Exceptions/KeyValueException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class KeyValueException extends ValidationException
 {

--- a/library/Exceptions/LanguageCodeException.php
+++ b/library/Exceptions/LanguageCodeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LanguageCodeException extends ValidationException
 {

--- a/library/Exceptions/LeapDateException.php
+++ b/library/Exceptions/LeapDateException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LeapDateException extends ValidationException
 {

--- a/library/Exceptions/LeapYearException.php
+++ b/library/Exceptions/LeapYearException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LeapYearException extends ValidationException
 {

--- a/library/Exceptions/LengthException.php
+++ b/library/Exceptions/LengthException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Mazen Touati <mazen_touati@hotmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LengthException extends ValidationException
 {

--- a/library/Exceptions/LessThanException.php
+++ b/library/Exceptions/LessThanException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LessThanException extends ValidationException
 {

--- a/library/Exceptions/LowercaseException.php
+++ b/library/Exceptions/LowercaseException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LowercaseException extends ValidationException
 {

--- a/library/Exceptions/LuhnException.php
+++ b/library/Exceptions/LuhnException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexander Gorshkov <mazanax@yandex.ru>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class LuhnException extends ValidationException
 {

--- a/library/Exceptions/MacAddressException.php
+++ b/library/Exceptions/MacAddressException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Fábio da Silva Ribeiro <fabiorphp@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MacAddressException extends ValidationException
 {

--- a/library/Exceptions/MaxAgeException.php
+++ b/library/Exceptions/MaxAgeException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MaxAgeException extends ValidationException
 {

--- a/library/Exceptions/MaxException.php
+++ b/library/Exceptions/MaxException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Andrew Peters <amp343@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MaxException extends ValidationException
 {

--- a/library/Exceptions/MimetypeException.php
+++ b/library/Exceptions/MimetypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MimetypeException extends ValidationException
 {

--- a/library/Exceptions/MinAgeException.php
+++ b/library/Exceptions/MinAgeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MinAgeException extends ValidationException
 {

--- a/library/Exceptions/MinException.php
+++ b/library/Exceptions/MinException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MinException extends ValidationException
 {

--- a/library/Exceptions/MultipleException.php
+++ b/library/Exceptions/MultipleException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class MultipleException extends ValidationException
 {

--- a/library/Exceptions/NegativeException.php
+++ b/library/Exceptions/NegativeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ismael Elias <ismael.esq@hotmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NegativeException extends ValidationException
 {

--- a/library/Exceptions/NfeAccessKeyException.php
+++ b/library/Exceptions/NfeAccessKeyException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Andrey Knupp Vital <andreykvital@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NfeAccessKeyException extends ValidationException
 {

--- a/library/Exceptions/NifException.php
+++ b/library/Exceptions/NifException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Julián Gutiérrez <juliangut@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NifException extends ValidationException
 {

--- a/library/Exceptions/NipException.php
+++ b/library/Exceptions/NipException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Tomasz Regdos <tomek@regdos.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NipException extends ValidationException
 {

--- a/library/Exceptions/NoException.php
+++ b/library/Exceptions/NoException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NoException extends ValidationException
 {

--- a/library/Exceptions/NoWhitespaceException.php
+++ b/library/Exceptions/NoWhitespaceException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NoWhitespaceException extends ValidationException
 {

--- a/library/Exceptions/NoneOfException.php
+++ b/library/Exceptions/NoneOfException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NoneOfException extends NestedValidationException
 {

--- a/library/Exceptions/NotBlankException.php
+++ b/library/Exceptions/NotBlankException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NotBlankException extends ValidationException
 {

--- a/library/Exceptions/NotEmojiException.php
+++ b/library/Exceptions/NotEmojiException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Mazen Touati <mazen_touati@hotmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NotEmojiException extends ValidationException
 {

--- a/library/Exceptions/NotEmptyException.php
+++ b/library/Exceptions/NotEmptyException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Bram Van der Sype <bram.vandersype@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NotEmptyException extends ValidationException
 {

--- a/library/Exceptions/NotException.php
+++ b/library/Exceptions/NotException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NotException extends GroupedValidationException
 {

--- a/library/Exceptions/NotOptionalException.php
+++ b/library/Exceptions/NotOptionalException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NotOptionalException extends ValidationException
 {

--- a/library/Exceptions/NullTypeException.php
+++ b/library/Exceptions/NullTypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NullTypeException extends ValidationException
 {

--- a/library/Exceptions/NullableException.php
+++ b/library/Exceptions/NullableException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jens Segers <segers.jens@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NullableException extends ValidationException
 {

--- a/library/Exceptions/NumberException.php
+++ b/library/Exceptions/NumberException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ismael Elias <ismael.esq@hotmail.com>
  * @author Vitaliy <reboot.m@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NumberException extends ValidationException
 {

--- a/library/Exceptions/NumericValException.php
+++ b/library/Exceptions/NumericValException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class NumericValException extends ValidationException
 {

--- a/library/Exceptions/ObjectTypeException.php
+++ b/library/Exceptions/ObjectTypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ObjectTypeException extends ValidationException
 {

--- a/library/Exceptions/OddException.php
+++ b/library/Exceptions/OddException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class OddException extends ValidationException
 {

--- a/library/Exceptions/OneOfException.php
+++ b/library/Exceptions/OneOfException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Bradyn Poulsen <bradyn@bradynpoulsen.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class OneOfException extends NestedValidationException
 {

--- a/library/Exceptions/OptionalException.php
+++ b/library/Exceptions/OptionalException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class OptionalException extends ValidationException
 {

--- a/library/Exceptions/PerfectSquareException.php
+++ b/library/Exceptions/PerfectSquareException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Kleber Hamada Sato <kleberhs007@yahoo.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PerfectSquareException extends ValidationException
 {

--- a/library/Exceptions/PeselException.php
+++ b/library/Exceptions/PeselException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Tomasz Regdos <tomek@regdos.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PeselException extends ValidationException
 {

--- a/library/Exceptions/PhoneException.php
+++ b/library/Exceptions/PhoneException.php
@@ -15,6 +15,7 @@ use Respect\Validation\Helpers\CountryInfo;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Michael Firsikov <michael.firsikov@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PhoneException extends ValidationException
 {

--- a/library/Exceptions/PhpLabelException.php
+++ b/library/Exceptions/PhpLabelException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PhpLabelException extends ValidationException
 {

--- a/library/Exceptions/PisException.php
+++ b/library/Exceptions/PisException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Bruno Koga <brunokoga187@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PisException extends ValidationException
 {

--- a/library/Exceptions/PolishIdCardException.php
+++ b/library/Exceptions/PolishIdCardException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PolishIdCardException extends ValidationException
 {

--- a/library/Exceptions/PortugueseNifException.php
+++ b/library/Exceptions/PortugueseNifException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Gonçalo Andrade <goncalo.andrade95@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PortugueseNifException extends ValidationException
 {

--- a/library/Exceptions/PositiveException.php
+++ b/library/Exceptions/PositiveException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ismael Elias <ismael.esq@hotmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PositiveException extends ValidationException
 {

--- a/library/Exceptions/PostalCodeException.php
+++ b/library/Exceptions/PostalCodeException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PostalCodeException extends ValidationException
 {

--- a/library/Exceptions/PrimeNumberException.php
+++ b/library/Exceptions/PrimeNumberException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ismael Elias <ismael.esq@hotmail.com>
  * @author Kleber Hamada Sato <kleberhs007@yahoo.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PrimeNumberException extends ValidationException
 {

--- a/library/Exceptions/PrintableException.php
+++ b/library/Exceptions/PrintableException.php
@@ -16,6 +16,7 @@ namespace Respect\Validation\Exceptions;
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PrintableException extends FilteredValidationException
 {

--- a/library/Exceptions/PunctException.php
+++ b/library/Exceptions/PunctException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class PunctException extends FilteredValidationException
 {

--- a/library/Exceptions/ReadableException.php
+++ b/library/Exceptions/ReadableException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ReadableException extends ValidationException
 {

--- a/library/Exceptions/RegexException.php
+++ b/library/Exceptions/RegexException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class RegexException extends ValidationException
 {

--- a/library/Exceptions/ResourceTypeException.php
+++ b/library/Exceptions/ResourceTypeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * Exception class for ResourceType.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ResourceTypeException extends ValidationException
 {

--- a/library/Exceptions/RomanException.php
+++ b/library/Exceptions/RomanException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class RomanException extends ValidationException
 {

--- a/library/Exceptions/ScalarValException.php
+++ b/library/Exceptions/ScalarValException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ScalarValException extends ValidationException
 {

--- a/library/Exceptions/SizeException.php
+++ b/library/Exceptions/SizeException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * Exception class for Size rule.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class SizeException extends NestedValidationException
 {

--- a/library/Exceptions/SlugException.php
+++ b/library/Exceptions/SlugException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Carlos André Ferrari <caferrari@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class SlugException extends ValidationException
 {

--- a/library/Exceptions/SortedException.php
+++ b/library/Exceptions/SortedException.php
@@ -14,6 +14,7 @@ use Respect\Validation\Rules\Sorted;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Mikhail Vyrtsev <reeywhaar@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class SortedException extends ValidationException
 {

--- a/library/Exceptions/SpaceException.php
+++ b/library/Exceptions/SpaceException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class SpaceException extends FilteredValidationException
 {

--- a/library/Exceptions/StartsWithException.php
+++ b/library/Exceptions/StartsWithException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class StartsWithException extends ValidationException
 {

--- a/library/Exceptions/StringTypeException.php
+++ b/library/Exceptions/StringTypeException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class StringTypeException extends ValidationException
 {

--- a/library/Exceptions/StringValException.php
+++ b/library/Exceptions/StringValException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class StringValException extends ValidationException
 {

--- a/library/Exceptions/SubsetException.php
+++ b/library/Exceptions/SubsetException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Singwai Chan <singwai.chan@live.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class SubsetException extends ValidationException
 {

--- a/library/Exceptions/SymbolicLinkException.php
+++ b/library/Exceptions/SymbolicLinkException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Gus Antoniassi <gus.antoniassi@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class SymbolicLinkException extends ValidationException
 {

--- a/library/Exceptions/TimeException.php
+++ b/library/Exceptions/TimeException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class TimeException extends ValidationException
 {

--- a/library/Exceptions/TldException.php
+++ b/library/Exceptions/TldException.php
@@ -16,6 +16,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class TldException extends ValidationException
 {

--- a/library/Exceptions/TrueValException.php
+++ b/library/Exceptions/TrueValException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class TrueValException extends ValidationException
 {

--- a/library/Exceptions/TypeException.php
+++ b/library/Exceptions/TypeException.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Exceptions;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class TypeException extends ValidationException
 {

--- a/library/Exceptions/UniqueException.php
+++ b/library/Exceptions/UniqueException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Krzysztof Śmiałek <admin@avensome.net>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class UniqueException extends ValidationException
 {

--- a/library/Exceptions/UploadedException.php
+++ b/library/Exceptions/UploadedException.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Exceptions;
  * @author Fajar Khairil <fajar.khairil@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class UploadedException extends ValidationException
 {

--- a/library/Exceptions/UppercaseException.php
+++ b/library/Exceptions/UppercaseException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class UppercaseException extends ValidationException
 {

--- a/library/Exceptions/UrlException.php
+++ b/library/Exceptions/UrlException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class UrlException extends ValidationException
 {

--- a/library/Exceptions/UuidException.php
+++ b/library/Exceptions/UuidException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Dick van der Heiden <d.vanderheiden@inthere.nl>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Michael Weimann <mail@michael-weimann.eu>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class UuidException extends ValidationException
 {

--- a/library/Exceptions/ValidatorException.php
+++ b/library/Exceptions/ValidatorException.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Exceptions;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class ValidatorException extends AllOfException
 {

--- a/library/Exceptions/VersionException.php
+++ b/library/Exceptions/VersionException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class VersionException extends ValidationException
 {

--- a/library/Exceptions/VideoUrlException.php
+++ b/library/Exceptions/VideoUrlException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ricardo Gobbo <ricardo@clicknow.com.br>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class VideoUrlException extends ValidationException
 {

--- a/library/Exceptions/VowelException.php
+++ b/library/Exceptions/VowelException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Kleber Hamada Sato <kleberhs007@yahoo.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class VowelException extends FilteredValidationException
 {

--- a/library/Exceptions/WhenException.php
+++ b/library/Exceptions/WhenException.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Exceptions;
  * @author Antonio Spinelli <tonicospinelli85@gmail.com>
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class WhenException extends ValidationException
 {

--- a/library/Exceptions/WritableException.php
+++ b/library/Exceptions/WritableException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class WritableException extends ValidationException
 {

--- a/library/Exceptions/XdigitException.php
+++ b/library/Exceptions/XdigitException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class XdigitException extends FilteredValidationException
 {

--- a/library/Exceptions/YesException.php
+++ b/library/Exceptions/YesException.php
@@ -12,6 +12,7 @@ namespace Respect\Validation\Exceptions;
 /**
  * @author Cameron Hall <me@chall.id.au>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ * @deprecated Using rule exceptions directly is deprecated, and will be removed in the next major version. Please use {@see ValidationException} instead.
  */
 final class YesException extends ValidationException
 {

--- a/library/Rules/AbstractAge.php
+++ b/library/Rules/AbstractAge.php
@@ -59,7 +59,7 @@ abstract class AbstractAge extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AbstractComparison.php
+++ b/library/Rules/AbstractComparison.php
@@ -44,7 +44,7 @@ abstract class AbstractComparison extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AbstractComposite.php
+++ b/library/Rules/AbstractComposite.php
@@ -39,7 +39,7 @@ abstract class AbstractComposite extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `setName()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::setName()} instead.
      */
     public function setName(string $name): Validatable
     {

--- a/library/Rules/AbstractComposite.php
+++ b/library/Rules/AbstractComposite.php
@@ -22,6 +22,8 @@ use function array_map;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Wojciech Frącz <fraczwojciech@gmail.com>
+ *
+ * @deprecated This class is deprecated, and will be removed in the next major version. Use {@see \Respect\Validation\Rules\Core\Composite} instead.
  */
 abstract class AbstractComposite extends AbstractRule
 {

--- a/library/Rules/AbstractEnvelope.php
+++ b/library/Rules/AbstractEnvelope.php
@@ -19,6 +19,8 @@ use Respect\Validation\Validatable;
  * having an custom message.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
+ *
+ * @deprecated This class is deprecated, and will be removed in the next major version. Use {@see \Respect\Validation\Rules\Core\Envelop} instead.
  */
 abstract class AbstractEnvelope extends AbstractRule
 {

--- a/library/Rules/AbstractEnvelope.php
+++ b/library/Rules/AbstractEnvelope.php
@@ -44,7 +44,7 @@ abstract class AbstractEnvelope extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AbstractFilterRule.php
+++ b/library/Rules/AbstractFilterRule.php
@@ -36,7 +36,7 @@ abstract class AbstractFilterRule extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AbstractRelated.php
+++ b/library/Rules/AbstractRelated.php
@@ -80,7 +80,7 @@ abstract class AbstractRelated extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `setName()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::setName()} instead.
      */
     public function setName(string $name): Validatable
     {
@@ -94,7 +94,7 @@ abstract class AbstractRelated extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -119,7 +119,7 @@ abstract class AbstractRelated extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -136,7 +136,7 @@ abstract class AbstractRelated extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -18,6 +18,8 @@ use Respect\Validation\Validatable;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  * @author Vicente Mendoza <vicentemmor@yahoo.com.mx>
+ *
+ * @deprecated This class is deprecated, and will be removed in the next major version. Use {@see \Respect\Validation\Rules\Core\Simple} instead.
  */
 abstract class AbstractRule implements Validatable
 {

--- a/library/Rules/AbstractRule.php
+++ b/library/Rules/AbstractRule.php
@@ -32,7 +32,7 @@ abstract class AbstractRule implements Validatable
     protected $template;
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -44,7 +44,7 @@ abstract class AbstractRule implements Validatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -52,7 +52,7 @@ abstract class AbstractRule implements Validatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `getName()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::getName()} instead.
      */
     public function getName(): ?string
     {
@@ -60,7 +60,8 @@ abstract class AbstractRule implements Validatable
     }
 
     /**
-     * {@inheritDoc}
+     * @param mixed[] $extraParams
+     * @deprecated Calling `reportError()` directly is deprecated, and will be removed in the next major version.
      */
     public function reportError($input, array $extraParams = []): ValidationException
     {
@@ -68,7 +69,7 @@ abstract class AbstractRule implements Validatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `setName()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::setName()} instead.
      */
     public function setName(string $name): Validatable
     {
@@ -78,7 +79,7 @@ abstract class AbstractRule implements Validatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `setTemplate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::setTemplate()} instead.
      */
     public function setTemplate(string $template): Validatable
     {
@@ -88,7 +89,8 @@ abstract class AbstractRule implements Validatable
     }
 
     /**
-     * @param mixed$input
+     * @deprecated Calling validator as a function is deprecated, and will be removed in the next major version.
+     * @param mixed $input
      */
     public function __invoke($input): bool
     {

--- a/library/Rules/AbstractSearcher.php
+++ b/library/Rules/AbstractSearcher.php
@@ -30,7 +30,7 @@ abstract class AbstractSearcher extends AbstractRule
     abstract protected function getDataSource($input = null): array;
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AbstractWrapper.php
+++ b/library/Rules/AbstractWrapper.php
@@ -16,6 +16,8 @@ use Respect\Validation\Validatable;
  *
  * @author Alasdair North <alasdair@runway.io>
  * @author Henrique Moody <henriquemoody@gmail.com>
+ *
+ * @deprecated This class is deprecated, and will be removed in the next major version. Use {@see \Respect\Validation\Rules\Core\Wrapper} instead.
  */
 abstract class AbstractWrapper extends AbstractRule
 {

--- a/library/Rules/AbstractWrapper.php
+++ b/library/Rules/AbstractWrapper.php
@@ -33,7 +33,7 @@ abstract class AbstractWrapper extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -41,7 +41,7 @@ abstract class AbstractWrapper extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -49,7 +49,7 @@ abstract class AbstractWrapper extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {
@@ -57,7 +57,7 @@ abstract class AbstractWrapper extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `setName()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::setName()} instead.
      */
     public function setName(string $name): Validatable
     {

--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -20,7 +20,7 @@ use function count;
 class AllOf extends AbstractComposite
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -42,7 +42,7 @@ class AllOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -52,7 +52,7 @@ class AllOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -19,7 +19,7 @@ namespace Respect\Validation\Rules;
 final class AlwaysInvalid extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AlwaysValid.php
+++ b/library/Rules/AlwaysValid.php
@@ -19,7 +19,7 @@ namespace Respect\Validation\Rules;
 final class AlwaysValid extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -21,7 +21,7 @@ use function count;
 final class AnyOf extends AbstractComposite
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -39,7 +39,7 @@ final class AnyOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {
@@ -53,7 +53,7 @@ final class AnyOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {

--- a/library/Rules/ArrayType.php
+++ b/library/Rules/ArrayType.php
@@ -22,7 +22,7 @@ use function is_array;
 final class ArrayType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/ArrayVal.php
+++ b/library/Rules/ArrayVal.php
@@ -26,7 +26,7 @@ use function is_array;
 final class ArrayVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -53,7 +53,7 @@ final class Base extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -23,7 +23,7 @@ use function preg_match;
 final class Base64 extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/BoolType.php
+++ b/library/Rules/BoolType.php
@@ -20,7 +20,7 @@ use function is_bool;
 final class BoolType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/BoolVal.php
+++ b/library/Rules/BoolVal.php
@@ -25,7 +25,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 final class BoolVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Bsn.php
+++ b/library/Rules/Bsn.php
@@ -27,7 +27,7 @@ use function strval;
 final class Bsn extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Call.php
+++ b/library/Rules/Call.php
@@ -46,7 +46,7 @@ final class Call extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -64,7 +64,7 @@ final class Call extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -82,7 +82,7 @@ final class Call extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -19,7 +19,7 @@ use function is_callable;
 final class CallableType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -44,7 +44,7 @@ final class Callback extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -46,7 +46,7 @@ final class Charset extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -24,7 +24,7 @@ use function preg_replace;
 final class Cnh extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -29,7 +29,7 @@ use function str_split;
 final class Cnpj extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -48,7 +48,7 @@ final class Contains extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Core/Composite.php
+++ b/library/Rules/Core/Composite.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules\Core;
+
+use Respect\Validation\Rules\AbstractComposite;
+use Respect\Validation\Validatable;
+
+abstract class Composite extends AbstractComposite
+{
+    public function __construct(Validatable $rule1, Validatable $rule2, Validatable ...$rules)
+    {
+        parent::__construct($rule1, $rule2, ...$rules);
+    }
+}

--- a/library/Rules/Core/Envelope.php
+++ b/library/Rules/Core/Envelope.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules\Core;
+
+use Respect\Validation\Rules\AbstractEnvelope;
+
+abstract class Envelope extends AbstractEnvelope
+{
+}

--- a/library/Rules/Core/Simple.php
+++ b/library/Rules/Core/Simple.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules\Core;
+
+use Respect\Validation\Rules\AbstractRule;
+
+abstract class Simple extends AbstractRule
+{
+    abstract public function isValid(mixed $input): bool;
+
+    /**
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see Validator::isValid()} instead.
+     */
+    public function validate($input): bool
+    {
+        return $this->isValid($input);
+    }
+}

--- a/library/Rules/Core/Wrapper.php
+++ b/library/Rules/Core/Wrapper.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules\Core;
+
+use Respect\Validation\Rules\AbstractWrapper;
+
+abstract class Wrapper extends AbstractWrapper
+{
+}

--- a/library/Rules/Countable.php
+++ b/library/Rules/Countable.php
@@ -23,7 +23,7 @@ use function is_array;
 final class Countable extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -27,7 +27,7 @@ use function preg_replace;
 final class Cpf extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -84,7 +84,7 @@ final class CreditCard extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -54,7 +54,7 @@ final class Date extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/DateTime.php
+++ b/library/Rules/DateTime.php
@@ -45,7 +45,7 @@ final class DateTime extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Decimal.php
+++ b/library/Rules/Decimal.php
@@ -33,7 +33,7 @@ final class Decimal extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -24,7 +24,7 @@ use function is_scalar;
 final class Directory extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -55,7 +55,7 @@ final class Domain extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -77,7 +77,7 @@ final class Domain extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {
@@ -91,7 +91,7 @@ final class Domain extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -40,7 +40,7 @@ final class Each extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -67,7 +67,7 @@ final class Each extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -81,7 +81,7 @@ final class Each extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -44,7 +44,7 @@ final class Email extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -45,7 +45,7 @@ final class EndsWith extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -34,7 +34,7 @@ final class Equals extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Equivalent.php
+++ b/library/Rules/Equivalent.php
@@ -35,7 +35,7 @@ final class Equivalent extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -23,7 +23,7 @@ use const FILTER_VALIDATE_INT;
 final class Even extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -23,7 +23,7 @@ use function is_scalar;
 final class Executable extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -21,7 +21,7 @@ use function is_string;
 final class Exists extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -38,7 +38,7 @@ final class Extension extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -36,7 +36,7 @@ final class Factor extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/FalseVal.php
+++ b/library/Rules/FalseVal.php
@@ -23,7 +23,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 final class FalseVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Fibonacci.php
+++ b/library/Rules/Fibonacci.php
@@ -21,7 +21,7 @@ use function is_numeric;
 final class Fibonacci extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -23,7 +23,7 @@ use function is_string;
 final class File extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -21,7 +21,7 @@ use function is_numeric;
 final class Finite extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/FloatType.php
+++ b/library/Rules/FloatType.php
@@ -20,7 +20,7 @@ use function is_float;
 final class FloatType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/FloatVal.php
+++ b/library/Rules/FloatVal.php
@@ -25,7 +25,7 @@ use const FILTER_VALIDATE_FLOAT;
 final class FloatVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Iban.php
+++ b/library/Rules/Iban.php
@@ -102,7 +102,7 @@ final class Iban extends AbstractRule
     ];
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Identical.php
+++ b/library/Rules/Identical.php
@@ -32,7 +32,7 @@ final class Identical extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Image.php
+++ b/library/Rules/Image.php
@@ -41,7 +41,7 @@ final class Image extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Imei.php
+++ b/library/Rules/Imei.php
@@ -27,8 +27,7 @@ final class Imei extends AbstractRule
 
     /**
      * @see https://en.wikipedia.org/wiki/International_Mobile_Station_Equipment_Identity
-     *
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -45,7 +45,7 @@ final class In extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -21,7 +21,7 @@ use function is_numeric;
 final class Infinite extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -32,7 +32,7 @@ final class Instance extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/IntType.php
+++ b/library/Rules/IntType.php
@@ -19,7 +19,7 @@ use function is_int;
 final class IntType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -25,7 +25,7 @@ use function preg_match;
 final class IntVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -76,7 +76,7 @@ final class Ip extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Isbn.php
+++ b/library/Rules/Isbn.php
@@ -32,7 +32,7 @@ final class Isbn extends AbstractRule
     ];
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/IterableType.php
+++ b/library/Rules/IterableType.php
@@ -21,7 +21,7 @@ final class IterableType extends AbstractRule
     use CanValidateIterable;
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -26,7 +26,7 @@ use const JSON_ERROR_NONE;
 final class Json extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -57,7 +57,7 @@ final class KeySet extends AbstractWrapper implements NonNegatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -69,7 +69,7 @@ final class KeySet extends AbstractWrapper implements NonNegatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -81,7 +81,7 @@ final class KeySet extends AbstractWrapper implements NonNegatable
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/KeyValue.php
+++ b/library/Rules/KeyValue.php
@@ -49,7 +49,7 @@ final class KeyValue extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -63,7 +63,7 @@ final class KeyValue extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -77,7 +77,7 @@ final class KeyValue extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -37,7 +37,7 @@ final class LeapDate extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -27,7 +27,7 @@ use function strtotime;
 final class LeapYear extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -66,7 +66,7 @@ final class Length extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -23,7 +23,7 @@ use function mb_strtolower;
 final class Lowercase extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Luhn.php
+++ b/library/Rules/Luhn.php
@@ -25,7 +25,7 @@ use function str_split;
 final class Luhn extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -23,7 +23,7 @@ use function preg_match;
 final class MacAddress extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -45,7 +45,7 @@ final class Mimetype extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -31,7 +31,7 @@ final class Multiple extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -21,7 +21,7 @@ use function is_numeric;
 final class Negative extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -29,7 +29,7 @@ use function str_split;
 final class NfeAccessKey extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -30,7 +30,7 @@ use function str_split;
 final class Nif extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Nip.php
+++ b/library/Rules/Nip.php
@@ -25,7 +25,7 @@ use function str_split;
 final class Nip extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -24,7 +24,7 @@ use function preg_match;
 final class NoWhitespace extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -20,7 +20,7 @@ use function count;
 final class NoneOf extends AbstractComposite
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -37,7 +37,7 @@ final class NoneOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Not.php
+++ b/library/Rules/Not.php
@@ -42,6 +42,9 @@ final class Not extends AbstractRule
         return $this->rule;
     }
 
+    /**
+     * @deprecated Calling `setName()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::setName()} instead.
+     */
     public function setName(string $name): Validatable
     {
         $this->rule->setName($name);
@@ -50,7 +53,7 @@ final class Not extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {
@@ -58,7 +61,7 @@ final class Not extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {

--- a/library/Rules/NotBlank.php
+++ b/library/Rules/NotBlank.php
@@ -26,7 +26,7 @@ use function trim;
 final class NotBlank extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NotEmoji.php
+++ b/library/Rules/NotEmoji.php
@@ -193,7 +193,7 @@ final class NotEmoji extends AbstractRule
     ];
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -22,7 +22,7 @@ use function trim;
 final class NotEmpty extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NotOptional.php
+++ b/library/Rules/NotOptional.php
@@ -24,7 +24,7 @@ final class NotOptional extends AbstractRule
     use CanValidateUndefined;
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NullType.php
+++ b/library/Rules/NullType.php
@@ -20,7 +20,7 @@ use function is_null;
 final class NullType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Nullable.php
+++ b/library/Rules/Nullable.php
@@ -17,7 +17,7 @@ namespace Respect\Validation\Rules;
 final class Nullable extends AbstractWrapper
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -29,7 +29,7 @@ final class Nullable extends AbstractWrapper
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -41,7 +41,7 @@ final class Nullable extends AbstractWrapper
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Number.php
+++ b/library/Rules/Number.php
@@ -22,7 +22,7 @@ use function is_numeric;
 final class Number extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/NumericVal.php
+++ b/library/Rules/NumericVal.php
@@ -21,7 +21,7 @@ use function is_numeric;
 final class NumericVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/ObjectType.php
+++ b/library/Rules/ObjectType.php
@@ -20,7 +20,7 @@ use function is_object;
 final class ObjectType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -24,7 +24,7 @@ use const FILTER_VALIDATE_INT;
 final class Odd extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -22,7 +22,7 @@ use function count;
 final class OneOf extends AbstractComposite
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -40,7 +40,7 @@ final class OneOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {
@@ -57,7 +57,7 @@ final class OneOf extends AbstractComposite
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {

--- a/library/Rules/Optional.php
+++ b/library/Rules/Optional.php
@@ -19,7 +19,7 @@ final class Optional extends AbstractWrapper
     use CanValidateUndefined;
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -31,7 +31,7 @@ final class Optional extends AbstractWrapper
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {
@@ -43,7 +43,7 @@ final class Optional extends AbstractWrapper
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -24,7 +24,7 @@ use function sqrt;
 final class PerfectSquare extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Pesel.php
+++ b/library/Rules/Pesel.php
@@ -22,7 +22,7 @@ use function preg_match;
 final class Pesel extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Phone.php
+++ b/library/Rules/Phone.php
@@ -51,6 +51,9 @@ final class Phone extends AbstractRule
         }
     }
 
+    /**
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
+     */
     public function validate($input): bool
     {
         if (!is_scalar($input)) {

--- a/library/Rules/PhpLabel.php
+++ b/library/Rules/PhpLabel.php
@@ -22,7 +22,7 @@ use function preg_match;
 final class PhpLabel extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -24,7 +24,7 @@ use function preg_replace;
 final class Pis extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/PolishIdCard.php
+++ b/library/Rules/PolishIdCard.php
@@ -28,7 +28,7 @@ final class PolishIdCard extends AbstractRule
     private const ASCII_CODE_A = 65;
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/PortugueseNif.php
+++ b/library/Rules/PortugueseNif.php
@@ -30,7 +30,7 @@ use function strlen;
 final class PortugueseNif extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -21,7 +21,7 @@ use function is_numeric;
 final class Positive extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -25,7 +25,7 @@ use function sqrt;
 final class PrimeNumber extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/PublicDomainSuffix.php
+++ b/library/Rules/PublicDomainSuffix.php
@@ -22,6 +22,9 @@ final class PublicDomainSuffix extends AbstractRule
 {
     use CanValidateUndefined;
 
+    /**
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
+     */
     public function validate($input): bool
     {
         if (!is_scalar($input)) {

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -24,7 +24,7 @@ use function is_string;
 final class Readable extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -35,7 +35,7 @@ final class Regex extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/ResourceType.php
+++ b/library/Rules/ResourceType.php
@@ -19,7 +19,7 @@ use function is_resource;
 final class ResourceType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/ScalarVal.php
+++ b/library/Rules/ScalarVal.php
@@ -19,7 +19,7 @@ use function is_scalar;
 final class ScalarVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -63,7 +63,7 @@ final class Size extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -24,7 +24,7 @@ use function preg_match;
 final class Slug extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Sorted.php
+++ b/library/Rules/Sorted.php
@@ -46,7 +46,7 @@ final class Sorted extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -44,7 +44,7 @@ final class StartsWith extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/StringType.php
+++ b/library/Rules/StringType.php
@@ -20,7 +20,7 @@ use function is_string;
 final class StringType extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/StringVal.php
+++ b/library/Rules/StringVal.php
@@ -22,7 +22,7 @@ use function method_exists;
 final class StringVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Subset.php
+++ b/library/Rules/Subset.php
@@ -36,7 +36,7 @@ final class Subset extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -23,7 +23,7 @@ use function is_string;
 final class SymbolicLink extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Time.php
+++ b/library/Rules/Time.php
@@ -53,7 +53,7 @@ final class Time extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -236,7 +236,7 @@ final class Tld extends AbstractRule
     ];
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/TrueVal.php
+++ b/library/Rules/TrueVal.php
@@ -23,7 +23,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 final class TrueVal extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Type.php
+++ b/library/Rules/Type.php
@@ -73,7 +73,7 @@ final class Type extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Unique.php
+++ b/library/Rules/Unique.php
@@ -24,7 +24,7 @@ use const SORT_REGULAR;
 final class Unique extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -24,7 +24,7 @@ use function is_uploaded_file;
 final class Uploaded extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -23,7 +23,7 @@ use function mb_strtoupper;
 final class Uppercase extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -53,7 +53,7 @@ final class Uuid extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -23,7 +23,7 @@ use function preg_match;
 final class Version extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -55,7 +55,7 @@ final class VideoUrl extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/When.php
+++ b/library/Rules/When.php
@@ -50,7 +50,7 @@ final class When extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {
@@ -62,7 +62,7 @@ final class When extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `assert()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::assert()} instead.
      */
     public function assert($input): void
     {
@@ -76,7 +76,7 @@ final class When extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `check()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::check()} instead.
      */
     public function check($input): void
     {

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -24,7 +24,7 @@ use function is_writable;
 final class Writable extends AbstractRule
 {
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Rules/Yes.php
+++ b/library/Rules/Yes.php
@@ -37,7 +37,7 @@ final class Yes extends AbstractRule
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Calling `validate()` directly from rules is deprecated. Please use {@see \Respect\Validation\Validator::isValid()} instead.
      */
     public function validate($input): bool
     {

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -26,13 +26,41 @@ final class Validator extends AllOf
     /**
      * Create instance validator.
      */
-    public static function create(): self
+    public static function create(Validatable ...$rules): self
     {
-        return new self();
+        return new self(...$rules);
     }
 
     /**
-     * {@inheritDoc}
+     * @param mixed $input
+     */
+    public function assert($input): void
+    {
+        parent::assert($input);
+    }
+
+    public function isValid(mixed $input): bool
+    {
+        return parent::validate($input);
+    }
+
+    public function setName(string $name): Validatable
+    {
+        return parent::setName($name);
+    }
+
+    public function getName(): ?string
+    {
+        return parent::getName();
+    }
+
+    public function setTemplate(string $template): Validatable
+    {
+        return parent::setTemplate($template);
+    }
+
+    /**
+     * @param mixed $input
      */
     public function check($input): void
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,5 +23,6 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
         <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall" />
+        <exclude name="Generic.Files.LineLength.TooLong" />
     </rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,6 +34,8 @@ parameters:
     # Why: Deprecations of version 3.0
     - message: '/Using rule exceptions directly is deprecated, and will be removed in the next major version\./'
 
+    - message: '/This class is deprecated, and will be removed in the next major version\./'
+
     -
         message: '/Calling `.+\(\)` directly from rules is deprecated. Please use {@see \\Respect\\Validation\\Validator::.+\(\)} instead./'
         path: tests/unit/Rules

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,6 +30,29 @@ parameters:
         # Why: I don't want to make changes to the code just to make phpstan happy
         message: '/Parameter #2 \$values of function vsprintf expects array<bool\|float\|int\|string\|null>, array<string, array<bool\|int\|string>\|bool\|float\|int\|string> given./'
         path: library/Rules/AbstractAge.php
+
+    # Why: Deprecations of version 3.0
+    -
+        message: '/Calling `.+\(\)` directly from rules is deprecated. Please use {@see \\Respect\\Validation\\Validator::.+\(\)} instead./'
+        path: tests/unit/Rules
+    -
+        message: '/Calling `.+\(\)` directly from rules is deprecated. Please use {@see \\Respect\\Validation\\Validator::.+\(\)} instead./'
+        path: tests/unit/FactoryTest.php
+    -
+        message: '/Calling `.+\(\)` directly from rules is deprecated. Please use {@see \\Respect\\Validation\\Validator::.+\(\)} instead./'
+        path: library/Validator.php
+    -
+        message: '/Calling validator as a function is deprecated, and will be removed in the next major version./'
+        path: tests/unit/Rules
+    -
+        message: '/Calling `reportError\(\)` directly is deprecated, and will be removed in the next major version./'
+        path: tests/unit/Rules
+    -
+        message: '/Calling `.+\(\)` directly from rules is deprecated. Please use {@see \\Respect\\Validation\\Validator::.+\(\)} instead./'
+        path: library/Rules
+    -
+        message: '/Calling `reportError\(\)` directly is deprecated, and will be removed in the next major version./'
+        path: library/Rules
   level: 8
   paths:
     - library/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,6 +32,8 @@ parameters:
         path: library/Rules/AbstractAge.php
 
     # Why: Deprecations of version 3.0
+    - message: '/Using rule exceptions directly is deprecated, and will be removed in the next major version\./'
+
     -
         message: '/Calling `.+\(\)` directly from rules is deprecated. Please use {@see \\Respect\\Validation\\Validator::.+\(\)} instead./'
         path: tests/unit/Rules


### PR DESCRIPTION
Version 3.0 will include a few crucial deprecations. This commit adds some soft deprecations to warn users about these changes.

Some of the biggest changes are:

* The method `validate()` will be renamed to `isValid()`.

* The method `validate()` will be repurposed to return an object with failures.

* It won't be possible to handle rules directly; users will need to use the `Validator` class to validate with any rule.

* It won't be possible to catch specific exceptions; users will need to catch `ValidationException`.

There will some more changes, but those are some of the most important ones, and are the ones that are easy to deprecate right now.