### PR TITLE
Make `Simple::isValid()` public

### DIFF
--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -28,7 +28,7 @@ final class AlwaysInvalid extends Simple
 {
     public const TEMPLATE_SIMPLE = '__simple__';
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return false;
     }

--- a/library/Rules/AlwaysValid.php
+++ b/library/Rules/AlwaysValid.php
@@ -20,7 +20,7 @@ use Respect\Validation\Rules\Core\Simple;
 )]
 final class AlwaysValid extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return true;
     }

--- a/library/Rules/ArrayType.php
+++ b/library/Rules/ArrayType.php
@@ -22,7 +22,7 @@ use function is_array;
 )]
 final class ArrayType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_array($input);
     }

--- a/library/Rules/ArrayVal.php
+++ b/library/Rules/ArrayVal.php
@@ -24,7 +24,7 @@ use function is_array;
 )]
 final class ArrayVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_array($input) || $input instanceof ArrayAccess || $input instanceof SimpleXMLElement;
     }

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -24,7 +24,7 @@ use function preg_match;
 )]
 final class Base64 extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/BoolType.php
+++ b/library/Rules/BoolType.php
@@ -22,7 +22,7 @@ use function is_bool;
 )]
 final class BoolType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_bool($input);
     }

--- a/library/Rules/BoolVal.php
+++ b/library/Rules/BoolVal.php
@@ -26,7 +26,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 )]
 final class BoolVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_bool(filter_var($input, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
     }

--- a/library/Rules/Bsn.php
+++ b/library/Rules/Bsn.php
@@ -29,7 +29,7 @@ use function strval;
 )]
 final class Bsn extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -22,7 +22,7 @@ use function is_callable;
 )]
 final class CallableType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_callable($input);
     }

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -40,7 +40,7 @@ final class Callback extends Simple
         $this->arguments = $arguments;
     }
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return (bool) call_user_func_array($this->callback, $this->getArguments($input));
     }

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -24,7 +24,7 @@ use function preg_replace;
 )]
 final class Cnh extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -27,7 +27,7 @@ use function str_split;
 )]
 final class Cnpj extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Core/Simple.php
+++ b/library/Rules/Core/Simple.php
@@ -13,7 +13,7 @@ use Respect\Validation\Result;
 
 abstract class Simple extends Standard
 {
-    abstract protected function isValid(mixed $input): bool;
+    abstract public function isValid(mixed $input): bool;
 
     public function evaluate(mixed $input): Result
     {

--- a/library/Rules/Countable.php
+++ b/library/Rules/Countable.php
@@ -23,7 +23,7 @@ use function is_array;
 )]
 final class Countable extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_array($input) || $input instanceof CountableInterface;
     }

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -25,7 +25,7 @@ use function preg_replace;
 )]
 final class Cpf extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         // Code ported from jsfromhell.com
         $c = preg_replace('/\D/', '', $input);

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -25,7 +25,7 @@ use function is_scalar;
 )]
 final class Directory extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isDir();

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -39,7 +39,7 @@ final class Email extends Simple
         $this->validator = $validator;
     }
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -24,7 +24,7 @@ use const FILTER_VALIDATE_INT;
 )]
 final class Even extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (filter_var($input, FILTER_VALIDATE_INT) === false) {
             return false;

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -24,7 +24,7 @@ use function is_scalar;
 )]
 final class Executable extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isExecutable();

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -24,7 +24,7 @@ use function is_string;
 )]
 final class Exists extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             $input = $input->getPathname();

--- a/library/Rules/FalseVal.php
+++ b/library/Rules/FalseVal.php
@@ -25,7 +25,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 )]
 final class FalseVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return filter_var($input, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === false;
     }

--- a/library/Rules/Fibonacci.php
+++ b/library/Rules/Fibonacci.php
@@ -22,7 +22,7 @@ use function is_numeric;
 )]
 final class Fibonacci extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -24,7 +24,7 @@ use function is_string;
 )]
 final class File extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isFile();

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -23,7 +23,7 @@ use function is_numeric;
 )]
 final class Finite extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_numeric($input) && is_finite((float) $input);
     }

--- a/library/Rules/FloatType.php
+++ b/library/Rules/FloatType.php
@@ -22,7 +22,7 @@ use function is_float;
 )]
 final class FloatType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_float($input);
     }

--- a/library/Rules/FloatVal.php
+++ b/library/Rules/FloatVal.php
@@ -25,7 +25,7 @@ use const FILTER_VALIDATE_FLOAT;
 )]
 final class FloatVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_float(filter_var($input, FILTER_VALIDATE_FLOAT));
     }

--- a/library/Rules/Hetu.php
+++ b/library/Rules/Hetu.php
@@ -30,7 +30,7 @@ final class Hetu extends Simple
 {
     use CanValidateDateTime;
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Iban.php
+++ b/library/Rules/Iban.php
@@ -105,7 +105,7 @@ final class Iban extends Simple
         'VG' => 24,
     ];
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Image.php
+++ b/library/Rules/Image.php
@@ -35,7 +35,7 @@ final class Image extends Simple
         $this->fileInfo = $fileInfo ?: new finfo(FILEINFO_MIME_TYPE);
     }
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $this->isValid($input->getPathname());

