### PR TITLE
Extend UUID rule support to versions 1 through 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=8.1",
         "respect/stringifier": "^2.0.0",
-        "symfony/polyfill-mbstring": "^1.28"
+        "symfony/polyfill-mbstring": "^1.28",
+        "ramsey/uuid": "^4"
     },
     "require-dev": {
         "egulias/email-validator": "^4.0",

--- a/docs/rules/Uuid.md
+++ b/docs/rules/Uuid.md
@@ -4,13 +4,15 @@
 - `Uuid(int $version)`
 
 Validates whether the input is a valid UUID. It also supports validation of
-specific versions 1, 3, 4 and 5.
+specific versions 1 to 8.
 
 ```php
 v::uuid()->isValid('Hello World!'); // false
 v::uuid()->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
 v::uuid(1)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // false
 v::uuid(4)->isValid('eb3115e5-bd16-4939-ab12-2b95745a30f3'); // true
+v::uuid(8)->isValid('00112233-4455-8677-8899-aabbccddeeff'); // true
+v::uuid(4)->isValid(new \Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2b95745a30f3')); // true
 ```
 
 ## Templates

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -10,14 +10,14 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use Attribute;
+use Ramsey\Uuid\Uuid as RamseyUuid;
+use Ramsey\Uuid\UuidInterface;
 use Respect\Validation\Exceptions\InvalidRuleConstructorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Rules\Core\Standard;
 
 use function is_string;
-use function preg_match;
-use function sprintf;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
@@ -34,41 +34,43 @@ final class Uuid extends Standard
 {
     public const TEMPLATE_VERSION = '__version__';
 
-    private const PATTERN_FORMAT = '/^[0-9a-f]{8}-[0-9a-f]{4}-%s[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
-
     public function __construct(
         private readonly ?int $version = null
     ) {
         if ($version !== null && !$this->isSupportedVersion($version)) {
             throw new InvalidRuleConstructorException(
-                'Only versions 1, 3, 4, and 5 are supported: %d given',
-                (string) $version
+                'Only versions 1 to 8 are supported: %d given',
+                (string)$version
             );
         }
     }
 
     public function evaluate(mixed $input): Result
     {
-        $template = $this->version ? self::TEMPLATE_VERSION : self::TEMPLATE_STANDARD;
+        $template   = $this->version ? self::TEMPLATE_VERSION : self::TEMPLATE_STANDARD;
         $parameters = ['version' => $this->version];
-        if (!is_string($input)) {
+
+        if (!is_string($input) && !($input instanceof UuidInterface)) {
             return Result::failed($input, $this, $parameters, $template);
         }
 
-        return new Result(preg_match($this->getPattern(), $input) > 0, $input, $this, $parameters, $template);
+        if (is_string($input) && RamseyUuid::isValid($input)) {
+            $uuid = RamseyUuid::fromString($input);
+        } elseif ($input instanceof UuidInterface) {
+            $uuid = $input;
+        } else {
+            return Result::failed($input, $this, $parameters, $template);
+        }
+
+        /** @phpstan-ignore-next-line */
+        $uuidVersion = $uuid->getFields()->getVersion();
+        $hasPassed   = $this->version ? $uuidVersion === $this->version : $uuidVersion !== null;
+
+        return new Result($hasPassed, $input, $this, $parameters, $template);
     }
 
     private function isSupportedVersion(int $version): bool
     {
-        return $version >= 1 && $version <= 5 && $version !== 2;
-    }
-
-    private function getPattern(): string
-    {
-        if ($this->version !== null) {
-            return sprintf(self::PATTERN_FORMAT, $this->version);
-        }
-
-        return sprintf(self::PATTERN_FORMAT, '[13-5]');
+        return $version >= 1 && $version <= 8;
     }
 }

--- a/tests/unit/Rules/UuidTest.php
+++ b/tests/unit/Rules/UuidTest.php
@@ -12,6 +12,8 @@ namespace Respect\Validation\Rules;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Ramsey\Uuid\Uuid as RamseyUuid;
+use ReflectionClass;
 use Respect\Validation\Exceptions\InvalidRuleConstructorException;
 use Respect\Validation\Test\RuleTestCase;
 use stdClass;
@@ -25,27 +27,24 @@ use const PHP_INT_MIN;
 #[CoversClass(Uuid::class)]
 final class UuidTest extends RuleTestCase
 {
-    private const UUID_VERSION_1 = 'e4eaaaf2-d142-11e1-b3e4-080027620cdd';
-    private const UUID_VERSION_3 = '11a38b9a-b3da-360f-9353-a5a725514269';
-    private const UUID_VERSION_4 = '25769c6c-d34d-4bfe-ba98-e0ee856f3e7a';
-    private const UUID_VERSION_5 = 'c4a760a8-dbcf-5254-a0d9-6a4474bd1b62';
+    private const UUID_VERSION_1 = 'e4eaaaf2-d142-11e1-b3e4-080027620cdd'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_2 = '000003e8-3702-21f0-9f00-325096b39f47'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_3 = '11a38b9a-b3da-360f-9353-a5a725514269'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_4 = '25769c6c-d34d-4bfe-ba98-e0ee856f3e7a'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_5 = 'c4a760a8-dbcf-5254-a0d9-6a4474bd1b62'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_6 = '1f037034-88c0-61d0-a876-e4456153c969'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_7 = '0196f7d6-f570-7041-8106-c0011f7a9bcd'; // @phpstan-ignore classConstant.unused
+    private const UUID_VERSION_8 = '00112233-4455-8677-8899-aabbccddeeff'; // @phpstan-ignore classConstant.unused
 
-    #[Test]
-    public function itShouldThrowExceptionWhenVersionIsTwo(): void
-    {
-        self::expectException(InvalidRuleConstructorException::class);
-        self::expectExceptionMessage('Only versions 1, 3, 4, and 5 are supported: 2 given');
-
-        new Uuid(2);
-    }
+    private const ALL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8];
 
     #[Test]
     public function itShouldThrowExceptionWhenVersionIsGreaterThanFive(): void
     {
-        $version = random_int(6, PHP_INT_MAX);
+        $version = random_int(8, PHP_INT_MAX);
 
         self::expectException(InvalidRuleConstructorException::class);
-        self::expectExceptionMessage('Only versions 1, 3, 4, and 5 are supported: ' . $version . ' given');
+        self::expectExceptionMessage('Only versions 1 to 8 are supported: ' . $version . ' given');
 
         new Uuid($version);
     }
@@ -56,7 +55,7 @@ final class UuidTest extends RuleTestCase
         $version = random_int(PHP_INT_MIN, 0);
 
         self::expectException(InvalidRuleConstructorException::class);
-        self::expectExceptionMessage('Only versions 1, 3, 4, and 5 are supported: ' . $version . ' given');
+        self::expectExceptionMessage('Only versions 1 to 8 are supported: ' . $version . ' given');
 
         new Uuid($version);
     }
@@ -66,49 +65,64 @@ final class UuidTest extends RuleTestCase
     {
         $sut = new Uuid();
 
-        return [
-            'any version with version 1' => [$sut, self::UUID_VERSION_1],
-            'any version with version 3' => [$sut, self::UUID_VERSION_3],
-            'any version with version 4' => [$sut, self::UUID_VERSION_4],
-            'any version with version 5' => [$sut, self::UUID_VERSION_5],
-            'version 1 with version 1' => [new Uuid(1), self::UUID_VERSION_1],
-            'version 3 with version 3' => [new Uuid(3), self::UUID_VERSION_3],
-            'version 4 with version 4' => [new Uuid(4), self::UUID_VERSION_4],
-            'version 5 with version 5' => [new Uuid(5), self::UUID_VERSION_5],
-        ];
+        $tests = [];
+
+        $classConstants = (new ReflectionClass(self::class))->getConstants();
+
+        foreach (self::ALL_VERSIONS as $version) {
+            $uuid1 = $classConstants['UUID_VERSION_' . $version];
+            $uuid2 = RamseyUuid::fromString($uuid1);
+
+            $tests[' any version with version ' . $version]                    = [$sut, $uuid1];
+            $tests['version ' . $version . ' with version ' . $version]        = [new Uuid($version), $uuid1];
+
+            $tests[' any version object with version ' . $version]             = [$sut, $uuid2];
+            $tests['version ' . $version . ' object with version ' . $version] = [new Uuid($version), $uuid2];
+        }
+
+        return $tests;
     }
 
     /** @return iterable<array{Uuid, mixed}> */
     public static function providerForInvalidInput(): iterable
     {
-        $sut = new Uuid();
-        $sutVersion1 = new Uuid(1);
-        $sutVersion3 = new Uuid(3);
-        $sutVersion4 = new Uuid(4);
-        $sutVersion5 = new Uuid(5);
+        $tests = [];
 
-        return [
-            'empty' => [$sut, ''],
-            'nil/empty' => [$sut, '00000000-0000-0000-0000-000000000000'],
-            'not UUID' => [$sut, 'Not an UUID'],
-            'invalid UUID' => [$sut, 'g71a18f4-3a13-11e7-a919-92ebcb67fe33'],
-            'invalid format' => [$sut, 'a71a18f43a1311e7a91992ebcb67fe33'],
-            'version 1 with version 3' => [$sutVersion1, self::UUID_VERSION_3],
-            'version 1 with version 4' => [$sutVersion1, self::UUID_VERSION_4],
-            'version 1 with version 5' => [$sutVersion1, self::UUID_VERSION_5],
-            'version 3 with version 1' => [$sutVersion3, self::UUID_VERSION_1],
-            'version 3 with version 4' => [$sutVersion3, self::UUID_VERSION_4],
-            'version 3 with version 5' => [$sutVersion3, self::UUID_VERSION_5],
-            'version 4 with version 1' => [$sutVersion4, self::UUID_VERSION_1],
-            'version 4 with version 3' => [$sutVersion4, self::UUID_VERSION_3],
-            'version 4 with version 5' => [$sutVersion4, self::UUID_VERSION_5],
-            'version 5 with version 1' => [$sutVersion5, self::UUID_VERSION_1],
-            'version 5 with version 3' => [$sutVersion5, self::UUID_VERSION_3],
-            'version 5 with version 4' => [$sutVersion5, self::UUID_VERSION_4],
-            'array' => [$sut, []],
-            'boolean true' => [$sut, true],
-            'boolean false' => [$sut, false],
-            'object' => [$sut, new stdClass()],
+        $baseTests      = [
+            'empty'          => '',
+            'nil/empty'      => '00000000-0000-0000-0000-000000000000',
+            'not UUID'       => 'Not an UUID',
+            'invalid UUID'   => 'g71a18f4-3a13-11e7-a919-92ebcb67fe33',
+            'invalid format' => 'a71a18f43a1311e7a91992ebcb67fe33',
+            'array'          => [],
+            'boolean true'   => true,
+            'boolean false'  => false,
+            'object'         => new stdClass(),
         ];
+
+        $classConstants = (new ReflectionClass(self::class))->getConstants();
+
+        $sut = new Uuid();
+
+        foreach ($baseTests as $name => $input) {
+            $tests[$name] = [$sut, $input];
+        }
+
+        foreach (self::ALL_VERSIONS as $version1) {
+            foreach (self::ALL_VERSIONS as $version2) {
+                if ($version1 === $version2) {
+                    continue;
+                }
+
+                $uuid1 = $classConstants['UUID_VERSION_' . $version2];
+                $uuid2 = RamseyUuid::fromString($uuid1);
+                $sut   = new Uuid($version1);
+
+                $tests['version ' . $version1 . ' with version ' . $version2] = [$sut, $uuid1];
+                $tests['version ' . $version1 . ' with version ' . $version2] = [$sut, $uuid2];
+            }
+        }
+
+        return $tests;
     }
 }


### PR DESCRIPTION
Updated the `Uuid` rule to validate UUID versions 1 to 8 using the `ramsey/uuid` library, replacing manual pattern checks. Updated tests and documentation accordingly, ensuring compatibility with string and `UuidInterface` inputs.