### PR TITLE
Create transformer for deprecated composite rules

### DIFF
--- a/library/Factory.php
+++ b/library/Factory.php
@@ -16,6 +16,7 @@ use Respect\Validation\Exceptions\InvalidClassException;
 use Respect\Validation\Transformers\Aliases;
 use Respect\Validation\Transformers\DeprecatedAge;
 use Respect\Validation\Transformers\DeprecatedAttribute;
+use Respect\Validation\Transformers\DeprecatedComposite;
 use Respect\Validation\Transformers\DeprecatedKey;
 use Respect\Validation\Transformers\DeprecatedKeyNested;
 use Respect\Validation\Transformers\DeprecatedKeyValue;
@@ -45,9 +46,17 @@ final class Factory
                 new DeprecatedKeyValue(
                     new DeprecatedMinAndMax(
                         new DeprecatedAge(
-                            new DeprecatedKeyNested(new DeprecatedLength(new DeprecatedType(new DeprecatedSize(
-                                new Aliases(new Prefix())
-                            ))))
+                            new DeprecatedKeyNested(
+                                new DeprecatedLength(
+                                    new DeprecatedType(
+                                        new DeprecatedSize(
+                                            new DeprecatedComposite(
+                                                new Aliases(new Prefix())
+                                            )
+                                        )
+                                    )
+                                )
+                            )
                         )
                     )
                 )

--- a/library/Transformers/DeprecatedComposite.php
+++ b/library/Transformers/DeprecatedComposite.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Transformers;
+
+use Respect\Validation\Rules\AlwaysInvalid;
+use Respect\Validation\Rules\AlwaysValid;
+
+use function count;
+use function in_array;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
+final class DeprecatedComposite implements Transformer
+{
+    public function __construct(
+        private readonly Transformer $next
+    ) {
+    }
+
+    public function transform(RuleSpec $ruleSpec): RuleSpec
+    {
+        if (!in_array($ruleSpec->name, ['allOf', 'anyOf', 'noneOf', 'oneOf'])) {
+            return $this->next->transform($ruleSpec);
+        }
+
+        $arguments = $ruleSpec->arguments;
+        if (count($arguments) >= 2) {
+            return $this->next->transform($ruleSpec);
+        }
+
+        if (count($arguments) === 0) {
+            trigger_error(
+                sprintf(
+                    'Calling %s() without any arguments has been deprecated, ' .
+                    'and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+                    $ruleSpec->name
+                ),
+                E_USER_DEPRECATED
+            );
+
+            return match ($ruleSpec->name) {
+                'allOf', 'noneOf' => new RuleSpec('alwaysValid'),
+                'anyOf', 'oneOf' => new RuleSpec('alwaysInvalid'),
+            };
+        }
+
+        trigger_error(
+            sprintf(
+                'Calling %s() with a single argument has been deprecated, ' .
+                'and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+                $ruleSpec->name
+            ),
+            E_USER_DEPRECATED
+        );
+
+        $arguments[] = match ($ruleSpec->name) {
+            'allOf' => new AlwaysValid(),
+            'anyOf', 'noneOf', 'oneOf' => new AlwaysInvalid(),
+        };
+
+        return new RuleSpec($ruleSpec->name, $arguments);
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,8 @@ parameters:
       path: tests/feature/Transformers/AliasesTest.php
     - message: '/Call to an undefined static method Respect\\Validation\\Validator::(min|max)Age\(\)./'
       path: tests/feature/Transformers/DeprecatedAgeTest.php
+    - message: '/Static method Respect\\Validation\\Mixins\\Builder::.+Of\(\) invoked with \d parameters?, at least 2 required/'
+      path: tests/feature/Transformers/DeprecatedCompositeTest.php
     - message: '/Call to an undefined static method Respect\\Validation\\Validator::attribute\(\)./'
       path: tests/feature/Transformers/DeprecatedAttributeTest.php
     - message: '/Static method Respect\\Validation\\Mixins\\Builder::key\(\) invoked with \d parameters?, 2 required/'

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -96,21 +96,20 @@ function expectDeprecation(Closure $callback, string $error): Closure
             return true;
         });
 