--- a/library/Rules/Imei.php
+++ b/library/Rules/Imei.php
@@ -26,7 +26,7 @@ final class Imei extends Simple
 {
     private const IMEI_SIZE = 15;
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -23,7 +23,7 @@ use function is_numeric;
 )]
 final class Infinite extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_numeric($input) && is_infinite((float) $input);
     }

--- a/library/Rules/IntType.php
+++ b/library/Rules/IntType.php
@@ -22,7 +22,7 @@ use function is_int;
 )]
 final class IntType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_int($input);
     }

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -24,7 +24,7 @@ use function preg_match;
 )]
 final class IntVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (is_int($input)) {
             return true;

--- a/library/Rules/Isbn.php
+++ b/library/Rules/Isbn.php
@@ -34,7 +34,7 @@ final class Isbn extends Simple
         '(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$',
     ];
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/IterableType.php
+++ b/library/Rules/IterableType.php
@@ -22,7 +22,7 @@ use function is_iterable;
 )]
 final class IterableType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_iterable($input);
     }

--- a/library/Rules/IterableVal.php
+++ b/library/Rules/IterableVal.php
@@ -23,7 +23,7 @@ final class IterableVal extends Simple
 {
     use CanValidateIterable;
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return $this->isIterable($input);
     }

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -28,7 +28,7 @@ use const JSON_ERROR_NONE;
 )]
 final class Json extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input) || $input === '') {
             return false;

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -29,7 +29,7 @@ final class LeapDate extends Simple
     ) {
     }
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof DateTimeInterface) {
             return $input->format('m-d') === '02-29';

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -27,7 +27,7 @@ use function strtotime;
 )]
 final class LeapYear extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (is_numeric($input)) {
             $date = strtotime(sprintf('%d-02-29', (int) $input));

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -23,7 +23,7 @@ use function mb_strtolower;
 )]
 final class Lowercase extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Luhn.php
+++ b/library/Rules/Luhn.php
@@ -27,7 +27,7 @@ use function str_split;
 )]
 final class Luhn extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!(new Digit())->evaluate($input)->isValid) {
             return false;

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -23,7 +23,7 @@ use function preg_match;
 )]
 final class MacAddress extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -22,7 +22,7 @@ use function is_numeric;
 )]
 final class Negative extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -28,7 +28,7 @@ use function str_split;
 )]
 final class NfeAccessKey extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (mb_strlen($input) !== 44) {
             return false;

--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -31,7 +31,7 @@ use function str_split;
 )]
 final class Nif extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Nip.php
+++ b/library/Rules/Nip.php
@@ -28,7 +28,7 @@ use function str_split;
 )]
 final class Nip extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -24,7 +24,7 @@ use function preg_match;
 )]
 final class NoWhitespace extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (is_null($input)) {
             return true;

--- a/library/Rules/NotEmoji.php
+++ b/library/Rules/NotEmoji.php
@@ -196,7 +196,7 @@ final class NotEmoji extends Simple
         '\x{3299}',
     ];
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/NullType.php
+++ b/library/Rules/NullType.php
@@ -22,7 +22,7 @@ use function is_null;
 )]
 final class NullType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_null($input);
     }

--- a/library/Rules/Number.php
+++ b/library/Rules/Number.php
@@ -23,7 +23,7 @@ use function is_numeric;
 )]
 final class Number extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/NumericVal.php
+++ b/library/Rules/NumericVal.php
@@ -22,7 +22,7 @@ use function is_numeric;
 )]
 final class NumericVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_numeric($input);
     }

--- a/library/Rules/ObjectType.php
+++ b/library/Rules/ObjectType.php
@@ -22,7 +22,7 @@ use function is_object;
 )]
 final class ObjectType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_object($input);
     }

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -25,7 +25,7 @@ use const FILTER_VALIDATE_INT;
 )]
 final class Odd extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -24,7 +24,7 @@ use function sqrt;
 )]
 final class PerfectSquare extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_numeric($input) && floor(sqrt((float) $input)) == sqrt((float) $input);
     }

--- a/library/Rules/Pesel.php
+++ b/library/Rules/Pesel.php
@@ -23,7 +23,7 @@ use function preg_match;
 )]
 final class Pesel extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/PhpLabel.php
+++ b/library/Rules/PhpLabel.php
@@ -23,7 +23,7 @@ use function preg_match;
 )]
 final class PhpLabel extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_string($input) && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $input);
     }

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -25,7 +25,7 @@ use function preg_replace;
 )]
 final class Pis extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/PolishIdCard.php
