### PR TITLE
chore: Mark all rules as attributes

### DIFF
--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\AllOfException;
 
 use function count;
@@ -17,6 +18,7 @@ use function count;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 class AllOf extends AbstractComposite
 {
     /**

--- a/library/Rules/Alnum.php
+++ b/library/Rules/Alnum.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_alnum;
 
 /**
@@ -21,6 +23,7 @@ use function ctype_alnum;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Alnum extends AbstractFilterRule
 {
     /**

--- a/library/Rules/Alpha.php
+++ b/library/Rules/Alpha.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_alpha;
 
 /**
@@ -18,6 +20,7 @@ use function ctype_alpha;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Alpha extends AbstractFilterRule
 {
     /**

--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates any input as invalid.
  *
@@ -16,6 +18,7 @@ namespace Respect\Validation\Rules;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class AlwaysInvalid extends AbstractRule
 {
     /**

--- a/library/Rules/AlwaysValid.php
+++ b/library/Rules/AlwaysValid.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates any input as valid.
  *
@@ -16,6 +18,7 @@ namespace Respect\Validation\Rules;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class AlwaysValid extends AbstractRule
 {
     /**

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\AnyOfException;
 use Respect\Validation\Exceptions\ValidationException;
 
@@ -18,6 +19,7 @@ use function count;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class AnyOf extends AbstractComposite
 {
     /**

--- a/library/Rules/ArrayType.php
+++ b/library/Rules/ArrayType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_array;
 
 /**
@@ -19,6 +21,7 @@ use function is_array;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author João Torquato <joao.otl@gmail.com>
  */
+#[Attribute]
 final class ArrayType extends AbstractRule
 {
     /**

--- a/library/Rules/ArrayVal.php
+++ b/library/Rules/ArrayVal.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use ArrayAccess;
+use Attribute;
 use SimpleXMLElement;
 
 use function is_array;
@@ -23,6 +24,7 @@ use function is_array;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class ArrayVal extends AbstractRule
 {
     /**

--- a/library/Rules/Attribute.php
+++ b/library/Rules/Attribute.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute as BaseAttribute;
 use ReflectionException;
 use ReflectionProperty;
 use Respect\Validation\Validatable;
@@ -23,6 +24,7 @@ use function property_exists;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[BaseAttribute]
 final class Attribute extends AbstractRelated
 {
     public function __construct(string $reference, ?Validatable $rule = null, bool $mandatory = true)

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function is_null;
@@ -24,6 +25,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Base extends AbstractRule
 {
     /**

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function mb_strlen;
 use function preg_match;
@@ -20,6 +22,7 @@ use function preg_match;
  * @author Jens Segers <segers.jens@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Base64 extends AbstractRule
 {
     /**

--- a/library/Rules/Between.php
+++ b/library/Rules/Between.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Helpers\CanCompareValues;
 
@@ -18,6 +19,7 @@ use Respect\Validation\Helpers\CanCompareValues;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Between extends AbstractEnvelope
 {
     use CanCompareValues;

--- a/library/Rules/BoolType.php
+++ b/library/Rules/BoolType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_bool;
 
 /**
@@ -17,6 +19,7 @@ use function is_bool;
  * @author Devin Torres <devin@devintorres.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class BoolType extends AbstractRule
 {
     /**

--- a/library/Rules/BoolVal.php
+++ b/library/Rules/BoolVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 use function is_bool;
 
@@ -22,6 +24,7 @@ use const FILTER_VALIDATE_BOOLEAN;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class BoolVal extends AbstractRule
 {
     /**

--- a/library/Rules/Bsn.php
+++ b/library/Rules/Bsn.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_digit;
 use function intval;
 use function is_scalar;
@@ -24,6 +26,7 @@ use function strval;
  * @author Ronald Drenth <ronalddrenth@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Bsn extends AbstractRule
 {
     /**

--- a/library/Rules/Call.php
+++ b/library/Rules/Call.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Validatable;
 use Throwable;
@@ -24,6 +25,7 @@ use function set_error_handler;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Call extends AbstractRule
 {
     /**

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_callable;
 
 /**
@@ -16,6 +18,7 @@ use function is_callable;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class CallableType extends AbstractRule
 {
     /**

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_merge;
 use function call_user_func_array;
 use function count;
@@ -20,6 +22,7 @@ use function count;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Callback extends AbstractRule
 {
     /**

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_diff;
@@ -23,6 +24,7 @@ use function mb_list_encodings;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Charset extends AbstractRule
 {
     /**

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function mb_strlen;
 use function preg_replace;
@@ -21,6 +23,7 @@ use function preg_replace;
  * @author Kinn Coelho Julião <kinncj@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Cnh extends AbstractRule
 {
     /**

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_map;
 use function array_sum;
 use function count;
@@ -26,6 +28,7 @@ use function str_split;
  * @author Renato Moura <renato@naturalweb.com.br>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Cnpj extends AbstractRule
 {
     /**

--- a/library/Rules/Consonant.php
+++ b/library/Rules/Consonant.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function preg_match;
 
 /**
@@ -18,6 +20,7 @@ use function preg_match;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Consonant extends AbstractFilterRule
 {
     /**

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function in_array;
 use function is_array;
 use function is_scalar;
@@ -23,6 +25,7 @@ use function mb_strpos;
  * @author Marcelo Araujo <msaraujo@php.net>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Contains extends AbstractRule
 {
     /**

--- a/library/Rules/ContainsAny.php
+++ b/library/Rules/ContainsAny.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_map;
 
 /**
@@ -17,6 +19,7 @@ use function array_map;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Kirill Dlussky <kirill@dlussky.ru>
  */
+#[Attribute]
 final class ContainsAny extends AbstractEnvelope
 {
     /**

--- a/library/Rules/Control.php
+++ b/library/Rules/Control.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_cntrl;
 
 /**
@@ -19,6 +21,7 @@ use function ctype_cntrl;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Control extends AbstractFilterRule
 {
     /**

--- a/library/Rules/Countable.php
+++ b/library/Rules/Countable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Countable as CountableInterface;
 
 use function is_array;
@@ -20,6 +21,7 @@ use function is_array;
  * @author João Torquato <joao.otl@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Countable extends AbstractRule
 {
     /**

--- a/library/Rules/CountryCode.php
+++ b/library/Rules/CountryCode.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_column;
@@ -26,6 +27,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class CountryCode extends AbstractSearcher
 {
     /**

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function intval;
 use function mb_strlen;
 use function preg_match;
@@ -24,6 +26,7 @@ use function preg_replace;
  * @author Jean Pimentel <jeanfap@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Cpf extends AbstractRule
 {
     /**

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_keys;
@@ -29,6 +30,7 @@ use function sprintf;
  * @author William Espindola <oi@williamespindola.com.br>
  * @author Rakshit Arora <rakshit087@gmail.com>
  */
+#[Attribute]
 final class CreditCard extends AbstractRule
 {
     public const ANY = 'Any';

--- a/library/Rules/CurrencyCode.php
+++ b/library/Rules/CurrencyCode.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates currency codes in ISO 4217.
  *
@@ -17,6 +19,7 @@ namespace Respect\Validation\Rules;
  * @author Tim Strijdhorst <tstrijdhorst@users.noreply.github.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class CurrencyCode extends AbstractSearcher
 {
     /**

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 
@@ -24,6 +25,7 @@ use function strtotime;
  * @author Bruno Luiz da Silva <contato@brunoluiz.net>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Date extends AbstractRule
 {
     use CanValidateDateTime;

--- a/library/Rules/DateTime.php
+++ b/library/Rules/DateTime.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use DateTimeInterface;
 use Respect\Validation\Helpers\CanValidateDateTime;
 
@@ -21,6 +22,7 @@ use function strtotime;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class DateTime extends AbstractRule
 {
     use CanValidateDateTime;

--- a/library/Rules/Decimal.php
+++ b/library/Rules/Decimal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_numeric;
 use function is_string;
 use function number_format;
@@ -20,6 +22,7 @@ use function var_export;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Decimal extends AbstractRule
 {
     /**

--- a/library/Rules/Digit.php
+++ b/library/Rules/Digit.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_digit;
 
 /**
@@ -18,6 +20,7 @@ use function ctype_digit;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Digit extends AbstractFilterRule
 {
     /**

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Directory as NativeDirectory;
 use SplFileInfo;
 
@@ -21,6 +22,7 @@ use function is_scalar;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Directory extends AbstractRule
 {
     /**

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\DomainException;
 use Respect\Validation\Exceptions\NestedValidationException;
 use Respect\Validation\Exceptions\ValidationException;
@@ -30,6 +31,7 @@ use function mb_substr_count;
  * @author Nick Lombard <github@jigsoft.co.za>
  * @author Róbert Nagy <vrnagy@gmail.com>
  */
+#[Attribute]
 final class Domain extends AbstractRule
 {
     /**

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\EachException;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Helpers\CanValidateIterable;
@@ -22,6 +23,7 @@ use Respect\Validation\Validatable;
  * @author Nick Lombard <github@jigsoft.co.za>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Each extends AbstractRule
 {
     use CanValidateIterable;

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 
@@ -26,6 +27,7 @@ use const FILTER_VALIDATE_EMAIL;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class Email extends AbstractRule
 {
     /**

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function end;
 use function is_array;
 use function mb_strlen;
@@ -23,6 +25,7 @@ use function mb_strrpos;
  * @author Hugo Hamon <hugo.hamon@sensiolabs.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class EndsWith extends AbstractRule
 {
     /**

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates if the input is equal to some value.
  *
@@ -16,6 +18,7 @@ namespace Respect\Validation\Rules;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Hugo Hamon <hugo.hamon@sensiolabs.com>
  */
+#[Attribute]
 final class Equals extends AbstractRule
 {
     /**

--- a/library/Rules/Equivalent.php
+++ b/library/Rules/Equivalent.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function mb_strtoupper;
 
@@ -17,6 +19,7 @@ use function mb_strtoupper;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Equivalent extends AbstractRule
 {
     /**

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 
 use const FILTER_VALIDATE_INT;
@@ -20,6 +22,7 @@ use const FILTER_VALIDATE_INT;
  * @author Jean Pimentel <jeanfap@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class Even extends AbstractRule
 {
     /**

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use SplFileInfo;
 
 use function is_executable;
@@ -20,6 +21,7 @@ use function is_scalar;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Executable extends AbstractRule
 {
     /**

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use SplFileInfo;
 
 use function file_exists;
@@ -18,6 +19,7 @@ use function is_string;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author William Espindola <oi@williamespindola.com.br>
  */
+#[Attribute]
 final class Exists extends AbstractRule
 {
     /**

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use SplFileInfo;
 
 use function is_string;
@@ -22,6 +23,7 @@ use const PATHINFO_EXTENSION;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Extension extends AbstractRule
 {
     /**

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function abs;
 use function is_integer;
 use function is_numeric;
@@ -20,6 +22,7 @@ use function is_numeric;
  * @author David Meister <thedavidmeister@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Factor extends AbstractRule
 {
     /**

--- a/library/Rules/FalseVal.php
+++ b/library/Rules/FalseVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 
 use const FILTER_NULL_ON_FAILURE;
@@ -20,6 +22,7 @@ use const FILTER_VALIDATE_BOOLEAN;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class FalseVal extends AbstractRule
 {
     /**

--- a/library/Rules/Fibonacci.php
+++ b/library/Rules/Fibonacci.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_numeric;
 
 /**
@@ -18,6 +20,7 @@ use function is_numeric;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Samuel Heinzmann <samuel.heinzmann@swisscom.com>
  */
+#[Attribute]
 final class Fibonacci extends AbstractRule
 {
     /**

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use SplFileInfo;
 
 use function is_file;
@@ -20,6 +21,7 @@ use function is_string;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class File extends AbstractRule
 {
     /**

--- a/library/Rules/FilterVar.php
+++ b/library/Rules/FilterVar.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_key_exists;
@@ -30,6 +31,7 @@ use const FILTER_VALIDATE_URL;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class FilterVar extends AbstractEnvelope
 {
     private const ALLOWED_FILTERS = [

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_finite;
 use function is_numeric;
 
@@ -18,6 +20,7 @@ use function is_numeric;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Finite extends AbstractRule
 {
     /**

--- a/library/Rules/FloatType.php
+++ b/library/Rules/FloatType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_float;
 
 /**
@@ -17,6 +19,7 @@ use function is_float;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Reginaldo Junior <76regi@gmail.com>
  */
+#[Attribute]
 final class FloatType extends AbstractRule
 {
     /**

--- a/library/Rules/FloatVal.php
+++ b/library/Rules/FloatVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 use function is_float;
 
@@ -22,6 +24,7 @@ use const FILTER_VALIDATE_FLOAT;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jayson Reis <santosdosreis@gmail.com>
  */
+#[Attribute]
 final class FloatVal extends AbstractRule
 {
     /**

--- a/library/Rules/Graph.php
+++ b/library/Rules/Graph.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_graph;
 
 /**
@@ -19,6 +21,7 @@ use function ctype_graph;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Graph extends AbstractFilterRule
 {
     /**

--- a/library/Rules/GreaterThan.php
+++ b/library/Rules/GreaterThan.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates whether the input is less than a value.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class GreaterThan extends AbstractComparison
 {
     /**

--- a/library/Rules/HexRgbColor.php
+++ b/library/Rules/HexRgbColor.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates whether the input is a hex RGB color or not.
  *
  * @author Davide Pastore <pasdavide@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class HexRgbColor extends AbstractEnvelope
 {
     public function __construct()

--- a/library/Rules/Iban.php
+++ b/library/Rules/Iban.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function bcmod;
 use function is_string;
 use function ord;
@@ -24,6 +26,7 @@ use function substr;
  *
  * @author Mazen Touati <mazen_touati@hotmail.com>
  */
+#[Attribute]
 final class Iban extends AbstractRule
 {
     private const COUNTRIES_LENGTHS = [

--- a/library/Rules/Identical.php
+++ b/library/Rules/Identical.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates if the input is identical to some value.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Identical extends AbstractRule
 {
     /**

--- a/library/Rules/Image.php
+++ b/library/Rules/Image.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use finfo;
 use SplFileInfo;
 
@@ -25,6 +26,7 @@ use const FILEINFO_MIME_TYPE;
  * @author Guilherme Siani <guilherme@siani.com.br>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Image extends AbstractRule
 {
     /**

--- a/library/Rules/Imei.php
+++ b/library/Rules/Imei.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function mb_strlen;
 use function preg_replace;
@@ -21,6 +23,7 @@ use function preg_replace;
  * @author Diego Oliveira <contato@diegoholiveira.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Imei extends AbstractRule
 {
     private const IMEI_SIZE = 15;

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function in_array;
 use function is_array;
 use function mb_stripos;
@@ -21,6 +23,7 @@ use function mb_strpos;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class In extends AbstractRule
 {
     /**

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_infinite;
 use function is_numeric;
 
@@ -18,6 +20,7 @@ use function is_numeric;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Infinite extends AbstractRule
 {
     /**

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates if the input is an instance of the given class or interface.
  *
@@ -16,6 +18,7 @@ namespace Respect\Validation\Rules;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Instance extends AbstractRule
 {
     /**

--- a/library/Rules/IntType.php
+++ b/library/Rules/IntType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_int;
 
 /**
@@ -16,6 +18,7 @@ use function is_int;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class IntType extends AbstractRule
 {
     /**

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_int;
 use function is_string;
 use function preg_match;
@@ -22,6 +24,7 @@ use function preg_match;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class IntVal extends AbstractRule
 {
     /**

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function bccomp;
@@ -36,6 +37,7 @@ use const FILTER_VALIDATE_IP;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
+#[Attribute]
 final class Ip extends AbstractRule
 {
     /**

--- a/library/Rules/Isbn.php
+++ b/library/Rules/Isbn.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function implode;
 use function is_scalar;
 use function preg_match;
@@ -20,6 +22,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Moritz Fromm <moritzgitfromm@gmail.com>
  */
+#[Attribute]
 final class Isbn extends AbstractRule
 {
     /**

--- a/library/Rules/IterableType.php
+++ b/library/Rules/IterableType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Helpers\CanValidateIterable;
 
 /**
@@ -16,6 +17,7 @@ use Respect\Validation\Helpers\CanValidateIterable;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class IterableType extends AbstractRule
 {
     use CanValidateIterable;

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function function_exists;
 use function is_string;
 use function json_decode;
@@ -23,6 +25,7 @@ use const JSON_ERROR_NONE;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Json extends AbstractRule
 {
     /**

--- a/library/Rules/Key.php
+++ b/library/Rules/Key.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Validatable;
 
@@ -21,6 +22,7 @@ use function is_scalar;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Key extends AbstractRelated
 {
     /**

--- a/library/Rules/KeyNested.php
+++ b/library/Rules/KeyNested.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Rules;
 
 use ArrayAccess;
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_key_exists;
@@ -29,6 +30,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ivan Zinovyev <vanyazin@gmail.com>
  */
+#[Attribute]
 final class KeyNested extends AbstractRelated
 {
     /**

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\NonNegatable;
 use Respect\Validation\Validatable;
@@ -25,6 +26,7 @@ use function is_array;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class KeySet extends AbstractWrapper implements NonNegatable
 {
     /**

--- a/library/Rules/KeyValue.php
+++ b/library/Rules/KeyValue.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Factory;
@@ -20,6 +21,7 @@ use function in_array;
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class KeyValue extends AbstractRule
 {
     /**

--- a/library/Rules/LanguageCode.php
+++ b/library/Rules/LanguageCode.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_column;
@@ -23,6 +24,7 @@ use function sprintf;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class LanguageCode extends AbstractEnvelope
 {
     public const ALPHA2 = 'alpha-2';

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use DateTimeImmutable;
 use DateTimeInterface;
 
@@ -21,6 +22,7 @@ use function is_scalar;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jayson Reis <santosdosreis@gmail.com>
  */
+#[Attribute]
 final class LeapDate extends AbstractRule
 {
     /**

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use DateTimeInterface;
 
 use function date;
@@ -24,6 +25,7 @@ use function strtotime;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jayson Reis <santosdosreis@gmail.com>
  */
+#[Attribute]
 final class LeapYear extends AbstractRule
 {
     /**

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Countable as CountableInterface;
 use Respect\Validation\Exceptions\ComponentException;
 
@@ -32,6 +33,7 @@ use function sprintf;
  * @author João Torquato <joao.otl@gmail.com>
  * @author Marcelo Araujo <msaraujo@php.net>
  */
+#[Attribute]
 final class Length extends AbstractRule
 {
     /**

--- a/library/Rules/LessThan.php
+++ b/library/Rules/LessThan.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates whether the input is less than a value.
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class LessThan extends AbstractComparison
 {
     /**

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function mb_strtolower;
 
@@ -20,6 +22,7 @@ use function mb_strtolower;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  */
+#[Attribute]
 final class Lowercase extends AbstractRule
 {
     /**

--- a/library/Rules/Luhn.php
+++ b/library/Rules/Luhn.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_map;
 use function count;
 use function str_split;
@@ -22,6 +24,7 @@ use function str_split;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Luhn extends AbstractRule
 {
     /**

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function preg_match;
 
@@ -20,6 +22,7 @@ use function preg_match;
  * @author Fábio da Silva Ribeiro <fabiorphp@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class MacAddress extends AbstractRule
 {
     /**

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates whether the input is less than or equal to a value.
  *
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Max extends AbstractComparison
 {
     /**

--- a/library/Rules/MaxAge.php
+++ b/library/Rules/MaxAge.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates a maximum age for a given date.
  *
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class MaxAge extends AbstractAge
 {
     /**

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use finfo;
 use SplFileInfo;
 
@@ -23,6 +24,7 @@ use const FILEINFO_MIME_TYPE;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Mimetype extends AbstractRule
 {
     /**

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates whether the input is greater than or equal to a value.
  *
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Min extends AbstractComparison
 {
     /**

--- a/library/Rules/MinAge.php
+++ b/library/Rules/MinAge.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates a minimum age for a given date.
  *
@@ -17,6 +19,7 @@ namespace Respect\Validation\Rules;
  * @author Jean Pimentel <jeanfap@gmail.com>
  * @author Kennedy Tedesco <kennedyt.tw@gmail.com>
  */
+#[Attribute]
 final class MinAge extends AbstractAge
 {
     /**

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 
 use const FILTER_VALIDATE_INT;
@@ -18,6 +20,7 @@ use const FILTER_VALIDATE_INT;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  */
+#[Attribute]
 final class Multiple extends AbstractRule
 {
     /**

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_numeric;
 
 /**
@@ -18,6 +20,7 @@ use function is_numeric;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ismael Elias <ismael.esq@hotmail.com>
  */
+#[Attribute]
 final class Negative extends AbstractRule
 {
     /**

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_map;
 use function floor;
 use function mb_strlen;
@@ -26,6 +28,7 @@ use function str_split;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NfeAccessKey extends AbstractRule
 {
     /**

--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_pop;
 use function array_sum;
 use function is_numeric;
@@ -27,6 +29,7 @@ use function str_split;
  * @author Julián Gutiérrez <juliangut@gmail.com>
  * @author Senén <senen@instasent.com>
  */
+#[Attribute]
 final class Nif extends AbstractRule
 {
     /**

--- a/library/Rules/Nip.php
+++ b/library/Rules/Nip.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_map;
 use function is_scalar;
 use function preg_match;
@@ -22,6 +24,7 @@ use function str_split;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Tomasz Regdos <tomek@regdos.com>
  */
+#[Attribute]
 final class Nip extends AbstractRule
 {
     /**

--- a/library/Rules/No.php
+++ b/library/Rules/No.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function nl_langinfo;
 
 use const NOEXPR;
@@ -18,6 +20,7 @@ use const NOEXPR;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class No extends AbstractEnvelope
 {
     public function __construct(bool $useLocale = false)

--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_null;
 use function is_scalar;
 use function preg_match;
@@ -21,6 +23,7 @@ use function preg_match;
  * @author Danilo Benevides <danilobenevides01@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NoWhitespace extends AbstractRule
 {
     /**

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\NoneOfException;
 
 use function count;
@@ -17,6 +18,7 @@ use function count;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NoneOf extends AbstractComposite
 {
     /**

--- a/library/Rules/Not.php
+++ b/library/Rules/Not.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\NonNegatable;
@@ -25,6 +26,7 @@ use function sprintf;
  * @author Caio César Tavares <caiotava@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Not extends AbstractRule
 {
     /**

--- a/library/Rules/NotBlank.php
+++ b/library/Rules/NotBlank.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use stdClass;
 
 use function array_filter;
@@ -23,6 +24,7 @@ use function trim;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NotBlank extends AbstractRule
 {
     /**

--- a/library/Rules/NotEmoji.php
+++ b/library/Rules/NotEmoji.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function implode;
 use function is_string;
 use function preg_match;
@@ -18,6 +20,7 @@ use function preg_match;
  *
  * @author Mazen Touati <mazen_touati@hotmail.com>
  */
+#[Attribute]
 final class NotEmoji extends AbstractRule
 {
     private const RANGES = [

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function trim;
 
@@ -19,6 +21,7 @@ use function trim;
  * @author Bram Van der Sype <bram.vandersype@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NotEmpty extends AbstractRule
 {
     /**

--- a/library/Rules/NotOptional.php
+++ b/library/Rules/NotOptional.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Helpers\CanValidateUndefined;
 
 /**
@@ -19,6 +20,7 @@ use Respect\Validation\Helpers\CanValidateUndefined;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NotOptional extends AbstractRule
 {
     use CanValidateUndefined;

--- a/library/Rules/NullType.php
+++ b/library/Rules/NullType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_null;
 
 /**
@@ -17,6 +19,7 @@ use function is_null;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NullType extends AbstractRule
 {
     /**

--- a/library/Rules/Nullable.php
+++ b/library/Rules/Nullable.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates the given input with a defined rule when input is not NULL.
  *
  * @author Jens Segers <segers.jens@gmail.com>
  */
+#[Attribute]
 final class Nullable extends AbstractWrapper
 {
     /**

--- a/library/Rules/Number.php
+++ b/library/Rules/Number.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_nan;
 use function is_numeric;
 
@@ -19,6 +21,7 @@ use function is_numeric;
  * @author Ismael Elias <ismael.esq@hotmail.com>
  * @author Vitaliy <reboot.m@gmail.com>
  */
+#[Attribute]
 final class Number extends AbstractRule
 {
     /**

--- a/library/Rules/NumericVal.php
+++ b/library/Rules/NumericVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_numeric;
 
 /**
@@ -18,6 +20,7 @@ use function is_numeric;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class NumericVal extends AbstractRule
 {
     /**

--- a/library/Rules/ObjectType.php
+++ b/library/Rules/ObjectType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_object;
 
 /**
@@ -17,6 +19,7 @@ use function is_object;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class ObjectType extends AbstractRule
 {
     /**

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 use function is_numeric;
 
@@ -21,6 +23,7 @@ use const FILTER_VALIDATE_INT;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  */
+#[Attribute]
 final class Odd extends AbstractRule
 {
     /**

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\OneOfException;
 use Respect\Validation\Exceptions\ValidationException;
 
@@ -19,6 +20,7 @@ use function count;
  * @author Bradyn Poulsen <bradyn@bradynpoulsen.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class OneOf extends AbstractComposite
 {
     /**

--- a/library/Rules/Optional.php
+++ b/library/Rules/Optional.php
@@ -9,11 +9,13 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Helpers\CanValidateUndefined;
 
 /**
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Optional extends AbstractWrapper
 {
     use CanValidateUndefined;

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function floor;
 use function is_numeric;
 use function sqrt;
@@ -21,6 +23,7 @@ use function sqrt;
  * @author Kleber Hamada Sato <kleberhs007@yahoo.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class PerfectSquare extends AbstractRule
 {
     /**

--- a/library/Rules/Pesel.php
+++ b/library/Rules/Pesel.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function preg_match;
 
@@ -19,6 +21,7 @@ use function preg_match;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Tomasz Regdos <tomek@regdos.com>
  */
+#[Attribute]
 final class Pesel extends AbstractRule
 {
     /**

--- a/library/Rules/Phone.php
+++ b/library/Rules/Phone.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
 use Respect\Validation\Exceptions\ComponentException;
@@ -28,6 +29,7 @@ use function sprintf;
  * @author Graham Campbell <graham@mineuk.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Phone extends AbstractRule
 {
     /**

--- a/library/Rules/PhpLabel.php
+++ b/library/Rules/PhpLabel.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function preg_match;
 
@@ -19,6 +21,7 @@ use function preg_match;
  * @author Emmerson Siqueira <emmersonsiqueira@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class PhpLabel extends AbstractRule
 {
     /**

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function mb_strlen;
 use function preg_match;
@@ -21,6 +23,7 @@ use function preg_replace;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Pis extends AbstractRule
 {
     /**

--- a/library/Rules/PolishIdCard.php
+++ b/library/Rules/PolishIdCard.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function ord;
 use function preg_match;
@@ -20,6 +22,7 @@ use function preg_match;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class PolishIdCard extends AbstractRule
 {
     private const ASCII_CODE_0 = 48;

--- a/library/Rules/PortugueseNif.php
+++ b/library/Rules/PortugueseNif.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_keys;
 use function array_map;
 use function array_pop;
@@ -27,6 +29,7 @@ use function strlen;
  *
  * @author Gonçalo Andrade <goncalo.andrade95@gmail.com>
  */
+#[Attribute]
 final class PortugueseNif extends AbstractRule
 {
     /**

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_numeric;
 
 /**
@@ -18,6 +20,7 @@ use function is_numeric;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ismael Elias <ismael.esq@hotmail.com>
  */
+#[Attribute]
 final class Positive extends AbstractRule
 {
     /**

--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function sprintf;
@@ -20,6 +21,7 @@ use function sprintf;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class PostalCode extends AbstractEnvelope
 {
     private const DEFAULT_PATTERN = '/^$/';

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ceil;
 use function is_numeric;
 use function sqrt;
@@ -22,6 +24,7 @@ use function sqrt;
  * @author Ismael Elias <ismael.esq@hotmail.com>
  * @author Kleber Hamada Sato <kleberhs007@yahoo.com>
  */
+#[Attribute]
 final class PrimeNumber extends AbstractRule
 {
     /**

--- a/library/Rules/Printable.php
+++ b/library/Rules/Printable.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_print;
 
 /**
@@ -20,6 +22,7 @@ use function ctype_print;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Printable extends AbstractFilterRule
 {
     /**

--- a/library/Rules/PublicDomainSuffix.php
+++ b/library/Rules/PublicDomainSuffix.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Helpers\CanValidateUndefined;
 use Respect\Validation\Helpers\DomainInfo;
 
@@ -18,6 +19,7 @@ use function in_array;
 use function is_scalar;
 use function strtoupper;
 
+#[Attribute]
 final class PublicDomainSuffix extends AbstractRule
 {
     use CanValidateUndefined;

--- a/library/Rules/Punct.php
+++ b/library/Rules/Punct.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_punct;
 
 /**
@@ -19,6 +21,7 @@ use function ctype_punct;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Punct extends AbstractFilterRule
 {
     /**

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Psr\Http\Message\StreamInterface;
 use SplFileInfo;
 
@@ -21,6 +22,7 @@ use function is_string;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Readable extends AbstractRule
 {
     /**

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 use function preg_match;
 
@@ -19,6 +21,7 @@ use function preg_match;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Regex extends AbstractRule
 {
     /**

--- a/library/Rules/ResourceType.php
+++ b/library/Rules/ResourceType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_resource;
 
 /**
@@ -16,6 +18,7 @@ use function is_resource;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class ResourceType extends AbstractRule
 {
     /**

--- a/library/Rules/Roman.php
+++ b/library/Rules/Roman.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 /**
  * Validates if the input is a Roman numeral.
  *
@@ -16,6 +18,7 @@ namespace Respect\Validation\Rules;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  */
+#[Attribute]
 final class Roman extends AbstractEnvelope
 {
     public function __construct()

--- a/library/Rules/ScalarVal.php
+++ b/library/Rules/ScalarVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_scalar;
 
 /**
@@ -16,6 +18,7 @@ use function is_scalar;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class ScalarVal extends AbstractRule
 {
     /**

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Respect\Validation\Exceptions\ComponentException;
@@ -28,6 +29,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Felipe Stival <v0idpwn@gmail.com>
  */
+#[Attribute]
 final class Size extends AbstractRule
 {
     /**

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function mb_strstr;
 use function preg_match;
@@ -21,6 +23,7 @@ use function preg_match;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Slug extends AbstractRule
 {
     /**

--- a/library/Rules/Sorted.php
+++ b/library/Rules/Sorted.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_values;
@@ -24,6 +25,7 @@ use function str_split;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Mikhail Vyrtsev <reeywhaar@gmail.com>
  */
+#[Attribute]
 final class Sorted extends AbstractRule
 {
     public const ASCENDING = 'ASC';

--- a/library/Rules/Space.php
+++ b/library/Rules/Space.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_space;
 
 /**
@@ -19,6 +21,7 @@ use function ctype_space;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Space extends AbstractFilterRule
 {
     /**

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_array;
 use function is_string;
 use function mb_stripos;
@@ -22,6 +24,7 @@ use function reset;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Marcelo Araujo <msaraujo@php.net>
  */
+#[Attribute]
 final class StartsWith extends AbstractRule
 {
     /**

--- a/library/Rules/StringType.php
+++ b/library/Rules/StringType.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 
 /**
@@ -17,6 +19,7 @@ use function is_string;
  * @author Alexandre Gomes Gaigalas <alganet@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class StringType extends AbstractRule
 {
     /**

--- a/library/Rules/StringVal.php
+++ b/library/Rules/StringVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_object;
 use function is_scalar;
 use function method_exists;
@@ -19,6 +21,7 @@ use function method_exists;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class StringVal extends AbstractRule
 {
     /**

--- a/library/Rules/SubdivisionCode.php
+++ b/library/Rules/SubdivisionCode.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Helpers\CountryInfo;
 
 use function array_keys;
@@ -22,6 +23,7 @@ use function array_keys;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Mazen Touati <mazen_touati@hotmail.com>
  */
+#[Attribute]
 final class SubdivisionCode extends AbstractSearcher
 {
     /**

--- a/library/Rules/Subset.php
+++ b/library/Rules/Subset.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_diff;
 use function is_array;
 
@@ -18,6 +20,7 @@ use function is_array;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Singwai Chan <singwai.chan@live.com>
  */
+#[Attribute]
 final class Subset extends AbstractRule
 {
     /**

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use SplFileInfo;
 
 use function is_link;
@@ -20,6 +21,7 @@ use function is_string;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Gus Antoniassi <gus.antoniassi@gmail.com>
  */
+#[Attribute]
 final class SymbolicLink extends AbstractRule
 {
     /**

--- a/library/Rules/Time.php
+++ b/library/Rules/Time.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 
@@ -23,6 +24,7 @@ use function strtotime;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Time extends AbstractRule
 {
     use CanValidateDateTime;

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function in_array;
 use function is_scalar;
 use function mb_strtoupper;
@@ -21,6 +23,7 @@ use function mb_strtoupper;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class Tld extends AbstractRule
 {
     /**

--- a/library/Rules/TrueVal.php
+++ b/library/Rules/TrueVal.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function filter_var;
 
 use const FILTER_NULL_ON_FAILURE;
@@ -20,6 +22,7 @@ use const FILTER_VALIDATE_BOOLEAN;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class TrueVal extends AbstractRule
 {
     /**

--- a/library/Rules/Type.php
+++ b/library/Rules/Type.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_keys;
@@ -24,6 +25,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class Type extends AbstractRule
 {
     /**

--- a/library/Rules/Unique.php
+++ b/library/Rules/Unique.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function array_is_list;
 use function in_array;
 use function is_array;
@@ -20,6 +22,7 @@ use function is_array;
  * @author Krzysztof Śmiałek <admin@avensome.net>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class Unique extends AbstractRule
 {
     /**

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Psr\Http\Message\UploadedFileInterface;
 use SplFileInfo;
 
@@ -21,6 +22,7 @@ use function is_uploaded_file;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Paul Karikari <paulkarikari1@gmail.com>
  */
+#[Attribute]
 final class Uploaded extends AbstractRule
 {
     /**

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function mb_strtoupper;
 
@@ -20,6 +22,7 @@ use function mb_strtoupper;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Jean Pimentel <jeanfap@gmail.com>
  */
+#[Attribute]
 final class Uppercase extends AbstractRule
 {
     /**

--- a/library/Rules/Url.php
+++ b/library/Rules/Url.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use const FILTER_VALIDATE_URL;
@@ -18,6 +19,7 @@ use const FILTER_VALIDATE_URL;
  *
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Url extends AbstractEnvelope
 {
     /**

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function is_string;
@@ -24,6 +25,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Michael Weimann <mail@michael-weimann.eu>
  */
+#[Attribute]
 final class Uuid extends AbstractRule
 {
     /**

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function preg_match;
 
@@ -20,6 +22,7 @@ use function preg_match;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Version extends AbstractRule
 {
     /**

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\ComponentException;
 
 use function array_keys;
@@ -25,6 +26,7 @@ use function sprintf;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Ricardo Gobbo <ricardo@clicknow.com.br>
  */
+#[Attribute]
 final class VideoUrl extends AbstractRule
 {
     private const SERVICES = [

--- a/library/Rules/Vowel.php
+++ b/library/Rules/Vowel.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function preg_match;
 
 /**
@@ -17,6 +19,7 @@ use function preg_match;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Nick Lombard <github@jigsoft.co.za>
  */
+#[Attribute]
 final class Vowel extends AbstractFilterRule
 {
     /**

--- a/library/Rules/When.php
+++ b/library/Rules/When.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Respect\Validation\Exceptions\AlwaysInvalidException;
 use Respect\Validation\Validatable;
 
@@ -20,6 +21,7 @@ use Respect\Validation\Validatable;
  * @author Henrique Moody <henriquemoody@gmail.com>
  * @author Hugo Hamon <hugo.hamon@sensiolabs.com>
  */
+#[Attribute]
 final class When extends AbstractRule
 {
     /**

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
 use Psr\Http\Message\StreamInterface;
 use SplFileInfo;
 
@@ -21,6 +22,7 @@ use function is_writable;
  * @author Danilo Correa <danilosilva87@gmail.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Writable extends AbstractRule
 {
     /**

--- a/library/Rules/Xdigit.php
+++ b/library/Rules/Xdigit.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function ctype_xdigit;
 
 /**
  * @author Andre Ramaciotti <andre@ramaciotti.com>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Xdigit extends AbstractFilterRule
 {
     /**

--- a/library/Rules/Yes.php
+++ b/library/Rules/Yes.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
 
+use Attribute;
+
 use function is_string;
 use function nl_langinfo;
 use function preg_match;
@@ -21,6 +23,7 @@ use const YESEXPR;
  * @author Cameron Hall <me@chall.id.au>
  * @author Henrique Moody <henriquemoody@gmail.com>
  */
+#[Attribute]
 final class Yes extends AbstractRule
 {
     /**


### PR DESCRIPTION
### Overview

Marks all Respect rules as attributes

### Why?

This way we have type-hint support when using some of these rules as attributes. See this https://github.com/Attributes-PHP/validation