-        try {
-            $callback->call($this);
-        } catch (Throwable $e) {
-            restore_error_handler();
-            expect($lastError)->toBe($error);
-            throw $e;
-        }
+        $callback->call($this);
+        restore_error_handler();
+        expect($lastError)->toBe($error);
     };
 }
 
-function expectMessageAndError(Closure $callback, string $message, string $error): Closure
+function expectMessageAndDeprecation(Closure $callback, string $message, string $error): Closure
 {
     return function () use ($callback, $message, $error): void {
         $lastError = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$lastError): bool {
+            if ($errno !== E_USER_DEPRECATED) {
+                return false;
+            }
             $lastError = $errstr;
 
             return true;

--- a/tests/feature/Transformers/DeprecatedAgeTest.php
+++ b/tests/feature/Transformers/DeprecatedAgeTest.php
@@ -9,49 +9,49 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::minAge(18)->assert('17 years ago'),
     'The number of years between now and "17 years ago" must be greater than or equal to 18',
     'The minAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::not(v::minAge(18))->assert('-30 years'),
     'The number of years between now and "-30 years" must be less than 18',
     'The minAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::minAge(18)->assert('yesterday'),
     'The number of years between now and "yesterday" must be greater than or equal to 18',
     'The minAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::minAge(18, 'd/m/Y')->assert('12/10/2010'),
     'The number of years between now and "12/10/2010" must be greater than or equal to 18',
     'The minAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #5', expectMessageAndError(
+test('Scenario #5', expectMessageAndDeprecation(
     fn() => v::maxAge(12)->assert('50 years ago'),
     'The number of years between now and "50 years ago" must be less than or equal to 12',
     'The maxAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #6', expectMessageAndError(
+test('Scenario #6', expectMessageAndDeprecation(
     fn() => v::not(v::maxAge(12))->assert('11 years ago'),
     'The number of years between now and "11 years ago" must be greater than 12',
     'The maxAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #7', expectMessageAndError(
+test('Scenario #7', expectMessageAndDeprecation(
     fn() => v::maxAge(12, 'Y-m-d')->assert('1988-09-09'),
     'The number of years between now and "1988-09-09" must be less than or equal to 12',
     'The maxAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',
 ));
 
-test('Scenario #8', expectMessageAndError(
+test('Scenario #8', expectMessageAndDeprecation(
     fn() => v::not(v::maxAge(12, 'Y-m-d'))->assert('2018-01-01'),
     'The number of years between now and "2018-01-01" must be greater than 12',
     'The maxAge() rule has been deprecated and will be removed in the next major version. Use dateTimeDiff() instead.',

--- a/tests/feature/Transformers/DeprecatedAttributeTest.php
+++ b/tests/feature/Transformers/DeprecatedAttributeTest.php
@@ -11,49 +11,49 @@ $object = new stdClass();
 $object->foo = true;
 $object->bar = 42;
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::attribute('baz')->assert($object),
     '`.baz` must be present',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use propertyExists() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::not(v::attribute('foo'))->assert($object),
     '`.foo` must not be present',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use propertyExists() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::attribute('foo', v::falseVal())->assert($object),
     '`.foo` must evaluate to `false`',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use property() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::not(v::attribute('foo', v::trueVal()))->assert($object),
     '`.foo` must not evaluate to `true`',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use property() instead.',
 ));
 
-test('Scenario #5', expectMessageAndError(
+test('Scenario #5', expectMessageAndDeprecation(
     fn() => v::attribute('foo', v::falseVal(), true)->assert($object),
     '`.foo` must evaluate to `false`',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use property() instead.',
 ));
 
-test('Scenario #6', expectMessageAndError(
+test('Scenario #6', expectMessageAndDeprecation(
     fn() => v::not(v::attribute('foo', v::trueVal(), true))->assert($object),
     '`.foo` must not evaluate to `true`',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use property() instead.',
 ));
 
-test('Scenario #7', expectMessageAndError(
+test('Scenario #7', expectMessageAndDeprecation(
     fn() => v::attribute('foo', v::falseVal(), false)->assert($object),
     '`.foo` must evaluate to `false`',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use propertyOptional() instead.',
 ));
 
-test('Scenario #8', expectMessageAndError(
+test('Scenario #8', expectMessageAndDeprecation(
     fn() => v::not(v::attribute('foo', v::trueVal(), false))->assert($object),
     '`.foo` must not evaluate to `true`',
     'The attribute() rule has been deprecated and will be removed in the next major version. Use propertyOptional() instead.',

--- a/tests/feature/Transformers/DeprecatedCompositeTest.php
+++ b/tests/feature/Transformers/DeprecatedCompositeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+date_default_timezone_set('UTC');
+
+test('Calling allOf without any arguments', expectDeprecation(
+    fn() => v::allOf()->assert('input'),
+    'Calling allOf() without any arguments has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling allOf with a single passing rule as argument', expectDeprecation(
+    fn() => v::allOf(v::stringType())->assert('input'),
+    'Calling allOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling allOf with a single failing rule as argument', expectMessageAndDeprecation(
+    fn() => v::allOf(v::intType())->assert('input'),
+    '"input" must be an integer',
+    'Calling allOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling anyOf without any arguments', expectMessageAndDeprecation(
+    fn() => v::anyOf()->assert('input'),
+    '"input" must be valid',
+    'Calling anyOf() without any arguments has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling anyOf with a single passing rule as argument', expectDeprecation(
+    fn() => v::anyOf(v::stringType())->assert('input'),
+    'Calling anyOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling anyOf with a single failing rule as argument', expectMessageAndDeprecation(
+    fn() => v::anyOf(v::intType())->assert('input'),
+    '"input" must be an integer',
+    'Calling anyOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling noneOf without any arguments', expectDeprecation(
+    fn() => v::noneOf()->assert('input'),
+    'Calling noneOf() without any arguments has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling noneOf with a single passing rule as argument', expectMessageAndDeprecation(
+    fn() => v::noneOf(v::stringType())->assert('input'),
+    '"input" must not be a string',
+    'Calling noneOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling noneOf with a single failing rule as argument', expectDeprecation(
+    fn() => v::noneOf(v::intType())->assert('input'),
+    'Calling noneOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling oneOf without any arguments', expectMessageAndDeprecation(
+    fn() => v::oneOf()->assert('input'),
+    '"input" must be valid',
+    'Calling oneOf() without any arguments has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling oneOf with a single passing rule as argument', expectDeprecation(
+    fn() => v::oneOf(v::stringType())->assert('input'),
+    'Calling oneOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));
+
+test('Calling oneOf with a single failing rule as argument', expectMessageAndDeprecation(
+    fn() => v::oneOf(v::intType())->assert('input'),
+    '"input" must be an integer',
+    'Calling oneOf() with a single argument has been deprecated, and will be not be allowed in the next major version. Use it with at least 2 arguments.',
+));

--- a/tests/feature/Transformers/DeprecatedKeyNestedTest.php
+++ b/tests/feature/Transformers/DeprecatedKeyNestedTest.php
@@ -13,43 +13,43 @@ $input = [
     ],
 ];
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar.baz')->assert(['foo.bar.baz' => false]),
     '`.foo` must be present',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',
 ));
 
-test('Scenario #A', expectMessageAndError(
+test('Scenario #A', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar.baz')->assert(['foo' => []]),
     '`.foo.bar` must be present',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',
 ));
 
-test('Scenario #B', expectMessageAndError(
+test('Scenario #B', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar.baz')->assert(['foo' => []]),
     '`.foo.bar` must be present',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',
 ));
 
-test('Scenario #C', expectMessageAndError(
+test('Scenario #C', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar.baz')->assert(['foo' => ['bar' => []]]),
     '`.foo.bar.baz` must be present',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar', v::negative())->assert($input),
     '`.foo.bar` must be a negative number',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar', v::stringType())->assert(new ArrayObject($input)),
     '`.foo.bar` must be a string',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::keyNested('foo.bar', v::floatType(), false)->assert($input),
     '`.foo.bar` must be float',
     'The keyNested() rule is deprecated and will be removed in the next major version. Use nested key() or property() instead.',

--- a/tests/feature/Transformers/DeprecatedKeyTest.php
+++ b/tests/feature/Transformers/DeprecatedKeyTest.php
@@ -9,37 +9,37 @@ declare(strict_types=1);
 
 $array = ['foo' => true, 'bar' => 42];
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::key('baz')->assert($array),
     '`.baz` must be present',
     'Calling key() without a second parameter has been deprecated, and will be not be allowed in the next major version. Use keyExists() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::not(v::key('foo'))->assert($array),
     '`.foo` must not be present',
     'Calling key() without a second parameter has been deprecated, and will be not be allowed in the next major version. Use keyExists() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::key('foo', v::falseVal(), true)->assert($array),
     '`.foo` must evaluate to `false`',
     'Calling key() with a third parameter has been deprecated, and will be not be allowed in the next major version. Use key() without the third parameter.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::not(v::key('foo', v::trueVal(), true))->assert($array),
     '`.foo` must not evaluate to `true`',
     'Calling key() with a third parameter has been deprecated, and will be not be allowed in the next major version. Use key() without the third parameter.',
 ));
 
-test('Scenario #5', expectMessageAndError(
+test('Scenario #5', expectMessageAndDeprecation(
     fn() => v::key('foo', v::falseVal(), false)->assert($array),
     '`.foo` must evaluate to `false`',
     'Calling key() with a third parameter has been deprecated, and will be not be allowed in the next major version. Use keyOptional() instead.',
 ));
 
-test('Scenario #6', expectMessageAndError(
+test('Scenario #6', expectMessageAndDeprecation(
     fn() => v::not(v::key('foo', v::trueVal(), false))->assert($array),
     '`.foo` must not evaluate to `true`',
     'Calling key() with a third parameter has been deprecated, and will be not be allowed in the next major version. Use keyOptional() instead.',

--- a/tests/feature/Transformers/DeprecatedKeyValueTest.php
+++ b/tests/feature/Transformers/DeprecatedKeyValueTest.php
@@ -7,61 +7,61 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'equals', 'bar')->assert(['bar' => 42]),
     '`.foo` must be present',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 42]),
     '`.bar` must be present',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'json', 'bar')->assert(['foo' => 42, 'bar' => 43]),
     '`.bar` must be valid to validate `.foo`',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 1, 'bar' => 2]),
     '`.foo` must be equal to 2',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #5', expectMessageAndError(
+test('Scenario #5', expectMessageAndDeprecation(
     fn() => v::not(v::keyValue('foo', 'equals', 'bar'))->assert(['foo' => 1, 'bar' => 1]),
     '`.foo` must not be equal to 1',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #6', expectMessageAndError(
+test('Scenario #6', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'equals', 'bar')->assert(['bar' => 42]),
     '`.foo` must be present',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #7', expectMessageAndError(
+test('Scenario #7', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 42]),
     '`.bar` must be present',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #8', expectMessageAndError(
+test('Scenario #8', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'json', 'bar')->assert(['foo' => 42, 'bar' => 43]),
     '`.bar` must be valid to validate `.foo`',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #9', expectMessageAndError(
+test('Scenario #9', expectMessageAndDeprecation(
     fn() => v::keyValue('foo', 'equals', 'bar')->assert(['foo' => 1, 'bar' => 2]),
     '`.foo` must be equal to 2',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',
 ));
 
-test('Scenario #10', expectMessageAndError(
+test('Scenario #10', expectMessageAndDeprecation(
     fn() => v::not(v::keyValue('foo', 'equals', 'bar'))->assert(['foo' => 1, 'bar' => 1]),
     '`.foo` must not be equal to 1',
     'The keyValue() rule has been deprecated and will be removed in the next major version. Use nested lazy() instead.',

--- a/tests/feature/Transformers/DeprecatedLengthTest.php
+++ b/tests/feature/Transformers/DeprecatedLengthTest.php
@@ -9,145 +9,145 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::length(0, 5, false)->assert('forest'),
     'The length of "forest" must be less than 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThan(5) instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::length(10, 20)->assert('river'),
     'The length of "river" must be between 10 and 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetween(10, 20) instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::length(15, null, false)->assert('mountain'),
     'The length of "mountain" must be greater than 15',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThan(15) instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::length(20)->assert('ocean'),
     'The length of "ocean" must be greater than or equal to 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThanOrEqual(20) instead.',
 ));
 
-test('Scenario #5', expectMessageAndError(
+test('Scenario #5', expectMessageAndDeprecation(
     fn() => v::length(2, 5)->assert('desert'),
     'The length of "desert" must be between 2 and 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetween(2, 5) instead.',
 ));
 
-test('Scenario #6', expectMessageAndError(
+test('Scenario #6', expectMessageAndDeprecation(
     fn() => v::not(v::length(0, 15))->assert('rainforest'),
     'The length of "rainforest" must be greater than 15',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThanOrEqual(15) instead.',
 ));
 
-test('Scenario #7', expectMessageAndError(
+test('Scenario #7', expectMessageAndDeprecation(
     fn() => v::not(v::length(0, 20, false))->assert('glacier'),
     'The length of "glacier" must not be less than 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThan(20) instead.',
 ));
 
-test('Scenario #8', expectMessageAndError(
+test('Scenario #8', expectMessageAndDeprecation(
     fn() => v::not(v::length(3, null))->assert('meadow'),
     'The length of "meadow" must be less than 3',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThanOrEqual(3) instead.',
 ));
 
-test('Scenario #9', expectMessageAndError(
+test('Scenario #9', expectMessageAndDeprecation(
     fn() => v::not(v::length(5, null, false))->assert('volcano'),
     'The length of "volcano" must not be greater than 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThan(5) instead.',
 ));
 
-test('Scenario #10', expectMessageAndError(
+test('Scenario #10', expectMessageAndDeprecation(
     fn() => v::not(v::length(5, 20))->assert('canyon'),
     'The length of "canyon" must not be between 5 and 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetween(5, 20) instead.',
 ));
 
-test('Scenario #11', expectMessageAndError(
+test('Scenario #11', expectMessageAndDeprecation(
     fn() => v::length(0, 5, false)->assert('prairie'),
     'The length of "prairie" must be less than 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThan(5) instead.',
 ));
 
-test('Scenario #12', expectMessageAndError(
+test('Scenario #12', expectMessageAndDeprecation(
     fn() => v::length(0, 5)->assert('wetland'),
     'The length of "wetland" must be less than or equal to 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThanOrEqual(5) instead.',
 ));
 
-test('Scenario #13', expectMessageAndError(
+test('Scenario #13', expectMessageAndDeprecation(
     fn() => v::length(15, null, false)->assert('tundra'),
     'The length of "tundra" must be greater than 15',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThan(15) instead.',
 ));
 
-test('Scenario #14', expectMessageAndError(
+test('Scenario #14', expectMessageAndDeprecation(
     fn() => v::length(20)->assert('savanna'),
     'The length of "savanna" must be greater than or equal to 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThanOrEqual(20) instead.',
 ));
 
-test('Scenario #15', expectMessageAndError(
+test('Scenario #15', expectMessageAndDeprecation(
     fn() => v::length(7, 10)->assert('marsh'),
     'The length of "marsh" must be between 7 and 10',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetween(7, 10) instead.',
 ));
 
-test('Scenario #16', expectMessageAndError(
+test('Scenario #16', expectMessageAndDeprecation(
     fn() => v::length(4, 10, false)->assert('reef'),
     'The length of "reef" must be greater than 4 and less than 10',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetweenExclusive(4, 10) instead.',
 ));
 
-test('Scenario #17', expectMessageAndError(
+test('Scenario #17', expectMessageAndDeprecation(
     fn() => v::not(v::length(0, 15))->assert('valley'),
     'The length of "valley" must be greater than 15',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThanOrEqual(15) instead.',
 ));
 
-test('Scenario #18', expectMessageAndError(
+test('Scenario #18', expectMessageAndDeprecation(
     fn() => v::not(v::length(0, 20, false))->assert('island'),
     'The length of "island" must not be less than 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthLessThan(20) instead.',
 ));
 
-test('Scenario #19', expectMessageAndError(
+test('Scenario #19', expectMessageAndDeprecation(
     fn() => v::not(v::length(5, null))->assert('plateau'),
     'The length of "plateau" must be less than 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThanOrEqual(5) instead.',
 ));
 
-test('Scenario #20', expectMessageAndError(
+test('Scenario #20', expectMessageAndDeprecation(
     fn() => v::not(v::length(3, null, false))->assert('fjord'),
     'The length of "fjord" must not be greater than 3',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthGreaterThan(3) instead.',
 ));
 
-test('Scenario #21', expectMessageAndError(
+test('Scenario #21', expectMessageAndDeprecation(
     fn() => v::not(v::length(5, 20))->assert('delta'),
     'The length of "delta" must not be between 5 and 20',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetween(5, 20) instead.',
 ));
 
-test('Scenario #22', expectMessageAndError(
+test('Scenario #22', expectMessageAndDeprecation(
     fn() => v::not(v::length(5, 11, false))->assert('waterfall'),
     'The length of "waterfall" must not be greater than 5 or less than 11',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthBetweenExclusive(5, 11) instead.',
 ));
 
-test('Scenario #23', expectMessageAndError(
+test('Scenario #23', expectMessageAndDeprecation(
     fn() => v::length(8, 8)->assert('estuary'),
     'The length of "estuary" must be equal to 8',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthEquals(8) instead.',
 ));
 
-test('Scenario #24', expectMessageAndError(
+test('Scenario #24', expectMessageAndDeprecation(
     fn() => v::not(v::length(5, 5))->assert('grove'),
     'The length of "grove" must not be equal to 5',
     'Calling length() with scalar values has been deprecated, and will not be allowed in the next major version. Use lengthEquals(5) instead.',

--- a/tests/feature/Transformers/DeprecatedMaxTest.php
+++ b/tests/feature/Transformers/DeprecatedMaxTest.php
@@ -7,25 +7,25 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::max(10)->assert(11),
     '11 must be less than or equal to 10',
     'Calling max() with a scalar value has been deprecated, and will be not allows in the next major version. Use lessThanOrEqual() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::not(v::max(10))->assert(5),
     '5 must be greater than 10',
     'Calling max() with a scalar value has been deprecated, and will be not allows in the next major version. Use lessThanOrEqual() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::max('today')->assert('tomorrow'),
     '"tomorrow" must be less than or equal to "today"',
     'Calling max() with a scalar value has been deprecated, and will be not allows in the next major version. Use lessThanOrEqual() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::not(v::max('b'))->assert('a'),
     '"a" must be greater than "b"',
     'Calling max() with a scalar value has been deprecated, and will be not allows in the next major version. Use lessThanOrEqual() instead.',

--- a/tests/feature/Transformers/DeprecatedMinTest.php
+++ b/tests/feature/Transformers/DeprecatedMinTest.php
@@ -7,25 +7,25 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::min(INF)->assert(10),
     '10 must be greater than or equal to `INF`',
     'Calling min() with a scalar value has been deprecated, and will be not allows in the next major version. Use greaterThanOrEqual() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::not(v::min(5))->assert(INF),
     '`INF` must be less than 5',
     'Calling min() with a scalar value has been deprecated, and will be not allows in the next major version. Use greaterThanOrEqual() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::min('today')->assert('yesterday'),
     '"yesterday" must be greater than or equal to "today"',
     'Calling min() with a scalar value has been deprecated, and will be not allows in the next major version. Use greaterThanOrEqual() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::not(v::min('a'))->assert('z'),
     '"z" must be less than "a"',
     'Calling min() with a scalar value has been deprecated, and will be not allows in the next major version. Use greaterThanOrEqual() instead.',

--- a/tests/feature/Transformers/DeprecatedSizeTest.php
+++ b/tests/feature/Transformers/DeprecatedSizeTest.php
@@ -21,49 +21,49 @@ beforeEach(function (): void {
         ->url();
 });
 
-test('Greater than, only integer', expectMessageAndError(
+test('Greater than, only integer', expectMessageAndDeprecation(
     fn() => v::size(6042, null)->assert($this->filename),
     'The size in bytes of "vfs://root/filename.blob" must be greater than or equal to 6042',
     $baseError . 'Use size(\'B\', greaterThanOrEqual(6042)) instead.',
 ));
 
-test('Greater than, with storage unit', expectMessageAndError(
+test('Greater than, with storage unit', expectMessageAndDeprecation(
     fn() => v::size('2.5MB', null)->assert($this->filename),
     'The size in megabytes of "vfs://root/filename.blob" must be greater than or equal to 2.5',
     $baseError . 'Use size(\'MB\', greaterThanOrEqual(2.5)) instead.',
 ));
 
-test('Less than, only integer', expectMessageAndError(
+test('Less than, only integer', expectMessageAndDeprecation(
     fn() => v::size(null, 526)->assert($this->filename),
     'The size in bytes of "vfs://root/filename.blob" must be less than or equal to 526',
     $baseError . 'Use size(\'B\', lessThanOrEqual(526)) instead.',
 ));
 
-test('Less than, with storage unit', expectMessageAndError(
+test('Less than, with storage unit', expectMessageAndDeprecation(
     fn() => v::size(null, '1KB')->assert($this->filename),
     'The size in kilobytes of "vfs://root/filename.blob" must be less than or equal to 1',
     $baseError . 'Use size(\'KB\', lessThanOrEqual(1)) instead.',
 ));
 
-test('Equal, only integer', expectMessageAndError(
+test('Equal, only integer', expectMessageAndDeprecation(
     fn() => v::size(1024, 1024)->assert($this->filename),
     'The size in bytes of "vfs://root/filename.blob" must be equal to 1024',
     $baseError . 'Use size(\'B\', equals(1024)) instead.',
 ));
 
-test('Equal, with storage unit', expectMessageAndError(
+test('Equal, with storage unit', expectMessageAndDeprecation(
     fn() => v::size('1PB', '1PB')->assert($this->filename),
     'The size in petabytes of "vfs://root/filename.blob" must be equal to 1',
     $baseError . 'Use size(\'PB\', equals(1)) instead.',
 ));
 
-test('Between, only integer', expectMessageAndError(
+test('Between, only integer', expectMessageAndDeprecation(
     fn() => v::size(1, 1024)->assert($this->filename),
     'The size in bytes of "vfs://root/filename.blob" must be between 1 and 1024',
     $baseError . 'Use size(\'B\', between(1, 1024)) instead.',
 ));
 
-test('Between, with storage unit', expectMessageAndError(
+test('Between, with storage unit', expectMessageAndDeprecation(
     fn() => v::size('1zb', '2.5zb')->assert($this->filename),
     'The size in zettabytes of "vfs://root/filename.blob" must be between 1 and 2.5',
     $baseError . 'Use size(\'ZB\', between(1, 2.5)) instead.',

--- a/tests/feature/Transformers/DeprecatedTypeTest.php
+++ b/tests/feature/Transformers/DeprecatedTypeTest.php
@@ -7,73 +7,73 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessageAndError(
+test('Scenario #1', expectMessageAndDeprecation(
     fn() => v::type('array')->assert(1),
     '1 must be an array',
     'The type() rule is deprecated and will be removed in the next major version. Use arrayType() instead.',
 ));
 
-test('Scenario #2', expectMessageAndError(
+test('Scenario #2', expectMessageAndDeprecation(
     fn() => v::type('bool')->assert(1),
     '1 must be a boolean',
     'The type() rule is deprecated and will be removed in the next major version. Use boolType() instead.',
 ));
 
-test('Scenario #3', expectMessageAndError(
+test('Scenario #3', expectMessageAndDeprecation(
     fn() => v::type('boolean')->assert(1),
     '1 must be a boolean',
     'The type() rule is deprecated and will be removed in the next major version. Use boolType() instead.',
 ));
 
-test('Scenario #4', expectMessageAndError(
+test('Scenario #4', expectMessageAndDeprecation(
     fn() => v::type('callable')->assert(1),
     '1 must be a callable',
     'The type() rule is deprecated and will be removed in the next major version. Use callableType() instead.',
 ));
 
-test('Scenario #5', expectMessageAndError(
+test('Scenario #5', expectMessageAndDeprecation(
     fn() => v::type('double')->assert(1),
     '1 must be float',
     'The type() rule is deprecated and will be removed in the next major version. Use floatType() instead.',
 ));
 
-test('Scenario #6', expectMessageAndError(
+test('Scenario #6', expectMessageAndDeprecation(
     fn() => v::type('float')->assert(1),
     '1 must be float',
     'The type() rule is deprecated and will be removed in the next major version. Use floatType() instead.',
 ));
 
-test('Scenario #7', expectMessageAndError(
+test('Scenario #7', expectMessageAndDeprecation(
     fn() => v::type('int')->assert('1'),
     '"1" must be an integer',
     'The type() rule is deprecated and will be removed in the next major version. Use intType() instead.',
 ));
 
-test('Scenario #8', expectMessageAndError(
+test('Scenario #8', expectMessageAndDeprecation(
     fn() => v::type('integer')->assert('1'),
     '"1" must be an integer',
     'The type() rule is deprecated and will be removed in the next major version. Use intType() instead.',
 ));
 
-test('Scenario #9', expectMessageAndError(
+test('Scenario #9', expectMessageAndDeprecation(
     fn() => v::type('null')->assert(1),
     '1 must be null',
     'The type() rule is deprecated and will be removed in the next major version. Use nullType() instead.',
 ));
 
-test('Scenario #10', expectMessageAndError(
+test('Scenario #10', expectMessageAndDeprecation(
     fn() => v::type('object')->assert(1),
     '1 must be an object',
     'The type() rule is deprecated and will be removed in the next major version. Use objectType() instead.',
 ));
 
-test('Scenario #11', expectMessageAndError(
+test('Scenario #11', expectMessageAndDeprecation(
     fn() => v::type('resource')->assert(1),
     '1 must be a resource',
     'The type() rule is deprecated and will be removed in the next major version. Use resourceType() instead.',
 ));
 
-test('Scenario #12', expectMessageAndError(
+test('Scenario #12', expectMessageAndDeprecation(
     fn() => v::type('string')->assert(1),
     '1 must be a string',
     'The type() rule is deprecated and will be removed in the next major version. Use stringType() instead.',


### PR DESCRIPTION
This transformers will help transition from the current major version to the next. In the current version, it's possible to call `allOf`, `anyOf`, `noneOf`, and `oneOf` without any arguments or with only one, and that doesn't make much sense.