+++ b/library/Rules/PolishIdCard.php
@@ -32,7 +32,7 @@ final class PolishIdCard extends Simple
     private const ASCII_CODE_9 = 57;
     private const ASCII_CODE_A = 65;
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/PortugueseNif.php
+++ b/library/Rules/PortugueseNif.php
@@ -33,7 +33,7 @@ use function strlen;
 )]
 final class PortugueseNif extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         // Validate format and length
         if (!is_string($input)) {

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -22,7 +22,7 @@ use function is_numeric;
 )]
 final class Positive extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_numeric($input)) {
             return false;

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -24,7 +24,7 @@ use function sqrt;
 )]
 final class PrimeNumber extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_numeric($input) || $input <= 1) {
             return false;

--- a/library/Rules/PublicDomainSuffix.php
+++ b/library/Rules/PublicDomainSuffix.php
@@ -30,7 +30,7 @@ final class PublicDomainSuffix extends Simple
 {
     use CanValidateUndefined;
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -25,7 +25,7 @@ use function is_string;
 )]
 final class Readable extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isReadable();

--- a/library/Rules/ResourceType.php
+++ b/library/Rules/ResourceType.php
@@ -22,7 +22,7 @@ use function is_resource;
 )]
 final class ResourceType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_resource($input);
     }

--- a/library/Rules/ScalarVal.php
+++ b/library/Rules/ScalarVal.php
@@ -22,7 +22,7 @@ use function is_scalar;
 )]
 final class ScalarVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_scalar($input);
     }

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -24,7 +24,7 @@ use function preg_match;
 )]
 final class Slug extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input) || mb_strstr($input, '--')) {
             return false;

--- a/library/Rules/StringType.php
+++ b/library/Rules/StringType.php
@@ -22,7 +22,7 @@ use function is_string;
 )]
 final class StringType extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_string($input);
     }

--- a/library/Rules/StringVal.php
+++ b/library/Rules/StringVal.php
@@ -24,7 +24,7 @@ use function method_exists;
 )]
 final class StringVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return is_scalar($input) || (is_object($input) && method_exists($input, '__toString'));
     }

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -24,7 +24,7 @@ use function is_string;
 )]
 final class SymbolicLink extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isLink();

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -237,7 +237,7 @@ final class Tld extends Simple
         'ZA', 'ZAPPOS', 'ZARA', 'ZERO', 'ZIP', 'ZM', 'ZONE', 'ZUERICH', 'ZW',
     ];
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_scalar($input)) {
             return false;

--- a/library/Rules/TrueVal.php
+++ b/library/Rules/TrueVal.php
@@ -25,7 +25,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 )]
 final class TrueVal extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return filter_var($input, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === true;
     }

--- a/library/Rules/Unique.php
+++ b/library/Rules/Unique.php
@@ -25,7 +25,7 @@ use const SORT_REGULAR;
 )]
 final class Unique extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_array($input)) {
             return false;

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -25,7 +25,7 @@ use function is_uploaded_file;
 )]
 final class Uploaded extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $this->isValid($input->getPathname());

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -23,7 +23,7 @@ use function mb_strtoupper;
 )]
 final class Uppercase extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -26,7 +26,7 @@ use function preg_match;
 )]
 final class Version extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -25,7 +25,7 @@ use function is_writable;
 )]
 final class Writable extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if ($input instanceof SplFileInfo) {
             return $input->isWritable();

--- a/library/Rules/Yes.php
+++ b/library/Rules/Yes.php
@@ -31,7 +31,7 @@ final class Yes extends Simple
     ) {
     }
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         if (!is_string($input)) {
             return false;

--- a/tests/feature/Issues/Issue1477Test.php
+++ b/tests/feature/Issues/Issue1477Test.php
@@ -15,7 +15,7 @@ test('https://github.com/Respect/Validation/issues/1477', expectAll(
             'Address',
             v::templated(
                 new class extends Simple {
-                    protected function isValid(mixed $input): bool
+                    public function isValid(mixed $input): bool
                     {
                         return false;
                     }

--- a/tests/library/Rules/Core/ConcreteSimple.php
+++ b/tests/library/Rules/Core/ConcreteSimple.php
@@ -13,7 +13,7 @@ use Respect\Validation\Rules\Core\Simple;
 
 final class ConcreteSimple extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return true;
     }

--- a/tests/library/Rules/CustomRule.php
+++ b/tests/library/Rules/CustomRule.php
@@ -13,7 +13,7 @@ use Respect\Validation\Rules\Core\Simple;
 
 final class CustomRule extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return false;
     }

--- a/tests/library/Rules/Stub.php
+++ b/tests/library/Rules/Stub.php
@@ -55,7 +55,7 @@ final class Stub extends Simple
         return new self(...array_fill(0, $expectedCount, false));
     }
 
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         $this->inputs[] = $input;
 

--- a/tests/library/Rules/Valid.php
+++ b/tests/library/Rules/Valid.php
@@ -13,7 +13,7 @@ use Respect\Validation\Rules\Core\Simple;
 
 final class Valid extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         return true;
     }


### PR DESCRIPTION
There's no reason not to make this method public. It will actually be easier for users to test their rules when they extend this class if this method is public.