### PR TITLE
Add support for UUID validation using ramsey/uuid to support all UUID…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,16 @@
         "phpunit/phpunit": "^9.6",
         "psr/http-message": "^1.0",
         "respect/coding-standard": "^4.0",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "ramsey/uuid": "^4"
     },
     "suggest": {
         "ext-bcmath": "Arbitrary Precision Mathematics",
         "ext-fileinfo": "File Information",
         "ext-mbstring": "Multibyte String Functions",
         "egulias/email-validator": "Improves the Email rule if available",
-        "giggsey/libphonenumber-for-php-lite": "Enables the phone rule if available"
+        "giggsey/libphonenumber-for-php-lite": "Enables the phone rule if available",
+        "ramsey/uuid": "Improves UUID checking if available"
     },
     "autoload": {
         "psr-4": {

--- a/docs/rules/Uuid.md
+++ b/docs/rules/Uuid.md
@@ -2,6 +2,7 @@
 
 - `Uuid()`
 - `Uuid(int $version)`
+- `Uuid(?int $version, ?bool $useRamseyUuid)`
 
 Validates whether the input is a valid UUID. It also supports validation of
 specific versions 1, 3, 4 and 5.
@@ -11,6 +12,19 @@ v::uuid()->isValid('Hello World!'); // false
 v::uuid()->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
 v::uuid(1)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // false
 v::uuid(4)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+```
+
+Optionally, you are able to use ramsey/uuid library to support validation
+of all UUID versions 1 to 8, This will be automatically enabled if ramsey/uuid
+is detected but can be manually disabled to revert to the original behavior.
+
+```php
+v::uuid(null, true)->isValid('Hello World!'); // false
+v::uuid(null, true)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid(1, true)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // false
+v::uuid(4, true)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid(8, true)->isValid('00112233-4455-8677-8899-aabbccddeeff'); // true
+v::uuid(8, false)->isValid('00112233-4455-8677-8899-aabbccddeeff'); // false <-- same UUID as above, but with ramsey/uuid disabled
 ```
 
 ## Categorization

--- a/library/ChainedValidator.php
+++ b/library/ChainedValidator.php
@@ -357,7 +357,7 @@ interface ChainedValidator extends Validatable
 
     public function url(): ChainedValidator;
 
-    public function uuid(?int $version = null): ChainedValidator;
+    public function uuid(?int $version = null, ?bool $useRamseyUuid = null): ChainedValidator;
 
     public function version(): ChainedValidator;
 

--- a/library/StaticValidator.php
+++ b/library/StaticValidator.php
@@ -355,7 +355,7 @@ interface StaticValidator
 
     public static function url(): ChainedValidator;
 
-    public static function uuid(?int $version = null): ChainedValidator;
+    public static function uuid(?int $version = null, ?bool $useRamseyUuid = null): ChainedValidator;
 
     public static function version(): ChainedValidator;
 

--- a/tests/unit/Rules/UuidTest.php
+++ b/tests/unit/Rules/UuidTest.php
@@ -9,17 +9,20 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Ramsey\Uuid\Uuid as RamseyUuid;
+use ReflectionClass;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Test\RuleTestCase;
 use stdClass;
 
+use function class_exists;
 use function random_int;
 
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
 /**
- * @group rule
+ * @group  rule
  *
  * @covers \Respect\Validation\Rules\Uuid
  *
@@ -29,10 +32,19 @@ use const PHP_INT_MIN;
  */
 final class UuidTest extends RuleTestCase
 {
-    private const UUID_VERSION_1 = 'e4eaaaf2-d142-11e1-b3e4-080027620cdd';
-    private const UUID_VERSION_3 = '11a38b9a-b3da-360f-9353-a5a725514269';
-    private const UUID_VERSION_4 = '25769c6c-d34d-4bfe-ba98-e0ee856f3e7a';
-    private const UUID_VERSION_5 = 'c4a760a8-dbcf-5254-a0d9-6a4474bd1b62';
+    private const UUID_VERSION_1 = 'e4eaaaf2-d142-11e1-b3e4-080027620cdd'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_2 = '000003e8-3702-21f0-9f00-325096b39f47'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_3 = '11a38b9a-b3da-360f-9353-a5a725514269'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_4 = '25769c6c-d34d-4bfe-ba98-e0ee856f3e7a'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_5 = 'c4a760a8-dbcf-5254-a0d9-6a4474bd1b62'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_6 = '1f037034-88c0-61d0-a876-e4456153c969'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_7 = '0196f7d6-f570-7041-8106-c0011f7a9bcd'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_8 = '00112233-4455-8677-8899-aabbccddeeff'; // @phpstan-ignore classConstant.unused
+
+    private const NATIVE_VERSIONS = [1, 3, 4, 5];
+    private const ALL_VERSIONS    = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    private static ?bool $ramseyUuidIsLoaded = null;
 
     /**
      * @test
@@ -42,20 +54,27 @@ final class UuidTest extends RuleTestCase
         self::expectException(ComponentException::class);
         self::expectExceptionMessage('Only versions 1, 3, 4, and 5 are supported: 2 given');
 
-        new Uuid(2);
+        new Uuid(2, false);
     }
 
     /**
      * @test
      */
-    public function itShouldThrowExceptionWhenVersionIsGreaterThanFive(): void
+    public function itShouldThrowExceptionWhenVersionIsGreaterThanMax(): void
     {
         $version = random_int(6, PHP_INT_MAX);
 
         self::expectException(ComponentException::class);
         self::expectExceptionMessage('Only versions 1, 3, 4, and 5 are supported: ' . $version . ' given');
+        new Uuid($version, false);
 
-        new Uuid($version);
+        if (!self::ramseyUuidIsLoaded()) {
+            return;
+        }
+
+        self::expectException(ComponentException::class);
+        self::expectExceptionMessage('Only versions 1 to 8 are supported: ' . $version . ' given');
+        new Uuid($version, true);
     }
 
     /**
@@ -67,8 +86,15 @@ final class UuidTest extends RuleTestCase
 
         self::expectException(ComponentException::class);
         self::expectExceptionMessage('Only versions 1, 3, 4, and 5 are supported: ' . $version . ' given');
+        new Uuid($version, false);
 
-        new Uuid($version);
+        if (!self::ramseyUuidIsLoaded()) {
+            return;
+        }
+
+        self::expectException(ComponentException::class);
+        self::expectExceptionMessage('Only versions 1 to 8 are supported: ' . $version . ' given');
+        new Uuid($version, true);
     }
 
     /**
@@ -76,18 +102,39 @@ final class UuidTest extends RuleTestCase
      */
     public static function providerForValidInput(): array
     {
-        $sut = new Uuid();
+        $tests = [];
 
-        return [
-            'any version with version 1' => [$sut, self::UUID_VERSION_1],
-            'any version with version 3' => [$sut, self::UUID_VERSION_3],
-            'any version with version 4' => [$sut, self::UUID_VERSION_4],
-            'any version with version 5' => [$sut, self::UUID_VERSION_5],
-            'version 1 with version 1' => [new Uuid(1), self::UUID_VERSION_1],
-            'version 3 with version 3' => [new Uuid(3), self::UUID_VERSION_3],
-            'version 4 with version 4' => [new Uuid(4), self::UUID_VERSION_4],
-            'version 5 with version 5' => [new Uuid(5), self::UUID_VERSION_5],
-        ];
+        $thisClass      = new ReflectionClass(self::class);
+        $classConstants = $thisClass->getConstants();
+
+        $sutNative = new Uuid();
+        foreach (self::NATIVE_VERSIONS as $version) {
+            $tests[' any version with version ' . $version] = [
+                $sutNative,
+                $classConstants['UUID_VERSION_' . $version],
+            ];
+
+            $tests['version ' . $version . ' with version ' . $version] = [
+                new Uuid($version),
+                $classConstants['UUID_VERSION_' . $version],
+            ];
+        }
+
+        if (self::ramseyUuidIsLoaded()) {
+            $sutRamsey = new Uuid(null, true);
+            foreach (self::ALL_VERSIONS as $version) {
+                $tests[' any version with version ' . $version . ' ramsey/uuid']             = [
+                    $sutRamsey,
+                    $classConstants['UUID_VERSION_' . $version],
+                ];
+                $tests['version ' . $version . ' with version ' . $version . ' ramsey/uuid'] = [
+                    new Uuid($version, true),
+                    $classConstants['UUID_VERSION_' . $version],
+                ];
+            }
+        }
+
+        return $tests;
     }
 
     /**
@@ -95,34 +142,68 @@ final class UuidTest extends RuleTestCase
      */
     public static function providerForInvalidInput(): array
     {
-        $sut = new Uuid();
-        $sutVersion1 = new Uuid(1);
-        $sutVersion3 = new Uuid(3);
-        $sutVersion4 = new Uuid(4);
-        $sutVersion5 = new Uuid(5);
-
-        return [
-            'empty' => [$sut, ''],
-            'nil/empty' => [$sut, '00000000-0000-0000-0000-000000000000'],
-            'not UUID' => [$sut, 'Not an UUID'],
-            'invalid UUID' => [$sut, 'g71a18f4-3a13-11e7-a919-92ebcb67fe33'],
-            'invalid format' => [$sut, 'a71a18f43a1311e7a91992ebcb67fe33'],
-            'version 1 with version 3' => [$sutVersion1, self::UUID_VERSION_3],
-            'version 1 with version 4' => [$sutVersion1, self::UUID_VERSION_4],
-            'version 1 with version 5' => [$sutVersion1, self::UUID_VERSION_5],
-            'version 3 with version 1' => [$sutVersion3, self::UUID_VERSION_1],
-            'version 3 with version 4' => [$sutVersion3, self::UUID_VERSION_4],
-            'version 3 with version 5' => [$sutVersion3, self::UUID_VERSION_5],
-            'version 4 with version 1' => [$sutVersion4, self::UUID_VERSION_1],
-            'version 4 with version 3' => [$sutVersion4, self::UUID_VERSION_3],
-            'version 4 with version 5' => [$sutVersion4, self::UUID_VERSION_5],
-            'version 5 with version 1' => [$sutVersion5, self::UUID_VERSION_1],
-            'version 5 with version 3' => [$sutVersion5, self::UUID_VERSION_3],
-            'version 5 with version 4' => [$sutVersion5, self::UUID_VERSION_4],
-            'array' => [$sut, []],
-            'boolean true' => [$sut, true],
-            'boolean false' => [$sut, false],
-            'object' => [$sut, new stdClass()],
+        $tests          = [];
+        $baseTests      = [
+            'empty'          => '',
+            'nil/empty'      => '00000000-0000-0000-0000-000000000000',
+            'not UUID'       => 'Not an UUID',
+            'invalid UUID'   => 'g71a18f4-3a13-11e7-a919-92ebcb67fe33',
+            'invalid format' => 'a71a18f43a1311e7a91992ebcb67fe33',
+            'array'          => [],
+            'boolean true'   => true,
+            'boolean false'  => false,
+            'object'         => new stdClass(),
         ];
+        $thisClass      = new ReflectionClass(self::class);
+        $classConstants = $thisClass->getConstants();
+
+        $sutNative = new Uuid();
+        foreach ($baseTests as $name => $input) {
+            $tests[$name] = [$sutNative, $input];
+        }
+
+        foreach (self::NATIVE_VERSIONS as $version1) {
+            foreach (self::NATIVE_VERSIONS as $version2) {
+                if ($version1 === $version2) {
+                    continue;
+                }
+
+                $tests['version ' . $version1 . ' with version ' . $version2] = [
+                    new Uuid($version1),
+                    $classConstants['UUID_VERSION_' . $version2],
+                ];
+            }
+        }
+
+        if (self::ramseyUuidIsLoaded()) {
+            $sutRamsey = new Uuid(null, true);
+            foreach ($baseTests as $name => $input) {
+                $tests[$name . ' ramsey/uuid'] = [$sutRamsey, $input];
+            }
+
+            foreach (self::ALL_VERSIONS as $version1) {
+                foreach (self::ALL_VERSIONS as $version2) {
+                    if ($version1 === $version2) {
+                        continue;
+                    }
+
+                    $tests['version ' . $version1 . ' with version ' . $version2] = [
+                        new Uuid($version1, true),
+                        $classConstants['UUID_VERSION_' . $version2],
+                    ];
+                }
+            }
+        }
+
+        return $tests;
+    }
+
+    protected static function ramseyUuidIsLoaded(): bool
+    {
+        if (self::$ramseyUuidIsLoaded === null) {
+            self::$ramseyUuidIsLoaded = class_exists(RamseyUuid::class);
+        }
+
+        return self::$ramseyUuidIsLoaded;
     }
 }


### PR DESCRIPTION
… versions

As suggested in https://github.com/Respect/Validation/issues/1471

Defaults to the original behavior if ramsey/uuid is not installed or explicitly disabled.