### PR TITLE
Change how we're writing Pest tests

### DIFF
--- a/tests/feature/AssertWithKeysTest.php
+++ b/tests/feature/AssertWithKeysTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectFullMessage(
+test('Scenario #1', catchFullMessage(
     fn() => v::create()
         ->key(
             'mysql',
@@ -36,17 +36,17 @@ test('Scenario #1', expectFullMessage(
                 'password' => 42,
             ],
         ]),
-    <<<'FULL_MESSAGE'
-    - the given data must pass all the rules
-      - `.mysql` must pass all the rules
-        - `.host` must be a string
-        - `.user` must be present
-        - `.password` must be present
-        - `.schema` must be a string
-      - `.postgresql` must pass all the rules
-        - `.host` must be present
-        - `.user` must be a string
-        - `.password` must be a string
-        - `.schema` must be present
-    FULL_MESSAGE,
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - the given data must pass all the rules
+              - `.mysql` must pass all the rules
+                - `.host` must be a string
+                - `.user` must be present
+                - `.password` must be present
+                - `.schema` must be a string
+              - `.postgresql` must pass all the rules
+                - `.host` must be present
+                - `.user` must be a string
+                - `.password` must be a string
+                - `.schema` must be present
+            FULL_MESSAGE)
 ));

--- a/tests/feature/AssertWithPropertiesTest.php
+++ b/tests/feature/AssertWithPropertiesTest.php
@@ -7,9 +7,26 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectFullMessage(
-    function (): void {
-        $array = [
+test('Scenario #1', catchFullMessage(
+    fn () => v::create()
+        ->property(
+            'mysql',
+            v::create()
+                ->property('host', v::stringType())
+                ->property('user', v::stringType())
+                ->property('password', v::stringType())
+                ->property('schema', v::stringType()),
+        )
+        ->property(
+            'postgresql',
+            v::create()
+                ->property('host', v::stringType())
+                ->property('user', v::stringType())
+                ->property('password', v::stringType())
+                ->property('schema', v::stringType()),
+        )
+        ->setName('the given data')
+        ->assert(json_decode((string) json_encode([
             'mysql' => [
                 'host' => 42,
                 'user' => 'user',
@@ -22,33 +39,12 @@ test('Scenario #1', expectFullMessage(
                 'password' => 'password',
                 'schema' => 'schema',
             ],
-        ];
-        $object = json_decode((string) json_encode($array));
-        v::create()
-            ->property(
-                'mysql',
-                v::create()
-                    ->property('host', v::stringType())
-                    ->property('user', v::stringType())
-                    ->property('password', v::stringType())
-                    ->property('schema', v::stringType()),
-            )
-            ->property(
-                'postgresql',
-                v::create()
-                    ->property('host', v::stringType())
-                    ->property('user', v::stringType())
-                    ->property('password', v::stringType())
-                    ->property('schema', v::stringType()),
-            )
-            ->setName('the given data')
-            ->assert($object);
-    },
-    <<<'FULL_MESSAGE'
-    - the given data must pass all the rules
-      - `.mysql` must pass the rules
-        - `.host` must be a string
-      - `.postgresql` must pass the rules
-        - `.user` must be a string
-    FULL_MESSAGE,
+        ]))),
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - the given data must pass all the rules
+          - `.mysql` must pass the rules
+            - `.host` must be a string
+          - `.postgresql` must pass the rules
+            - `.user` must be a string
+        FULL_MESSAGE)
 ));

--- a/tests/feature/AssertWithTemplatesTest.php
+++ b/tests/feature/AssertWithTemplatesTest.php
@@ -7,30 +7,34 @@
 
 declare(strict_types=1);
 
-test('Template as a string in the chain', expectAll(
+test('Template as a string in the chain', catchAll(
     fn() => v::alwaysInvalid()->setTemplate('My string template in the chain')->assert(1),
-    'My string template in the chain',
-    '- My string template in the chain',
-    ['alwaysInvalid' => 'My string template in the chain'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('My string template in the chain')
+        ->and($fullMessage)->toBe('- My string template in the chain')
+        ->and($messages)->toBe(['alwaysInvalid' => 'My string template in the chain']),
 ));
 
-test('Template as an array in the chain', expectAll(
+test('Template as an array in the chain', catchAll(
     fn() => v::alwaysInvalid()->setTemplates(['alwaysInvalid' => 'My array template in the chain'])->assert(1),
-    'My array template in the chain',
-    '- My array template in the chain',
-    ['alwaysInvalid' => 'My array template in the chain'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('My array template in the chain')
+        ->and($fullMessage)->toBe('- My array template in the chain')
+        ->and($messages)->toBe(['alwaysInvalid' => 'My array template in the chain']),
 ));
 
-test('Runtime template as string', expectAll(
+test('Runtime template as string', catchAll(
     fn() => v::alwaysInvalid()->assert(1, 'My runtime template as string'),
-    'My runtime template as string',
-    '- My runtime template as string',
-    ['alwaysInvalid' => 'My runtime template as string'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('My runtime template as string')
+        ->and($fullMessage)->toBe('- My runtime template as string')
+        ->and($messages)->toBe(['alwaysInvalid' => 'My runtime template as string']),
 ));
 
-test('Runtime template as an array', expectAll(
+test('Runtime template as an array', catchAll(
     fn() => v::alwaysInvalid()->assert(1, ['alwaysInvalid' => 'My runtime template an array']),
-    'My runtime template an array',
-    '- My runtime template an array',
-    ['alwaysInvalid' => 'My runtime template an array'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('My runtime template an array')
+        ->and($fullMessage)->toBe('- My runtime template an array')
+        ->and($messages)->toBe(['alwaysInvalid' => 'My runtime template an array']),
 ));

--- a/tests/feature/DoNotRelyOnNestedValidationExceptionInterfaceForCheckTest.php
+++ b/tests/feature/DoNotRelyOnNestedValidationExceptionInterfaceForCheckTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 use Respect\Validation\Validator;
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => Validator::alnum('__')->lengthBetween(1, 15)->noWhitespace()->assert('really messed up screen#name'),
-    '"really messed up screen#name" must contain only letters (a-z), digits (0-9), and "__"',
+    fn(string $message) => expect($message)->toBe('"really messed up screen#name" must contain only letters (a-z), digits (0-9), and "__"')
 ));

--- a/tests/feature/GetFullMessageShouldIncludeAllValidationMessagesInAChainTest.php
+++ b/tests/feature/GetFullMessageShouldIncludeAllValidationMessagesInAChainTest.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 use Respect\Validation\Validator;
 
-test('Scenario #1', expectFullMessage(
+test('Scenario #1', catchFullMessage(
     fn() => Validator::stringType()->lengthBetween(2, 15)->assert(0),
-    <<<'FULL_MESSAGE'
-    - 0 must pass all the rules
-      - 0 must be a string
-      - 0 must be a countable value or a string
-    FULL_MESSAGE,
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - 0 must pass all the rules
+          - 0 must be a string
+          - 0 must be a countable value or a string
+        FULL_MESSAGE)
 ));

--- a/tests/feature/GetMessagesShouldIncludeAllValidationMessagesInAChainTest.php
+++ b/tests/feature/GetMessagesShouldIncludeAllValidationMessagesInAChainTest.php
@@ -7,23 +7,19 @@
 
 declare(strict_types=1);
 
-use Respect\Validation\Validator;
-
 date_default_timezone_set('UTC');
 
-test('Scenario #1', expectMessages(
-    function (): void {
-        Validator::create()
-            ->key('username', Validator::lengthBetween(2, 32))->key('birthdate', Validator::dateTime())
-            ->key('password', Validator::notEmpty())
-            ->key('email', Validator::email())
-            ->assert(['username' => 'u', 'birthdate' => 'Not a date', 'password' => '']);
-    },
-    [
+test('Scenario #1', catchMessages(
+    fn () => v::create()
+        ->key('username', v::lengthBetween(2, 32))->key('birthdate', v::dateTime())
+        ->key('password', v::notEmpty())
+        ->key('email', v::email())
+        ->assert(['username' => 'u', 'birthdate' => 'Not a date', 'password' => '']),
+    fn(array $messages) => expect($messages)->toBe([
         '__root__' => '`["username": "u", "birthdate": "Not a date", "password": ""]` must pass all the rules',
         'username' => 'The length of `.username` must be between 2 and 32',
         'birthdate' => '`.birthdate` must be a valid date/time',
         'password' => '`.password` must not be empty',
         'email' => '`.email` must be present',
-    ],
+    ])
 ));

--- a/tests/feature/GetMessagesTest.php
+++ b/tests/feature/GetMessagesTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessages(
+test('Scenario #1', catchMessages(
     fn() => v::create()
         ->key('mysql', v::create()
             ->key('host', v::stringType())
@@ -19,7 +19,7 @@ test('Scenario #1', expectMessages(
             ->key('password', v::stringType())
             ->key('schema', v::stringType()))
         ->assert(['mysql' => ['host' => 42, 'schema' => 42], 'postgresql' => ['user' => 42, 'password' => 42]]),
-    [
+    fn(array $messages) => expect($messages)->toBe([
         '__root__' => '`["mysql": ["host": 42, "schema": 42], "postgresql": ["user": 42, "password": 42]]` must pass all the rules',
         'mysql' => [
             '__root__' => '`.mysql` must pass all the rules',
@@ -35,5 +35,5 @@ test('Scenario #1', expectMessages(
             'password' => '`.password` must be a string',
             'schema' => '`.schema` must be present',
         ],
-    ],
+    ])
 ));

--- a/tests/feature/GetMessagesWithReplacementsTest.php
+++ b/tests/feature/GetMessagesWithReplacementsTest.php
@@ -7,48 +7,46 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessages(
-    function (): void {
-        v::create()
-            ->key(
-                'mysql',
-                v::create()
-                    ->key('host', v::stringType())
-                    ->key('user', v::stringType())
-                    ->key('password', v::stringType())
-                    ->key('schema', v::stringType()),
-            )
-            ->key(
-                'postgresql',
-                v::create()
-                    ->key('host', v::stringType())
-                    ->key('user', v::stringType())
-                    ->key('password', v::stringType())
-                    ->key('schema', v::stringType()),
-            )
-            ->assert(
-                [
-                    'mysql' => [
-                        'host' => 42,
-                        'schema' => 42,
-                    ],
-                    'postgresql' => [
-                        'user' => 42,
-                        'password' => 42,
-                    ],
+test('Scenario #1', catchMessages(
+    fn () => v::create()
+        ->key(
+            'mysql',
+            v::create()
+                ->key('host', v::stringType())
+                ->key('user', v::stringType())
+                ->key('password', v::stringType())
+                ->key('schema', v::stringType()),
+        )
+        ->key(
+            'postgresql',
+            v::create()
+                ->key('host', v::stringType())
+                ->key('user', v::stringType())
+                ->key('password', v::stringType())
+                ->key('schema', v::stringType()),
+        )
+        ->assert(
+            [
+                'mysql' => [
+                    'host' => 42,
+                    'schema' => 42,
                 ],
-                [
-                    'mysql' => [
-                        'user' => 'Value should be a MySQL username',
-                        'host' => '`{{name}}` should be a MySQL host',
-                    ],
-                    'postgresql' => [
-                        'schema' => 'You must provide a valid PostgreSQL schema',
-                    ],
+                'postgresql' => [
+                    'user' => 42,
+                    'password' => 42,
                 ],
-            );
-    },
-    [
+            ],
+            [
+                'mysql' => [
+                    'user' => 'Value should be a MySQL username',
+                    'host' => '`{{name}}` should be a MySQL host',
+                ],
+                'postgresql' => [
+                    'schema' => 'You must provide a valid PostgreSQL schema',
+                ],
+            ],
+        ),
+    fn(array $messages) => expect($messages)->toBe([
         '__root__' => '`["mysql": ["host": 42, "schema": 42], "postgresql": ["user": 42, "password": 42]]` must pass all the rules',
         'mysql' => [
             '__root__' => '`.mysql` must pass all the rules',
@@ -64,5 +62,5 @@ test('Scenario #1', expectMessages(
             'password' => '`.password` must be a string',
             'schema' => 'You must provide a valid PostgreSQL schema',
         ],
-    ],
+    ])
 ));

--- a/tests/feature/Issues/Issue1033Test.php
+++ b/tests/feature/Issues/Issue1033Test.php
@@ -7,19 +7,20 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/1033', expectAll(
+test('https://github.com/Respect/Validation/issues/1033', catchAll(
     fn() => v::each(v::equals(1))->assert(['A', 'B', 'B']),
-    '`.0` must be equal to 1',
-    <<<'FULL_MESSAGE'
-    - Each item in `["A", "B", "B"]` must be valid
-      - `.0` must be equal to 1
-      - `.1` must be equal to 1
-      - `.2` must be equal to 1
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in `["A", "B", "B"]` must be valid',
-        0 => '`.0` must be equal to 1',
-        1 => '`.1` must be equal to 1',
-        2 => '`.2` must be equal to 1',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must be equal to 1')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - Each item in `["A", "B", "B"]` must be valid
+              - `.0` must be equal to 1
+              - `.1` must be equal to 1
+              - `.2` must be equal to 1
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in `["A", "B", "B"]` must be valid',
+            0 => '`.0` must be equal to 1',
+            1 => '`.1` must be equal to 1',
+            2 => '`.2` must be equal to 1',
+        ])
 ));

--- a/tests/feature/Issues/Issue1244Test.php
+++ b/tests/feature/Issues/Issue1244Test.php
@@ -7,9 +7,10 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/1244', expectAll(
+test('https://github.com/Respect/Validation/issues/1244', catchAll(
     fn() => v::key('firstname', v::notBlank()->setName('First Name'))->assert([]),
-    'First Name must be present',
-    '- First Name must be present',
-    ['firstname' => 'First Name must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('First Name must be present')
+        ->and($fullMessage)->toBe('- First Name must be present')
+        ->and($messages)->toBe(['firstname' => 'First Name must be present'])
 ));

--- a/tests/feature/Issues/Issue1289Test.php
+++ b/tests/feature/Issues/Issue1289Test.php
@@ -16,7 +16,7 @@ use Respect\Validation\Rules\StringType;
 use Respect\Validation\Rules\StringVal;
 use Respect\Validation\Validator;
 
-test('https://github.com/Respect/Validation/issues/1289', expectAll(
+test('https://github.com/Respect/Validation/issues/1289', catchAll(
     fn() => Validator::create(
         new Each(
             Validator::create(
@@ -38,30 +38,31 @@ test('https://github.com/Respect/Validation/issues/1289', expectAll(
             ),
         ),
     )
-        ->assert([
-            [
-                'default' => 2,
-                'description' => [],
-                'children' => ['nope'],
+            ->assert([
+                [
+                    'default' => 2,
+                    'description' => [],
+                    'children' => ['nope'],
+                ],
+            ]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0.default` must be a string')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - `.0` must pass the rules
+              - `.default` must pass one of the rules
+                - `.default` must be a string
+                - `.default` must be a boolean
+              - `.description` must be a string value
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            0 => [
+                '__root__' => '`.0` must pass the rules',
+                'default' => [
+                    '__root__' => '`.default` must pass one of the rules',
+                    'stringType' => '`.default` must be a string',
+                    'boolType' => '`.default` must be a boolean',
+                ],
+                'description' => '`.description` must be a string value',
             ],
-        ]),
-    '`.0.default` must be a string',
-    <<<'FULL_MESSAGE'
-    - `.0` must pass the rules
-      - `.default` must pass one of the rules
-        - `.default` must be a string
-        - `.default` must be a boolean
-      - `.description` must be a string value
-    FULL_MESSAGE,
-    [
-        0 => [
-            '__root__' => '`.0` must pass the rules',
-            'default' => [
-                '__root__' => '`.default` must pass one of the rules',
-                'stringType' => '`.default` must be a string',
-                'boolType' => '`.default` must be a boolean',
-            ],
-            'description' => '`.description` must be a string value',
-        ],
-    ],
+        ])
 ));

--- a/tests/feature/Issues/Issue1333Test.php
+++ b/tests/feature/Issues/Issue1333Test.php
@@ -7,17 +7,18 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/1333', expectAll(
+test('https://github.com/Respect/Validation/issues/1333', catchAll(
     fn() => v::noWhitespace()->email()->setName('User Email')->assert('not email'),
-    'User Email must not contain whitespaces',
-    <<<'FULL_MESSAGE'
-    - User Email must pass all the rules
-      - User Email must not contain whitespaces
-      - User Email must be a valid email address
-    FULL_MESSAGE,
-    [
-        '__root__' => 'User Email must pass all the rules',
-        'noWhitespace' => 'User Email must not contain whitespaces',
-        'email' => 'User Email must be a valid email address',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('User Email must not contain whitespaces')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - User Email must pass all the rules
+              - User Email must not contain whitespaces
+              - User Email must be a valid email address
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'User Email must pass all the rules',
+            'noWhitespace' => 'User Email must not contain whitespaces',
+            'email' => 'User Email must be a valid email address',
+        ])
 ));

--- a/tests/feature/Issues/Issue1334Test.php
+++ b/tests/feature/Issues/Issue1334Test.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/1334', expectAll(
+test('https://github.com/Respect/Validation/issues/1334', catchAll(
     function (): void {
         v::notEmpty()->iterableType()->each(
             v::key('street', v::stringType()->notEmpty())
@@ -22,28 +22,29 @@ test('https://github.com/Respect/Validation/issues/1334', expectAll(
             ],
         );
     },
-    '`.0.street` must be present',
-    <<<'FULL_MESSAGE'
-    - Each item in `[["region": "Oregon", "country": "USA", "other": 123], ["street": "", "region": "Oregon", "country": "USA"], ["s ... ]` must be valid
-      - `.0` must pass the rules
-        - `.street` must be present
-        - `.other` must pass the rules
-          - `.other` must be a string or must be null
-      - `.1` must pass the rules
-        - `.street` must not be empty
-      - `.2` must pass the rules
-        - `.street` must be a string
-    FULL_MESSAGE,
-    [
-        'each' => [
-            '__root__' => 'Each item in `[["region": "Oregon", "country": "USA", "other": 123], ["street": "", "region": "Oregon", "country": "USA"], ["s ... ]` must be valid',
-            0 => [
-                '__root__' => '`.0` must pass the rules',
-                'street' => '`.street` must be present',
-                'other' => '`.other` must be a string or must be null',
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0.street` must be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - Each item in `[["region": "Oregon", "country": "USA", "other": 123], ["street": "", "region": "Oregon", "country": "USA"], ["s ... ]` must be valid
+              - `.0` must pass the rules
+                - `.street` must be present
+                - `.other` must pass the rules
+                  - `.other` must be a string or must be null
+              - `.1` must pass the rules
+                - `.street` must not be empty
+              - `.2` must pass the rules
+                - `.street` must be a string
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            'each' => [
+                '__root__' => 'Each item in `[["region": "Oregon", "country": "USA", "other": 123], ["street": "", "region": "Oregon", "country": "USA"], ["s ... ]` must be valid',
+                0 => [
+                    '__root__' => '`.0` must pass the rules',
+                    'street' => '`.street` must be present',
+                    'other' => '`.other` must be a string or must be null',
+                ],
+                1 => '`.street` must not be empty',
+                2 => '`.street` must be a string',
             ],
-            1 => '`.street` must not be empty',
-            2 => '`.street` must be a string',
-        ],
-    ],
+        ])
 ));

--- a/tests/feature/Issues/Issue1376Test.php
+++ b/tests/feature/Issues/Issue1376Test.php
@@ -7,32 +7,33 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/1376', expectAll(
+test('https://github.com/Respect/Validation/issues/1376', catchAll(
     fn() => v::create()
         ->property('title', v::lengthBetween(2, 3)->stringType())
         ->property('description', v::stringType())
         ->property('author', v::intType()->lengthBetween(1, 2))
         ->property('user', v::intVal()->lengthBetween(1, 2))
         ->assert((object) ['author' => 'foo']),
-    '`.title` must be present',
-    <<<'FULL_MESSAGE'
-    - `stdClass { +$author="foo" }` must pass all the rules
-      - `.title` must be present
-      - `.description` must be present
-      - `.author` must pass all the rules
-        - `.author` must be an integer
-        - The length of `.author` must be between 1 and 2
-      - `.user` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`stdClass { +$author="foo" }` must pass all the rules',
-        'title' => '`.title` must be present',
-        'description' => '`.description` must be present',
-        'author' => [
-            '__root__' => '`.author` must pass all the rules',
-            'intType' => '`.author` must be an integer',
-            'lengthBetween' => 'The length of `.author` must be between 1 and 2',
-        ],
-        'user' => '`.user` must be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.title` must be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - `stdClass { +$author="foo" }` must pass all the rules
+              - `.title` must be present
+              - `.description` must be present
+              - `.author` must pass all the rules
+                - `.author` must be an integer
+                - The length of `.author` must be between 1 and 2
+              - `.user` must be present
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`stdClass { +$author="foo" }` must pass all the rules',
+            'title' => '`.title` must be present',
+            'description' => '`.description` must be present',
+            'author' => [
+                '__root__' => '`.author` must pass all the rules',
+                'intType' => '`.author` must be an integer',
+                'lengthBetween' => 'The length of `.author` must be between 1 and 2',
+            ],
+            'user' => '`.user` must be present',
+        ])
 ));

--- a/tests/feature/Issues/Issue1469Test.php
+++ b/tests/feature/Issues/Issue1469Test.php
@@ -7,59 +7,59 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/1469', expectAll(
-    function (): void {
-        v::create()
-            ->arrayVal()
-            ->keySet(
-                v::key(
-                    'order_items',
-                    v::create()
-                        ->arrayVal()
-                        ->each(
-                            v::keySet(
-                                v::key('product_title', v::stringVal()->notEmpty()),
-                                v::key('quantity', v::intVal()->notEmpty()),
-                            )
+test('https://github.com/Respect/Validation/issues/1469', catchAll(
+    fn () => v::create()
+        ->arrayVal()
+        ->keySet(
+            v::key(
+                'order_items',
+                v::create()
+                    ->arrayVal()
+                    ->each(
+                        v::keySet(
+                            v::key('product_title', v::stringVal()->notEmpty()),
+                            v::key('quantity', v::intVal()->notEmpty()),
                         )
-                        ->notEmpty()
-                ),
-            )
-            ->assert([
-                'order_items' => [
-                    [
-                        'product_title' => 'test',
-                        'quantity' => 'test',
-                    ],
-                    [
-                        'product_title2' => 'test',
-                    ],
+                    )
+                    ->notEmpty()
+            ),
+        )
+        ->assert([
+            'order_items' => [
+                [
+                    'product_title' => 'test',
+                    'quantity' => 'test',
                 ],
-            ]);
-    },
-    '`.order_items.0.quantity` must be an integer value',
-    <<<'FULL_MESSAGE'
-    - Each item in `.order_items` must be valid
-      - `.0` validation failed
-        - `.quantity` must be an integer value
-      - `.1` contains both missing and extra keys
-        - `.product_title` must be present
-        - `.quantity` must be present
-        - `.product_title2` must not be present
-    FULL_MESSAGE,
-    [
-        'keySet' => [
-            '__root__' => 'Each item in `.order_items` must be valid',
-            0 => 'quantity must be an integer value',
-            1 => [
-                '__root__' => '`.order_items` contains both missing and extra keys',
-                'product_title' => '`.product_title` must be present',
-                'quantity' => '`.quantity` must be present',
-                'product_title2' => '`.product_title2` must not be present',
+                [
+                    'product_title2' => 'test',
+                ],
             ],
-        ],
-    ],
-))->skip(<<<TEST_SKIP
+        ]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.order_items.0.quantity` must be an integer value')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - Each item in `.order_items` must be valid
+              - `.0` validation failed
+                - `.quantity` must be an integer value
+              - `.1` contains both missing and extra keys
+                - `.product_title` must be present
+                - `.quantity` must be present
+                - `.product_title2` must not be present
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            'keySet' => [
+                '__root__' => 'Each item in `.order_items` must be valid',
+                0 => 'quantity must be an integer value',
+                1 => [
+                    '__root__' => '`.order_items` contains both missing and extra keys',
+                    'product_title' => '`.product_title` must be present',
+                    'quantity' => '`.quantity` must be present',
+                    'product_title2' => '`.product_title2` must not be present',
+                ],
+            ],
+        ])
+))
+->skip(<<<TEST_SKIP
 This test is skipped because the issue is not fixed yet.
 
 When changing the path of a `Result` we don't change the path of its children. I took this approach because we don't

--- a/tests/feature/Issues/Issue1477Test.php
+++ b/tests/feature/Issues/Issue1477Test.php
@@ -9,22 +9,21 @@ declare(strict_types=1);
 
 use Respect\Validation\Rules\Core\Simple;
 
-test('https://github.com/Respect/Validation/issues/1477', expectAll(
-    function (): void {
-        v::key(
-            'Address',
-            v::templated(
-                new class extends Simple {
-                    public function isValid(mixed $input): bool
-                    {
-                        return false;
-                    }
-                },
-                '{{name}} is not good!',
-            ),
-        )->assert(['Address' => 'cvejvn']);
-    },
-    '`.Address` is not good!',
-    '- `.Address` is not good!',
-    ['Address' => '`.Address` is not good!'],
+test('https://github.com/Respect/Validation/issues/1477', catchAll(
+    fn () => v::key(
+        'Address',
+        v::templated(
+            new class extends Simple {
+                public function isValid(mixed $input): bool
+                {
+                    return false;
+                }
+            },
+            '{{name}} is not good!',
+        ),
+    )->assert(['Address' => 'cvejvn']),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.Address` is not good!')
+        ->and($fullMessage)->toBe('- `.Address` is not good!')
+        ->and($messages)->toBe(['Address' => '`.Address` is not good!'])
 ));

--- a/tests/feature/Issues/Issue179Test.php
+++ b/tests/feature/Issues/Issue179Test.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/179', expectAll(
+test('https://github.com/Respect/Validation/issues/179', catchAll(
     function (): void {
         $config = [
             'host' => 1,
@@ -23,15 +23,16 @@ test('https://github.com/Respect/Validation/issues/179', expectAll(
         $validator->key('schema', v::stringType());
         $validator->assert($config);
     },
-    '`.host` must be a string',
-    <<<'FULL_MESSAGE'
-    - Settings must pass the rules
-      - `.host` must be a string
-      - `.user` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Settings must pass the rules',
-        'host' => '`.host` must be a string',
-        'user' => '`.user` must be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.host` must be a string')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - Settings must pass the rules
+              - `.host` must be a string
+              - `.user` must be present
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Settings must pass the rules',
+            'host' => '`.host` must be a string',
+            'user' => '`.user` must be present',
+        ])
 ));

--- a/tests/feature/Issues/Issue425Test.php
+++ b/tests/feature/Issues/Issue425Test.php
@@ -7,14 +7,15 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/425', expectAll(
+test('https://github.com/Respect/Validation/issues/425', catchAll(
     function (): void {
         $validator = v::create()
             ->key('age', v::intType()->notEmpty()->noneOf(v::stringType(), v::arrayType()))
             ->key('reference', v::stringType()->notEmpty()->lengthBetween(1, 50));
         $validator->assert(['age' => 1]);
     },
-    '`.reference` must be present',
-    '- `.reference` must be present',
-    ['reference' => '`.reference` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.reference` must be present')
+        ->and($fullMessage)->toBe('- `.reference` must be present')
+        ->and($messages)->toBe(['reference' => '`.reference` must be present'])
 ));

--- a/tests/feature/Issues/Issue446Test.php
+++ b/tests/feature/Issues/Issue446Test.php
@@ -12,12 +12,13 @@ $arr = [
     'email' => 'hello@hello.com',
 ];
 
-test('https://github.com/Respect/Validation/issues/446', expectAll(
+test('https://github.com/Respect/Validation/issues/446', catchAll(
     fn() => v::create()
         ->key('name', v::lengthBetween(2, 32))
         ->key('email', v::email())
         ->assert($arr),
-    'The length of `.name` must be between 2 and 32',
-    '- The length of `.name` must be between 2 and 32',
-    ['name' => 'The length of `.name` must be between 2 and 32'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of `.name` must be between 2 and 32')
+        ->and($fullMessage)->toBe('- The length of `.name` must be between 2 and 32')
+        ->and($messages)->toBe(['name' => 'The length of `.name` must be between 2 and 32'])
 ));

--- a/tests/feature/Issues/Issue619Test.php
+++ b/tests/feature/Issues/Issue619Test.php
@@ -7,9 +7,10 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/619', expectAll(
+test('https://github.com/Respect/Validation/issues/619', catchAll(
     fn() => v::instance(stdClass::class)->setTemplate('invalid object')->assert('test'),
-    'invalid object',
-    '- invalid object',
-    ['instance' => 'invalid object'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('invalid object')
+        ->and($fullMessage)->toBe('- invalid object')
+        ->and($messages)->toBe(['instance' => 'invalid object'])
 ));

--- a/tests/feature/Issues/Issue739Test.php
+++ b/tests/feature/Issues/Issue739Test.php
@@ -7,9 +7,10 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/739', expectAll(
+test('https://github.com/Respect/Validation/issues/739', catchAll(
     fn() => v::when(v::alwaysInvalid(), v::alwaysValid())->assert('foo'),
-    '"foo" is invalid',
-    '- "foo" is invalid',
-    ['alwaysInvalid' => '"foo" is invalid'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"foo" is invalid')
+        ->and($fullMessage)->toBe('- "foo" is invalid')
+        ->and($messages)->toBe(['alwaysInvalid' => '"foo" is invalid'])
 ));

--- a/tests/feature/Issues/Issue796Test.php
+++ b/tests/feature/Issues/Issue796Test.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/796', expectAll(
+test('https://github.com/Respect/Validation/issues/796', catchAll(
     fn() => v::create()
         ->key(
             'mysql',
@@ -40,17 +40,18 @@ test('https://github.com/Respect/Validation/issues/796', expectAll(
                 'schema' => 'schema',
             ],
         ]),
-    '`.mysql.host` must be a string',
-    <<<'FULL_MESSAGE'
-    - the given data must pass all the rules
-      - `.mysql` must pass the rules
-        - `.host` must be a string
-      - `.postgresql` must pass the rules
-        - `.user` must be a string
-    FULL_MESSAGE,
-    [
-        '__root__' => 'the given data must pass all the rules',
-        'mysql' => '`.host` must be a string',
-        'postgresql' => '`.user` must be a string',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.mysql.host` must be a string')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - the given data must pass all the rules
+              - `.mysql` must pass the rules
+                - `.host` must be a string
+              - `.postgresql` must pass the rules
+                - `.user` must be a string
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'the given data must pass all the rules',
+            'mysql' => '`.host` must be a string',
+            'postgresql' => '`.user` must be a string',
+        ])
 ));

--- a/tests/feature/Issues/Issue799Test.php
+++ b/tests/feature/Issues/Issue799Test.php
@@ -11,34 +11,36 @@ use Respect\Validation\Test\Stubs\CountableStub;
 
 $input = 'http://www.google.com/search?q=respect.github.com';
 
-test('https://github.com/Respect/Validation/issues/799 | #1', expectAll(
+test('https://github.com/Respect/Validation/issues/799 | #1', catchAll(
     fn() => v::create()
         ->call(
             [new CountableStub(1), 'count'],
             v::arrayVal()->key('scheme', v::startsWith('https')),
         )
         ->assert($input),
-    '1 must be an array value',
-    <<<'FULL_MESSAGE'
-    - 1 must pass all the rules
-      - 1 must be an array value
-      - `.scheme` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '1 must pass all the rules',
-        'arrayVal' => '1 must be an array value',
-        'scheme' => '`.scheme` must be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('1 must be an array value')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - 1 must pass all the rules
+              - 1 must be an array value
+              - `.scheme` must be present
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '1 must pass all the rules',
+            'arrayVal' => '1 must be an array value',
+            'scheme' => '`.scheme` must be present',
+        ])
 ));
 
-test('https://github.com/Respect/Validation/issues/799 | #2', expectAll(
+test('https://github.com/Respect/Validation/issues/799 | #2', catchAll(
     fn() => v::create()
         ->call(
-            fn ($url) => parse_url($url),
+            fn ($url) => parse_url((string) $url),
             v::arrayVal()->key('scheme', v::startsWith('https')),
         )
         ->assert($input),
-    '`.scheme` must start with "https"',
-    '- `.scheme` must start with "https"',
-    ['scheme' => '`.scheme` must start with "https"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.scheme` must start with "https"')
+        ->and($fullMessage)->toBe('- `.scheme` must start with "https"')
+        ->and($messages)->toBe(['scheme' => '`.scheme` must start with "https"'])
 ));

--- a/tests/feature/Issues/Issue805Test.php
+++ b/tests/feature/Issues/Issue805Test.php
@@ -7,9 +7,10 @@
 
 declare(strict_types=1);
 
-test('https://github.com/Respect/Validation/issues/805', expectAll(
+test('https://github.com/Respect/Validation/issues/805', catchAll(
     fn() => v::key('email', v::email()->setTemplate('WRONG EMAIL!!!!!!'))->assert(['email' => 'qwe']),
-    'WRONG EMAIL!!!!!!',
-    '- WRONG EMAIL!!!!!!',
-    ['email' => 'WRONG EMAIL!!!!!!'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('WRONG EMAIL!!!!!!')
+        ->and($fullMessage)->toBe('- WRONG EMAIL!!!!!!')
+        ->and($messages)->toBe(['email' => 'WRONG EMAIL!!!!!!'])
 ));

--- a/tests/feature/KeysAsValidatorNamesTest.php
+++ b/tests/feature/KeysAsValidatorNamesTest.php
@@ -9,19 +9,16 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-use Respect\Validation\Validator;
-
-test('Scenario #1', expectFullMessage(
-    function (): void {
-        Validator::create()
-            ->key('username', Validator::length(Validator::between(2, 32)))
-            ->key('birthdate', Validator::dateTime())
-            ->setName('User Subscription Form')
-            ->assert(['username' => '0', 'birthdate' => 'Whatever']);
-    },
-    <<<'FULL_MESSAGE'
-    - User Subscription Form must pass all the rules
-      - The length of `.username` must be between 2 and 32
-      - `.birthdate` must be a valid date/time
-    FULL_MESSAGE,
+test('Scenario #1', catchFullMessage(
+    fn () =>
+    v::create()
+        ->key('username', v::length(v::between(2, 32)))
+        ->key('birthdate', v::dateTime())
+        ->setName('User Subscription Form')
+        ->assert(['username' => '0', 'birthdate' => 'Whatever']),
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - User Subscription Form must pass all the rules
+          - The length of `.username` must be between 2 and 32
+          - `.birthdate` must be a valid date/time
+        FULL_MESSAGE)
 ));

--- a/tests/feature/NotWithRecursionTest.php
+++ b/tests/feature/NotWithRecursionTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::not(
         v::not(
             v::not(
@@ -19,10 +19,10 @@ test('Scenario #1', expectMessage(
             ),
         ),
     )->assert(2),
-    '2 must not be an integer value',
+    fn(string $message) => expect($message)->toBe('2 must not be an integer value')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::not(
         v::not(
             v::not(
@@ -34,9 +34,9 @@ test('Scenario #2', expectFullMessage(
             ),
         ),
     )->assert(2),
-    <<<'FULL_MESSAGE'
-    - 2 must pass the rules
-      - 2 must not be an integer value
-      - 2 must not be a positive number
-    FULL_MESSAGE,
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - 2 must pass the rules
+          - 2 must not be an integer value
+          - 2 must not be a positive number
+        FULL_MESSAGE)
 ));

--- a/tests/feature/NotWithoutRecursionTest.php
+++ b/tests/feature/NotWithoutRecursionTest.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 use Respect\Validation\Validator;
 
-test('Scenario #1', expectMessage(
-    function (): void {
-        $validator = Validator::not(Validator::intVal()->positive());
-        $validator->assert(2);
-    },
-    '2 must not be an integer value',
-));
+test('Scenario #1', catchMessage(function (): void {
+    $validator = Validator::not(Validator::intVal()->positive());
+    $validator->assert(2);
+},
+fn(string $message) => expect($message)->toBe('2 must not be an integer value')));

--- a/tests/feature/Readme/CustomMessagesTest.php
+++ b/tests/feature/Readme/CustomMessagesTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessages(
+test('Scenario #1', catchMessages(
     fn() => v::alnum()
         ->noWhitespace()
         ->length(v::between(1, 15))
@@ -16,10 +16,10 @@ test('Scenario #1', expectMessages(
             'noWhitespace' => '{{name}} cannot contain spaces',
             'length' => '{{name}} must not have more than 15 chars',
         ]),
-    [
+    fn(array $messages) => expect($messages)->toBe([
         '__root__' => '"really messed up screen#name" must pass all the rules',
         'alnum' => '"really messed up screen#name" must contain only letters and digits',
         'noWhitespace' => '"really messed up screen#name" cannot contain spaces',
         'lengthBetween' => 'The length of "really messed up screen#name" must be between 1 and 15',
-    ],
+    ])
 ));

--- a/tests/feature/Readme/ExampleTest.php
+++ b/tests/feature/Readme/ExampleTest.php
@@ -7,12 +7,12 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectFullMessage(
+test('Scenario #1', catchFullMessage(
     fn() => v::alnum()->noWhitespace()->lengthBetween(1, 15)->assert('really messed up screen#name'),
-    <<<'FULL_MESSAGE'
-    - "really messed up screen#name" must pass all the rules
-      - "really messed up screen#name" must contain only letters (a-z) and digits (0-9)
-      - "really messed up screen#name" must not contain whitespaces
-      - The length of "really messed up screen#name" must be between 1 and 15
-    FULL_MESSAGE,
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "really messed up screen#name" must pass all the rules
+          - "really messed up screen#name" must contain only letters (a-z) and digits (0-9)
+          - "really messed up screen#name" must not contain whitespaces
+          - The length of "really messed up screen#name" must be between 1 and 15
+        FULL_MESSAGE)
 ));

--- a/tests/feature/Readme/GettingMessagesAsAnArrayTest.php
+++ b/tests/feature/Readme/GettingMessagesAsAnArrayTest.php
@@ -7,12 +7,12 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessages(
+test('Scenario #1', catchMessages(
     fn() => v::alnum()->noWhitespace()->lengthBetween(1, 15)->assert('really messed up screen#name'),
-    [
+    fn(array $messages) => expect($messages)->toBe([
         '__root__' => '"really messed up screen#name" must pass all the rules',
         'alnum' => '"really messed up screen#name" must contain only letters (a-z) and digits (0-9)',
         'noWhitespace' => '"really messed up screen#name" must not contain whitespaces',
         'lengthBetween' => 'The length of "really messed up screen#name" must be between 1 and 15',
-    ],
+    ])
 ));

--- a/tests/feature/Rules/AllOfTest.php
+++ b/tests/feature/Rules/AllOfTest.php
@@ -7,106 +7,110 @@
 
 declare(strict_types=1);
 
-test('Default: fail, fail', expectAll(
+test('Default: fail, fail', catchAll(
     fn() => v::allOf(v::intType(), v::negative())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass all the rules
-      - "string" must be an integer
-      - "string" must be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass all the rules',
-        'intType' => '"string" must be an integer',
-        'negative' => '"string" must be a negative number',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - "string" must pass all the rules
+              - "string" must be an integer
+              - "string" must be a negative number
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass all the rules',
+            'intType' => '"string" must be an integer',
+            'negative' => '"string" must be a negative number',
+        ]),
 ));
 
-test('Default: fail, pass', expectAll(
+test('Default: fail, pass', catchAll(
     fn() => v::allOf(v::intType(), v::stringType())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must be an integer
-    FULL_MESSAGE,
-    [
-        'intType' => '"string" must be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe('- "string" must be an integer')
+        ->and($messages)->toBe(['intType' => '"string" must be an integer']),
 ));
 
-test('Default: fail, fail, pass', expectAll(
+test('Default: fail, fail, pass', catchAll(
     fn() => v::allOf(v::intType(), v::positive(), v::stringType())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass the rules
-      - "string" must be an integer
-      - "string" must be a positive number
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass the rules',
-        'intType' => '"string" must be an integer',
-        'positive' => '"string" must be a positive number',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - "string" must pass the rules
+              - "string" must be an integer
+              - "string" must be a positive number
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass the rules',
+            'intType' => '"string" must be an integer',
+            'positive' => '"string" must be a positive number',
+        ]),
 ));
 
-test('Inverted: pass, pass', expectAll(
+test('Inverted: pass, pass', catchAll(
     fn() => v::not(v::allOf(v::intType(), v::negative()))->assert(-1),
-    '-1 must not be an integer',
-    <<<'FULL_MESSAGE'
-    - -1 must pass the rules
-      - -1 must not be an integer
-      - -1 must not be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '-1 must pass the rules',
-        'intType' => '-1 must not be an integer',
-        'negative' => '-1 must not be a negative number',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - -1 must pass the rules
+              - -1 must not be an integer
+              - -1 must not be a negative number
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '-1 must pass the rules',
+            'intType' => '-1 must not be an integer',
+            'negative' => '-1 must not be a negative number',
+        ]),
 ));
 
-test('Inverted: pass, fail, fail', expectAll(
+test('Inverted: pass, fail, fail', catchAll(
     fn() => v::allOf(v::intType(), v::alpha(), v::stringType())->assert(2),
-    '2 must contain only letters (a-z)',
-    <<<'FULL_MESSAGE'
-    - 2 must pass the rules
-      - 2 must contain only letters (a-z)
-      - 2 must be a string
-    FULL_MESSAGE,
-    [
-        '__root__' => '2 must pass the rules',
-        'alpha' => '2 must contain only letters (a-z)',
-        'stringType' => '2 must be a string',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('2 must contain only letters (a-z)')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - 2 must pass the rules
+              - 2 must contain only letters (a-z)
+              - 2 must be a string
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '2 must pass the rules',
+            'alpha' => '2 must contain only letters (a-z)',
+            'stringType' => '2 must be a string',
+        ]),
 ));
 
-test('Wrapping "not"', expectAll(
+test('Wrapping "not"', catchAll(
     fn() => v::allOf(v::not(v::intType()), v::greaterThan(2))->assert(4),
-    '4 must not be an integer',
-    '- 4 must not be an integer',
-    ['notIntType' => '4 must not be an integer'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('4 must not be an integer')
+        ->and($fullMessage)->toBe('- 4 must not be an integer')
+        ->and($messages)->toBe(['notIntType' => '4 must not be an integer']),
 ));
 
-test('With a single template', expectAll(
+test('With a single template', catchAll(
     fn() => v::allOf(v::stringType(), v::arrayType())->assert(5, 'This is a single template'),
-    'This is a single template',
-    '- This is a single template',
-    ['allOf' => 'This is a single template'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('This is a single template')
+        ->and($fullMessage)->toBe('- This is a single template')
+        ->and($messages)->toBe(['allOf' => 'This is a single template']),
 ));
 
-test('With multiple templates', expectAll(
+test('With multiple templates', catchAll(
     fn() => v::allOf(v::stringType(), v::uppercase())->assert(5, [
         '__root__' => 'Two things are wrong',
         'stringType' => 'Template for "stringType"',
         'uppercase' => 'Template for "uppercase"',
     ]),
-    'Template for "stringType"',
-    <<<'FULL_MESSAGE'
-    - Two things are wrong
-      - Template for "stringType"
-      - Template for "uppercase"
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Two things are wrong',
-        'stringType' => 'Template for "stringType"',
-        'uppercase' => 'Template for "uppercase"',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template for "stringType"')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+            - Two things are wrong
+              - Template for "stringType"
+              - Template for "uppercase"
+            FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Two things are wrong',
+            'stringType' => 'Template for "stringType"',
+            'uppercase' => 'Template for "uppercase"',
+        ]),
 ));

--- a/tests/feature/Rules/AlnumTest.php
+++ b/tests/feature/Rules/AlnumTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::alnum()->assert('abc%1'),
-    '"abc%1" must contain only letters (a-z) and digits (0-9)',
+    fn (string $message) => expect($message)->toBe('"abc%1" must contain only letters (a-z) and digits (0-9)'),
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::alnum(' ')->assert('abc%2'),
-    '"abc%2" must contain only letters (a-z), digits (0-9), and " "',
+    fn (string $message) => expect($message)->toBe('"abc%2" must contain only letters (a-z), digits (0-9), and " "'),
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::alnum())->assert('abcd3'),
-    '"abcd3" must not contain letters (a-z) or digits (0-9)',
+    fn (string $message) => expect($message)->toBe('"abcd3" must not contain letters (a-z) or digits (0-9)'),
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::alnum('% '))->assert('abc%4'),
-    '"abc%4" must not contain letters (a-z), digits (0-9), or "% "',
+    fn (string $message) => expect($message)->toBe('"abc%4" must not contain letters (a-z), digits (0-9), or "% "'),
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::alnum()->assert('abc^1'),
-    '- "abc^1" must contain only letters (a-z) and digits (0-9)',
+    fn (string $fullMessage) => expect($fullMessage)->toBe('- "abc^1" must contain only letters (a-z) and digits (0-9)'),
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::alnum())->assert('abcd2'),
-    '- "abcd2" must not contain letters (a-z) or digits (0-9)',
+    fn (string $fullMessage) => expect($fullMessage)->toBe('- "abcd2" must not contain letters (a-z) or digits (0-9)'),
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::alnum('* &%')->assert('abc^3'),
-    '- "abc^3" must contain only letters (a-z), digits (0-9), and "* &%"',
+    fn (string $fullMessage) => expect($fullMessage)->toBe('- "abc^3" must contain only letters (a-z), digits (0-9), and "* &%"'),
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::alnum('^'))->assert('abc^4'),
-    '- "abc^4" must not contain letters (a-z), digits (0-9), or "^"',
+    fn (string $fullMessage) => expect($fullMessage)->toBe('- "abc^4" must not contain letters (a-z), digits (0-9), or "^"'),
 ));

--- a/tests/feature/Rules/AlphaTest.php
+++ b/tests/feature/Rules/AlphaTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::alpha()->assert('aaa%a'),
-    '"aaa%a" must contain only letters (a-z)',
+    fn(string $message) => expect($message)->toBe('"aaa%a" must contain only letters (a-z)')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::alpha(' ')->assert('bbb%b'),
-    '"bbb%b" must contain only letters (a-z) and " "',
+    fn(string $message) => expect($message)->toBe('"bbb%b" must contain only letters (a-z) and " "')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::alpha())->assert('ccccc'),
-    '"ccccc" must not contain letters (a-z)',
+    fn(string $message) => expect($message)->toBe('"ccccc" must not contain letters (a-z)')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::alpha('% '))->assert('ddd%d'),
-    '"ddd%d" must not contain letters (a-z) or "% "',
+    fn(string $message) => expect($message)->toBe('"ddd%d" must not contain letters (a-z) or "% "')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::alpha()->assert('eee^e'),
-    '- "eee^e" must contain only letters (a-z)',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "eee^e" must contain only letters (a-z)')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::alpha())->assert('fffff'),
-    '- "fffff" must not contain letters (a-z)',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "fffff" must not contain letters (a-z)')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::alpha('* &%')->assert('ggg^g'),
-    '- "ggg^g" must contain only letters (a-z) and "* &%"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ggg^g" must contain only letters (a-z) and "* &%"')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::alpha('^'))->assert('hhh^h'),
-    '- "hhh^h" must not contain letters (a-z) or "^"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "hhh^h" must not contain letters (a-z) or "^"')
 ));

--- a/tests/feature/Rules/AlwaysInvalidTest.php
+++ b/tests/feature/Rules/AlwaysInvalidTest.php
@@ -7,12 +7,12 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::alwaysInvalid()->assert('whatever'),
-    '"whatever" must be valid',
+    fn(string $message) => expect($message)->toBe('"whatever" must be valid')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::alwaysInvalid()->assert(''),
-    '- "" must be valid',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "" must be valid')
 ));

--- a/tests/feature/Rules/AlwaysValidTest.php
+++ b/tests/feature/Rules/AlwaysValidTest.php
@@ -7,12 +7,12 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::not(v::alwaysValid())->assert(true),
-    '`true` must be invalid',
+    fn(string $message) => expect($message)->toBe('`true` must be invalid')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::not(v::alwaysValid())->assert(true),
-    '- `true` must be invalid',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be invalid')
 ));

--- a/tests/feature/Rules/AnyOfTest.php
+++ b/tests/feature/Rules/AnyOfTest.php
@@ -7,47 +7,50 @@
 
 declare(strict_types=1);
 
-test('Default: fail, fail', expectAll(
+test('Default: fail, fail', catchAll(
     fn() => v::anyOf(v::intType(), v::negative())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass at least one of the rules
-      - "string" must be an integer
-      - "string" must be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass at least one of the rules',
-        'intType' => '"string" must be an integer',
-        'negative' => '"string" must be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass at least one of the rules
+          - "string" must be an integer
+          - "string" must be a negative number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass at least one of the rules',
+            'intType' => '"string" must be an integer',
+            'negative' => '"string" must be a negative number',
+        ])
 ));
 
-test('Inverted: pass, pass', expectAll(
+test('Inverted: pass, pass', catchAll(
     fn() => v::not(v::anyOf(v::intType(), v::negative()))->assert(-1),
-    '-1 must not be an integer',
-    <<<'FULL_MESSAGE'
-    - -1 must pass at least one of the rules
-      - -1 must not be an integer
-      - -1 must not be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '-1 must pass at least one of the rules',
-        'intType' => '-1 must not be an integer',
-        'negative' => '-1 must not be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - -1 must pass at least one of the rules
+          - -1 must not be an integer
+          - -1 must not be a negative number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '-1 must pass at least one of the rules',
+            'intType' => '-1 must not be an integer',
+            'negative' => '-1 must not be a negative number',
+        ])
 ));
 
-test('Inverted: pass, pass, fail', expectAll(
+test('Inverted: pass, pass, fail', catchAll(
     fn() => v::not(v::anyOf(v::intType(), v::negative(), v::stringType()))->assert(-1),
-    '-1 must not be an integer',
-    <<<'FULL_MESSAGE'
-    - -1 must pass at least one of the rules
-      - -1 must not be an integer
-      - -1 must not be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '-1 must pass at least one of the rules',
-        'intType' => '-1 must not be an integer',
-        'negative' => '-1 must not be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - -1 must pass at least one of the rules
+          - -1 must not be an integer
+          - -1 must not be a negative number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '-1 must pass at least one of the rules',
+            'intType' => '-1 must not be an integer',
+            'negative' => '-1 must not be a negative number',
+        ])
 ));

--- a/tests/feature/Rules/ArrayTypeTest.php
+++ b/tests/feature/Rules/ArrayTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::arrayType()->assert('teste'),
-    '"teste" must be an array',
+    fn(string $message) => expect($message)->toBe('"teste" must be an array')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::arrayType())->assert([]),
-    '`[]` must not be an array',
+    fn(string $message) => expect($message)->toBe('`[]` must not be an array')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::arrayType()->assert(new ArrayObject()),
-    '- `ArrayObject { getArrayCopy() => [] }` must be an array',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [] }` must be an array')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::arrayType())->assert([1, 2, 3]),
-    '- `[1, 2, 3]` must not be an array',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[1, 2, 3]` must not be an array')
 ));

--- a/tests/feature/Rules/ArrayValTest.php
+++ b/tests/feature/Rules/ArrayValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::arrayVal()->assert('Bla %123'),
-    '"Bla %123" must be an array value',
+    fn(string $message) => expect($message)->toBe('"Bla %123" must be an array value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::arrayVal())->assert([42]),
-    '`[42]` must not be an array value',
+    fn(string $message) => expect($message)->toBe('`[42]` must not be an array value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::arrayVal()->assert(new stdClass()),
-    '- `stdClass {}` must be an array value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be an array value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::arrayVal())->assert(new ArrayObject([2, 3])),
-    '- `ArrayObject { getArrayCopy() => [2, 3] }` must not be an array value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [2, 3] }` must not be an array value')
 ));

--- a/tests/feature/Rules/AttributesTest.php
+++ b/tests/feature/Rules/AttributesTest.php
@@ -9,79 +9,86 @@ declare(strict_types=1);
 
 use Respect\Validation\Test\Stubs\WithAttributes;
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('', '2024-06-23', 'john.doe@gmail.com')),
-    '`.name` must not be empty',
-    '- `.name` must not be empty',
-    ['name' => '`.name` must not be empty'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.name` must not be empty')
+        ->and($fullMessage)->toBe('- `.name` must not be empty')
+        ->and($messages)->toBe(['name' => '`.name` must not be empty'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '2024-06-23', 'john.doe@gmail.com', '+1234567890')),
-    '`.phone` must be a valid telephone number or must be null',
-    '- `.phone` must be a valid telephone number or must be null',
-    ['phone' => '`.phone` must be a valid telephone number or must be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.phone` must be a valid telephone number or must be null')
+        ->and($fullMessage)->toBe('- `.phone` must be a valid telephone number or must be null')
+        ->and($messages)->toBe(['phone' => '`.phone` must be a valid telephone number or must be null'])
 ));
 
-test('Not an object', expectAll(
+test('Not an object', catchAll(
     fn() => v::attributes()->assert([]),
-    '`[]` must be an object',
-    '- `[]` must be an object',
-    ['attributes' => '`[]` must be an object'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`[]` must be an object')
+        ->and($fullMessage)->toBe('- `[]` must be an object')
+        ->and($messages)->toBe(['attributes' => '`[]` must be an object'])
 ));
 
-test('Nullable', expectAll(
+test('Nullable', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '2024-06-23', 'john.doe@gmail.com', 'not a phone number')),
-    '`.phone` must be a valid telephone number or must be null',
-    '- `.phone` must be a valid telephone number or must be null',
-    ['phone' => '`.phone` must be a valid telephone number or must be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.phone` must be a valid telephone number or must be null')
+        ->and($fullMessage)->toBe('- `.phone` must be a valid telephone number or must be null')
+        ->and($messages)->toBe(['phone' => '`.phone` must be a valid telephone number or must be null'])
 ));
 
-test('Multiple attributes, all failed', expectAll(
+test('Multiple attributes, all failed', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('', 'not a date', 'not an email', 'not a phone number')),
-    '`.name` must not be empty',
-    <<<'FULL_MESSAGE'
-    - `Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" +$email="not an email" +$phone ... }` must pass the rules
-      - `.name` must not be empty
-      - `.birthdate` must pass all the rules
-        - `.birthdate` must be a valid date in the format "2005-12-30"
-        - For comparison with now, `.birthdate` must be a valid datetime
-      - `.email` must be a valid email address or must be null
-      - `.phone` must be a valid telephone number or must be null
-    FULL_MESSAGE,
-    [
-        '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" +$email="not an email" +$phone ... }` must pass the rules',
-        'name' => '`.name` must not be empty',
-        'birthdate' => [
-            '__root__' => '`.birthdate` must pass all the rules',
-            'date' => '`.birthdate` must be a valid date in the format "2005-12-30"',
-            'dateTimeDiffLessThanOrEqual' => 'For comparison with now, `.birthdate` must be a valid datetime',
-        ],
-        'email' => '`.email` must be a valid email address or must be null',
-        'phone' => '`.phone` must be a valid telephone number or must be null',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.name` must not be empty')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" +$email="not an email" +$phone ... }` must pass the rules
+          - `.name` must not be empty
+          - `.birthdate` must pass all the rules
+            - `.birthdate` must be a valid date in the format "2005-12-30"
+            - For comparison with now, `.birthdate` must be a valid datetime
+          - `.email` must be a valid email address or must be null
+          - `.phone` must be a valid telephone number or must be null
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" +$email="not an email" +$phone ... }` must pass the rules',
+            'name' => '`.name` must not be empty',
+            'birthdate' => [
+                '__root__' => '`.birthdate` must pass all the rules',
+                'date' => '`.birthdate` must be a valid date in the format "2005-12-30"',
+                'dateTimeDiffLessThanOrEqual' => 'For comparison with now, `.birthdate` must be a valid datetime',
+            ],
+            'email' => '`.email` must be a valid email address or must be null',
+            'phone' => '`.phone` must be a valid telephone number or must be null',
+        ])
 ));
 
-test('Failed attributes on the class', expectAll(
+test('Failed attributes on the class', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '2024-06-23')),
-    '`.email` must be defined',
-    <<<'FULL_MESSAGE'
-    - `Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" +$email=null +$phone=n ... }` must pass at least one of the rules
-      - `.email` must be defined
-      - `.phone` must be defined
-    FULL_MESSAGE,
-    [
-        'anyOf' => [
-            '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" +$email=null +$phone=n ... }` must pass at least one of the rules',
-            'email' => '`.email` must be defined',
-            'phone' => '`.phone` must be defined',
-        ],
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.email` must be defined')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" +$email=null +$phone=n ... }` must pass at least one of the rules
+          - `.email` must be defined
+          - `.phone` must be defined
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            'anyOf' => [
+                '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" +$email=null +$phone=n ... }` must pass at least one of the rules',
+                'email' => '`.email` must be defined',
+                'phone' => '`.phone` must be defined',
+            ],
+        ])
 ));
 
-test('Multiple attributes, one failed', expectAll(
+test('Multiple attributes, one failed', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '22 years ago', 'john.doe@gmail.com')),
-    '`.birthdate` must be a valid date in the format "2005-12-30"',
-    '- `.birthdate` must be a valid date in the format "2005-12-30"',
-    ['birthdate' => '`.birthdate` must be a valid date in the format "2005-12-30"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.birthdate` must be a valid date in the format "2005-12-30"')
+        ->and($fullMessage)->toBe('- `.birthdate` must be a valid date in the format "2005-12-30"')
+        ->and($messages)->toBe(['birthdate' => '`.birthdate` must be a valid date in the format "2005-12-30"'])
 ));

--- a/tests/feature/Rules/Base64Test.php
+++ b/tests/feature/Rules/Base64Test.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::base64()->assert('=c3VyZS4'),
-    '"=c3VyZS4" must be a base64 encoded string',
+    fn(string $message) => expect($message)->toBe('"=c3VyZS4" must be a base64 encoded string')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::base64())->assert('c3VyZS4='),
-    '"c3VyZS4=" must not be a base64 encoded string',
+    fn(string $message) => expect($message)->toBe('"c3VyZS4=" must not be a base64 encoded string')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::base64()->assert('=c3VyZS4'),
-    '- "=c3VyZS4" must be a base64 encoded string',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "=c3VyZS4" must be a base64 encoded string')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::base64())->assert('c3VyZS4='),
-    '- "c3VyZS4=" must not be a base64 encoded string',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "c3VyZS4=" must not be a base64 encoded string')
 ));

--- a/tests/feature/Rules/BaseTest.php
+++ b/tests/feature/Rules/BaseTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::base(61)->assert('Z01xSsg5675hic20dj'),
-    '"Z01xSsg5675hic20dj" must be a number in base 61',
+    fn(string $message) => expect($message)->toBe('"Z01xSsg5675hic20dj" must be a number in base 61')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::base(2)->assert(''),
-    '- "" must be a number in base 2',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "" must be a number in base 2')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::base(2))->assert('011010001'),
-    '"011010001" must not be a number in base 2',
+    fn(string $message) => expect($message)->toBe('"011010001" must not be a number in base 2')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::base(2))->assert('011010001'),
-    '- "011010001" must not be a number in base 2',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "011010001" must not be a number in base 2')
 ));

--- a/tests/feature/Rules/BeetwenTest.php
+++ b/tests/feature/Rules/BeetwenTest.php
@@ -7,32 +7,32 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::between(1, 2)->assert(0),
-    '0 must be between 1 and 2',
+    fn(string $message) => expect($message)->toBe('0 must be between 1 and 2')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::between('yesterday', 'tomorrow'))->assert('today'),
-    '"today" must not be between "yesterday" and "tomorrow"',
+    fn(string $message) => expect($message)->toBe('"today" must not be between "yesterday" and "tomorrow"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::between('a', 'c')->assert('d'),
-    '- "d" must be between "a" and "c"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "d" must be between "a" and "c"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::between(-INF, INF))->assert(0),
-    '- 0 must not be between `-INF` and `INF`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0 must not be between `-INF` and `INF`')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::not(v::between('a', 'b'))->assert('a'),
-    '- "a" must not be between "a" and "b"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must not be between "a" and "b"')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::between(1, 42))->assert(41),
-    '- 41 must not be between 1 and 42',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 41 must not be between 1 and 42')
 ));

--- a/tests/feature/Rules/BetweenExclusiveTest.php
+++ b/tests/feature/Rules/BetweenExclusiveTest.php
@@ -7,30 +7,34 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::betweenExclusive(1, 10)->assert(12),
-    '12 must be greater than 1 and less than 10',
-    '- 12 must be greater than 1 and less than 10',
-    ['betweenExclusive' => '12 must be greater than 1 and less than 10'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('12 must be greater than 1 and less than 10')
+        ->and($fullMessage)->toBe('- 12 must be greater than 1 and less than 10')
+        ->and($messages)->toBe(['betweenExclusive' => '12 must be greater than 1 and less than 10'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::betweenExclusive(1, 10))->assert(5),
-    '5 must not be greater than 1 or less than 10',
-    '- 5 must not be greater than 1 or less than 10',
-    ['notBetweenExclusive' => '5 must not be greater than 1 or less than 10'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('5 must not be greater than 1 or less than 10')
+        ->and($fullMessage)->toBe('- 5 must not be greater than 1 or less than 10')
+        ->and($messages)->toBe(['notBetweenExclusive' => '5 must not be greater than 1 or less than 10'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::betweenExclusive(1, 10)->setTemplate('Bewildered bees buzzed between blooming begonias')->assert(12),
-    'Bewildered bees buzzed between blooming begonias',
-    '- Bewildered bees buzzed between blooming begonias',
-    ['betweenExclusive' => 'Bewildered bees buzzed between blooming begonias'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Bewildered bees buzzed between blooming begonias')
+        ->and($fullMessage)->toBe('- Bewildered bees buzzed between blooming begonias')
+        ->and($messages)->toBe(['betweenExclusive' => 'Bewildered bees buzzed between blooming begonias'])
 ));
 
-test('With name', expectAll(
+test('With name', catchAll(
     fn() => v::betweenExclusive(1, 10)->setName('Range')->assert(10),
-    'Range must be greater than 1 and less than 10',
-    '- Range must be greater than 1 and less than 10',
-    ['betweenExclusive' => 'Range must be greater than 1 and less than 10'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Range must be greater than 1 and less than 10')
+        ->and($fullMessage)->toBe('- Range must be greater than 1 and less than 10')
+        ->and($messages)->toBe(['betweenExclusive' => 'Range must be greater than 1 and less than 10'])
 ));

--- a/tests/feature/Rules/BoolTypeTest.php
+++ b/tests/feature/Rules/BoolTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::boolType()->assert('teste'),
-    '"teste" must be a boolean',
+    fn(string $message) => expect($message)->toBe('"teste" must be a boolean')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::boolType())->assert(true),
-    '`true` must not be a boolean',
+    fn(string $message) => expect($message)->toBe('`true` must not be a boolean')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::boolType()->assert([]),
-    '- `[]` must be a boolean',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be a boolean')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::boolType())->assert(false),
-    '- `false` must not be a boolean',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `false` must not be a boolean')
 ));

--- a/tests/feature/Rules/BoolValTest.php
+++ b/tests/feature/Rules/BoolValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::boolVal()->assert('ok'),
-    '"ok" must be a boolean value',
+    fn(string $message) => expect($message)->toBe('"ok" must be a boolean value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::boolVal())->assert('yes'),
-    '"yes" must not be a boolean value',
+    fn(string $message) => expect($message)->toBe('"yes" must not be a boolean value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::boolVal()->assert('yep'),
-    '- "yep" must be a boolean value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "yep" must be a boolean value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::boolVal())->assert('on'),
-    '- "on" must not be a boolean value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "on" must not be a boolean value')
 ));

--- a/tests/feature/Rules/BsnTest.php
+++ b/tests/feature/Rules/BsnTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::bsn()->assert('acb'),
-    '"acb" must be a valid BSN',
+    fn(string $message) => expect($message)->toBe('"acb" must be a valid BSN')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::bsn())->assert('612890053'),
-    '"612890053" must not be a valid BSN',
+    fn(string $message) => expect($message)->toBe('"612890053" must not be a valid BSN')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::bsn()->assert('abc'),
-    '- "abc" must be a valid BSN',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc" must be a valid BSN')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::bsn())->assert('612890053'),
-    '- "612890053" must not be a valid BSN',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "612890053" must not be a valid BSN')
 ));

--- a/tests/feature/Rules/CallTest.php
+++ b/tests/feature/Rules/CallTest.php
@@ -7,32 +7,32 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::call('trim', v::noWhitespace())->assert(' two words '),
-    '"two words" must not contain whitespaces',
+    fn(string $message) => expect($message)->toBe('"two words" must not contain whitespaces')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::call('stripslashes', v::stringType()))->assert(' some\thing '),
-    '" something " must not be a string',
+    fn(string $message) => expect($message)->toBe('" something " must not be a string')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::call('stripslashes', v::alwaysValid())->assert([]),
-    '`[]` must be a suitable argument for "stripslashes"',
+    fn(string $message) => expect($message)->toBe('`[]` must be a suitable argument for "stripslashes"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::call('strval', v::intType())->assert(1234),
-    '- "1234" must be an integer',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1234" must be an integer')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::not(v::call('is_float', v::boolType()))->assert(1.2),
-    '- `true` must not be a boolean',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must not be a boolean')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::call('array_shift', v::alwaysValid())->assert(INF),
-    '- `INF` must be a suitable argument for "array_shift"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `INF` must be a suitable argument for "array_shift"')
 ));

--- a/tests/feature/Rules/CallableTypeTest.php
+++ b/tests/feature/Rules/CallableTypeTest.php
@@ -7,24 +7,24 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::callableType()->assert([]),
-    '`[]` must be a callable',
+    fn(string $message) => expect($message)->toBe('`[]` must be a callable')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::callableType())->assert('trim'),
-    '"trim" must not be a callable',
+    fn(string $message) => expect($message)->toBe('"trim" must not be a callable')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::callableType()->assert(true),
-    '- `true` must be a callable',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be a callable')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::callableType())->assert(function (): void {
         // Do nothing
     }),
-    '- `Closure {}` must not be a callable',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `Closure {}` must not be a callable')
 ));

--- a/tests/feature/Rules/CallbackTest.php
+++ b/tests/feature/Rules/CallbackTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::callback('is_string')->assert([]),
-    '`[]` must be valid',
+    fn(string $message) => expect($message)->toBe('`[]` must be valid')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::callback('is_string'))->assert('foo'),
-    '"foo" must be invalid',
+    fn(string $message) => expect($message)->toBe('"foo" must be invalid')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::callback('is_string')->assert(true),
-    '- `true` must be valid',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be valid')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::callback('is_string'))->assert('foo'),
-    '- "foo" must be invalid',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo" must be invalid')
 ));

--- a/tests/feature/Rules/CharsetTest.php
+++ b/tests/feature/Rules/CharsetTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::charset('ASCII')->assert('açaí'),
-    '"açaí" must only contain characters from the `["ASCII"]` charset',
+    fn(string $message) => expect($message)->toBe('"açaí" must only contain characters from the `["ASCII"]` charset')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::charset('UTF-8'))->assert('açaí'),
-    '"açaí" must not contain any characters from the `["UTF-8"]` charset',
+    fn(string $message) => expect($message)->toBe('"açaí" must not contain any characters from the `["UTF-8"]` charset')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::charset('ASCII')->assert('açaí'),
-    '- "açaí" must only contain characters from the `["ASCII"]` charset',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "açaí" must only contain characters from the `["ASCII"]` charset')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::charset('UTF-8'))->assert('açaí'),
-    '- "açaí" must not contain any characters from the `["UTF-8"]` charset',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "açaí" must not contain any characters from the `["UTF-8"]` charset')
 ));

--- a/tests/feature/Rules/CircuitTest.php
+++ b/tests/feature/Rules/CircuitTest.php
@@ -7,86 +7,99 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::trueVal())->assert(false),
-    '`false` must evaluate to `true`',
-    '- `false` must evaluate to `true`',
-    ['trueVal' => '`false` must evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`false` must evaluate to `true`')
+        ->and($fullMessage)->toBe('- `false` must evaluate to `true`')
+        ->and($messages)->toBe(['trueVal' => '`false` must evaluate to `true`'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::circuit(v::alwaysValid(), v::trueVal()))->assert(true),
-    '`true` must not evaluate to `true`',
-    '- `true` must not evaluate to `true`',
-    ['notTrueVal' => '`true` must not evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`true` must not evaluate to `true`')
+        ->and($fullMessage)->toBe('- `true` must not evaluate to `true`')
+        ->and($messages)->toBe(['notTrueVal' => '`true` must not evaluate to `true`'])
 ));
 
-test('Default with inverted failing rule', expectAll(
+test('Default with inverted failing rule', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal()))->assert(true),
-    '`true` must not evaluate to `true`',
-    '- `true` must not evaluate to `true`',
-    ['notTrueVal' => '`true` must not evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`true` must not evaluate to `true`')
+        ->and($fullMessage)->toBe('- `true` must not evaluate to `true`')
+        ->and($messages)->toBe(['notTrueVal' => '`true` must not evaluate to `true`'])
 ));
 
-test('With wrapped name, default', expectAll(
+test('With wrapped name, default', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::trueVal()->setName('Wrapped'))->setName('Wrapper')->assert(false),
-    'Wrapped must evaluate to `true`',
-    '- Wrapped must evaluate to `true`',
-    ['trueVal' => 'Wrapped must evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must evaluate to `true`')
+        ->and($fullMessage)->toBe('- Wrapped must evaluate to `true`')
+        ->and($messages)->toBe(['trueVal' => 'Wrapped must evaluate to `true`'])
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::trueVal())->setName('Wrapper')->assert(false),
-    'Wrapper must evaluate to `true`',
-    '- Wrapper must evaluate to `true`',
-    ['trueVal' => 'Wrapper must evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must evaluate to `true`')
+        ->and($fullMessage)->toBe('- Wrapper must evaluate to `true`')
+        ->and($messages)->toBe(['trueVal' => 'Wrapper must evaluate to `true`'])
 ));
 
-test('With the name set in the wrapped rule of an inverted failing rule', expectAll(
+test('With the name set in the wrapped rule of an inverted failing rule', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal()->setName('Wrapped'))->setName('Not'))->setName('Wrapper')->assert(true),
-    'Wrapped must not evaluate to `true`',
-    '- Wrapped must not evaluate to `true`',
-    ['notTrueVal' => 'Wrapped must not evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not evaluate to `true`')
+        ->and($fullMessage)->toBe('- Wrapped must not evaluate to `true`')
+        ->and($messages)->toBe(['notTrueVal' => 'Wrapped must not evaluate to `true`'])
 ));
 
-test('With the name set in an inverted failing rule', expectAll(
+test('With the name set in an inverted failing rule', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal())->setName('Not'))->setName('Wrapper')->assert(true),
-    'Not must not evaluate to `true`',
-    '- Not must not evaluate to `true`',
-    ['notTrueVal' => 'Not must not evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not evaluate to `true`')
+        ->and($fullMessage)->toBe('- Not must not evaluate to `true`')
+        ->and($messages)->toBe(['notTrueVal' => 'Not must not evaluate to `true`'])
 ));
 
-test('With the name set in the "circuit" that has an inverted failing rule', expectAll(
+test('With the name set in the "circuit" that has an inverted failing rule', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::not(v::trueVal()))->setName('Wrapper')->assert(true),
-    'Wrapper must not evaluate to `true`',
-    '- Wrapper must not evaluate to `true`',
-    ['notTrueVal' => 'Wrapper must not evaluate to `true`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not evaluate to `true`')
+        ->and($fullMessage)->toBe('- Wrapper must not evaluate to `true`')
+        ->and($messages)->toBe(['notTrueVal' => 'Wrapper must not evaluate to `true`'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::trueVal())
         ->setTemplate('Circuit cool cats cunningly continuous cookies')
         ->assert(false),
-    'Circuit cool cats cunningly continuous cookies',
-    '- Circuit cool cats cunningly continuous cookies',
-    ['trueVal' => 'Circuit cool cats cunningly continuous cookies'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Circuit cool cats cunningly continuous cookies')
+        ->and($fullMessage)->toBe('- Circuit cool cats cunningly continuous cookies')
+        ->and($messages)->toBe(['trueVal' => 'Circuit cool cats cunningly continuous cookies'])
 ));
 
-test('With multiple templates', expectAll(
+test('With multiple templates', catchAll(
     fn() => v::circuit(v::alwaysValid(), v::trueVal())
         ->setTemplates(['trueVal' => 'Clever clowns craft circuit clever clocks'])
         ->assert(false),
-    'Clever clowns craft circuit clever clocks',
-    '- Clever clowns craft circuit clever clocks',
-    ['trueVal' => 'Clever clowns craft circuit clever clocks'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Clever clowns craft circuit clever clocks')
+        ->and($fullMessage)->toBe('- Clever clowns craft circuit clever clocks')
+        ->and($messages)->toBe(['trueVal' => 'Clever clowns craft circuit clever clocks'])
 ));
 
-test('Real example', expectAll(
+test('Real example', catchAll(
     fn() => v::circuit(
         v::key('countyCode', v::countryCode()),
-        v::lazy(fn ($input) => v::key('subdivisionCode', v::subdivisionCode($input['countyCode']))),
+        v::lazy(
+            fn ($input) => v::key('subdivisionCode', v::subdivisionCode($input['countyCode']))
+        ),
     )->assert(['countyCode' => 'BR', 'subdivisionCode' => 'CA']),
-    '`.subdivisionCode` must be a subdivision code of Brazil',
-    '- `.subdivisionCode` must be a subdivision code of Brazil',
-    ['subdivisionCode' => '`.subdivisionCode` must be a subdivision code of Brazil'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.subdivisionCode` must be a subdivision code of Brazil')
+        ->and($fullMessage)->toBe('- `.subdivisionCode` must be a subdivision code of Brazil')
+        ->and($messages)->toBe(['subdivisionCode' => '`.subdivisionCode` must be a subdivision code of Brazil'])
 ));

--- a/tests/feature/Rules/CnhTest.php
+++ b/tests/feature/Rules/CnhTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::cnh()->assert('batman'),
-    '"batman" must be a valid CNH number',
+    fn(string $message) => expect($message)->toBe('"batman" must be a valid CNH number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::cnh())->assert('02650306461'),
-    '"02650306461" must not be a valid CNH number',
+    fn(string $message) => expect($message)->toBe('"02650306461" must not be a valid CNH number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::cnh()->assert('bruce wayne'),
-    '- "bruce wayne" must be a valid CNH number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bruce wayne" must be a valid CNH number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::cnh())->assert('02650306461'),
-    '- "02650306461" must not be a valid CNH number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "02650306461" must not be a valid CNH number')
 ));

--- a/tests/feature/Rules/CnpjTest.php
+++ b/tests/feature/Rules/CnpjTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::cnpj()->assert('não cnpj'),
-    '"não cnpj" must be a valid CNPJ number',
+    fn(string $message) => expect($message)->toBe('"não cnpj" must be a valid CNPJ number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::cnpj())->assert('65.150.175/0001-20'),
-    '"65.150.175/0001-20" must not be a valid CNPJ number',
+    fn(string $message) => expect($message)->toBe('"65.150.175/0001-20" must not be a valid CNPJ number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::cnpj()->assert('test'),
-    '- "test" must be a valid CNPJ number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "test" must be a valid CNPJ number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::cnpj())->assert('65.150.175/0001-20'),
-    '- "65.150.175/0001-20" must not be a valid CNPJ number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "65.150.175/0001-20" must not be a valid CNPJ number')
 ));

--- a/tests/feature/Rules/CntrlTest.php
+++ b/tests/feature/Rules/CntrlTest.php
@@ -9,42 +9,42 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::control()->assert('16-50'),
-    '"16-50" must only contain control characters',
+    fn(string $message) => expect($message)->toBe('"16-50" must only contain control characters')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::control('16')->assert('16-50'),
-    '"16-50" must only contain control characters and "16"',
+    fn(string $message) => expect($message)->toBe('"16-50" must only contain control characters and "16"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::control())->assert("\n"),
-    '"\\n" must not contain control characters',
+    fn(string $message) => expect($message)->toBe('"\\n" must not contain control characters')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::control('16'))->assert("16\n"),
-    '"16\\n" must not contain control characters or "16"',
+    fn(string $message) => expect($message)->toBe('"16\\n" must not contain control characters or "16"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::control()->assert('Foo'),
-    '- "Foo" must only contain control characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must only contain control characters')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::control('Bar')->assert('Foo'),
-    '- "Foo" must only contain control characters and "Bar"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must only contain control characters and "Bar"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::control())->assert("\n"),
-    '- "\\n" must not contain control characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "\\n" must not contain control characters')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::control('Bar'))->assert("Bar\n"),
-    '- "Bar\\n" must not contain control characters or "Bar"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Bar\\n" must not contain control characters or "Bar"')
 ));

--- a/tests/feature/Rules/ConsonantTest.php
+++ b/tests/feature/Rules/ConsonantTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::consonant()->assert('aeiou'),
-    '"aeiou" must only contain consonants',
+    fn(string $message) => expect($message)->toBe('"aeiou" must only contain consonants')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::consonant('d')->assert('daeiou'),
-    '"daeiou" must only contain consonants and "d"',
+    fn(string $message) => expect($message)->toBe('"daeiou" must only contain consonants and "d"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::consonant())->assert('bcd'),
-    '"bcd" must not contain consonants',
+    fn(string $message) => expect($message)->toBe('"bcd" must not contain consonants')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::consonant('a'))->assert('abcd'),
-    '"abcd" must not contain consonants or "a"',
+    fn(string $message) => expect($message)->toBe('"abcd" must not contain consonants or "a"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::consonant()->assert('aeiou'),
-    '- "aeiou" must only contain consonants',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "aeiou" must only contain consonants')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::consonant('d')->assert('daeiou'),
-    '- "daeiou" must only contain consonants and "d"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "daeiou" must only contain consonants and "d"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::consonant())->assert('bcd'),
-    '- "bcd" must not contain consonants',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bcd" must not contain consonants')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::consonant('a'))->assert('abcd'),
-    '- "abcd" must not contain consonants or "a"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abcd" must not contain consonants or "a"')
 ));

--- a/tests/feature/Rules/ContainsAnyTest.php
+++ b/tests/feature/Rules/ContainsAnyTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::containsAny(['foo', 'bar'])->assert('baz'),
-    '"baz" must contain at least one value from `["foo", "bar"]`',
+    fn(string $message) => expect($message)->toBe('"baz" must contain at least one value from `["foo", "bar"]`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::containsAny(['foo', 'bar']))->assert('fool'),
-    '"fool" must not contain any value from `["foo", "bar"]`',
+    fn(string $message) => expect($message)->toBe('"fool" must not contain any value from `["foo", "bar"]`')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::containsAny(['foo', 'bar'])->assert(['baz']),
-    '- `["baz"]` must contain at least one value from `["foo", "bar"]`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["baz"]` must contain at least one value from `["foo", "bar"]`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::containsAny(['foo', 'bar'], true))->assert(['bar', 'foo']),
-    '- `["bar", "foo"]` must not contain any value from `["foo", "bar"]`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["bar", "foo"]` must not contain any value from `["foo", "bar"]`')
 ));

--- a/tests/feature/Rules/ContainsTest.php
+++ b/tests/feature/Rules/ContainsTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::contains('foo')->assert('bar'),
-    '"bar" must contain "foo"',
+    fn(string $message) => expect($message)->toBe('"bar" must contain "foo"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::contains('foo'))->assert('fool'),
-    '"fool" must not contain "foo"',
+    fn(string $message) => expect($message)->toBe('"fool" must not contain "foo"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::contains('foo')->assert(['bar']),
-    '- `["bar"]` must contain "foo"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["bar"]` must contain "foo"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::contains('foo', true))->assert(['bar', 'foo']),
-    '- `["bar", "foo"]` must not contain "foo"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["bar", "foo"]` must not contain "foo"')
 ));

--- a/tests/feature/Rules/CountableTest.php
+++ b/tests/feature/Rules/CountableTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::countable()->assert(1.0),
-    '1.0 must be a countable value',
+    fn(string $message) => expect($message)->toBe('1.0 must be a countable value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::countable())->assert([]),
-    '`[]` must not be a countable value',
+    fn(string $message) => expect($message)->toBe('`[]` must not be a countable value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::countable()->assert('Not countable!'),
-    '- "Not countable!" must be a countable value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Not countable!" must be a countable value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::countable())->assert(new ArrayObject()),
-    '- `ArrayObject { getArrayCopy() => [] }` must not be a countable value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [] }` must not be a countable value')
 ));

--- a/tests/feature/Rules/CountryCodeTest.php
+++ b/tests/feature/Rules/CountryCodeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::countryCode()->assert('1'),
-    '"1" must be a valid country code',
+    fn(string $message) => expect($message)->toBe('"1" must be a valid country code')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::countryCode())->assert('BR'),
-    '"BR" must not be a valid country code',
+    fn(string $message) => expect($message)->toBe('"BR" must not be a valid country code')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::countryCode()->assert('1'),
-    '- "1" must be a valid country code',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must be a valid country code')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::countryCode())->assert('BR'),
-    '- "BR" must not be a valid country code',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "BR" must not be a valid country code')
 ));

--- a/tests/feature/Rules/CpfTest.php
+++ b/tests/feature/Rules/CpfTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::cpf()->assert('this thing'),
-    '"this thing" must be a valid CPF number',
+    fn(string $message) => expect($message)->toBe('"this thing" must be a valid CPF number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::cpf())->assert('276.865.775-11'),
-    '"276.865.775-11" must not be a valid CPF number',
+    fn(string $message) => expect($message)->toBe('"276.865.775-11" must not be a valid CPF number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::cpf()->assert('your mother'),
-    '- "your mother" must be a valid CPF number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "your mother" must be a valid CPF number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::cpf())->assert('61836182848'),
-    '- "61836182848" must not be a valid CPF number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "61836182848" must not be a valid CPF number')
 ));

--- a/tests/feature/Rules/CreditCardTest.php
+++ b/tests/feature/Rules/CreditCardTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::creditCard('Discover')->assert(3566002020360505),
-    '3566002020360505 must be a valid Discover credit card number',
+    fn(string $message) => expect($message)->toBe('3566002020360505 must be a valid Discover credit card number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::creditCard('Visa'))->assert(4024007153361885),
-    '4024007153361885 must not be a valid Visa credit card number',
+    fn(string $message) => expect($message)->toBe('4024007153361885 must not be a valid Visa credit card number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::creditCard('MasterCard')->assert(3566002020360505),
-    '- 3566002020360505 must be a valid MasterCard credit card number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3566002020360505 must be a valid MasterCard credit card number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::creditCard())->assert(5555444433331111),
-    '- 5555444433331111 must not be a valid credit card number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 5555444433331111 must not be a valid credit card number')
 ));

--- a/tests/feature/Rules/CurrencyCodeTest.php
+++ b/tests/feature/Rules/CurrencyCodeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::currencyCode()->assert('batman'),
-    '"batman" must be a valid currency code',
+    fn(string $message) => expect($message)->toBe('"batman" must be a valid currency code')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::currencyCode())->assert('BRL'),
-    '"BRL" must not be a valid currency code',
+    fn(string $message) => expect($message)->toBe('"BRL" must not be a valid currency code')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::currencyCode()->assert('ppz'),
-    '- "ppz" must be a valid currency code',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ppz" must be a valid currency code')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::currencyCode())->assert('GBP'),
-    '- "GBP" must not be a valid currency code',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "GBP" must not be a valid currency code')
 ));

--- a/tests/feature/Rules/DateTest.php
+++ b/tests/feature/Rules/DateTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::date()->assert('2018-01-29T08:32:54+00:00'),
-    '"2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"',
+    fn(string $message) => expect($message)->toBe('"2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::date())->assert('2018-01-29'),
-    '"2018-01-29" must not be a valid date in the format "2005-12-30"',
+    fn(string $message) => expect($message)->toBe('"2018-01-29" must not be a valid date in the format "2005-12-30"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::date()->assert('2018-01-29T08:32:54+00:00'),
-    '- "2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::date('d/m/Y'))->assert('29/01/2018'),
-    '- "29/01/2018" must not be a valid date in the format "30/12/2005"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "29/01/2018" must not be a valid date in the format "30/12/2005"')
 ));

--- a/tests/feature/Rules/DateTimeDiffTest.php
+++ b/tests/feature/Rules/DateTimeDiffTest.php
@@ -7,142 +7,156 @@
 
 declare(strict_types=1);
 
-test('With $type = "years"', expectAll(
+test('With $type = "years"', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2))->assert('1 year ago'),
-    'The number of years between now and "1 year ago" must be equal to 2',
-    '- The number of years between now and "1 year ago" must be equal to 2',
-    ['dateTimeDiffEquals' => 'The number of years between now and "1 year ago" must be equal to 2'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of years between now and "1 year ago" must be equal to 2')
+        ->and($fullMessage)->toBe('- The number of years between now and "1 year ago" must be equal to 2')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'The number of years between now and "1 year ago" must be equal to 2'])
 ));
 
-test('With $type = "months"', expectAll(
+test('With $type = "months"', catchAll(
     fn() => v::dateTimeDiff('months', v::equals(3))->assert('2 months ago'),
-    'The number of months between now and "2 months ago" must be equal to 3',
-    '- The number of months between now and "2 months ago" must be equal to 3',
-    ['dateTimeDiffEquals' => 'The number of months between now and "2 months ago" must be equal to 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of months between now and "2 months ago" must be equal to 3')
+        ->and($fullMessage)->toBe('- The number of months between now and "2 months ago" must be equal to 3')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'The number of months between now and "2 months ago" must be equal to 3'])
 ));
 
-test('With $type = "days"', expectAll(
+test('With $type = "days"', catchAll(
     fn() => v::dateTimeDiff('days', v::equals(4))->assert('3 days ago'),
-    'The number of days between now and "3 days ago" must be equal to 4',
-    '- The number of days between now and "3 days ago" must be equal to 4',
-    ['dateTimeDiffEquals' => 'The number of days between now and "3 days ago" must be equal to 4'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of days between now and "3 days ago" must be equal to 4')
+        ->and($fullMessage)->toBe('- The number of days between now and "3 days ago" must be equal to 4')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'The number of days between now and "3 days ago" must be equal to 4'])
 ));
 
-test('With $type = "hours"', expectAll(
+test('With $type = "hours"', catchAll(
     fn() => v::dateTimeDiff('hours', v::equals(5))->assert('4 hours ago'),
-    'The number of hours between now and "4 hours ago" must be equal to 5',
-    '- The number of hours between now and "4 hours ago" must be equal to 5',
-    ['dateTimeDiffEquals' => 'The number of hours between now and "4 hours ago" must be equal to 5'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of hours between now and "4 hours ago" must be equal to 5')
+        ->and($fullMessage)->toBe('- The number of hours between now and "4 hours ago" must be equal to 5')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'The number of hours between now and "4 hours ago" must be equal to 5'])
 ));
 
-test('With $type = "minutes"', expectAll(
+test('With $type = "minutes"', catchAll(
     fn() => v::dateTimeDiff('minutes', v::equals(6))->assert('5 minutes ago'),
-    'The number of minutes between now and "5 minutes ago" must be equal to 6',
-    '- The number of minutes between now and "5 minutes ago" must be equal to 6',
-    ['dateTimeDiffEquals' => 'The number of minutes between now and "5 minutes ago" must be equal to 6'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of minutes between now and "5 minutes ago" must be equal to 6')
+        ->and($fullMessage)->toBe('- The number of minutes between now and "5 minutes ago" must be equal to 6')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'The number of minutes between now and "5 minutes ago" must be equal to 6'])
 ));
 
-test('With $type = "microseconds"', expectAll(
+test('With $type = "microseconds"', catchAll(
     fn() => v::dateTimeDiff('microseconds', v::equals(7))->assert('6 microseconds ago'),
-    'The number of microseconds between now and "6 microseconds ago" must be equal to 7',
-    '- The number of microseconds between now and "6 microseconds ago" must be equal to 7',
-    ['dateTimeDiffEquals' => 'The number of microseconds between now and "6 microseconds ago" must be equal to 7'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of microseconds between now and "6 microseconds ago" must be equal to 7')
+        ->and($fullMessage)->toBe('- The number of microseconds between now and "6 microseconds ago" must be equal to 7')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'The number of microseconds between now and "6 microseconds ago" must be equal to 7'])
 ));
 
-test('With custom $format', expectAllToMatch(
+test('With custom $format', catchAll(
     fn() => v::dateTimeDiff('years', v::lessThan(8), 'd/m/Y')->assert('09/12/1988'),
-    'The number of years between "%d/%d/%d" and "09/12/1988" must be less than 8',
-    '- The number of years between "%d/%d/%d" and "09/12/1988" must be less than 8',
-    ['dateTimeDiffLessThan' => 'The number of years between "%d/%d/%d" and "09/12/1988" must be less than 8'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toMatch('|The number of years between "\d+/\d+/\d+" and "09/12/1988" must be less than 8|')
+        ->and($fullMessage)->toMatch('|- The number of years between "\d+/\d+/\d+" and "09/12/1988" must be less than 8|'),
 ));
 
-test('With input in non-parseable date', expectAll(
+test('With input in non-parseable date', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2))->assert('not a date'),
-    'For comparison with now, "not a date" must be a valid datetime',
-    '- For comparison with now, "not a date" must be a valid datetime',
-    ['dateTimeDiffEquals' => 'For comparison with now, "not a date" must be a valid datetime'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('For comparison with now, "not a date" must be a valid datetime')
+        ->and($fullMessage)->toBe('- For comparison with now, "not a date" must be a valid datetime')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'For comparison with now, "not a date" must be a valid datetime'])
 ));
 
-test('With input in incorrect $format', expectAllToMatch(
+test('With input in incorrect $format', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2), 'Y-m-d')->assert('1 year ago'),
-    'For comparison with %d-%d-%d, "1 year ago" must be a valid datetime in the format %d-%d-%d',
-    '- For comparison with %d-%d-%d, "1 year ago" must be a valid datetime in the format %d-%d-%d',
-    ['dateTimeDiffEquals' => 'For comparison with %d-%d-%d, "1 year ago" must be a valid datetime in the format %d-%d-%d'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toMatch('/For comparison with \d+-\d+-\d+, "1 year ago" must be a valid datetime in the format \d+-\d+-\d+/')
+        ->and($fullMessage)->toMatch('/- For comparison with \d+-\d+-\d+, "1 year ago" must be a valid datetime in the format \d+-\d+-\d+/')
 ));
 
-test('With custom $now', expectAllToMatch(
+test('With custom $now', catchAll(
     fn() => v::dateTimeDiff('years', v::lessThan(9), null, new DateTimeImmutable())->assert('09/12/1988'),
-    'The number of years between "%d-%d-%d %d:%d:%d.%d" and "09/12/1988" must be less than 9',
-    '- The number of years between "%d-%d-%d %d:%d:%d.%d" and "09/12/1988" must be less than 9',
-    ['dateTimeDiffLessThan' => 'The number of years between "%d-%d-%d %d:%d:%d.%d" and "09/12/1988" must be less than 9'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toMatch('/The number of years between "\d+-\d+-\d+ \d+:\d+:\d+.\d+" and "09\/12\/1988" must be less than 9/')
+        ->and($fullMessage)->toMatch('/- The number of years between "\d+-\d+-\d+ \d+:\d+:\d+.\d+" and "09\/12\/1988" must be less than 9/'),
 ));
 
-test('With custom template', expectAll(
+test('With custom template', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2)->setTemplate('Custom template'))->assert('1 year ago'),
-    'Custom template',
-    '- Custom template',
-    ['equals' => 'Custom template'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Custom template')
+        ->and($fullMessage)->toBe('- Custom template')
+        ->and($messages)->toBe(['equals' => 'Custom template'])
 ));
 
-test('Wrapped by "not"', expectAll(
+test('Wrapped by "not"', catchAll(
     fn() => v::not(v::dateTimeDiff('years', v::lessThan(8)))->assert('7 year ago'),
-    'The number of years between now and "7 year ago" must not be less than 8',
-    '- The number of years between now and "7 year ago" must not be less than 8',
-    ['notDateTimeDiffLessThan' => 'The number of years between now and "7 year ago" must not be less than 8'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of years between now and "7 year ago" must not be less than 8')
+        ->and($fullMessage)->toBe('- The number of years between now and "7 year ago" must not be less than 8')
+        ->and($messages)->toBe(['notDateTimeDiffLessThan' => 'The number of years between now and "7 year ago" must not be less than 8'])
 ));
 
-test('Wrapping "not"', expectAll(
+test('Wrapping "not"', catchAll(
     fn() => v::dateTimeDiff('years', v::not(v::lessThan(9)))->assert('8 year ago'),
-    'The number of years between now and "8 year ago" must not be less than 9',
-    '- The number of years between now and "8 year ago" must not be less than 9',
-    ['dateTimeDiffNotLessThan' => 'The number of years between now and "8 year ago" must not be less than 9'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of years between now and "8 year ago" must not be less than 9')
+        ->and($fullMessage)->toBe('- The number of years between now and "8 year ago" must not be less than 9')
+        ->and($messages)->toBe(['dateTimeDiffNotLessThan' => 'The number of years between now and "8 year ago" must not be less than 9'])
 ));
 
-test('Wrapped with custom template', expectAll(
+test('Wrapped with custom template', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2)->setTemplate('Wrapped with custom template'))->assert('1 year ago'),
-    'Wrapped with custom template',
-    '- Wrapped with custom template',
-    ['equals' => 'Wrapped with custom template'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped with custom template')
+        ->and($fullMessage)->toBe('- Wrapped with custom template')
+        ->and($messages)->toBe(['equals' => 'Wrapped with custom template'])
 ));
 
-test('Wrapper with custom template', expectAll(
+test('Wrapper with custom template', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2))->setTemplate('Wrapper with custom template')->assert('1 year ago'),
-    'Wrapper with custom template',
-    '- Wrapper with custom template',
-    ['dateTimeDiffEquals' => 'Wrapper with custom template'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper with custom template')
+        ->and($fullMessage)->toBe('- Wrapper with custom template')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'Wrapper with custom template'])
 ));
 
-test('Without adjacent result', expectAll(
+test('Without adjacent result', catchAll(
     fn() => v::dateTimeDiff('years', v::primeNumber()->between(2, 5))->assert('1 year ago'),
-    'The number of years between now and "1 year ago" must be a prime number',
-    <<<'FULL_MESSAGE'
-    - "1 year ago" must pass all the rules
-      - The number of years between now and "1 year ago" must be a prime number
-      - The number of years between now and "1 year ago" must be between 2 and 5
-    FULL_MESSAGE,
-    [
-        '__root__' => '"1 year ago" must pass all the rules',
-        'dateTimeDiffPrimeNumber' => 'The number of years between now and "1 year ago" must be a prime number',
-        'dateTimeDiffBetween' => 'The number of years between now and "1 year ago" must be between 2 and 5',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of years between now and "1 year ago" must be a prime number')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "1 year ago" must pass all the rules
+          - The number of years between now and "1 year ago" must be a prime number
+          - The number of years between now and "1 year ago" must be between 2 and 5
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"1 year ago" must pass all the rules',
+            'dateTimeDiffPrimeNumber' => 'The number of years between now and "1 year ago" must be a prime number',
+            'dateTimeDiffBetween' => 'The number of years between now and "1 year ago" must be between 2 and 5',
+        ])
 ));
 
-test('Without adjacent result with templates', expectAll(
+test('Without adjacent result with templates', catchAll(
     fn() => v::dateTimeDiff('years', v::primeNumber()->between(2, 5))->setTemplates([
         'dateTimeDiff' => [
             'primeNumber' => 'Interval must be a valid prime number',
             'between' => 'Interval must be between 2 and 5',
         ],
     ])->assert('1 year ago'),
-    'The number of years between now and "1 year ago" must be a prime number',
-    <<<'FULL_MESSAGE'
-    - "1 year ago" must pass all the rules
-      - The number of years between now and "1 year ago" must be a prime number
-      - The number of years between now and "1 year ago" must be between 2 and 5
-    FULL_MESSAGE,
-    [
-        '__root__' => '"1 year ago" must pass all the rules',
-        'dateTimeDiffPrimeNumber' => 'The number of years between now and "1 year ago" must be a prime number',
-        'dateTimeDiffBetween' => 'The number of years between now and "1 year ago" must be between 2 and 5',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The number of years between now and "1 year ago" must be a prime number')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "1 year ago" must pass all the rules
+          - The number of years between now and "1 year ago" must be a prime number
+          - The number of years between now and "1 year ago" must be between 2 and 5
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"1 year ago" must pass all the rules',
+            'dateTimeDiffPrimeNumber' => 'The number of years between now and "1 year ago" must be a prime number',
+            'dateTimeDiffBetween' => 'The number of years between now and "1 year ago" must be between 2 and 5',
+        ])
 ));

--- a/tests/feature/Rules/DateTimeTest.php
+++ b/tests/feature/Rules/DateTimeTest.php
@@ -9,42 +9,42 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::dateTime()->assert('FooBarBazz'),
-    '"FooBarBazz" must be a valid date/time',
+    fn(string $message) => expect($message)->toBe('"FooBarBazz" must be a valid date/time')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::dateTime('c')->assert('06-12-1995'),
-    '"06-12-1995" must be a valid date/time in the format "2005-12-30T01:02:03+00:00"',
+    fn(string $message) => expect($message)->toBe('"06-12-1995" must be a valid date/time in the format "2005-12-30T01:02:03+00:00"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::dateTime()->assert('QuxQuuxx'),
-    '- "QuxQuuxx" must be a valid date/time',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "QuxQuuxx" must be a valid date/time')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::dateTime('r')->assert(2018013030),
-    '- 2018013030 must be a valid date/time in the format "Fri, 30 Dec 2005 01:02:03 +0000"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2018013030 must be a valid date/time in the format "Fri, 30 Dec 2005 01:02:03 +0000"')
 ));
 
-test('Scenario #5', expectMessage(
+test('Scenario #5', catchMessage(
     fn() => v::not(v::dateTime())->assert('4 days ago'),
-    '"4 days ago" must not be a valid date/time',
+    fn(string $message) => expect($message)->toBe('"4 days ago" must not be a valid date/time')
 ));
 
-test('Scenario #6', expectMessage(
+test('Scenario #6', catchMessage(
     fn() => v::not(v::dateTime('Y-m-d'))->assert('1988-09-09'),
-    '"1988-09-09" must not be a valid date/time in the format "2005-12-30"',
+    fn(string $message) => expect($message)->toBe('"1988-09-09" must not be a valid date/time in the format "2005-12-30"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::dateTime())->assert('+3 weeks'),
-    '- "+3 weeks" must not be a valid date/time',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "+3 weeks" must not be a valid date/time')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::dateTime('d/m/y'))->assert('23/07/99'),
-    '- "23/07/99" must not be a valid date/time in the format "30/12/05"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "23/07/99" must not be a valid date/time in the format "30/12/05"')
 ));

--- a/tests/feature/Rules/DecimalTest.php
+++ b/tests/feature/Rules/DecimalTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::decimal(3)->assert(0.1234),
-    '0.1234 must have 3 decimals',
+    fn(string $message) => expect($message)->toBe('0.1234 must have 3 decimals')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::decimal(2)->assert(0.123),
-    '- 0.123 must have 2 decimals',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0.123 must have 2 decimals')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::decimal(5))->assert(0.12345),
-    '0.12345 must not have 5 decimals',
+    fn(string $message) => expect($message)->toBe('0.12345 must not have 5 decimals')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::decimal(2))->assert(0.34),
-    '- 0.34 must not have 2 decimals',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0.34 must not have 2 decimals')
 ));

--- a/tests/feature/Rules/DigitTest.php
+++ b/tests/feature/Rules/DigitTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::digit()->assert('abc'),
-    '"abc" must contain only digits (0-9)',
+    fn(string $message) => expect($message)->toBe('"abc" must contain only digits (0-9)')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::digit('-')->assert('a-b'),
-    '"a-b" must contain only digits (0-9) and "-"',
+    fn(string $message) => expect($message)->toBe('"a-b" must contain only digits (0-9) and "-"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::digit())->assert('123'),
-    '"123" must not contain digits (0-9)',
+    fn(string $message) => expect($message)->toBe('"123" must not contain digits (0-9)')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::digit('-'))->assert('1-3'),
-    '"1-3" must not contain digits (0-9) and "-"',
+    fn(string $message) => expect($message)->toBe('"1-3" must not contain digits (0-9) and "-"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::digit()->assert('abc'),
-    '- "abc" must contain only digits (0-9)',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc" must contain only digits (0-9)')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::digit('-')->assert('a-b'),
-    '- "a-b" must contain only digits (0-9) and "-"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a-b" must contain only digits (0-9) and "-"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::digit())->assert('123'),
-    '- "123" must not contain digits (0-9)',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "123" must not contain digits (0-9)')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::digit('-'))->assert('1-3'),
-    '- "1-3" must not contain digits (0-9) and "-"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1-3" must not contain digits (0-9) and "-"')
 ));

--- a/tests/feature/Rules/DirectoryTest.php
+++ b/tests/feature/Rules/DirectoryTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::directory()->assert('batman'),
-    '"batman" must be a directory',
+    fn(string $message) => expect($message)->toBe('"batman" must be a directory')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::directory())->assert(dirname('/etc/')),
-    '"/" must not be a directory',
+    fn(string $message) => expect($message)->toBe('"/" must not be a directory')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::directory()->assert('ppz'),
-    '- "ppz" must be a directory',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ppz" must be a directory')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::directory())->assert(dirname('/etc/')),
-    '- "/" must not be a directory',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "/" must not be a directory')
 ));

--- a/tests/feature/Rules/DomainTest.php
+++ b/tests/feature/Rules/DomainTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::domain()->assert('batman'),
-    '"batman" must be a valid domain',
+    fn(string $message) => expect($message)->toBe('"batman" must be a valid domain')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::domain())->assert('r--w.com'),
-    '"r--w.com" must not be a valid domain',
+    fn(string $message) => expect($message)->toBe('"r--w.com" must not be a valid domain')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::domain()->assert('p-éz-.kk'),
-    '- "p-éz-.kk" must be a valid domain',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "p-éz-.kk" must be a valid domain')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::domain())->assert('github.com'),
-    '- "github.com" must not be a valid domain',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "github.com" must not be a valid domain')
 ));

--- a/tests/feature/Rules/EachTest.php
+++ b/tests/feature/Rules/EachTest.php
@@ -7,187 +7,202 @@
 
 declare(strict_types=1);
 
-test('Non-iterable', expectAll(
+test('Non-iterable', catchAll(
     fn() => v::each(v::intType())->assert(null),
-    '`null` must be iterable',
-    '- `null` must be iterable',
-    ['each' => '`null` must be iterable'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`null` must be iterable')
+        ->and($fullMessage)->toBe('- `null` must be iterable')
+        ->and($messages)->toBe(['each' => '`null` must be iterable']),
 ));
 
-test('Empty', expectAll(
+test('Empty', catchAll(
     fn() => v::each(v::intType())->assert([]),
-    '`[]` must not be empty',
-    '- `[]` must not be empty',
-    ['each' => '`[]` must not be empty'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`[]` must not be empty')
+        ->and($fullMessage)->toBe('- `[]` must not be empty')
+        ->and($messages)->toBe(['each' => '`[]` must not be empty']),
 ));
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::each(v::intType())->assert(['a', 'b', 'c']),
-    '`.0` must be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in `["a", "b", "c"]` must be valid
-      - `.0` must be an integer
-      - `.1` must be an integer
-      - `.2` must be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in `["a", "b", "c"]` must be valid',
-        0 => '`.0` must be an integer',
-        1 => '`.1` must be an integer',
-        2 => '`.2` must be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in `["a", "b", "c"]` must be valid
+          - `.0` must be an integer
+          - `.1` must be an integer
+          - `.2` must be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in `["a", "b", "c"]` must be valid',
+            0 => '`.0` must be an integer',
+            1 => '`.1` must be an integer',
+            2 => '`.2` must be an integer',
+        ]),
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::each(v::intType()))->assert([1, 2, 3]),
-    '`.0` must not be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in `[1, 2, 3]` must be invalid
-      - `.0` must not be an integer
-      - `.1` must not be an integer
-      - `.2` must not be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in `[1, 2, 3]` must be invalid',
-        0 => '`.0` must not be an integer',
-        1 => '`.1` must not be an integer',
-        2 => '`.2` must not be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in `[1, 2, 3]` must be invalid
+          - `.0` must not be an integer
+          - `.1` must not be an integer
+          - `.2` must not be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in `[1, 2, 3]` must be invalid',
+            0 => '`.0` must not be an integer',
+            1 => '`.1` must not be an integer',
+            2 => '`.2` must not be an integer',
+        ]),
 ));
 
-test('With name, non-iterable', expectAll(
+test('With name, non-iterable', catchAll(
     fn() => v::each(v::intType()->setName('Wrapped'))->assert(null),
-    'Wrapped must be iterable',
-    '- Wrapped must be iterable',
-    ['each' => 'Wrapped must be iterable'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be iterable')
+        ->and($fullMessage)->toBe('- Wrapped must be iterable')
+        ->and($messages)->toBe(['each' => 'Wrapped must be iterable']),
 ));
 
-test('With name, empty', expectAll(
+test('With name, empty', catchAll(
     fn() => v::each(v::intType()->setName('Wrapped'))->assert([]),
-    'Wrapped must not be empty',
-    '- Wrapped must not be empty',
-    ['each' => 'Wrapped must not be empty'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be empty')
+        ->and($fullMessage)->toBe('- Wrapped must not be empty')
+        ->and($messages)->toBe(['each' => 'Wrapped must not be empty']),
 ));
 
-test('With name, default', expectAll(
+test('With name, default', catchAll(
     fn() => v::each(v::intType()->setName('Wrapped'))->setName('Wrapper')->assert(['a', 'b', 'c']),
-    'Wrapped must be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in Wrapped must be valid
-      - Wrapped must be an integer
-      - Wrapped must be an integer
-      - Wrapped must be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in Wrapped must be valid',
-        0 => 'Wrapped must be an integer',
-        1 => 'Wrapped must be an integer',
-        2 => 'Wrapped must be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in Wrapped must be valid
+          - Wrapped must be an integer
+          - Wrapped must be an integer
+          - Wrapped must be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in Wrapped must be valid',
+            0 => 'Wrapped must be an integer',
+            1 => 'Wrapped must be an integer',
+            2 => 'Wrapped must be an integer',
+        ]),
 ));
 
-test('With name, inverted', expectAll(
+test('With name, inverted', catchAll(
     fn() => v::not(v::each(v::intType()->setName('Wrapped'))->setName('Wrapper'))->setName('Not')->assert([1, 2, 3]),
-    'Wrapped must not be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in Wrapped must be invalid
-      - Wrapped must not be an integer
-      - Wrapped must not be an integer
-      - Wrapped must not be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in Wrapped must be invalid',
-        0 => 'Wrapped must not be an integer',
-        1 => 'Wrapped must not be an integer',
-        2 => 'Wrapped must not be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in Wrapped must be invalid
+          - Wrapped must not be an integer
+          - Wrapped must not be an integer
+          - Wrapped must not be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in Wrapped must be invalid',
+            0 => 'Wrapped must not be an integer',
+            1 => 'Wrapped must not be an integer',
+            2 => 'Wrapped must not be an integer',
+        ]),
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::each(v::intType())->setName('Wrapper')->assert(['a', 'b', 'c']),
-    '`.0` must be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in Wrapper must be valid
-      - `.0` must be an integer
-      - `.1` must be an integer
-      - `.2` must be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in Wrapper must be valid',
-        0 => '`.0` must be an integer',
-        1 => '`.1` must be an integer',
-        2 => '`.2` must be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in Wrapper must be valid
+          - `.0` must be an integer
+          - `.1` must be an integer
+          - `.2` must be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in Wrapper must be valid',
+            0 => '`.0` must be an integer',
+            1 => '`.1` must be an integer',
+            2 => '`.2` must be an integer',
+        ]),
 ));
 
-test('With wrapper name, inverted', expectAll(
+test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::each(v::intType())->setName('Wrapper'))->setName('Not')->assert([1, 2, 3]),
-    '`.0` must not be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in Wrapper must be invalid
-      - `.0` must not be an integer
-      - `.1` must not be an integer
-      - `.2` must not be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in Wrapper must be invalid',
-        0 => '`.0` must not be an integer',
-        1 => '`.1` must not be an integer',
-        2 => '`.2` must not be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in Wrapper must be invalid
+          - `.0` must not be an integer
+          - `.1` must not be an integer
+          - `.2` must not be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in Wrapper must be invalid',
+            0 => '`.0` must not be an integer',
+            1 => '`.1` must not be an integer',
+            2 => '`.2` must not be an integer',
+        ]),
 ));
 
-test('With Not name, inverted', expectAll(
+test('With Not name, inverted', catchAll(
     fn() => v::not(v::each(v::intType()))->setName('Not')->assert([1, 2, 3]),
-    '`.0` must not be an integer',
-    <<<'FULL_MESSAGE'
-    - Each item in Not must be invalid
-      - `.0` must not be an integer
-      - `.1` must not be an integer
-      - `.2` must not be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in Not must be invalid',
-        0 => '`.0` must not be an integer',
-        1 => '`.1` must not be an integer',
-        2 => '`.2` must not be an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in Not must be invalid
+          - `.0` must not be an integer
+          - `.1` must not be an integer
+          - `.2` must not be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in Not must be invalid',
+            0 => '`.0` must not be an integer',
+            1 => '`.1` must not be an integer',
+            2 => '`.2` must not be an integer',
+        ]),
 ));
 
-test('With template, non-iterable', expectAll(
+test('With template, non-iterable', catchAll(
     fn() => v::each(v::intType())->setTemplate('You should have passed an iterable')->assert(null),
-    'You should have passed an iterable',
-    '- You should have passed an iterable',
-    ['each' => 'You should have passed an iterable'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('You should have passed an iterable')
+        ->and($fullMessage)->toBe('- You should have passed an iterable')
+        ->and($messages)->toBe(['each' => 'You should have passed an iterable']),
 ));
 
-test('With template, empty', expectAll(
+test('With template, empty', catchAll(
     fn() => v::each(v::intType())->setTemplate('You should have passed an non-empty')
         ->assert([]),
-    'You should have passed an non-empty',
-    '- You should have passed an non-empty',
-    ['each' => 'You should have passed an non-empty'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('You should have passed an non-empty')
+        ->and($fullMessage)->toBe('- You should have passed an non-empty')
+        ->and($messages)->toBe(['each' => 'You should have passed an non-empty']),
 ));
 
-test('With template, default', expectAll(
+test('With template, default', catchAll(
     fn() => v::each(v::intType())
         ->setTemplate('All items should have been integers')
         ->assert(['a', 'b', 'c']),
-    'All items should have been integers',
-    '- All items should have been integers',
-    ['each' => 'All items should have been integers'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('All items should have been integers')
+        ->and($fullMessage)->toBe('- All items should have been integers')
+        ->and($messages)->toBe(['each' => 'All items should have been integers']),
 ));
 
-test('with template, inverted', expectAll(
+test('with template, inverted', catchAll(
     fn() => v::not(v::each(v::intType()))
         ->setTemplate('All items should not have been integers')
         ->assert([1, 2, 3]),
-    'All items should not have been integers',
-    '- All items should not have been integers',
-    ['notEach' => 'All items should not have been integers'],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('All items should not have been integers')
+        ->and($fullMessage)->toBe('- All items should not have been integers')
+        ->and($messages)->toBe(['notEach' => 'All items should not have been integers']),
 ));
 
-test('With array template, default', expectAll(
+test('With array template, default', catchAll(
     fn() => v::each(v::intType())
         ->setTemplates([
             'each' => [
@@ -198,96 +213,100 @@ test('With array template, default', expectAll(
             ],
         ])
         ->assert(['a', 'b', 'c']),
-    'First item should have been an integer',
-    <<<'FULL_MESSAGE'
-    - Here a sequence of items that did not pass the validation
-      - First item should have been an integer
-      - Second item should have been an integer
-      - Third item should have been an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Here a sequence of items that did not pass the validation',
-        0 => 'First item should have been an integer',
-        1 => 'Second item should have been an integer',
-        2 => 'Third item should have been an integer',
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('First item should have been an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Here a sequence of items that did not pass the validation
+          - First item should have been an integer
+          - Second item should have been an integer
+          - Third item should have been an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Here a sequence of items that did not pass the validation',
+            0 => 'First item should have been an integer',
+            1 => 'Second item should have been an integer',
+            2 => 'Third item should have been an integer',
+        ]),
 ));
 
-test('With array template and name, default', expectAll(
+test('With array template and name, default', catchAll(
     fn() => v::each(v::intType()->setName('Wrapped'))
-        ->setName('Wrapper')
-        ->setTemplates([
-            'Wrapped' => [
-                '__root__' => 'Here a sequence of items that did not pass the validation',
-                0 => 'First item should have been an integer',
-                1 => 'Second item should have been an integer',
-                2 => 'Third item should have been an integer',
-            ],
-        ])
-        ->assert(['a', 'b', 'c']),
-    'First item should have been an integer',
-    <<<'FULL_MESSAGE'
-    - Here a sequence of items that did not pass the validation
-      - First item should have been an integer
-      - Second item should have been an integer
-      - Third item should have been an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Here a sequence of items that did not pass the validation',
-        0 => 'First item should have been an integer',
-        1 => 'Second item should have been an integer',
-        2 => 'Third item should have been an integer',
-    ],
+                ->setName('Wrapper')
+                ->setTemplates([
+                    'Wrapped' => [
+                        '__root__' => 'Here a sequence of items that did not pass the validation',
+                        0 => 'First item should have been an integer',
+                        1 => 'Second item should have been an integer',
+                        2 => 'Third item should have been an integer',
+                    ],
+                ])
+                ->assert(['a', 'b', 'c']),
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('First item should have been an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Here a sequence of items that did not pass the validation
+          - First item should have been an integer
+          - Second item should have been an integer
+          - Third item should have been an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Here a sequence of items that did not pass the validation',
+            0 => 'First item should have been an integer',
+            1 => 'Second item should have been an integer',
+            2 => 'Third item should have been an integer',
+        ]),
 ));
 
-test('Chained wrapped rule', expectAll(
+test('Chained wrapped rule', catchAll(
     fn() => v::each(v::between(5, 7)->odd())->assert([2, 4]),
-    '`.0` must be between 5 and 7',
-    <<<'FULL_MESSAGE'
-    - Each item in `[2, 4]` must be valid
-      - `.0` must pass all the rules
-        - `.0` must be between 5 and 7
-        - `.0` must be an odd number
-      - `.1` must pass all the rules
-        - `.1` must be between 5 and 7
-        - `.1` must be an odd number
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in `[2, 4]` must be valid',
-        0 => [
-            '__root__' => '`.0` must pass all the rules',
-            'between' => '`.0` must be between 5 and 7',
-            'odd' => '`.0` must be an odd number',
-        ],
-        1 => [
-            '__root__' => '`.1` must pass all the rules',
-            'between' => '`.1` must be between 5 and 7',
-            'odd' => '`.1` must be an odd number',
-        ],
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0` must be between 5 and 7')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in `[2, 4]` must be valid
+          - `.0` must pass all the rules
+            - `.0` must be between 5 and 7
+            - `.0` must be an odd number
+          - `.1` must pass all the rules
+            - `.1` must be between 5 and 7
+            - `.1` must be an odd number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in `[2, 4]` must be valid',
+            0 => [
+                '__root__' => '`.0` must pass all the rules',
+                'between' => '`.0` must be between 5 and 7',
+                'odd' => '`.0` must be an odd number',
+            ],
+            1 => [
+                '__root__' => '`.1` must pass all the rules',
+                'between' => '`.1` must be between 5 and 7',
+                'odd' => '`.1` must be an odd number',
+            ],
+        ]),
 ));
 
-test('Multiple nested rules', expectAll(
+test('Multiple nested rules', catchAll(
     fn() => v::each(v::arrayType()->key('my_int', v::intType()->odd()))->assert([['not_int' => 'wrong'], ['my_int' => 2], 'not an array']),
-    '`.0.my_int` must be present',
-    <<<'FULL_MESSAGE'
-    - Each item in `[["not_int": "wrong"], ["my_int": 2], "not an array"]` must be valid
-      - `.0` must pass the rules
-        - `.my_int` must be present
-      - `.1` must pass the rules
-        - `.my_int` must be an odd number
-      - `.2` must pass all the rules
-        - `.2` must be an array
-        - `.my_int` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Each item in `[["not_int": "wrong"], ["my_int": 2], "not an array"]` must be valid',
-        0 => '`.my_int` must be present',
-        1 => '`.my_int` must be an odd number',
-        2 => [
-            '__root__' => '`.2` must pass all the rules',
-            'arrayType' => '`.2` must be an array',
-            'my_int' => '`.my_int` must be present',
-        ],
-    ],
+    fn (string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.0.my_int` must be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Each item in `[["not_int": "wrong"], ["my_int": 2], "not an array"]` must be valid
+          - `.0` must pass the rules
+            - `.my_int` must be present
+          - `.1` must pass the rules
+            - `.my_int` must be an odd number
+          - `.2` must pass all the rules
+            - `.2` must be an array
+            - `.my_int` must be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Each item in `[["not_int": "wrong"], ["my_int": 2], "not an array"]` must be valid',
+            0 => '`.my_int` must be present',
+            1 => '`.my_int` must be an odd number',
+            2 => [
+                '__root__' => '`.2` must pass all the rules',
+                'arrayType' => '`.2` must be an array',
+                'my_int' => '`.my_int` must be present',
+            ],
+        ]),
 ));

--- a/tests/feature/Rules/EmailTest.php
+++ b/tests/feature/Rules/EmailTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::email()->assert('batman'),
-    '"batman" must be a valid email address',
+    fn(string $message) => expect($message)->toBe('"batman" must be a valid email address')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::email())->assert('bruce.wayne@gothancity.com'),
-    '"bruce.wayne@gothancity.com" must not be an email address',
+    fn(string $message) => expect($message)->toBe('"bruce.wayne@gothancity.com" must not be an email address')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::email()->assert('bruce wayne'),
-    '- "bruce wayne" must be a valid email address',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bruce wayne" must be a valid email address')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::email())->assert('iambatman@gothancity.com'),
-    '- "iambatman@gothancity.com" must not be an email address',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "iambatman@gothancity.com" must not be an email address')
 ));

--- a/tests/feature/Rules/EndsWithTest.php
+++ b/tests/feature/Rules/EndsWithTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::endsWith('foo')->assert('bar'),
-    '"bar" must end with "foo"',
+    fn(string $message) => expect($message)->toBe('"bar" must end with "foo"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::endsWith('foo'))->assert(['bar', 'foo']),
-    '`["bar", "foo"]` must not end with "foo"',
+    fn(string $message) => expect($message)->toBe('`["bar", "foo"]` must not end with "foo"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::endsWith('foo')->assert(''),
-    '- "" must end with "foo"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "" must end with "foo"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::endsWith('foo'))->assert(['bar', 'foo']),
-    '- `["bar", "foo"]` must not end with "foo"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["bar", "foo"]` must not end with "foo"')
 ));

--- a/tests/feature/Rules/EqualsTest.php
+++ b/tests/feature/Rules/EqualsTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::equals(123)->assert(321),
-    '321 must be equal to 123',
+    fn(string $message) => expect($message)->toBe('321 must be equal to 123')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::equals(321))->assert(321),
-    '321 must not be equal to 321',
+    fn(string $message) => expect($message)->toBe('321 must not be equal to 321')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::equals(123)->assert(321),
-    '- 321 must be equal to 123',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 321 must be equal to 123')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::equals(321))->assert(321),
-    '- 321 must not be equal to 321',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 321 must not be equal to 321')
 ));

--- a/tests/feature/Rules/EquivalentTest.php
+++ b/tests/feature/Rules/EquivalentTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::equivalent(true)->assert(false),
-    '`false` must be equivalent to `true`',
+    fn(string $message) => expect($message)->toBe('`false` must be equivalent to `true`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::equivalent('Something'))->assert('someThing'),
-    '"someThing" must not be equivalent to "Something"',
+    fn(string $message) => expect($message)->toBe('"someThing" must not be equivalent to "Something"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::equivalent(123)->assert('true'),
-    '- "true" must be equivalent to 123',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "true" must be equivalent to 123')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::equivalent(true))->assert(1),
-    '- 1 must not be equivalent to `true`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 1 must not be equivalent to `true`')
 ));

--- a/tests/feature/Rules/EvenTest.php
+++ b/tests/feature/Rules/EvenTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::even()->assert(-1),
-    '-1 must be an even number',
+    fn(string $message) => expect($message)->toBe('-1 must be an even number')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::even()->assert(5),
-    '- 5 must be an even number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 5 must be an even number')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::even())->assert(6),
-    '6 must be an odd number',
+    fn(string $message) => expect($message)->toBe('6 must be an odd number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::even())->assert(8),
-    '- 8 must be an odd number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 8 must be an odd number')
 ));

--- a/tests/feature/Rules/ExecutableTest.php
+++ b/tests/feature/Rules/ExecutableTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::executable()->assert('bar'),
-    '"bar" must be an executable file',
+    fn(string $message) => expect($message)->toBe('"bar" must be an executable file')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::executable())->assert('tests/fixtures/executable'),
-    '"tests/fixtures/executable" must not be an executable file',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/executable" must not be an executable file')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::executable()->assert('bar'),
-    '- "bar" must be an executable file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bar" must be an executable file')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::executable())->assert('tests/fixtures/executable'),
-    '- "tests/fixtures/executable" must not be an executable file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/executable" must not be an executable file')
 ));

--- a/tests/feature/Rules/ExistsTest.php
+++ b/tests/feature/Rules/ExistsTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::exists()->assert('/path/of/a/non-existent/file'),
-    '"/path/of/a/non-existent/file" must be an existing file',
+    fn(string $message) => expect($message)->toBe('"/path/of/a/non-existent/file" must be an existing file')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::exists())->assert('tests/fixtures/valid-image.gif'),
-    '"tests/fixtures/valid-image.gif" must not be an existing file',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.gif" must not be an existing file')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::exists()->assert('/path/of/a/non-existent/file'),
-    '- "/path/of/a/non-existent/file" must be an existing file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "/path/of/a/non-existent/file" must be an existing file')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::exists())->assert('tests/fixtures/valid-image.png'),
-    '- "tests/fixtures/valid-image.png" must not be an existing file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.png" must not be an existing file')
 ));

--- a/tests/feature/Rules/ExtensionTest.php
+++ b/tests/feature/Rules/ExtensionTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::extension('png')->assert('filename.txt'),
-    '"filename.txt" must have "png" extension',
+    fn(string $message) => expect($message)->toBe('"filename.txt" must have "png" extension')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::extension('gif'))->assert('filename.gif'),
-    '"filename.gif" must not have "gif" extension',
+    fn(string $message) => expect($message)->toBe('"filename.gif" must not have "gif" extension')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::extension('mp3')->assert('filename.wav'),
-    '- "filename.wav" must have "mp3" extension',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename.wav" must have "mp3" extension')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::extension('png'))->assert('tests/fixtures/invalid-image.png'),
-    '- "tests/fixtures/invalid-image.png" must not have "png" extension',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must not have "png" extension')
 ));

--- a/tests/feature/Rules/FactorTest.php
+++ b/tests/feature/Rules/FactorTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::factor(3)->assert(2),
-    '2 must be a factor of 3',
+    fn(string $message) => expect($message)->toBe('2 must be a factor of 3')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::factor(0))->assert(300),
-    '300 must not be a factor of 0',
+    fn(string $message) => expect($message)->toBe('300 must not be a factor of 0')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::factor(5)->assert(3),
-    '- 3 must be a factor of 5',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3 must be a factor of 5')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::factor(6))->assert(1),
-    '- 1 must not be a factor of 6',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 1 must not be a factor of 6')
 ));

--- a/tests/feature/Rules/FalseValTest.php
+++ b/tests/feature/Rules/FalseValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::falseVal()->assert(true),
-    '`true` must evaluate to `false`',
+    fn(string $message) => expect($message)->toBe('`true` must evaluate to `false`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::falseVal())->assert('false'),
-    '"false" must not evaluate to `false`',
+    fn(string $message) => expect($message)->toBe('"false" must not evaluate to `false`')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::falseVal()->assert(1),
-    '- 1 must evaluate to `false`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 1 must evaluate to `false`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::falseVal())->assert(0),
-    '- 0 must not evaluate to `false`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0 must not evaluate to `false`')
 ));

--- a/tests/feature/Rules/FibonacciTest.php
+++ b/tests/feature/Rules/FibonacciTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::fibonacci()->assert(4),
-    '4 must be a valid Fibonacci number',
+    fn(string $message) => expect($message)->toBe('4 must be a valid Fibonacci number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::fibonacci())->assert(5),
-    '5 must not be a valid Fibonacci number',
+    fn(string $message) => expect($message)->toBe('5 must not be a valid Fibonacci number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::fibonacci()->assert(16),
-    '- 16 must be a valid Fibonacci number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 16 must be a valid Fibonacci number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::fibonacci())->assert(21),
-    '- 21 must not be a valid Fibonacci number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 21 must not be a valid Fibonacci number')
 ));

--- a/tests/feature/Rules/FileTest.php
+++ b/tests/feature/Rules/FileTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::file()->assert('tests/fixtures/non-existent.sh'),
-    '"tests/fixtures/non-existent.sh" must be a valid file',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/non-existent.sh" must be a valid file')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::file())->assert('tests/fixtures/valid-image.png'),
-    '"tests/fixtures/valid-image.png" must be an invalid file',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must be an invalid file')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::file()->assert('tests/fixtures/non-existent.sh'),
-    '- "tests/fixtures/non-existent.sh" must be a valid file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/non-existent.sh" must be a valid file')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::file())->assert('tests/fixtures/valid-image.png'),
-    '- "tests/fixtures/valid-image.png" must be an invalid file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.png" must be an invalid file')
 ));

--- a/tests/feature/Rules/FilterVarTest.php
+++ b/tests/feature/Rules/FilterVarTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::filterVar(FILTER_VALIDATE_IP)->assert(42),
-    '42 must be valid',
+    fn(string $message) => expect($message)->toBe('42 must be valid')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::filterVar(FILTER_VALIDATE_BOOLEAN))->assert('On'),
-    '"On" must not be valid',
+    fn(string $message) => expect($message)->toBe('"On" must not be valid')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::filterVar(FILTER_VALIDATE_EMAIL)->assert(1.5),
-    '- 1.5 must be valid',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 1.5 must be valid')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::filterVar(FILTER_VALIDATE_FLOAT))->assert(1.0),
-    '- 1.0 must not be valid',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 1.0 must not be valid')
 ));

--- a/tests/feature/Rules/FiniteTest.php
+++ b/tests/feature/Rules/FiniteTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::finite()->assert(''),
-    '"" must be a finite number',
+    fn(string $message) => expect($message)->toBe('"" must be a finite number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::finite())->assert(10),
-    '10 must not be a finite number',
+    fn(string $message) => expect($message)->toBe('10 must not be a finite number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::finite()->assert([12]),
-    '- `[12]` must be a finite number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[12]` must be a finite number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::finite())->assert('123456'),
-    '- "123456" must not be a finite number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "123456" must not be a finite number')
 ));

--- a/tests/feature/Rules/FloatTypeTest.php
+++ b/tests/feature/Rules/FloatTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::floatType()->assert('42.33'),
-    '"42.33" must be float',
+    fn(string $message) => expect($message)->toBe('"42.33" must be float')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::floatType())->assert(INF),
-    '`INF` must not be float',
+    fn(string $message) => expect($message)->toBe('`INF` must not be float')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::floatType()->assert(true),
-    '- `true` must be float',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be float')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::floatType())->assert(2.0),
-    '- 2.0 must not be float',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2.0 must not be float')
 ));

--- a/tests/feature/Rules/FloatvalTest.php
+++ b/tests/feature/Rules/FloatvalTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::floatVal()->assert('a'),
-    '"a" must be a float value',
+    fn(string $message) => expect($message)->toBe('"a" must be a float value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::floatVal())->assert(165.0),
-    '165.0 must not be a float value',
+    fn(string $message) => expect($message)->toBe('165.0 must not be a float value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::floatVal()->assert('a'),
-    '- "a" must be a float value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a float value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::floatVal())->assert('165.7'),
-    '- "165.7" must not be a float value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "165.7" must not be a float value')
 ));

--- a/tests/feature/Rules/GraphTest.php
+++ b/tests/feature/Rules/GraphTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::graph()->assert("foo\nbar"),
-    '"foo\\nbar" must contain only graphical characters',
+    fn(string $message) => expect($message)->toBe('"foo\\nbar" must contain only graphical characters')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::graph('foo')->assert("foo\nbar"),
-    '"foo\\nbar" must contain only graphical characters and "foo"',
+    fn(string $message) => expect($message)->toBe('"foo\\nbar" must contain only graphical characters and "foo"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::graph())->assert('foobar'),
-    '"foobar" must not contain graphical characters',
+    fn(string $message) => expect($message)->toBe('"foobar" must not contain graphical characters')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::graph("\n"))->assert("foo\nbar"),
-    '"foo\\nbar" must not contain graphical characters or "\\n"',
+    fn(string $message) => expect($message)->toBe('"foo\\nbar" must not contain graphical characters or "\\n"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::graph()->assert("foo\nbar"),
-    '- "foo\\nbar" must contain only graphical characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must contain only graphical characters')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::graph('foo')->assert("foo\nbar"),
-    '- "foo\\nbar" must contain only graphical characters and "foo"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must contain only graphical characters and "foo"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::graph())->assert('foobar'),
-    '- "foobar" must not contain graphical characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foobar" must not contain graphical characters')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::graph("\n"))->assert("foo\nbar"),
-    '- "foo\\nbar" must not contain graphical characters or "\\n"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must not contain graphical characters or "\\n"')
 ));

--- a/tests/feature/Rules/GreaterThanOrEqualTest.php
+++ b/tests/feature/Rules/GreaterThanOrEqualTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::greaterThanOrEqual(INF)->assert(10),
-    '10 must be greater than or equal to `INF`',
+    fn(string $message) => expect($message)->toBe('10 must be greater than or equal to `INF`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::greaterThanOrEqual(5))->assert(INF),
-    '`INF` must be less than 5',
+    fn(string $message) => expect($message)->toBe('`INF` must be less than 5')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::greaterThanOrEqual('today')->assert('yesterday'),
-    '- "yesterday" must be greater than or equal to "today"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "yesterday" must be greater than or equal to "today"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::greaterThanOrEqual('a'))->assert('z'),
-    '- "z" must be less than "a"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "z" must be less than "a"')
 ));

--- a/tests/feature/Rules/GreaterThanTest.php
+++ b/tests/feature/Rules/GreaterThanTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::greaterThan(21)->assert(12),
-    '12 must be greater than 21',
+    fn(string $message) => expect($message)->toBe('12 must be greater than 21')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::greaterThan('yesterday'))->assert('today'),
-    '"today" must not be greater than "yesterday"',
+    fn(string $message) => expect($message)->toBe('"today" must not be greater than "yesterday"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::greaterThan('2018-09-09')->assert('1988-09-09'),
-    '- "1988-09-09" must be greater than "2018-09-09"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1988-09-09" must be greater than "2018-09-09"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::greaterThan('a'))->assert('ba'),
-    '- "ba" must not be greater than "a"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ba" must not be greater than "a"')
 ));

--- a/tests/feature/Rules/HetuTest.php
+++ b/tests/feature/Rules/HetuTest.php
@@ -7,30 +7,34 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::hetu()->assert('010106A901O'),
-    '"010106A901O" must be a valid Finnish personal identity code',
-    '- "010106A901O" must be a valid Finnish personal identity code',
-    ['hetu' => '"010106A901O" must be a valid Finnish personal identity code'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"010106A901O" must be a valid Finnish personal identity code')
+        ->and($fullMessage)->toBe('- "010106A901O" must be a valid Finnish personal identity code')
+        ->and($messages)->toBe(['hetu' => '"010106A901O" must be a valid Finnish personal identity code'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::hetu())->assert('010106A9012'),
-    '"010106A9012" must not be a valid Finnish personal identity code',
-    '- "010106A9012" must not be a valid Finnish personal identity code',
-    ['notHetu' => '"010106A9012" must not be a valid Finnish personal identity code'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"010106A9012" must not be a valid Finnish personal identity code')
+        ->and($fullMessage)->toBe('- "010106A9012" must not be a valid Finnish personal identity code')
+        ->and($messages)->toBe(['notHetu' => '"010106A9012" must not be a valid Finnish personal identity code'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::hetu()->assert('010106A901O', 'That is not a HETU'),
-    'That is not a HETU',
-    '- That is not a HETU',
-    ['hetu' => 'That is not a HETU'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('That is not a HETU')
+        ->and($fullMessage)->toBe('- That is not a HETU')
+        ->and($messages)->toBe(['hetu' => 'That is not a HETU'])
 ));
 
-test('With name', expectAll(
+test('With name', catchAll(
     fn() => v::hetu()->setName('Hetu')->assert('010106A901O'),
-    'Hetu must be a valid Finnish personal identity code',
-    '- Hetu must be a valid Finnish personal identity code',
-    ['hetu' => 'Hetu must be a valid Finnish personal identity code'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Hetu must be a valid Finnish personal identity code')
+        ->and($fullMessage)->toBe('- Hetu must be a valid Finnish personal identity code')
+        ->and($messages)->toBe(['hetu' => 'Hetu must be a valid Finnish personal identity code'])
 ));

--- a/tests/feature/Rules/HexRgbColorTest.php
+++ b/tests/feature/Rules/HexRgbColorTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::hexRgbColor()->assert('invalid'),
-    '"invalid" must be a hex RGB color',
+    fn(string $message) => expect($message)->toBe('"invalid" must be a hex RGB color')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::hexRgbColor())->assert('#808080'),
-    '"#808080" must not be a hex RGB color',
+    fn(string $message) => expect($message)->toBe('"#808080" must not be a hex RGB color')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::hexRgbColor()->assert('invalid'),
-    '- "invalid" must be a hex RGB color',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "invalid" must be a hex RGB color')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::hexRgbColor())->assert('#808080'),
-    '- "#808080" must not be a hex RGB color',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "#808080" must not be a hex RGB color')
 ));

--- a/tests/feature/Rules/IbanTest.php
+++ b/tests/feature/Rules/IbanTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::iban()->assert('SE35 5000 5880 7742'),
-    '"SE35 5000 5880 7742" must be a valid IBAN',
+    fn(string $message) => expect($message)->toBe('"SE35 5000 5880 7742" must be a valid IBAN')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::iban())->assert('GB82 WEST 1234 5698 7654 32'),
-    '"GB82 WEST 1234 5698 7654 32" must not be a valid IBAN',
+    fn(string $message) => expect($message)->toBe('"GB82 WEST 1234 5698 7654 32" must not be a valid IBAN')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::iban()->assert('NOT AN IBAN'),
-    '- "NOT AN IBAN" must be a valid IBAN',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "NOT AN IBAN" must be a valid IBAN')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::iban())->assert('HU93 1160 0006 0000 0000 1234 5676'),
-    '- "HU93 1160 0006 0000 0000 1234 5676" must not be a valid IBAN',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "HU93 1160 0006 0000 0000 1234 5676" must not be a valid IBAN')
 ));

--- a/tests/feature/Rules/IdenticalTest.php
+++ b/tests/feature/Rules/IdenticalTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::identical(123)->assert(321),
-    '321 must be identical to 123',
+    fn(string $message) => expect($message)->toBe('321 must be identical to 123')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::identical(321))->assert(321),
-    '321 must not be identical to 321',
+    fn(string $message) => expect($message)->toBe('321 must not be identical to 321')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::identical(123)->assert(321),
-    '- 321 must be identical to 123',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 321 must be identical to 123')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::identical(321))->assert(321),
-    '- 321 must not be identical to 321',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 321 must not be identical to 321')
 ));

--- a/tests/feature/Rules/ImageTest.php
+++ b/tests/feature/Rules/ImageTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::image()->assert('tests/fixtures/invalid-image.png'),
-    '"tests/fixtures/invalid-image.png" must be a valid image file',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/invalid-image.png" must be a valid image file')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::image())->assert('tests/fixtures/valid-image.png'),
-    '"tests/fixtures/valid-image.png" must not be a valid image file',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be a valid image file')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::image()->assert(new stdClass()),
-    '- `stdClass {}` must be a valid image file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a valid image file')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::image())->assert('tests/fixtures/valid-image.gif'),
-    '- "tests/fixtures/valid-image.gif" must not be a valid image file',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.gif" must not be a valid image file')
 ));

--- a/tests/feature/Rules/ImeiTest.php
+++ b/tests/feature/Rules/ImeiTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::imei()->assert('490154203237512'),
-    '"490154203237512" must be a valid IMEI number',
+    fn(string $message) => expect($message)->toBe('"490154203237512" must be a valid IMEI number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::imei())->assert('350077523237513'),
-    '"350077523237513" must not be a valid IMEI number',
+    fn(string $message) => expect($message)->toBe('"350077523237513" must not be a valid IMEI number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::imei()->assert(null),
-    '- `null` must be a valid IMEI number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `null` must be a valid IMEI number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::imei())->assert('356938035643809'),
-    '- "356938035643809" must not be a valid IMEI number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "356938035643809" must not be a valid IMEI number')
 ));

--- a/tests/feature/Rules/InTest.php
+++ b/tests/feature/Rules/InTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::in([3, 2])->assert(1),
-    '1 must be in `[3, 2]`',
+    fn(string $message) => expect($message)->toBe('1 must be in `[3, 2]`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::in('foobar'))->assert('foo'),
-    '"foo" must not be in "foobar"',
+    fn(string $message) => expect($message)->toBe('"foo" must not be in "foobar"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::in([2, '1', 3], true)->assert('2'),
-    '- "2" must be in `[2, "1", 3]`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2" must be in `[2, "1", 3]`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::in([2, '1', 3], true))->assert('1'),
-    '- "1" must not be in `[2, "1", 3]`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must not be in `[2, "1", 3]`')
 ));

--- a/tests/feature/Rules/InfiniteTest.php
+++ b/tests/feature/Rules/InfiniteTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::infinite()->assert(-9),
-    '-9 must be an infinite number',
+    fn(string $message) => expect($message)->toBe('-9 must be an infinite number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::infinite())->assert(INF),
-    '`INF` must not be an infinite number',
+    fn(string $message) => expect($message)->toBe('`INF` must not be an infinite number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::infinite()->assert(new stdClass()),
-    '- `stdClass {}` must be an infinite number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be an infinite number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::infinite())->assert(INF * -1),
-    '- `-INF` must not be an infinite number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `-INF` must not be an infinite number')
 ));

--- a/tests/feature/Rules/InstanceTest.php
+++ b/tests/feature/Rules/InstanceTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::instance(DateTime::class)->assert(''),
-    '"" must be an instance of `DateTime`',
+    fn(string $message) => expect($message)->toBe('"" must be an instance of `DateTime`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::instance(Traversable::class))->assert(new ArrayObject()),
-    '`ArrayObject { getArrayCopy() => [] }` must not be an instance of `Traversable`',
+    fn(string $message) => expect($message)->toBe('`ArrayObject { getArrayCopy() => [] }` must not be an instance of `Traversable`')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::instance(ArrayIterator::class)->assert(new stdClass()),
-    '- `stdClass {}` must be an instance of `ArrayIterator`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be an instance of `ArrayIterator`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::instance(stdClass::class))->assert(new stdClass()),
-    '- `stdClass {}` must not be an instance of `stdClass`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must not be an instance of `stdClass`')
 ));

--- a/tests/feature/Rules/IntTypeTest.php
+++ b/tests/feature/Rules/IntTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::intType()->assert(new stdClass()),
-    '`stdClass {}` must be an integer',
+    fn(string $message) => expect($message)->toBe('`stdClass {}` must be an integer')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::intType())->assert(42),
-    '42 must not be an integer',
+    fn(string $message) => expect($message)->toBe('42 must not be an integer')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::intType()->assert(INF),
-    '- `INF` must be an integer',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `INF` must be an integer')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::intType())->assert(1234567890),
-    '- 1234567890 must not be an integer',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 1234567890 must not be an integer')
 ));

--- a/tests/feature/Rules/IntValTest.php
+++ b/tests/feature/Rules/IntValTest.php
@@ -7,32 +7,32 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::intVal()->assert('42.33'),
-    '"42.33" must be an integer value',
+    fn(string $message) => expect($message)->toBe('"42.33" must be an integer value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::intVal())->assert(2),
-    '2 must not be an integer value',
+    fn(string $message) => expect($message)->toBe('2 must not be an integer value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::intVal()->assert('Foo'),
-    '- "Foo" must be an integer value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must be an integer value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::intVal())->assert(3),
-    '- 3 must not be an integer value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3 must not be an integer value')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::not(v::intVal())->assert(-42),
-    '- -42 must not be an integer value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- -42 must not be an integer value')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::intVal())->assert('-42'),
-    '- "-42" must not be an integer value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "-42" must not be an integer value')
 ));

--- a/tests/feature/Rules/IpTest.php
+++ b/tests/feature/Rules/IpTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::ip()->assert('257.0.0.1'),
-    '"257.0.0.1" must be an IP address',
+    fn(string $message) => expect($message)->toBe('"257.0.0.1" must be an IP address')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::ip())->assert('127.0.0.1'),
-    '"127.0.0.1" must not be an IP address',
+    fn(string $message) => expect($message)->toBe('"127.0.0.1" must not be an IP address')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::ip('127.0.1.*')->assert('127.0.0.1'),
-    '"127.0.0.1" must be an IP address in the 127.0.1.0-127.0.1.255 range',
+    fn(string $message) => expect($message)->toBe('"127.0.0.1" must be an IP address in the 127.0.1.0-127.0.1.255 range')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::ip('127.0.1.*'))->assert('127.0.1.1'),
-    '"127.0.1.1" must not be an IP address in the 127.0.1.0-127.0.1.255 range',
+    fn(string $message) => expect($message)->toBe('"127.0.1.1" must not be an IP address in the 127.0.1.0-127.0.1.255 range')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::ip()->assert('257.0.0.1'),
-    '- "257.0.0.1" must be an IP address',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "257.0.0.1" must be an IP address')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::ip())->assert('127.0.0.1'),
-    '- "127.0.0.1" must not be an IP address',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "127.0.0.1" must not be an IP address')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::ip('127.0.1.*')->assert('127.0.0.1'),
-    '- "127.0.0.1" must be an IP address in the 127.0.1.0-127.0.1.255 range',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "127.0.0.1" must be an IP address in the 127.0.1.0-127.0.1.255 range')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::ip('127.0.1.*'))->assert('127.0.1.1'),
-    '- "127.0.1.1" must not be an IP address in the 127.0.1.0-127.0.1.255 range',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "127.0.1.1" must not be an IP address in the 127.0.1.0-127.0.1.255 range')
 ));

--- a/tests/feature/Rules/IsbnTest.php
+++ b/tests/feature/Rules/IsbnTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::isbn()->assert('ISBN-12: 978-0-596-52068-7'),
-    '"ISBN-12: 978-0-596-52068-7" must be a valid ISBN',
+    fn(string $message) => expect($message)->toBe('"ISBN-12: 978-0-596-52068-7" must be a valid ISBN')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::isbn())->assert('ISBN-13: 978-0-596-52068-7'),
-    '"ISBN-13: 978-0-596-52068-7" must not be a valid ISBN',
+    fn(string $message) => expect($message)->toBe('"ISBN-13: 978-0-596-52068-7" must not be a valid ISBN')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::isbn()->assert('978 10 596 52068 7'),
-    '- "978 10 596 52068 7" must be a valid ISBN',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "978 10 596 52068 7" must be a valid ISBN')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::isbn())->assert('978 0 596 52068 7'),
-    '- "978 0 596 52068 7" must not be a valid ISBN',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "978 0 596 52068 7" must not be a valid ISBN')
 ));

--- a/tests/feature/Rules/IterableTypeTest.php
+++ b/tests/feature/Rules/IterableTypeTest.php
@@ -7,30 +7,34 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::iterableType()->assert(null),
-    '`null` must be iterable',
-    '- `null` must be iterable',
-    ['iterableType' => '`null` must be iterable'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`null` must be iterable')
+        ->and($fullMessage)->toBe('- `null` must be iterable')
+        ->and($messages)->toBe(['iterableType' => '`null` must be iterable'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::iterableType())->assert([1, 2, 3]),
-    '`[1, 2, 3]` must not iterable',
-    '- `[1, 2, 3]` must not iterable',
-    ['notIterableType' => '`[1, 2, 3]` must not iterable'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`[1, 2, 3]` must not iterable')
+        ->and($fullMessage)->toBe('- `[1, 2, 3]` must not iterable')
+        ->and($messages)->toBe(['notIterableType' => '`[1, 2, 3]` must not iterable'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::iterableType()->assert(null, 'Not an iterable at all'),
-    'Not an iterable at all',
-    '- Not an iterable at all',
-    ['iterableType' => 'Not an iterable at all'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not an iterable at all')
+        ->and($fullMessage)->toBe('- Not an iterable at all')
+        ->and($messages)->toBe(['iterableType' => 'Not an iterable at all'])
 ));
 
-test('With name', expectAll(
+test('With name', catchAll(
     fn() => v::iterableType()->setName('Options')->assert(null),
-    'Options must be iterable',
-    '- Options must be iterable',
-    ['iterableType' => 'Options must be iterable'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Options must be iterable')
+        ->and($fullMessage)->toBe('- Options must be iterable')
+        ->and($messages)->toBe(['iterableType' => 'Options must be iterable'])
 ));

--- a/tests/feature/Rules/IterableValTest.php
+++ b/tests/feature/Rules/IterableValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::iterableVal()->assert(3),
-    '3 must be an iterable value',
+    fn(string $message) => expect($message)->toBe('3 must be an iterable value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::iterableVal())->assert([2, 3]),
-    '`[2, 3]` must not be an iterable value',
+    fn(string $message) => expect($message)->toBe('`[2, 3]` must not be an iterable value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::iterableVal()->assert('String'),
-    '- "String" must be an iterable value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "String" must be an iterable value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::iterableVal())->assert(new stdClass()),
-    '- `stdClass {}` must not be an iterable value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must not be an iterable value')
 ));

--- a/tests/feature/Rules/JsonTest.php
+++ b/tests/feature/Rules/JsonTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::json()->assert(false),
-    '`false` must be a valid JSON string',
+    fn(string $message) => expect($message)->toBe('`false` must be a valid JSON string')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::json())->assert('{"foo": "bar", "number":1}'),
-    '"{\\"foo\\": \\"bar\\", \\"number\\":1}" must not be a valid JSON string',
+    fn(string $message) => expect($message)->toBe('"{\\"foo\\": \\"bar\\", \\"number\\":1}" must not be a valid JSON string')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::json()->assert(new stdClass()),
-    '- `stdClass {}` must be a valid JSON string',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a valid JSON string')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::json())->assert('{}'),
-    '- "{}" must not be a valid JSON string',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "{}" must not be a valid JSON string')
 ));

--- a/tests/feature/Rules/KeyExistsTest.php
+++ b/tests/feature/Rules/KeyExistsTest.php
@@ -7,30 +7,34 @@
 
 declare(strict_types=1);
 
-test('Default mode', expectAll(
+test('Default mode', catchAll(
     fn() => v::keyExists('foo')->assert(['bar' => 'baz']),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('Inverted mode', expectAll(
+test('Inverted mode', catchAll(
     fn() => v::not(v::keyExists('foo'))->assert(['foo' => 'baz']),
-    '`.foo` must not be present',
-    '- `.foo` must not be present',
-    ['foo' => '`.foo` must not be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must not be present')
+        ->and($fullMessage)->toBe('- `.foo` must not be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must not be present'])
 ));
 
-test('Custom name', expectAll(
+test('Custom name', catchAll(
     fn() => v::keyExists('foo')->setName('Custom name')->assert(['bar' => 'baz']),
-    'Custom name must be present',
-    '- Custom name must be present',
-    ['foo' => 'Custom name must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Custom name must be present')
+        ->and($fullMessage)->toBe('- Custom name must be present')
+        ->and($messages)->toBe(['foo' => 'Custom name must be present'])
 ));
 
-test('Custom template', expectAll(
+test('Custom template', catchAll(
     fn() => v::keyExists('foo')->assert(['bar' => 'baz'], 'Custom template for {{name}}'),
-    'Custom template for `.foo`',
-    '- Custom template for `.foo`',
-    ['foo' => 'Custom template for `.foo`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Custom template for `.foo`')
+        ->and($fullMessage)->toBe('- Custom template for `.foo`')
+        ->and($messages)->toBe(['foo' => 'Custom template for `.foo`'])
 ));

--- a/tests/feature/Rules/KeyOptionalTest.php
+++ b/tests/feature/Rules/KeyOptionalTest.php
@@ -7,72 +7,82 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::keyOptional('foo', v::intType())->assert(['foo' => 'string']),
-    '`.foo` must be an integer',
-    '- `.foo` must be an integer',
-    ['foo' => '`.foo` must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must be an integer'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType()))->assert(['foo' => 12]),
-    '`.foo` must not be an integer',
-    '- `.foo` must not be an integer',
-    ['foo' => '`.foo` must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must not be an integer'])
 ));
 
-test('Inverted with missing key', expectAll(
+test('Inverted with missing key', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType()))->assert([]),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('With wrapped name, default', expectAll(
+test('With wrapped name, default', catchAll(
     fn() => v::keyOptional('foo', v::intType()->setName('Wrapped'))->setName('Wrapper')->assert(['foo' => 'string']),
-    'Wrapped must be an integer',
-    '- Wrapped must be an integer',
-    ['foo' => 'Wrapped must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must be an integer'])
 ));
 
-test('With wrapped name, inverted', expectAll(
+test('With wrapped name, inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType()->setName('Wrapped'))->setName('Wrapper'))->setName('Not')->assert(['foo' => 12]),
-    'Wrapped must not be an integer',
-    '- Wrapped must not be an integer',
-    ['foo' => 'Wrapped must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must not be an integer'])
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::keyOptional('foo', v::intType())->setName('Wrapper')->assert(['foo' => 'string']),
-    'Wrapper must be an integer',
-    '- Wrapper must be an integer',
-    ['foo' => 'Wrapper must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer'])
 ));
 
-test('With wrapper name, inverted', expectAll(
+test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType())->setName('Wrapper'))->setName('Not')->assert(['foo' => 12]),
-    'Wrapper must not be an integer',
-    '- Wrapper must not be an integer',
-    ['foo' => 'Wrapper must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer'])
 ));
 
-test('With "Not" name, inverted', expectAll(
+test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType()))->setName('Not')->assert(['foo' => 12]),
-    'Not must not be an integer',
-    '- Not must not be an integer',
-    ['foo' => 'Not must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not be an integer')
+        ->and($fullMessage)->toBe('- Not must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Not must not be an integer'])
 ));
 
-test('With template, default', expectAll(
+test('With template, default', catchAll(
     fn() => v::keyOptional('foo', v::intType())->assert(['foo' => 'string'], 'That key is off-key'),
-    'That key is off-key',
-    '- That key is off-key',
-    ['foo' => 'That key is off-key'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('That key is off-key')
+        ->and($fullMessage)->toBe('- That key is off-key')
+        ->and($messages)->toBe(['foo' => 'That key is off-key'])
 ));
 
-test('With template, inverted', expectAll(
+test('With template, inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType()))->assert(['foo' => 12], 'No off-key key'),
-    'No off-key key',
-    '- No off-key key',
-    ['foo' => 'No off-key key'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('No off-key key')
+        ->and($fullMessage)->toBe('- No off-key key')
+        ->and($messages)->toBe(['foo' => 'No off-key key'])
 ));

--- a/tests/feature/Rules/KeySetTest.php
+++ b/tests/feature/Rules/KeySetTest.php
@@ -7,209 +7,222 @@
 
 declare(strict_types=1);
 
-test('one rule / one failed', expectAll(
+test('one rule / one failed', catchAll(
     fn() => v::keySet(v::key('foo', v::intType()))->assert(['foo' => 'string']),
-    '`.foo` must be an integer',
-    '- `.foo` must be an integer',
-    ['foo' => '`.foo` must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must be an integer'])
 ));
 
-test('one rule / one missing key', expectAll(
+test('one rule / one missing key', catchAll(
     fn() => v::keySet(v::keyExists('foo'))->assert([]),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('one rule / one extra key', expectAll(
+test('one rule / one extra key', catchAll(
     fn() => v::keySet(v::keyExists('foo'))->assert(['foo' => 42, 'bar' => 'string']),
-    '`.bar` must not be present',
-    '- `.bar` must not be present',
-    ['bar' => '`.bar` must not be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.bar` must not be present')
+        ->and($fullMessage)->toBe('- `.bar` must not be present')
+        ->and($messages)->toBe(['bar' => '`.bar` must not be present'])
 ));
 
-test('one rule / one extra key / one missing key', expectAll(
+test('one rule / one extra key / one missing key', catchAll(
     fn() => v::keySet(v::keyExists('foo'))->assert(['bar' => true]),
-    '`.foo` must be present',
-    <<<'FULL_MESSAGE'
-    - `["bar": true]` contains both missing and extra keys
-      - `.foo` must be present
-      - `.bar` must not be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["bar": true]` contains both missing and extra keys',
-        'foo' => '`.foo` must be present',
-        'bar' => '`.bar` must not be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["bar": true]` contains both missing and extra keys
+          - `.foo` must be present
+          - `.bar` must not be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["bar": true]` contains both missing and extra keys',
+            'foo' => '`.foo` must be present',
+            'bar' => '`.bar` must not be present',
+        ])
 ));
 
-test('one rule / two extra keys', expectAll(
+test('one rule / two extra keys', catchAll(
     fn() => v::keySet(v::keyExists('foo'))->assert(['foo' => 42, 'bar' => 'string', 'baz' => true]),
-    '`.bar` must not be present',
-    <<<'FULL_MESSAGE'
-    - `["foo": 42, "bar": "string", "baz": true]` contains extra keys
-      - `.bar` must not be present
-      - `.baz` must not be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["foo": 42, "bar": "string", "baz": true]` contains extra keys',
-        'bar' => '`.bar` must not be present',
-        'baz' => '`.baz` must not be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.bar` must not be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["foo": 42, "bar": "string", "baz": true]` contains extra keys
+          - `.bar` must not be present
+          - `.baz` must not be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["foo": 42, "bar": "string", "baz": true]` contains extra keys',
+            'bar' => '`.bar` must not be present',
+            'baz' => '`.baz` must not be present',
+        ])
 ));
 
-test('one rule / more than ten extra keys', expectAll(
+test('one rule / more than ten extra keys', catchAll(
     fn() => v::keySet(v::keyExists('foo'))
-        ->assert([
-            'foo' => 42,
-            'bar' => 'string',
-            'baz' => true,
-            'qux' => false,
-            'quux' => 42,
-            'corge' => 'string',
-            'grault' => true,
-            'garply' => false,
-            'waldo' => 42,
-            'fred' => 'string',
-            'plugh' => true,
-            'xyzzy' => false,
-            'thud' => 42,
-        ]),
-    '`.bar` must not be present',
-    <<<'FULL_MESSAGE'
-    - `["foo": 42, "bar": "string", "baz": true, "qux": false, "quux": 42, ...]` contains extra keys
-      - `.bar` must not be present
-      - `.baz` must not be present
-      - `.qux` must not be present
-      - `.quux` must not be present
-      - `.corge` must not be present
-      - `.grault` must not be present
-      - `.garply` must not be present
-      - `.waldo` must not be present
-      - `.fred` must not be present
-      - `.plugh` must not be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["foo": 42, "bar": "string", "baz": true, "qux": false, "quux": 42, ...]` contains extra keys',
-        'bar' => '`.bar` must not be present',
-        'baz' => '`.baz` must not be present',
-        'qux' => '`.qux` must not be present',
-        'quux' => '`.quux` must not be present',
-        'corge' => '`.corge` must not be present',
-        'grault' => '`.grault` must not be present',
-        'garply' => '`.garply` must not be present',
-        'waldo' => '`.waldo` must not be present',
-        'fred' => '`.fred` must not be present',
-        'plugh' => '`.plugh` must not be present',
-    ],
+            ->assert([
+                'foo' => 42,
+                'bar' => 'string',
+                'baz' => true,
+                'qux' => false,
+                'quux' => 42,
+                'corge' => 'string',
+                'grault' => true,
+                'garply' => false,
+                'waldo' => 42,
+                'fred' => 'string',
+                'plugh' => true,
+                'xyzzy' => false,
+                'thud' => 42,
+            ]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.bar` must not be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["foo": 42, "bar": "string", "baz": true, "qux": false, "quux": 42, ...]` contains extra keys
+          - `.bar` must not be present
+          - `.baz` must not be present
+          - `.qux` must not be present
+          - `.quux` must not be present
+          - `.corge` must not be present
+          - `.grault` must not be present
+          - `.garply` must not be present
+          - `.waldo` must not be present
+          - `.fred` must not be present
+          - `.plugh` must not be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["foo": 42, "bar": "string", "baz": true, "qux": false, "quux": 42, ...]` contains extra keys',
+            'bar' => '`.bar` must not be present',
+            'baz' => '`.baz` must not be present',
+            'qux' => '`.qux` must not be present',
+            'quux' => '`.quux` must not be present',
+            'corge' => '`.corge` must not be present',
+            'grault' => '`.grault` must not be present',
+            'garply' => '`.garply` must not be present',
+            'waldo' => '`.waldo` must not be present',
+            'fred' => '`.fred` must not be present',
+            'plugh' => '`.plugh` must not be present',
+        ])
 ));
 
-test('multiple rules / one failed', expectAll(
+test('multiple rules / one failed', catchAll(
     fn() => v::keySet(v::keyExists('foo'), v::keyExists('bar'))->assert(['foo' => 42]),
-    '`.bar` must be present',
-    '- `.bar` must be present',
-    ['bar' => '`.bar` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.bar` must be present')
+        ->and($fullMessage)->toBe('- `.bar` must be present')
+        ->and($messages)->toBe(['bar' => '`.bar` must be present'])
 ));
 
-test('multiple rules / all failed', expectAll(
+test('multiple rules / all failed', catchAll(
     fn() => v::keySet(v::keyExists('foo'), v::keyExists('bar'))->assert([]),
-    '`.foo` must be present',
-    <<<'FULL_MESSAGE'
-    - `[]` contains missing keys
-      - `.foo` must be present
-      - `.bar` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`[]` contains missing keys',
-        'foo' => '`.foo` must be present',
-        'bar' => '`.bar` must be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `[]` contains missing keys
+          - `.foo` must be present
+          - `.bar` must be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`[]` contains missing keys',
+            'foo' => '`.foo` must be present',
+            'bar' => '`.bar` must be present',
+        ])
 ));
 
-test('multiple rules / one extra key', expectAll(
+test('multiple rules / one extra key', catchAll(
     fn() => v::keySet(
         v::keyExists('foo'),
         v::keyExists('bar'),
     )->assert(['foo' => 42, 'bar' => 'string', 'baz' => true]),
-    '`.baz` must not be present',
-    '- `.baz` must not be present',
-    ['baz' => '`.baz` must not be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.baz` must not be present')
+        ->and($fullMessage)->toBe('- `.baz` must not be present')
+        ->and($messages)->toBe(['baz' => '`.baz` must not be present'])
 ));
 
-test('multiple rules / one extra key / one missing', expectAll(
+test('multiple rules / one extra key / one missing', catchAll(
     fn() => v::keySet(
         v::keyExists('foo'),
         v::keyExists('bar'),
     )->assert(['bar' => 'string', 'baz' => true]),
-    '`.foo` must be present',
-    <<<'FULL_MESSAGE'
-    - `["bar": "string", "baz": true]` contains both missing and extra keys
-      - `.foo` must be present
-      - `.baz` must not be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["bar": "string", "baz": true]` contains both missing and extra keys',
-        'foo' => '`.foo` must be present',
-        'baz' => '`.baz` must not be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["bar": "string", "baz": true]` contains both missing and extra keys
+          - `.foo` must be present
+          - `.baz` must not be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["bar": "string", "baz": true]` contains both missing and extra keys',
+            'foo' => '`.foo` must be present',
+            'baz' => '`.baz` must not be present',
+        ])
 ));
 
-test('multiple rules / two extra keys', expectAll(
+test('multiple rules / two extra keys', catchAll(
     fn() => v::keySet(
         v::keyExists('foo'),
         v::keyExists('bar'),
         v::keyOptional('qux', v::intType()),
     )->assert(['foo' => 42, 'bar' => 'string', 'baz' => true, 'qux' => false]),
-    '`.qux` must be an integer',
-    <<<'FULL_MESSAGE'
-    - `["foo": 42, "bar": "string", "baz": true, "qux": false]` contains extra keys
-      - `.qux` must be an integer
-      - `.baz` must not be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["foo": 42, "bar": "string", "baz": true, "qux": false]` contains extra keys',
-        'qux' => '`.qux` must be an integer',
-        'baz' => '`.baz` must not be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.qux` must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["foo": 42, "bar": "string", "baz": true, "qux": false]` contains extra keys
+          - `.qux` must be an integer
+          - `.baz` must not be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["foo": 42, "bar": "string", "baz": true, "qux": false]` contains extra keys',
+            'qux' => '`.qux` must be an integer',
+            'baz' => '`.baz` must not be present',
+        ])
 ));
 
-test('multiple rules / all failed validation', expectAll(
+test('multiple rules / all failed validation', catchAll(
     fn() => v::keySet(
         v::key('foo', v::intType()),
         v::key('bar', v::intType()),
         v::key('baz', v::intType()),
     )
-        ->assert(['foo' => 42, 'bar' => 'string', 'baz' => true]),
-    '`.bar` must be an integer',
-    <<<'FULL_MESSAGE'
-    - `["foo": 42, "bar": "string", "baz": true]` validation failed
-      - `.bar` must be an integer
-      - `.baz` must be an integer
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["foo": 42, "bar": "string", "baz": true]` validation failed',
-        'bar' => '`.bar` must be an integer',
-        'baz' => '`.baz` must be an integer',
-    ],
+            ->assert(['foo' => 42, 'bar' => 'string', 'baz' => true]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.bar` must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["foo": 42, "bar": "string", "baz": true]` validation failed
+          - `.bar` must be an integer
+          - `.baz` must be an integer
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["foo": 42, "bar": "string", "baz": true]` validation failed',
+            'bar' => '`.bar` must be an integer',
+            'baz' => '`.baz` must be an integer',
+        ])
 ));
 
-test('multiple rules / single missing key / single failed validation', expectAll(
+test('multiple rules / single missing key / single failed validation', catchAll(
     fn() => v::keySet(
         v::create()
             ->key('foo', v::intType())
             ->key('bar', v::intType())
             ->key('baz', v::intType()),
     )
-        ->assert(['foo' => 42, 'bar' => 'string']),
-    '`.bar` must be an integer',
-    <<<'FULL_MESSAGE'
-    - `["foo": 42, "bar": "string"]` contains missing keys
-      - `.bar` must be an integer
-      - `.baz` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => '`["foo": 42, "bar": "string"]` contains missing keys',
-        'bar' => '`.bar` must be an integer',
-        'baz' => '`.baz` must be present',
-    ],
+            ->assert(['foo' => 42, 'bar' => 'string']),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.bar` must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `["foo": 42, "bar": "string"]` contains missing keys
+          - `.bar` must be an integer
+          - `.baz` must be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`["foo": 42, "bar": "string"]` contains missing keys',
+            'bar' => '`.bar` must be an integer',
+            'baz' => '`.baz` must be present',
+        ])
 ));

--- a/tests/feature/Rules/KeyTest.php
+++ b/tests/feature/Rules/KeyTest.php
@@ -7,93 +7,106 @@
 
 declare(strict_types=1);
 
-test('Missing key', expectAll(
+test('Missing key', catchAll(
     fn() => v::key('foo', v::intType())->assert([]),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::key('foo', v::intType())->assert(['foo' => 'string']),
-    '`.foo` must be an integer',
-    '- `.foo` must be an integer',
-    ['foo' => '`.foo` must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must be an integer'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType()))->assert(['foo' => 12]),
-    '`.foo` must not be an integer',
-    '- `.foo` must not be an integer',
-    ['foo' => '`.foo` must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must not be an integer'])
 ));
 
-test('Double-inverted with missing key', expectAll(
+test('Double-inverted with missing key', catchAll(
     fn() => v::not(v::not(v::key('foo', v::intType())))->assert([]),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('With wrapped name, missing key', expectAll(
+test('With wrapped name, missing key', catchAll(
     fn() => v::key('foo', v::intType()->setName('Wrapped'))->assert([]),
-    'Wrapped must be present',
-    '- Wrapped must be present',
-    ['foo' => 'Wrapped must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be present')
+        ->and($fullMessage)->toBe('- Wrapped must be present')
+        ->and($messages)->toBe(['foo' => 'Wrapped must be present'])
 ));
 
-test('With wrapped name, default', expectAll(
+test('With wrapped name, default', catchAll(
     fn() => v::key('foo', v::intType()->setName('Wrapped'))->setName('Wrapper')->assert(['foo' => 'string']),
-    'Wrapped must be an integer',
-    '- Wrapped must be an integer',
-    ['foo' => 'Wrapped must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must be an integer'])
 ));
 
-test('With wrapped name, inverted', expectAll(
+test('With wrapped name, inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType()->setName('Wrapped'))->setName('Wrapper'))->setName('Not')->assert(['foo' => 12]),
-    'Wrapped must not be an integer',
-    '- Wrapped must not be an integer',
-    ['foo' => 'Wrapped must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must not be an integer'])
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::key('foo', v::intType())->setName('Wrapper')->assert(['foo' => 'string']),
-    'Wrapper must be an integer',
-    '- Wrapper must be an integer',
-    ['foo' => 'Wrapper must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer'])
 ));
 
-test('With wrapper name, missing key', expectAll(
+test('With wrapper name, missing key', catchAll(
     fn() => v::key('foo', v::intType())->setName('Wrapper')->assert([]),
-    'Wrapper must be present',
-    '- Wrapper must be present',
-    ['foo' => 'Wrapper must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be present')
+        ->and($fullMessage)->toBe('- Wrapper must be present')
+        ->and($messages)->toBe(['foo' => 'Wrapper must be present'])
 ));
 
-test('With wrapper name, inverted', expectAll(
+test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType())->setName('Wrapper'))->setName('Not')->assert(['foo' => 12]),
-    'Wrapper must not be an integer',
-    '- Wrapper must not be an integer',
-    ['foo' => 'Wrapper must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer'])
 ));
 
-test('With "Not" name, inverted', expectAll(
+test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType()))->setName('Not')->assert(['foo' => 12]),
-    'Not must not be an integer',
-    '- Not must not be an integer',
-    ['foo' => 'Not must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not be an integer')
+        ->and($fullMessage)->toBe('- Not must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Not must not be an integer'])
 ));
 
-test('With template, default', expectAll(
+test('With template, default', catchAll(
     fn() => v::key('foo', v::intType())->assert(['foo' => 'string'], 'That key is off-key'),
-    'That key is off-key',
-    '- That key is off-key',
-    ['foo' => 'That key is off-key'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('That key is off-key')
+        ->and($fullMessage)->toBe('- That key is off-key')
+        ->and($messages)->toBe(['foo' => 'That key is off-key'])
 ));
 
-test('With template, inverted', expectAll(
+test('With template, inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType()))->assert(['foo' => 12], 'No off-key key'),
-    'No off-key key',
-    '- No off-key key',
-    ['foo' => 'No off-key key'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('No off-key key')
+        ->and($fullMessage)->toBe('- No off-key key')
+        ->and($messages)->toBe(['foo' => 'No off-key key'])
 ));

--- a/tests/feature/Rules/LanguageCodeTest.php
+++ b/tests/feature/Rules/LanguageCodeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::languageCode()->assert(null),
-    '`null` must be a valid language code',
+    fn(string $message) => expect($message)->toBe('`null` must be a valid language code')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::languageCode())->assert('pt'),
-    '"pt" must not be a valid language code',
+    fn(string $message) => expect($message)->toBe('"pt" must not be a valid language code')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::languageCode()->assert('por'),
-    '- "por" must be a valid language code',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "por" must be a valid language code')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::languageCode())->assert('en'),
-    '- "en" must not be a valid language code',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "en" must not be a valid language code')
 ));

--- a/tests/feature/Rules/LazyTest.php
+++ b/tests/feature/Rules/LazyTest.php
@@ -7,58 +7,82 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
-    fn() => v::lazy(fn() => v::intType())->assert(true),
-    '`true` must be an integer',
-    '- `true` must be an integer',
-    ['intType' => '`true` must be an integer'],
+test('Default', catchAll(
+    fn() => v::lazy(
+        fn() => v::intType()
+    )->assert(true),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`true` must be an integer')
+        ->and($fullMessage)->toBe('- `true` must be an integer')
+        ->and($messages)->toBe(['intType' => '`true` must be an integer'])
 ));
 
-test('Inverted', expectAll(
-    fn() => v::not(v::lazy(fn() => v::intType()))->assert(2),
-    '2 must not be an integer',
-    '- 2 must not be an integer',
-    ['notIntType' => '2 must not be an integer'],
+test('Inverted', catchAll(
+    fn() => v::not(v::lazy(
+        fn() => v::intType()
+    ))->assert(2),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('2 must not be an integer')
+        ->and($fullMessage)->toBe('- 2 must not be an integer')
+        ->and($messages)->toBe(['notIntType' => '2 must not be an integer'])
 ));
 
-test('With created name, default', expectAll(
-    fn() => v::lazy(fn() => v::intType()->setName('Created'))->setName('Wrapper')->assert(true),
-    'Created must be an integer',
-    '- Created must be an integer',
-    ['intType' => 'Created must be an integer'],
+test('With created name, default', catchAll(
+    fn() => v::lazy(
+        fn() => v::intType()->setName('Created')
+    )->setName('Wrapper')->assert(true),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Created must be an integer')
+        ->and($fullMessage)->toBe('- Created must be an integer')
+        ->and($messages)->toBe(['intType' => 'Created must be an integer'])
 ));
 
-test('With wrapper name, default', expectAll(
-    fn() => v::lazy(fn() => v::intType())->setName('Wrapper')->assert(true),
-    'Wrapper must be an integer',
-    '- Wrapper must be an integer',
-    ['intType' => 'Wrapper must be an integer'],
+test('With wrapper name, default', catchAll(
+    fn() => v::lazy(
+        fn() => v::intType()
+    )->setName('Wrapper')->assert(true),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must be an integer')
+        ->and($messages)->toBe(['intType' => 'Wrapper must be an integer'])
 ));
 
-test('With created name, inverted', expectAll(
-    fn() => v::not(v::lazy(fn() => v::intType()->setName('Created'))->setName('Wrapped'))->setName('Not')->assert(2),
-    'Created must not be an integer',
-    '- Created must not be an integer',
-    ['notIntType' => 'Created must not be an integer'],
+test('With created name, inverted', catchAll(
+    fn() => v::not(v::lazy(
+        fn() => v::intType()->setName('Created')
+    )->setName('Wrapped'))->setName('Not')->assert(2),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Created must not be an integer')
+        ->and($fullMessage)->toBe('- Created must not be an integer')
+        ->and($messages)->toBe(['notIntType' => 'Created must not be an integer'])
 ));
 
-test('With wrapper name, inverted', expectAll(
-    fn() => v::not(v::lazy(fn() => v::intType())->setName('Wrapped'))->setName('Not')->assert(2),
-    'Wrapped must not be an integer',
-    '- Wrapped must not be an integer',
-    ['notIntType' => 'Wrapped must not be an integer'],
+test('With wrapper name, inverted', catchAll(
+    fn() => v::not(v::lazy(
+        fn() => v::intType()
+    )->setName('Wrapped'))->setName('Not')->assert(2),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must not be an integer')
+        ->and($messages)->toBe(['notIntType' => 'Wrapped must not be an integer'])
 ));
 
-test('With not name, inverted', expectAll(
-    fn() => v::not(v::lazy(fn() => v::intType()))->setName('Not')->assert(2),
-    'Not must not be an integer',
-    '- Not must not be an integer',
-    ['notIntType' => 'Not must not be an integer'],
+test('With not name, inverted', catchAll(
+    fn() => v::not(v::lazy(
+        fn() => v::intType()
+    ))->setName('Not')->assert(2),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not be an integer')
+        ->and($fullMessage)->toBe('- Not must not be an integer')
+        ->and($messages)->toBe(['notIntType' => 'Not must not be an integer'])
 ));
 
-test('With template, default', expectAll(
-    fn() => v::lazy(fn() => v::intType())->assert(true, 'Lazy lizards lounging like lords in the local lagoon'),
-    'Lazy lizards lounging like lords in the local lagoon',
-    '- Lazy lizards lounging like lords in the local lagoon',
-    ['intType' => 'Lazy lizards lounging like lords in the local lagoon'],
+test('With template, default', catchAll(
+    fn() => v::lazy(
+        fn() => v::intType()
+    )->assert(true, 'Lazy lizards lounging like lords in the local lagoon'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Lazy lizards lounging like lords in the local lagoon')
+        ->and($fullMessage)->toBe('- Lazy lizards lounging like lords in the local lagoon')
+        ->and($messages)->toBe(['intType' => 'Lazy lizards lounging like lords in the local lagoon'])
 ));

--- a/tests/feature/Rules/LeapDateTest.php
+++ b/tests/feature/Rules/LeapDateTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::leapDate('Y-m-d')->assert('1989-02-29'),
-    '"1989-02-29" must be a valid leap date',
+    fn(string $message) => expect($message)->toBe('"1989-02-29" must be a valid leap date')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::leapDate('Y-m-d'))->assert('1988-02-29'),
-    '"1988-02-29" must not be a leap date',
+    fn(string $message) => expect($message)->toBe('"1988-02-29" must not be a leap date')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::leapDate('Y-m-d')->assert('1990-02-29'),
-    '- "1990-02-29" must be a valid leap date',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1990-02-29" must be a valid leap date')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::leapDate('Y-m-d'))->assert('1992-02-29'),
-    '- "1992-02-29" must not be a leap date',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1992-02-29" must not be a leap date')
 ));

--- a/tests/feature/Rules/LeapYearTest.php
+++ b/tests/feature/Rules/LeapYearTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::leapYear()->assert('2009'),
-    '"2009" must be a valid leap year',
+    fn(string $message) => expect($message)->toBe('"2009" must be a valid leap year')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::leapYear())->assert('2008'),
-    '"2008" must not be a leap year',
+    fn(string $message) => expect($message)->toBe('"2008" must not be a leap year')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::leapYear()->assert('2009-02-29'),
-    '- "2009-02-29" must be a valid leap year',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2009-02-29" must be a valid leap year')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::leapYear())->assert('2008'),
-    '- "2008" must not be a leap year',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2008" must not be a leap year')
 ));

--- a/tests/feature/Rules/LengthTest.php
+++ b/tests/feature/Rules/LengthTest.php
@@ -7,52 +7,58 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::length(v::equals(3))->assert('tulip'),
-    'The length of "tulip" must be equal to 3',
-    '- The length of "tulip" must be equal to 3',
-    ['lengthEquals' => 'The length of "tulip" must be equal to 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of "tulip" must be equal to 3')
+        ->and($fullMessage)->toBe('- The length of "tulip" must be equal to 3')
+        ->and($messages)->toBe(['lengthEquals' => 'The length of "tulip" must be equal to 3'])
 ));
 
-test('Inverted wrapped', expectAll(
+test('Inverted wrapped', catchAll(
     fn() => v::length(v::not(v::equals(4)))->assert('rose'),
-    'The length of "rose" must not be equal to 4',
-    '- The length of "rose" must not be equal to 4',
-    ['lengthNotEquals' => 'The length of "rose" must not be equal to 4'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of "rose" must not be equal to 4')
+        ->and($fullMessage)->toBe('- The length of "rose" must not be equal to 4')
+        ->and($messages)->toBe(['lengthNotEquals' => 'The length of "rose" must not be equal to 4'])
 ));
 
-test('Inverted wrapper', expectAll(
+test('Inverted wrapper', catchAll(
     fn() => v::not(v::length(v::equals(4)))->assert('fern'),
-    'The length of "fern" must not be equal to 4',
-    '- The length of "fern" must not be equal to 4',
-    ['notLengthEquals' => 'The length of "fern" must not be equal to 4'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of "fern" must not be equal to 4')
+        ->and($fullMessage)->toBe('- The length of "fern" must not be equal to 4')
+        ->and($messages)->toBe(['notLengthEquals' => 'The length of "fern" must not be equal to 4'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::length(v::equals(3))->assert('azalea', 'This is a template'),
-    'This is a template',
-    '- This is a template',
-    ['lengthEquals' => 'This is a template'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('This is a template')
+        ->and($fullMessage)->toBe('- This is a template')
+        ->and($messages)->toBe(['lengthEquals' => 'This is a template'])
 ));
 
-test('With wrapper name', expectAll(
+test('With wrapper name', catchAll(
     fn() => v::length(v::equals(3))->setName('Cactus')->assert('peyote'),
-    'The length of Cactus must be equal to 3',
-    '- The length of Cactus must be equal to 3',
-    ['lengthEquals' => 'The length of Cactus must be equal to 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of Cactus must be equal to 3')
+        ->and($fullMessage)->toBe('- The length of Cactus must be equal to 3')
+        ->and($messages)->toBe(['lengthEquals' => 'The length of Cactus must be equal to 3'])
 ));
 
-test('Chained wrapped rule', expectAll(
+test('Chained wrapped rule', catchAll(
     fn() => v::length(v::between(5, 7)->odd())->assert([]),
-    'The length of `[]` must be between 5 and 7',
-    <<<'FULL_MESSAGE'
-    - `[]` must pass all the rules
-      - The length of `[]` must be between 5 and 7
-      - The length of `[]` must be an odd number
-    FULL_MESSAGE,
-    [
-        '__root__' => '`[]` must pass all the rules',
-        'lengthBetween' => 'The length of `[]` must be between 5 and 7',
-        'lengthOdd' => 'The length of `[]` must be an odd number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of `[]` must be between 5 and 7')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `[]` must pass all the rules
+          - The length of `[]` must be between 5 and 7
+          - The length of `[]` must be an odd number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`[]` must pass all the rules',
+            'lengthBetween' => 'The length of `[]` must be between 5 and 7',
+            'lengthOdd' => 'The length of `[]` must be an odd number',
+        ])
 ));

--- a/tests/feature/Rules/LessThanOrEqualTest.php
+++ b/tests/feature/Rules/LessThanOrEqualTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::lessThanOrEqual(10)->assert(11),
-    '11 must be less than or equal to 10',
+    fn(string $message) => expect($message)->toBe('11 must be less than or equal to 10')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::lessThanOrEqual(10))->assert(5),
-    '5 must be greater than 10',
+    fn(string $message) => expect($message)->toBe('5 must be greater than 10')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::lessThanOrEqual('today')->assert('tomorrow'),
-    '- "tomorrow" must be less than or equal to "today"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tomorrow" must be less than or equal to "today"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::lessThanOrEqual('b'))->assert('a'),
-    '- "a" must be greater than "b"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be greater than "b"')
 ));

--- a/tests/feature/Rules/LessThanTest.php
+++ b/tests/feature/Rules/LessThanTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::lessThan(12)->assert(21),
-    '21 must be less than 12',
+    fn(string $message) => expect($message)->toBe('21 must be less than 12')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::lessThan('today'))->assert('yesterday'),
-    '"yesterday" must not be less than "today"',
+    fn(string $message) => expect($message)->toBe('"yesterday" must not be less than "today"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::lessThan('1988-09-09')->assert('2018-09-09'),
-    '- "2018-09-09" must be less than "1988-09-09"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-09-09" must be less than "1988-09-09"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::lessThan('b'))->assert('a'),
-    '- "a" must not be less than "b"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must not be less than "b"')
 ));

--- a/tests/feature/Rules/LowercaseTest.php
+++ b/tests/feature/Rules/LowercaseTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::lowercase()->assert('UPPERCASE'),
-    '"UPPERCASE" must contain only lowercase letters',
+    fn(string $message) => expect($message)->toBe('"UPPERCASE" must contain only lowercase letters')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::lowercase())->assert('lowercase'),
-    '"lowercase" must not contain only lowercase letters',
+    fn(string $message) => expect($message)->toBe('"lowercase" must not contain only lowercase letters')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::lowercase()->assert('UPPERCASE'),
-    '- "UPPERCASE" must contain only lowercase letters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "UPPERCASE" must contain only lowercase letters')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::lowercase())->assert('lowercase'),
-    '- "lowercase" must not contain only lowercase letters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "lowercase" must not contain only lowercase letters')
 ));

--- a/tests/feature/Rules/LuhnTest.php
+++ b/tests/feature/Rules/LuhnTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::luhn()->assert('2222400041240021'),
-    '"2222400041240021" must be a valid Luhn number',
+    fn(string $message) => expect($message)->toBe('"2222400041240021" must be a valid Luhn number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::luhn())->assert('2223000048400011'),
-    '"2223000048400011" must not be a valid Luhn number',
+    fn(string $message) => expect($message)->toBe('"2223000048400011" must not be a valid Luhn number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::luhn()->assert('340316193809334'),
-    '- "340316193809334" must be a valid Luhn number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "340316193809334" must be a valid Luhn number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::luhn())->assert('6011000990139424'),
-    '- "6011000990139424" must not be a valid Luhn number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "6011000990139424" must not be a valid Luhn number')
 ));

--- a/tests/feature/Rules/MacAddressTest.php
+++ b/tests/feature/Rules/MacAddressTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::macAddress()->assert('00-11222:33:44:55'),
-    '"00-11222:33:44:55" must be a valid MAC address',
+    fn(string $message) => expect($message)->toBe('"00-11222:33:44:55" must be a valid MAC address')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::macAddress())->assert('00:11:22:33:44:55'),
-    '"00:11:22:33:44:55" must not be a valid MAC address',
+    fn(string $message) => expect($message)->toBe('"00:11:22:33:44:55" must not be a valid MAC address')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::macAddress()->assert('90-bc-nk:1a-dd-cc'),
-    '- "90-bc-nk:1a-dd-cc" must be a valid MAC address',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "90-bc-nk:1a-dd-cc" must be a valid MAC address')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::macAddress())->assert('AF:0F:bd:12:44:ba'),
-    '- "AF:0F:bd:12:44:ba" must not be a valid MAC address',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AF:0F:bd:12:44:ba" must not be a valid MAC address')
 ));

--- a/tests/feature/Rules/MaxTest.php
+++ b/tests/feature/Rules/MaxTest.php
@@ -7,80 +7,90 @@
 
 declare(strict_types=1);
 
-test('Non-iterable', expectAll(
+test('Non-iterable', catchAll(
     fn() => v::max(v::negative())->assert(null),
-    '`null` must be iterable',
-    '- `null` must be iterable',
-    ['max' => '`null` must be iterable'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`null` must be iterable')
+        ->and($fullMessage)->toBe('- `null` must be iterable')
+        ->and($messages)->toBe(['max' => '`null` must be iterable'])
 ));
 
-test('Empty', expectAll(
+test('Empty', catchAll(
     fn() => v::max(v::negative())->assert([]),
-    '`[]` must not be empty',
-    '- `[]` must not be empty',
-    ['max' => '`[]` must not be empty'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`[]` must not be empty')
+        ->and($fullMessage)->toBe('- `[]` must not be empty')
+        ->and($messages)->toBe(['max' => '`[]` must not be empty'])
 ));
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::max(v::negative())->assert([1, 2, 3]),
-    'The maximum of `[1, 2, 3]` must be a negative number',
-    '- The maximum of `[1, 2, 3]` must be a negative number',
-    ['maxNegative' => 'The maximum of `[1, 2, 3]` must be a negative number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of `[1, 2, 3]` must be a negative number')
+        ->and($fullMessage)->toBe('- The maximum of `[1, 2, 3]` must be a negative number')
+        ->and($messages)->toBe(['maxNegative' => 'The maximum of `[1, 2, 3]` must be a negative number'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::max(v::negative()))->assert([-3, -2, -1]),
-    'The maximum of `[-3, -2, -1]` must not be a negative number',
-    '- The maximum of `[-3, -2, -1]` must not be a negative number',
-    ['notMaxNegative' => 'The maximum of `[-3, -2, -1]` must not be a negative number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of `[-3, -2, -1]` must not be a negative number')
+        ->and($fullMessage)->toBe('- The maximum of `[-3, -2, -1]` must not be a negative number')
+        ->and($messages)->toBe(['notMaxNegative' => 'The maximum of `[-3, -2, -1]` must not be a negative number'])
 ));
 
-test('With wrapped name, default', expectAll(
+test('With wrapped name, default', catchAll(
     fn() => v::max(v::negative()->setName('Wrapped'))->setName('Wrapper')->assert([1, 2, 3]),
-    'The maximum of Wrapped must be a negative number',
-    '- The maximum of Wrapped must be a negative number',
-    ['maxNegative' => 'The maximum of Wrapped must be a negative number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of Wrapped must be a negative number')
+        ->and($fullMessage)->toBe('- The maximum of Wrapped must be a negative number')
+        ->and($messages)->toBe(['maxNegative' => 'The maximum of Wrapped must be a negative number'])
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::max(v::negative())->setName('Wrapper')->assert([1, 2, 3]),
-    'The maximum of Wrapper must be a negative number',
-    '- The maximum of Wrapper must be a negative number',
-    ['maxNegative' => 'The maximum of Wrapper must be a negative number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of Wrapper must be a negative number')
+        ->and($fullMessage)->toBe('- The maximum of Wrapper must be a negative number')
+        ->and($messages)->toBe(['maxNegative' => 'The maximum of Wrapper must be a negative number'])
 ));
 
-test('With wrapped name, inverted', expectAll(
+test('With wrapped name, inverted', catchAll(
     fn() => v::not(v::max(v::negative()->setName('Wrapped')))->setName('Wrapper')->assert([-3, -2, -1]),
-    'The maximum of Wrapped must not be a negative number',
-    '- The maximum of Wrapped must not be a negative number',
-    ['notMaxNegative' => 'The maximum of Wrapped must not be a negative number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of Wrapped must not be a negative number')
+        ->and($fullMessage)->toBe('- The maximum of Wrapped must not be a negative number')
+        ->and($messages)->toBe(['notMaxNegative' => 'The maximum of Wrapped must not be a negative number'])
 ));
 
-test('With wrapper name, inverted', expectAll(
+test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::max(v::negative()))->setName('Wrapper')->assert([-3, -2, -1]),
-    'The maximum of Wrapper must not be a negative number',
-    '- The maximum of Wrapper must not be a negative number',
-    ['notMaxNegative' => 'The maximum of Wrapper must not be a negative number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of Wrapper must not be a negative number')
+        ->and($fullMessage)->toBe('- The maximum of Wrapper must not be a negative number')
+        ->and($messages)->toBe(['notMaxNegative' => 'The maximum of Wrapper must not be a negative number'])
 ));
 
-test('With template, default', expectAll(
+test('With template, default', catchAll(
     fn() => v::max(v::negative())->assert([1, 2, 3], 'The maximum of the value is not what we expect'),
-    'The maximum of the value is not what we expect',
-    '- The maximum of the value is not what we expect',
-    ['maxNegative' => 'The maximum of the value is not what we expect'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of the value is not what we expect')
+        ->and($fullMessage)->toBe('- The maximum of the value is not what we expect')
+        ->and($messages)->toBe(['maxNegative' => 'The maximum of the value is not what we expect'])
 ));
 
-test('Chained wrapped rule', expectAll(
+test('Chained wrapped rule', catchAll(
     fn() => v::max(v::between(5, 7)->odd())->assert([1, 2, 3, 4]),
-    'The maximum of `[1, 2, 3, 4]` must be between 5 and 7',
-    <<<'FULL_MESSAGE'
-    - `[1, 2, 3, 4]` must pass all the rules
-      - The maximum of `[1, 2, 3, 4]` must be between 5 and 7
-      - The maximum of `[1, 2, 3, 4]` must be an odd number
-    FULL_MESSAGE,
-    [
-        '__root__' => '`[1, 2, 3, 4]` must pass all the rules',
-        'maxBetween' => 'The maximum of `[1, 2, 3, 4]` must be between 5 and 7',
-        'maxOdd' => 'The maximum of `[1, 2, 3, 4]` must be an odd number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of `[1, 2, 3, 4]` must be between 5 and 7')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `[1, 2, 3, 4]` must pass all the rules
+          - The maximum of `[1, 2, 3, 4]` must be between 5 and 7
+          - The maximum of `[1, 2, 3, 4]` must be an odd number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`[1, 2, 3, 4]` must pass all the rules',
+            'maxBetween' => 'The maximum of `[1, 2, 3, 4]` must be between 5 and 7',
+            'maxOdd' => 'The maximum of `[1, 2, 3, 4]` must be an odd number',
+        ])
 ));

--- a/tests/feature/Rules/MimetypeTest.php
+++ b/tests/feature/Rules/MimetypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::mimetype('image/png')->assert('image.png'),
-    '"image.png" must have the "image/png" MIME type',
+    fn(string $message) => expect($message)->toBe('"image.png" must have the "image/png" MIME type')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::mimetype('image/png'))->assert('tests/fixtures/valid-image.png'),
-    '"tests/fixtures/valid-image.png" must not have the "image/png" MIME type',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not have the "image/png" MIME type')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::mimetype('image/png')->assert('tests/fixtures/invalid-image.png'),
-    '- "tests/fixtures/invalid-image.png" must have the "image/png" MIME type',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must have the "image/png" MIME type')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::mimetype('image/png'))->assert('tests/fixtures/valid-image.png'),
-    '- "tests/fixtures/valid-image.png" must not have the "image/png" MIME type',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.png" must not have the "image/png" MIME type')
 ));

--- a/tests/feature/Rules/MinTest.php
+++ b/tests/feature/Rules/MinTest.php
@@ -7,45 +7,50 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::min(v::equals(1))->assert([2, 3]),
-    'The minimum of `[2, 3]` must be equal to 1',
-    '- The minimum of `[2, 3]` must be equal to 1',
-    ['minEquals' => 'The minimum of `[2, 3]` must be equal to 1'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The minimum of `[2, 3]` must be equal to 1')
+        ->and($fullMessage)->toBe('- The minimum of `[2, 3]` must be equal to 1')
+        ->and($messages)->toBe(['minEquals' => 'The minimum of `[2, 3]` must be equal to 1'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::min(v::equals(1)))->assert([1, 2, 3]),
-    'The minimum of `[1, 2, 3]` must not be equal to 1',
-    '- The minimum of `[1, 2, 3]` must not be equal to 1',
-    ['notMinEquals' => 'The minimum of `[1, 2, 3]` must not be equal to 1'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The minimum of `[1, 2, 3]` must not be equal to 1')
+        ->and($fullMessage)->toBe('- The minimum of `[1, 2, 3]` must not be equal to 1')
+        ->and($messages)->toBe(['notMinEquals' => 'The minimum of `[1, 2, 3]` must not be equal to 1'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::min(v::equals(1))->assert([2, 3], 'That did not go as planned'),
-    'That did not go as planned',
-    '- That did not go as planned',
-    ['minEquals' => 'That did not go as planned'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('That did not go as planned')
+        ->and($fullMessage)->toBe('- That did not go as planned')
+        ->and($messages)->toBe(['minEquals' => 'That did not go as planned'])
 ));
 
-test('With name', expectAll(
+test('With name', catchAll(
     fn() => v::min(v::equals(1))->setName('Options')->assert([2, 3]),
-    'The minimum of Options must be equal to 1',
-    '- The minimum of Options must be equal to 1',
-    ['minEquals' => 'The minimum of Options must be equal to 1'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The minimum of Options must be equal to 1')
+        ->and($fullMessage)->toBe('- The minimum of Options must be equal to 1')
+        ->and($messages)->toBe(['minEquals' => 'The minimum of Options must be equal to 1'])
 ));
 
-test('Chained wrapped rule', expectAll(
+test('Chained wrapped rule', catchAll(
     fn() => v::min(v::between(5, 7)->odd())->assert([2, 3, 4]),
-    'The minimum of `[2, 3, 4]` must be between 5 and 7',
-    <<<'FULL_MESSAGE'
-    - `[2, 3, 4]` must pass all the rules
-      - The minimum of `[2, 3, 4]` must be between 5 and 7
-      - The minimum of `[2, 3, 4]` must be an odd number
-    FULL_MESSAGE,
-    [
-        '__root__' => '`[2, 3, 4]` must pass all the rules',
-        'minBetween' => 'The minimum of `[2, 3, 4]` must be between 5 and 7',
-        'minOdd' => 'The minimum of `[2, 3, 4]` must be an odd number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The minimum of `[2, 3, 4]` must be between 5 and 7')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - `[2, 3, 4]` must pass all the rules
+          - The minimum of `[2, 3, 4]` must be between 5 and 7
+          - The minimum of `[2, 3, 4]` must be an odd number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '`[2, 3, 4]` must pass all the rules',
+            'minBetween' => 'The minimum of `[2, 3, 4]` must be between 5 and 7',
+            'minOdd' => 'The minimum of `[2, 3, 4]` must be an odd number',
+        ])
 ));

--- a/tests/feature/Rules/MultipleTest.php
+++ b/tests/feature/Rules/MultipleTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::multiple(3)->assert(22),
-    '22 must be a multiple of 3',
+    fn(string $message) => expect($message)->toBe('22 must be a multiple of 3')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::multiple(3))->assert(9),
-    '9 must not be a multiple of 3',
+    fn(string $message) => expect($message)->toBe('9 must not be a multiple of 3')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::multiple(2)->assert(5),
-    '- 5 must be a multiple of 2',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 5 must be a multiple of 2')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::multiple(5))->assert(25),
-    '- 25 must not be a multiple of 5',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 25 must not be a multiple of 5')
 ));

--- a/tests/feature/Rules/NamedTest.php
+++ b/tests/feature/Rules/NamedTest.php
@@ -7,58 +7,65 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::named(v::stringType(), 'Potato')->assert(12),
-    'Potato must be a string',
-    '- Potato must be a string',
-    ['stringType' => 'Potato must be a string'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Potato must be a string')
+        ->and($fullMessage)->toBe('- Potato must be a string')
+        ->and($messages)->toBe(['stringType' => 'Potato must be a string'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::named(v::intType(), 'Zucchini'))->assert(12),
-    'Zucchini must not be an integer',
-    '- Zucchini must not be an integer',
-    ['notIntType' => 'Zucchini must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Zucchini must not be an integer')
+        ->and($fullMessage)->toBe('- Zucchini must not be an integer')
+        ->and($messages)->toBe(['notIntType' => 'Zucchini must not be an integer'])
 ));
 
-test('Template in Validator', expectAll(
+test('Template in Validator', catchAll(
     fn() => v::named(v::stringType(), 'Eggplant')
         ->setName('Mushroom')
         ->assert(12),
-    'Eggplant must be a string',
-    '- Eggplant must be a string',
-    ['stringType' => 'Eggplant must be a string'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Eggplant must be a string')
+        ->and($fullMessage)->toBe('- Eggplant must be a string')
+        ->and($messages)->toBe(['stringType' => 'Eggplant must be a string'])
 ));
 
-test('With bound', expectAll(
+test('With bound', catchAll(
     fn() => v::named(v::attributes(), 'Pumpkin')->assert(null),
-    'Pumpkin must be an object',
-    '- Pumpkin must be an object',
-    ['attributes' => 'Pumpkin must be an object'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Pumpkin must be an object')
+        ->and($fullMessage)->toBe('- Pumpkin must be an object')
+        ->and($messages)->toBe(['attributes' => 'Pumpkin must be an object'])
 ));
 
-test('With key that does not exist', expectAll(
+test('With key that does not exist', catchAll(
     fn() => v::key('vegetable', v::named(v::stringType(), 'Paprika'))->assert([]),
-    'Paprika must be present',
-    '- Paprika must be present',
-    ['vegetable' => 'Paprika must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Paprika must be present')
+        ->and($fullMessage)->toBe('- Paprika must be present')
+        ->and($messages)->toBe(['vegetable' => 'Paprika must be present'])
 ));
 
-test('With property that does not exist', expectAll(
+test('With property that does not exist', catchAll(
     fn() => v::key('vegetable', v::named(v::stringType(), 'Broccoli'))->assert((object) []),
-    'Broccoli must be present',
-    '- Broccoli must be present',
-    ['vegetable' => 'Broccoli must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Broccoli must be present')
+        ->and($fullMessage)->toBe('- Broccoli must be present')
+        ->and($messages)->toBe(['vegetable' => 'Broccoli must be present'])
 ));
 
-test('With key that fails validation', expectAll(
+test('With key that fails validation', catchAll(
     fn() => v::key('vegetable', v::named(v::stringType(), 'Artichoke'))->assert(['vegetable' => 12]),
-    'Artichoke must be a string',
-    '- Artichoke must be a string',
-    ['vegetable' => 'Artichoke must be a string'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Artichoke must be a string')
+        ->and($fullMessage)->toBe('- Artichoke must be a string')
+        ->and($messages)->toBe(['vegetable' => 'Artichoke must be a string'])
 ));
 
-test('With nested key that fails validation', expectAll(
+test('With nested key that fails validation', catchAll(
     fn() => v::key(
         'vegetables',
         v::named(
@@ -69,17 +76,18 @@ test('With nested key that fails validation', expectAll(
             'Vegetables'
         ),
     )->assert(['vegetables' => ['root' => 12, 'stems' => 12]]),
-    '`.vegetables.root` must be a string',
-    <<<'FULL_MESSAGE'
-    - Vegetables must pass all the rules
-      - `.root` must be a string
-      - `.stems` must be a string
-      - `.fruits` must be present
-    FULL_MESSAGE,
-    [
-        '__root__' => 'Vegetables must pass all the rules',
-        'root' => '`.root` must be a string',
-        'stems' => '`.stems` must be a string',
-        'fruits' => '`.fruits` must be present',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.vegetables.root` must be a string')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Vegetables must pass all the rules
+          - `.root` must be a string
+          - `.stems` must be a string
+          - `.fruits` must be present
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => 'Vegetables must pass all the rules',
+            'root' => '`.root` must be a string',
+            'stems' => '`.stems` must be a string',
+            'fruits' => '`.fruits` must be present',
+        ])
 ));

--- a/tests/feature/Rules/NegativeTest.php
+++ b/tests/feature/Rules/NegativeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::negative()->assert(16),
-    '16 must be a negative number',
+    fn(string $message) => expect($message)->toBe('16 must be a negative number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::negative())->assert(-10),
-    '-10 must not be a negative number',
+    fn(string $message) => expect($message)->toBe('-10 must not be a negative number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::negative()->assert('a'),
-    '- "a" must be a negative number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a negative number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::negative())->assert('-144'),
-    '- "-144" must not be a negative number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "-144" must not be a negative number')
 ));

--- a/tests/feature/Rules/NfeAccessKeyTest.php
+++ b/tests/feature/Rules/NfeAccessKeyTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906'),
-    '"31841136830118868211870485416765268625116906" must be a valid NFe access key',
+    fn(string $message) => expect($message)->toBe('"31841136830118868211870485416765268625116906" must be a valid NFe access key')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::nfeAccessKey())->assert('52060433009911002506550120000007800267301615'),
-    '"52060433009911002506550120000007800267301615" must not be a valid NFe access key',
+    fn(string $message) => expect($message)->toBe('"52060433009911002506550120000007800267301615" must not be a valid NFe access key')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906'),
-    '- "31841136830118868211870485416765268625116906" must be a valid NFe access key',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "31841136830118868211870485416765268625116906" must be a valid NFe access key')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nfeAccessKey())->assert('52060433009911002506550120000007800267301615'),
-    '- "52060433009911002506550120000007800267301615" must not be a valid NFe access key',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "52060433009911002506550120000007800267301615" must not be a valid NFe access key')
 ));

--- a/tests/feature/Rules/NifTest.php
+++ b/tests/feature/Rules/NifTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::nif()->assert('06357771Q'),
-    '"06357771Q" must be a valid NIF',
+    fn(string $message) => expect($message)->toBe('"06357771Q" must be a valid NIF')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::nif())->assert('71110316C'),
-    '"71110316C" must not be a valid NIF',
+    fn(string $message) => expect($message)->toBe('"71110316C" must not be a valid NIF')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::nif()->assert('06357771Q'),
-    '- "06357771Q" must be a valid NIF',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "06357771Q" must be a valid NIF')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nif())->assert('R1332622H'),
-    '- "R1332622H" must not be a valid NIF',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "R1332622H" must not be a valid NIF')
 ));

--- a/tests/feature/Rules/NipTest.php
+++ b/tests/feature/Rules/NipTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::nip()->assert('1645865778'),
-    '"1645865778" must be a valid Polish VAT identification number',
+    fn(string $message) => expect($message)->toBe('"1645865778" must be a valid Polish VAT identification number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::nip())->assert('1645865777'),
-    '"1645865777" must not be a valid Polish VAT identification number',
+    fn(string $message) => expect($message)->toBe('"1645865777" must not be a valid Polish VAT identification number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::nip()->assert('1645865778'),
-    '- "1645865778" must be a valid Polish VAT identification number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1645865778" must be a valid Polish VAT identification number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nip())->assert('1645865777'),
-    '- "1645865777" must not be a valid Polish VAT identification number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1645865777" must not be a valid Polish VAT identification number')
 ));

--- a/tests/feature/Rules/NoTest.php
+++ b/tests/feature/Rules/NoTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::not(v::no())->assert('No'),
-    '"No" must not be similar to "No"',
+    fn(string $message) => expect($message)->toBe('"No" must not be similar to "No"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::no()->assert('Yes'),
-    '"Yes" must be similar to "No"',
+    fn(string $message) => expect($message)->toBe('"Yes" must be similar to "No"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::not(v::no())->assert('No'),
-    '- "No" must not be similar to "No"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "No" must not be similar to "No"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::no()->assert('Yes'),
-    '- "Yes" must be similar to "No"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Yes" must be similar to "No"')
 ));

--- a/tests/feature/Rules/NoWhitespaceTest.php
+++ b/tests/feature/Rules/NoWhitespaceTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::noWhitespace()->assert('w poiur'),
-    '"w poiur" must not contain whitespaces',
+    fn(string $message) => expect($message)->toBe('"w poiur" must not contain whitespaces')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::noWhitespace())->assert('wpoiur'),
-    '"wpoiur" must contain at least one whitespace',
+    fn(string $message) => expect($message)->toBe('"wpoiur" must contain at least one whitespace')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::noWhitespace()->assert('w poiur'),
-    '- "w poiur" must not contain whitespaces',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "w poiur" must not contain whitespaces')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::noWhitespace())->assert('wpoiur'),
-    '- "wpoiur" must contain at least one whitespace',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "wpoiur" must contain at least one whitespace')
 ));

--- a/tests/feature/Rules/NoneOfTest.php
+++ b/tests/feature/Rules/NoneOfTest.php
@@ -7,58 +7,62 @@
 
 declare(strict_types=1);
 
-test('Default: fail, fail', expectAll(
+test('Default: fail, fail', catchAll(
     fn() => v::noneOf(v::intType(), v::negative())->assert(-1),
-    '-1 must not be an integer',
-    <<<'FULL_MESSAGE'
-    - -1 must pass all the rules
-      - -1 must not be an integer
-      - -1 must not be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '-1 must pass all the rules',
-        'intType' => '-1 must not be an integer',
-        'negative' => '-1 must not be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must not be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - -1 must pass all the rules
+          - -1 must not be an integer
+          - -1 must not be a negative number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '-1 must pass all the rules',
+            'intType' => '-1 must not be an integer',
+            'negative' => '-1 must not be a negative number',
+        ])
 ));
 
-test('Default: pass, fail', expectAll(
+test('Default: pass, fail', catchAll(
     fn() => v::noneOf(v::intType(), v::stringType())->assert('string'),
-    '"string" must not be a string',
-    <<<'FULL_MESSAGE'
-    - "string" must not be a string
-    FULL_MESSAGE,
-    [
-        'stringType' => '"string" must not be a string',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must not be a string')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must not be a string
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            'stringType' => '"string" must not be a string',
+        ])
 ));
 
-test('Default: pass, fail, fail', expectAll(
+test('Default: pass, fail, fail', catchAll(
     fn() => v::noneOf(v::intType(), v::alpha(), v::stringType())->assert('string'),
-    '"string" must not contain letters (a-z)',
-    <<<'FULL_MESSAGE'
-    - "string" must pass the rules
-      - "string" must not contain letters (a-z)
-      - "string" must not be a string
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass the rules',
-        'alpha' => '"string" must not contain letters (a-z)',
-        'stringType' => '"string" must not be a string',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must not contain letters (a-z)')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass the rules
+          - "string" must not contain letters (a-z)
+          - "string" must not be a string
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass the rules',
+            'alpha' => '"string" must not contain letters (a-z)',
+            'stringType' => '"string" must not be a string',
+        ])
 ));
 
-test('Inverted: fail, fail', expectAll(
+test('Inverted: fail, fail', catchAll(
     fn() => v::not(v::noneOf(v::intType(), v::negative()))->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass the rules
-      - "string" must be an integer
-      - "string" must be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass the rules',
-        'intType' => '"string" must be an integer',
-        'negative' => '"string" must be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass the rules
+          - "string" must be an integer
+          - "string" must be a negative number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass the rules',
+            'intType' => '"string" must be an integer',
+            'negative' => '"string" must be a negative number',
+        ])
 ));

--- a/tests/feature/Rules/NotBlankTest.php
+++ b/tests/feature/Rules/NotBlankTest.php
@@ -7,32 +7,32 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::notBlank()->assert(null),
-    '`null` must not be blank',
+    fn(string $message) => expect($message)->toBe('`null` must not be blank')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::notBlank()->setName('Field')->assert(null),
-    'Field must not be blank',
+    fn(string $message) => expect($message)->toBe('Field must not be blank')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::notBlank())->assert(1),
-    '1 must be blank',
+    fn(string $message) => expect($message)->toBe('1 must be blank')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::notBlank()->assert(''),
-    '- "" must not be blank',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "" must not be blank')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::notBlank()->setName('Field')->assert(''),
-    '- Field must not be blank',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- Field must not be blank')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::notBlank())->assert([1]),
-    '- `[1]` must be blank',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[1]` must be blank')
 ));

--- a/tests/feature/Rules/NotEmojiTest.php
+++ b/tests/feature/Rules/NotEmojiTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::notEmoji()->assert('🍕'),
-    '"🍕" must not contain an emoji',
+    fn(string $message) => expect($message)->toBe('"🍕" must not contain an emoji')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::notEmoji())->assert('AB'),
-    '"AB" must contain an emoji',
+    fn(string $message) => expect($message)->toBe('"AB" must contain an emoji')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::notEmoji()->assert('🏄'),
-    '- "🏄" must not contain an emoji',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "🏄" must not contain an emoji')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::notEmoji())->assert('YZ'),
-    '- "YZ" must contain an emoji',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "YZ" must contain an emoji')
 ));

--- a/tests/feature/Rules/NotEmptyTest.php
+++ b/tests/feature/Rules/NotEmptyTest.php
@@ -7,32 +7,32 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::notEmpty()->assert(null),
-    '`null` must not be empty',
+    fn(string $message) => expect($message)->toBe('`null` must not be empty')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::notEmpty()->setName('Field')->assert(null),
-    'Field must not be empty',
+    fn(string $message) => expect($message)->toBe('Field must not be empty')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::notEmpty())->assert(1),
-    '1 must be empty',
+    fn(string $message) => expect($message)->toBe('1 must be empty')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::notEmpty()->assert(''),
-    '- "" must not be empty',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "" must not be empty')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::notEmpty()->setName('Field')->assert(''),
-    '- Field must not be empty',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- Field must not be empty')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::notEmpty())->assert([1]),
-    '- `[1]` must be empty',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[1]` must be empty')
 ));

--- a/tests/feature/Rules/NotUndefTest.php
+++ b/tests/feature/Rules/NotUndefTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::notUndef()->assert(null),
-    '`null` must be defined',
+    fn(string $message) => expect($message)->toBe('`null` must be defined')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::notUndef())->assert(0),
-    '0 must be undefined',
+    fn(string $message) => expect($message)->toBe('0 must be undefined')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::notUndef()->setName('Field')->assert(null),
-    'Field must be defined',
+    fn(string $message) => expect($message)->toBe('Field must be defined')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::notUndef()->setName('Field'))->assert([]),
-    'Field must be undefined',
+    fn(string $message) => expect($message)->toBe('Field must be undefined')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::notUndef()->assert(''),
-    '- "" must be defined',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "" must be defined')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::notUndef())->assert([]),
-    '- `[]` must be undefined',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be undefined')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::notUndef()->setName('Field')->assert(''),
-    '- Field must be defined',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- Field must be defined')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::notUndef()->setName('Field'))->assert([]),
-    '- Field must be undefined',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- Field must be undefined')
 ));

--- a/tests/feature/Rules/NullOrTest.php
+++ b/tests/feature/Rules/NullOrTest.php
@@ -7,105 +7,117 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::nullOr(v::alpha())->assert(1234),
-    '1234 must contain only letters (a-z) or must be null',
-    '- 1234 must contain only letters (a-z) or must be null',
-    ['nullOrAlpha' => '1234 must contain only letters (a-z) or must be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('1234 must contain only letters (a-z) or must be null')
+        ->and($fullMessage)->toBe('- 1234 must contain only letters (a-z) or must be null')
+        ->and($messages)->toBe(['nullOrAlpha' => '1234 must contain only letters (a-z) or must be null'])
 ));
 
-test('Inverted wrapper', expectAll(
+test('Inverted wrapper', catchAll(
     fn() => v::not(v::nullOr(v::alpha()))->assert('alpha'),
-    '"alpha" must not contain letters (a-z) and must not be null',
-    '- "alpha" must not contain letters (a-z) and must not be null',
-    ['notNullOrAlpha' => '"alpha" must not contain letters (a-z) and must not be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"alpha" must not contain letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => '"alpha" must not contain letters (a-z) and must not be null'])
 ));
 
-test('Inverted wrapped', expectAll(
+test('Inverted wrapped', catchAll(
     fn() => v::nullOr(v::not(v::alpha()))->assert('alpha'),
-    '"alpha" must not contain letters (a-z) or must be null',
-    '- "alpha" must not contain letters (a-z) or must be null',
-    ['nullOrNotAlpha' => '"alpha" must not contain letters (a-z) or must be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"alpha" must not contain letters (a-z) or must be null')
+        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) or must be null')
+        ->and($messages)->toBe(['nullOrNotAlpha' => '"alpha" must not contain letters (a-z) or must be null'])
 ));
 
-test('Inverted nullined', expectAll(
+test('Inverted nullined', catchAll(
     fn() => v::not(v::nullOr(v::alpha()))->assert(null),
-    '`null` must not contain letters (a-z) and must not be null',
-    '- `null` must not contain letters (a-z) and must not be null',
-    ['notNullOrAlpha' => '`null` must not contain letters (a-z) and must not be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`null` must not contain letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- `null` must not contain letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => '`null` must not contain letters (a-z) and must not be null'])
 ));
 
-test('Inverted nullined, wrapped name', expectAll(
+test('Inverted nullined, wrapped name', catchAll(
     fn() => v::not(v::nullOr(v::alpha()->setName('Wrapped')))->assert(null),
-    'Wrapped must not contain letters (a-z) and must not be null',
-    '- Wrapped must not contain letters (a-z) and must not be null',
-    ['notNullOrAlpha' => 'Wrapped must not contain letters (a-z) and must not be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not contain letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- Wrapped must not contain letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Wrapped must not contain letters (a-z) and must not be null'])
 ));
 
-test('Inverted nullined, wrapper name', expectAll(
+test('Inverted nullined, wrapper name', catchAll(
     fn() => v::not(v::nullOr(v::alpha())->setName('Wrapper'))->assert(null),
-    'Wrapper must not contain letters (a-z) and must not be null',
-    '- Wrapper must not contain letters (a-z) and must not be null',
-    ['notNullOrAlpha' => 'Wrapper must not contain letters (a-z) and must not be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not contain letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- Wrapper must not contain letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Wrapper must not contain letters (a-z) and must not be null'])
 ));
 
-test('Inverted nullined, not name', expectAll(
+test('Inverted nullined, not name', catchAll(
     fn() => v::not(v::nullOr(v::alpha()))->setName('Not')->assert(null),
-    'Not must not contain letters (a-z) and must not be null',
-    '- Not must not contain letters (a-z) and must not be null',
-    ['notNullOrAlpha' => 'Not must not contain letters (a-z) and must not be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not contain letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- Not must not contain letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Not must not contain letters (a-z) and must not be null'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::nullOr(v::alpha())->assert(123, 'Nine nimble numismatists near Naples'),
-    'Nine nimble numismatists near Naples',
-    '- Nine nimble numismatists near Naples',
-    ['nullOrAlpha' => 'Nine nimble numismatists near Naples'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Nine nimble numismatists near Naples')
+        ->and($fullMessage)->toBe('- Nine nimble numismatists near Naples')
+        ->and($messages)->toBe(['nullOrAlpha' => 'Nine nimble numismatists near Naples'])
 ));
 
-test('With array template', expectAll(
+test('With array template', catchAll(
     fn() => v::nullOr(v::alpha())->assert(123, ['nullOrAlpha' => 'Next to nifty null notations']),
-    'Next to nifty null notations',
-    '- Next to nifty null notations',
-    ['nullOrAlpha' => 'Next to nifty null notations'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Next to nifty null notations')
+        ->and($fullMessage)->toBe('- Next to nifty null notations')
+        ->and($messages)->toBe(['nullOrAlpha' => 'Next to nifty null notations'])
 ));
 
-test('Inverted nullined with template', expectAll(
+test('Inverted nullined with template', catchAll(
     fn() => v::not(v::nullOr(v::alpha()))->assert(null, ['notNullOrAlpha' => 'Next to nifty null notations']),
-    'Next to nifty null notations',
-    '- Next to nifty null notations',
-    ['notNullOrAlpha' => 'Next to nifty null notations'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Next to nifty null notations')
+        ->and($fullMessage)->toBe('- Next to nifty null notations')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Next to nifty null notations'])
 ));
 
-test('Without adjacent result', expectAll(
+test('Without adjacent result', catchAll(
     fn() => v::nullOr(v::alpha()->stringType())->assert(1234),
-    '1234 must contain only letters (a-z) or must be null',
-    <<<'FULL_MESSAGE'
-    - 1234 must pass all the rules
-      - 1234 must contain only letters (a-z) or must be null
-      - 1234 must be a string or must be null
-    FULL_MESSAGE,
-    [
-        '__root__' => '1234 must pass all the rules',
-        'nullOrAlpha' => '1234 must contain only letters (a-z) or must be null',
-        'nullOrStringType' => '1234 must be a string or must be null',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('1234 must contain only letters (a-z) or must be null')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - 1234 must pass all the rules
+          - 1234 must contain only letters (a-z) or must be null
+          - 1234 must be a string or must be null
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '1234 must pass all the rules',
+            'nullOrAlpha' => '1234 must contain only letters (a-z) or must be null',
+            'nullOrStringType' => '1234 must be a string or must be null',
+        ])
 ));
 
-test('Without adjacent result with templates', expectAll(
+test('Without adjacent result with templates', catchAll(
     fn() => v::nullOr(v::alpha()->stringType())->assert(1234, [
         'nullOrAlpha' => 'Should be nul or alpha',
         'nullOrStringType' => 'Should be nul or string type',
     ]),
-    'Should be nul or alpha',
-    <<<'FULL_MESSAGE'
-    - 1234 must pass all the rules
-      - Should be nul or alpha
-      - Should be nul or string type
-    FULL_MESSAGE,
-    [
-        '__root__' => '1234 must pass all the rules',
-        'nullOrAlpha' => 'Should be nul or alpha',
-        'nullOrStringType' => 'Should be nul or string type',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Should be nul or alpha')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - 1234 must pass all the rules
+          - Should be nul or alpha
+          - Should be nul or string type
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '1234 must pass all the rules',
+            'nullOrAlpha' => 'Should be nul or alpha',
+            'nullOrStringType' => 'Should be nul or string type',
+        ])
 ));

--- a/tests/feature/Rules/NullTypeTest.php
+++ b/tests/feature/Rules/NullTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::nullType()->assert(''),
-    '"" must be null',
+    fn(string $message) => expect($message)->toBe('"" must be null')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::nullType())->assert(null),
-    '`null` must not be null',
+    fn(string $message) => expect($message)->toBe('`null` must not be null')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::nullType()->assert(false),
-    '- `false` must be null',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `false` must be null')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nullType())->assert(null),
-    '- `null` must not be null',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `null` must not be null')
 ));

--- a/tests/feature/Rules/NumberTest.php
+++ b/tests/feature/Rules/NumberTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::number()->assert(acos(1.01)),
-    '`NaN` must be a valid number',
+    fn(string $message) => expect($message)->toBe('`NaN` must be a valid number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::number())->assert(42),
-    '42 must not be a number',
+    fn(string $message) => expect($message)->toBe('42 must not be a number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::number()->assert(NAN),
-    '- `NaN` must be a valid number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `NaN` must be a valid number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::number())->assert(42),
-    '- 42 must not be a number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a number')
 ));

--- a/tests/feature/Rules/NumericValTest.php
+++ b/tests/feature/Rules/NumericValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::numericVal()->assert('a'),
-    '"a" must be a numeric value',
+    fn(string $message) => expect($message)->toBe('"a" must be a numeric value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::numericVal())->assert('1'),
-    '"1" must not be a numeric value',
+    fn(string $message) => expect($message)->toBe('"1" must not be a numeric value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::numericVal()->assert('a'),
-    '- "a" must be a numeric value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a numeric value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::numericVal())->assert('1'),
-    '- "1" must not be a numeric value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must not be a numeric value')
 ));

--- a/tests/feature/Rules/ObjectTypeTest.php
+++ b/tests/feature/Rules/ObjectTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::objectType()->assert([]),
-    '`[]` must be an object',
+    fn(string $message) => expect($message)->toBe('`[]` must be an object')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::objectType())->assert(new stdClass()),
-    '`stdClass {}` must not be an object',
+    fn(string $message) => expect($message)->toBe('`stdClass {}` must not be an object')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::objectType()->assert('test'),
-    '- "test" must be an object',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "test" must be an object')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::objectType())->assert(new ArrayObject()),
-    '- `ArrayObject { getArrayCopy() => [] }` must not be an object',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [] }` must not be an object')
 ));

--- a/tests/feature/Rules/OddTest.php
+++ b/tests/feature/Rules/OddTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::odd()->assert(2),
-    '2 must be an odd number',
+    fn(string $message) => expect($message)->toBe('2 must be an odd number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::odd())->assert(7),
-    '7 must be an even number',
+    fn(string $message) => expect($message)->toBe('7 must be an even number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::odd()->assert(2),
-    '- 2 must be an odd number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2 must be an odd number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::odd())->assert(9),
-    '- 9 must be an even number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 9 must be an even number')
 ));

--- a/tests/feature/Rules/OneOfTest.php
+++ b/tests/feature/Rules/OneOfTest.php
@@ -7,86 +7,92 @@
 
 declare(strict_types=1);
 
-test('Default: fail, fail', expectAll(
+test('Default: fail, fail', catchAll(
     fn() => v::oneOf(v::intType(), v::negative())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass one of the rules
-      - "string" must be an integer
-      - "string" must be a negative number
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass one of the rules',
-        'intType' => '"string" must be an integer',
-        'negative' => '"string" must be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass one of the rules
+          - "string" must be an integer
+          - "string" must be a negative number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass one of the rules',
+            'intType' => '"string" must be an integer',
+            'negative' => '"string" must be a negative number',
+        ])
 ));
 
-test('Default: fail, pass, pass', expectAll(
+test('Default: fail, pass, pass', catchAll(
     fn() => v::oneOf(v::intType(), v::stringType(), v::alpha())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass only one of the rules
-      - "string" must be an integer
-      - "string" must be a string
-      - "string" must contain only letters (a-z)
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass only one of the rules',
-        'intType' => '"string" must be an integer',
-        'stringType' => '"string" must be a string',
-        'alpha' => '"string" must contain only letters (a-z)',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass only one of the rules
+          - "string" must be an integer
+          - "string" must be a string
+          - "string" must contain only letters (a-z)
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass only one of the rules',
+            'intType' => '"string" must be an integer',
+            'stringType' => '"string" must be a string',
+            'alpha' => '"string" must contain only letters (a-z)',
+        ])
 ));
 
-test('Default: pass, fail, pass', expectAll(
+test('Default: pass, fail, pass', catchAll(
     fn() => v::oneOf(v::stringType(), v::intType(), v::alpha())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass only one of the rules
-      - "string" must be an integer
-      - "string" must be a string
-      - "string" must contain only letters (a-z)
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass only one of the rules',
-        'intType' => '"string" must be an integer',
-        'stringType' => '"string" must be a string',
-        'alpha' => '"string" must contain only letters (a-z)',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass only one of the rules
+          - "string" must be an integer
+          - "string" must be a string
+          - "string" must contain only letters (a-z)
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass only one of the rules',
+            'intType' => '"string" must be an integer',
+            'stringType' => '"string" must be a string',
+            'alpha' => '"string" must contain only letters (a-z)',
+        ])
 ));
 
-test('Default: pass, pass, fail', expectAll(
+test('Default: pass, pass, fail', catchAll(
     fn() => v::oneOf(v::stringType(), v::alpha(), v::intType())->assert('string'),
-    '"string" must be an integer',
-    <<<'FULL_MESSAGE'
-    - "string" must pass only one of the rules
-      - "string" must be an integer
-      - "string" must be a string
-      - "string" must contain only letters (a-z)
-    FULL_MESSAGE,
-    [
-        '__root__' => '"string" must pass only one of the rules',
-        'intType' => '"string" must be an integer',
-        'stringType' => '"string" must be a string',
-        'alpha' => '"string" must contain only letters (a-z)',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be an integer')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "string" must pass only one of the rules
+          - "string" must be an integer
+          - "string" must be a string
+          - "string" must contain only letters (a-z)
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"string" must pass only one of the rules',
+            'intType' => '"string" must be an integer',
+            'stringType' => '"string" must be a string',
+            'alpha' => '"string" must contain only letters (a-z)',
+        ])
 ));
 
-test('Inverted: fail, pass', expectAll(
+test('Inverted: fail, pass', catchAll(
     fn() => v::not(v::oneOf(v::intType(), v::positive()))->assert(-1),
-    '-1 must not be an integer',
-    '- -1 must not be an integer',
-    [
-        'intType' => '-1 must not be an integer',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must not be an integer')
+        ->and($fullMessage)->toBe('- -1 must not be an integer')
+        ->and($messages)->toBe([
+            'intType' => '-1 must not be an integer',
+        ])
 ));
 
-test('Inverted: fail, fail, pass', expectAll(
+test('Inverted: fail, fail, pass', catchAll(
     fn() => v::not(v::oneOf(v::stringType(), v::alpha(), v::negative()))->assert(-1),
-    '-1 must not be a negative number',
-    '- -1 must not be a negative number',
-    [
-        'negative' => '-1 must not be a negative number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must not be a negative number')
+        ->and($fullMessage)->toBe('- -1 must not be a negative number')
+        ->and($messages)->toBe([
+            'negative' => '-1 must not be a negative number',
+        ])
 ));

--- a/tests/feature/Rules/PerfectSquareTest.php
+++ b/tests/feature/Rules/PerfectSquareTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::perfectSquare()->assert(250),
-    '250 must be a perfect square number',
+    fn(string $message) => expect($message)->toBe('250 must be a perfect square number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::perfectSquare())->assert(9),
-    '9 must not be a perfect square number',
+    fn(string $message) => expect($message)->toBe('9 must not be a perfect square number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::perfectSquare()->assert(7),
-    '- 7 must be a perfect square number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 7 must be a perfect square number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::perfectSquare())->assert(400),
-    '- 400 must not be a perfect square number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 400 must not be a perfect square number')
 ));

--- a/tests/feature/Rules/PeselTest.php
+++ b/tests/feature/Rules/PeselTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::pesel()->assert('21120209251'),
-    '"21120209251" must be a valid PESEL',
+    fn(string $message) => expect($message)->toBe('"21120209251" must be a valid PESEL')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::pesel())->assert('21120209256'),
-    '"21120209256" must not be a valid PESEL',
+    fn(string $message) => expect($message)->toBe('"21120209256" must not be a valid PESEL')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::pesel()->assert('21120209251'),
-    '- "21120209251" must be a valid PESEL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "21120209251" must be a valid PESEL')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::pesel())->assert('21120209256'),
-    '- "21120209256" must not be a valid PESEL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "21120209256" must not be a valid PESEL')
 ));

--- a/tests/feature/Rules/PhoneTest.php
+++ b/tests/feature/Rules/PhoneTest.php
@@ -7,37 +7,42 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::phone()->assert('123'),
-    '"123" must be a valid telephone number',
-    '- "123" must be a valid telephone number',
-    ['phone' => '"123" must be a valid telephone number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"123" must be a valid telephone number')
+        ->and($fullMessage)->toBe('- "123" must be a valid telephone number')
+        ->and($messages)->toBe(['phone' => '"123" must be a valid telephone number'])
 ));
 
-test('Country-specific', expectAll(
+test('Country-specific', catchAll(
     fn() => v::phone('BR')->assert('+1 650 253 00 00'),
-    '"+1 650 253 00 00" must be a valid telephone number for country Brazil',
-    '- "+1 650 253 00 00" must be a valid telephone number for country Brazil',
-    ['phone' => '"+1 650 253 00 00" must be a valid telephone number for country Brazil'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"+1 650 253 00 00" must be a valid telephone number for country Brazil')
+        ->and($fullMessage)->toBe('- "+1 650 253 00 00" must be a valid telephone number for country Brazil')
+        ->and($messages)->toBe(['phone' => '"+1 650 253 00 00" must be a valid telephone number for country Brazil'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::phone())->assert('+55 11 91111 1111'),
-    '"+55 11 91111 1111" must not be a valid telephone number',
-    '- "+55 11 91111 1111" must not be a valid telephone number',
-    ['notPhone' => '"+55 11 91111 1111" must not be a valid telephone number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"+55 11 91111 1111" must not be a valid telephone number')
+        ->and($fullMessage)->toBe('- "+55 11 91111 1111" must not be a valid telephone number')
+        ->and($messages)->toBe(['notPhone' => '"+55 11 91111 1111" must not be a valid telephone number'])
 ));
 
-test('Default with name', expectAll(
+test('Default with name', catchAll(
     fn() => v::phone()->setName('Phone')->assert('123'),
-    'Phone must be a valid telephone number',
-    '- Phone must be a valid telephone number',
-    ['phone' => 'Phone must be a valid telephone number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Phone must be a valid telephone number')
+        ->and($fullMessage)->toBe('- Phone must be a valid telephone number')
+        ->and($messages)->toBe(['phone' => 'Phone must be a valid telephone number'])
 ));
 
-test('Country-specific with name', expectAll(
+test('Country-specific with name', catchAll(
     fn() => v::phone('US')->setName('Phone')->assert('123'),
-    'Phone must be a valid telephone number for country United States',
-    '- Phone must be a valid telephone number for country United States',
-    ['phone' => 'Phone must be a valid telephone number for country United States'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Phone must be a valid telephone number for country United States')
+        ->and($fullMessage)->toBe('- Phone must be a valid telephone number for country United States')
+        ->and($messages)->toBe(['phone' => 'Phone must be a valid telephone number for country United States'])
 ));

--- a/tests/feature/Rules/PhplabelTest.php
+++ b/tests/feature/Rules/PhplabelTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::phpLabel()->assert('f o o'),
-    '"f o o" must be a valid PHP label',
+    fn(string $message) => expect($message)->toBe('"f o o" must be a valid PHP label')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::phpLabel())->assert('correctOne'),
-    '"correctOne" must not be a valid PHP label',
+    fn(string $message) => expect($message)->toBe('"correctOne" must not be a valid PHP label')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::phpLabel()->assert('0wner'),
-    '- "0wner" must be a valid PHP label',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "0wner" must be a valid PHP label')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::phpLabel())->assert('Respect'),
-    '- "Respect" must not be a valid PHP label',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Respect" must not be a valid PHP label')
 ));

--- a/tests/feature/Rules/PisTest.php
+++ b/tests/feature/Rules/PisTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::pis()->assert('this thing'),
-    '"this thing" must be a valid PIS number',
+    fn(string $message) => expect($message)->toBe('"this thing" must be a valid PIS number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::pis())->assert('120.6671.406-4'),
-    '"120.6671.406-4" must not be a valid PIS number',
+    fn(string $message) => expect($message)->toBe('"120.6671.406-4" must not be a valid PIS number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::pis()->assert('your mother'),
-    '- "your mother" must be a valid PIS number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "your mother" must be a valid PIS number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::pis())->assert('120.9378.174-5'),
-    '- "120.9378.174-5" must not be a valid PIS number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "120.9378.174-5" must not be a valid PIS number')
 ));

--- a/tests/feature/Rules/PolishIdCardTest.php
+++ b/tests/feature/Rules/PolishIdCardTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 require_once 'vendor/autoload.php';
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::polishIdCard()->assert('AYE205411'),
-    '"AYE205411" must be a valid Polish Identity Card number',
+    fn(string $message) => expect($message)->toBe('"AYE205411" must be a valid Polish Identity Card number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::polishIdCard())->assert('AYE205410'),
-    '"AYE205410" must not be a valid Polish Identity Card number',
+    fn(string $message) => expect($message)->toBe('"AYE205410" must not be a valid Polish Identity Card number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::polishIdCard()->assert('AYE205411'),
-    '- "AYE205411" must be a valid Polish Identity Card number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AYE205411" must be a valid Polish Identity Card number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::polishIdCard())->assert('AYE205410'),
-    '- "AYE205410" must not be a valid Polish Identity Card number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AYE205410" must not be a valid Polish Identity Card number')
 ));

--- a/tests/feature/Rules/PositiveTest.php
+++ b/tests/feature/Rules/PositiveTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::positive()->assert(-10),
-    '-10 must be a positive number',
+    fn(string $message) => expect($message)->toBe('-10 must be a positive number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::positive())->assert(16),
-    '16 must not be a positive number',
+    fn(string $message) => expect($message)->toBe('16 must not be a positive number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::positive()->assert('a'),
-    '- "a" must be a positive number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a positive number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::positive())->assert('165'),
-    '- "165" must not be a positive number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "165" must not be a positive number')
 ));

--- a/tests/feature/Rules/PostalCodeTest.php
+++ b/tests/feature/Rules/PostalCodeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::postalCode('BR')->assert('1057BV'),
-    '"1057BV" must be a valid postal code on "BR"',
+    fn(string $message) => expect($message)->toBe('"1057BV" must be a valid postal code on "BR"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::postalCode('NL'))->assert('1057BV'),
-    '"1057BV" must not be a valid postal code on "NL"',
+    fn(string $message) => expect($message)->toBe('"1057BV" must not be a valid postal code on "NL"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::postalCode('BR')->assert('1057BV'),
-    '- "1057BV" must be a valid postal code on "BR"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1057BV" must be a valid postal code on "BR"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::postalCode('NL'))->assert('1057BV'),
-    '- "1057BV" must not be a valid postal code on "NL"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1057BV" must not be a valid postal code on "NL"')
 ));

--- a/tests/feature/Rules/PrimeNumberTest.php
+++ b/tests/feature/Rules/PrimeNumberTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::primeNumber()->assert(10),
-    '10 must be a prime number',
+    fn(string $message) => expect($message)->toBe('10 must be a prime number')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::primeNumber())->assert(3),
-    '3 must not be a prime number',
+    fn(string $message) => expect($message)->toBe('3 must not be a prime number')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::primeNumber()->assert('Foo'),
-    '- "Foo" must be a prime number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must be a prime number')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::primeNumber())->assert('+7'),
-    '- "+7" must not be a prime number',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "+7" must not be a prime number')
 ));

--- a/tests/feature/Rules/PrintableTest.php
+++ b/tests/feature/Rules/PrintableTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::printable()->assert(''),
-    '"" must contain only printable characters',
+    fn(string $message) => expect($message)->toBe('"" must contain only printable characters')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::printable())->assert('abc'),
-    '"abc" must not contain printable characters',
+    fn(string $message) => expect($message)->toBe('"abc" must not contain printable characters')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::printable()->assert('foo' . chr(10) . 'bar'),
-    '- "foo\\nbar" must contain only printable characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must contain only printable characters')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::printable())->assert('$%asd'),
-    '- "$%asd" must not contain printable characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "$%asd" must not contain printable characters')
 ));

--- a/tests/feature/Rules/PropertyExistsTest.php
+++ b/tests/feature/Rules/PropertyExistsTest.php
@@ -7,30 +7,34 @@
 
 declare(strict_types=1);
 
-test('Default mode', expectAll(
+test('Default mode', catchAll(
     fn() => v::propertyExists('foo')->assert((object) ['bar' => 'baz']),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('Inverted mode', expectAll(
+test('Inverted mode', catchAll(
     fn() => v::not(v::propertyExists('foo'))->assert((object) ['foo' => 'baz']),
-    '`.foo` must not be present',
-    '- `.foo` must not be present',
-    ['foo' => '`.foo` must not be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must not be present')
+        ->and($fullMessage)->toBe('- `.foo` must not be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must not be present'])
 ));
 
-test('Custom name', expectAll(
+test('Custom name', catchAll(
     fn() => v::propertyExists('foo')->setName('Custom name')->assert((object) ['bar' => 'baz']),
-    'Custom name must be present',
-    '- Custom name must be present',
-    ['foo' => 'Custom name must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Custom name must be present')
+        ->and($fullMessage)->toBe('- Custom name must be present')
+        ->and($messages)->toBe(['foo' => 'Custom name must be present'])
 ));
 
-test('Custom template', expectAll(
+test('Custom template', catchAll(
     fn() => v::propertyExists('foo')->assert((object) ['bar' => 'baz'], 'Custom template for {{name}}'),
-    'Custom template for `.foo`',
-    '- Custom template for `.foo`',
-    ['foo' => 'Custom template for `.foo`'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Custom template for `.foo`')
+        ->and($fullMessage)->toBe('- Custom template for `.foo`')
+        ->and($messages)->toBe(['foo' => 'Custom template for `.foo`'])
 ));

--- a/tests/feature/Rules/PropertyOptionalTest.php
+++ b/tests/feature/Rules/PropertyOptionalTest.php
@@ -7,74 +7,84 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::propertyOptional('foo', v::intType())->assert((object) ['foo' => 'string']),
-    '`.foo` must be an integer',
-    '- `.foo` must be an integer',
-    ['foo' => '`.foo` must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must be an integer'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType()))->assert((object) ['foo' => 12]),
-    '`.foo` must not be an integer',
-    '- `.foo` must not be an integer',
-    ['foo' => '`.foo` must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must not be an integer'])
 ));
 
-test('Inverted with missing property', expectAll(
+test('Inverted with missing property', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType()))->assert(new stdClass()),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('With wrapped name, default', expectAll(
+test('With wrapped name, default', catchAll(
     fn() => v::propertyOptional('foo', v::intType()->setName('Wrapped'))->setName('Wrapper')->assert((object) ['foo' => 'string']),
-    'Wrapped must be an integer',
-    '- Wrapped must be an integer',
-    ['foo' => 'Wrapped must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must be an integer'])
 ));
 
-test('With wrapped name, inverted', expectAll(
+test('With wrapped name, inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType()->setName('Wrapped'))->setName('Wrapper'))->setName('Not')->assert((object) ['foo' => 12]),
-    'Wrapped must not be an integer',
-    '- Wrapped must not be an integer',
-    ['foo' => 'Wrapped must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must not be an integer'])
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::propertyOptional('foo', v::intType())->setName('Wrapper')->assert((object) ['foo' => 'string']),
-    'Wrapper must be an integer',
-    '- Wrapper must be an integer',
-    ['foo' => 'Wrapper must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer'])
 ));
 
-test('With wrapper name, inverted', expectAll(
+test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType())->setName('Wrapper'))->setName('Not')->assert((object) ['foo' => 12]),
-    'Wrapper must not be an integer',
-    '- Wrapper must not be an integer',
-    ['foo' => 'Wrapper must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer'])
 ));
 
-test('With "Not" name, inverted', expectAll(
+test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType()))->setName('Not')->assert((object) ['foo' => 12]),
-    'Not must not be an integer',
-    '- Not must not be an integer',
-    ['foo' => 'Not must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not be an integer')
+        ->and($fullMessage)->toBe('- Not must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Not must not be an integer'])
 ));
 
-test('With template, default', expectAll(
+test('With template, default', catchAll(
     fn() => v::propertyOptional('foo', v::intType())
-        ->assert((object) ['foo' => 'string'], 'Proper property planners plan precise property plots'),
-    'Proper property planners plan precise property plots',
-    '- Proper property planners plan precise property plots',
-    ['foo' => 'Proper property planners plan precise property plots'],
+            ->assert((object) ['foo' => 'string'], 'Proper property planners plan precise property plots'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Proper property planners plan precise property plots')
+        ->and($fullMessage)->toBe('- Proper property planners plan precise property plots')
+        ->and($messages)->toBe(['foo' => 'Proper property planners plan precise property plots'])
 ));
 
-test('With template, inverted', expectAll(
+test('With template, inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType()))
-        ->assert((object) ['foo' => 12], 'Not proving prudent property planning promotes prosperity'),
-    'Not proving prudent property planning promotes prosperity',
-    '- Not proving prudent property planning promotes prosperity',
-    ['foo' => 'Not proving prudent property planning promotes prosperity'],
+            ->assert((object) ['foo' => 12], 'Not proving prudent property planning promotes prosperity'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not proving prudent property planning promotes prosperity')
+        ->and($fullMessage)->toBe('- Not proving prudent property planning promotes prosperity')
+        ->and($messages)->toBe(['foo' => 'Not proving prudent property planning promotes prosperity'])
 ));

--- a/tests/feature/Rules/PropertyTest.php
+++ b/tests/feature/Rules/PropertyTest.php
@@ -7,100 +7,113 @@
 
 declare(strict_types=1);
 
-test('Missing property', expectAll(
+test('Missing property', catchAll(
     fn() => v::property('foo', v::intType())->assert(new stdClass()),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::property('foo', v::intType())->assert((object) ['foo' => 'string']),
-    '`.foo` must be an integer',
-    '- `.foo` must be an integer',
-    ['foo' => '`.foo` must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must be an integer'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::property('foo', v::intType()))->assert((object) ['foo' => 12]),
-    '`.foo` must not be an integer',
-    '- `.foo` must not be an integer',
-    ['foo' => '`.foo` must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` must not be an integer'])
 ));
 
-test('Double-inverted with missing property', expectAll(
+test('Double-inverted with missing property', catchAll(
     fn() => v::not(v::not(v::property('foo', v::intType())))->assert(new stdClass()),
-    '`.foo` must be present',
-    '- `.foo` must be present',
-    ['foo' => '`.foo` must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be present')
+        ->and($fullMessage)->toBe('- `.foo` must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` must be present'])
 ));
 
-test('With wrapped name, missing property', expectAll(
+test('With wrapped name, missing property', catchAll(
     fn() => v::property('foo', v::intType()->setName('Wrapped'))->assert(new stdClass()),
-    'Wrapped must be present',
-    '- Wrapped must be present',
-    ['foo' => 'Wrapped must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be present')
+        ->and($fullMessage)->toBe('- Wrapped must be present')
+        ->and($messages)->toBe(['foo' => 'Wrapped must be present'])
 ));
 
-test('With wrapped name, default', expectAll(
+test('With wrapped name, default', catchAll(
     fn() => v::property('foo', v::intType()->setName('Wrapped'))->setName('Wrapper')->assert((object) ['foo' => 'string']),
-    'Wrapped must be an integer',
-    '- Wrapped must be an integer',
-    ['foo' => 'Wrapped must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must be an integer'])
 ));
 
-test('With wrapped name, inverted', expectAll(
+test('With wrapped name, inverted', catchAll(
     fn() => v::not(
         v::property('foo', v::intType()->setName('Wrapped'))->setName('Wrapper'),
     )
-        ->setName('Not')
-        ->assert((object) ['foo' => 12]),
-    'Wrapped must not be an integer',
-    '- Wrapped must not be an integer',
-    ['foo' => 'Wrapped must not be an integer'],
+            ->setName('Not')
+            ->assert((object) ['foo' => 12]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapped must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapped must not be an integer'])
 ));
 
-test('With wrapper name, default', expectAll(
+test('With wrapper name, default', catchAll(
     fn() => v::property('foo', v::intType())->setName('Wrapper')->assert((object) ['foo' => 'string']),
-    'Wrapper must be an integer',
-    '- Wrapper must be an integer',
-    ['foo' => 'Wrapper must be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer'])
 ));
 
-test('With wrapper name, missing property', expectAll(
+test('With wrapper name, missing property', catchAll(
     fn() => v::property('foo', v::intType())->setName('Wrapper')->assert(new stdClass()),
-    'Wrapper must be present',
-    '- Wrapper must be present',
-    ['foo' => 'Wrapper must be present'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must be present')
+        ->and($fullMessage)->toBe('- Wrapper must be present')
+        ->and($messages)->toBe(['foo' => 'Wrapper must be present'])
 ));
 
-test('With wrapper name, inverted', expectAll(
+test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::property('foo', v::intType())->setName('Wrapper'))->setName('Not')
-        ->assert((object) ['foo' => 12]),
-    'Wrapper must not be an integer',
-    '- Wrapper must not be an integer',
-    ['foo' => 'Wrapper must not be an integer'],
+            ->assert((object) ['foo' => 12]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not be an integer')
+        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer'])
 ));
 
-test('With "Not" name, inverted', expectAll(
+test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::property('foo', v::intType()))->setName('Not')->assert((object) ['foo' => 12]),
-    'Not must not be an integer',
-    '- Not must not be an integer',
-    ['foo' => 'Not must not be an integer'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not be an integer')
+        ->and($fullMessage)->toBe('- Not must not be an integer')
+        ->and($messages)->toBe(['foo' => 'Not must not be an integer'])
 ));
 
-test('With template, default', expectAll(
+test('With template, default', catchAll(
     fn() => v::property('foo', v::intType())
-        ->assert((object) ['foo' => 'string'], 'Particularly precautions perplexing property'),
-    'Particularly precautions perplexing property',
-    '- Particularly precautions perplexing property',
-    ['foo' => 'Particularly precautions perplexing property'],
+            ->assert((object) ['foo' => 'string'], 'Particularly precautions perplexing property'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Particularly precautions perplexing property')
+        ->and($fullMessage)->toBe('- Particularly precautions perplexing property')
+        ->and($messages)->toBe(['foo' => 'Particularly precautions perplexing property'])
 ));
 
-test('With template, inverted', expectAll(
+test('With template, inverted', catchAll(
     fn() => v::not(v::property('foo', v::intType()))
-        ->assert((object) ['foo' => 12], 'Not a prompt prospect of a particularly primitive property'),
-    'Not a prompt prospect of a particularly primitive property',
-    '- Not a prompt prospect of a particularly primitive property',
-    ['foo' => 'Not a prompt prospect of a particularly primitive property'],
+            ->assert((object) ['foo' => 12], 'Not a prompt prospect of a particularly primitive property'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not a prompt prospect of a particularly primitive property')
+        ->and($fullMessage)->toBe('- Not a prompt prospect of a particularly primitive property')
+        ->and($messages)->toBe(['foo' => 'Not a prompt prospect of a particularly primitive property'])
 ));

--- a/tests/feature/Rules/PunctTest.php
+++ b/tests/feature/Rules/PunctTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::punct()->assert('a'),
-    '"a" must contain only punctuation characters',
+    fn(string $message) => expect($message)->toBe('"a" must contain only punctuation characters')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::punct('c')->assert('b'),
-    '"b" must contain only punctuation characters and "c"',
+    fn(string $message) => expect($message)->toBe('"b" must contain only punctuation characters and "c"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::punct())->assert('.'),
-    '"." must not contain punctuation characters',
+    fn(string $message) => expect($message)->toBe('"." must not contain punctuation characters')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::punct('d'))->assert('?'),
-    '"?" must not contain punctuation characters or "d"',
+    fn(string $message) => expect($message)->toBe('"?" must not contain punctuation characters or "d"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::punct()->assert('e'),
-    '- "e" must contain only punctuation characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e" must contain only punctuation characters')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::punct('f')->assert('g'),
-    '- "g" must contain only punctuation characters and "f"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g" must contain only punctuation characters and "f"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::punct())->assert('!'),
-    '- "!" must not contain punctuation characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "!" must not contain punctuation characters')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::punct('h'))->assert(';'),
-    '- ";" must not contain punctuation characters or "h"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- ";" must not contain punctuation characters or "h"')
 ));

--- a/tests/feature/Rules/ReadableTest.php
+++ b/tests/feature/Rules/ReadableTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::readable()->assert('tests/fixtures/invalid-image.jpg'),
-    '"tests/fixtures/invalid-image.jpg" must be readable',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/invalid-image.jpg" must be readable')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::readable())->assert('tests/fixtures/valid-image.png'),
-    '"tests/fixtures/valid-image.png" must not be readable',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be readable')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::readable()->assert(new stdClass()),
-    '- `stdClass {}` must be readable',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be readable')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::readable())->assert('tests/fixtures/valid-image.png'),
-    '- "tests/fixtures/valid-image.png" must not be readable',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.png" must not be readable')
 ));

--- a/tests/feature/Rules/RegexTest.php
+++ b/tests/feature/Rules/RegexTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::regex('/^w+$/')->assert('w poiur'),
-    '"w poiur" must match the pattern `/^w+$/`',
+    fn(string $message) => expect($message)->toBe('"w poiur" must match the pattern `/^w+$/`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::regex('/^[a-z]+$/'))->assert('wpoiur'),
-    '"wpoiur" must not match the pattern `/^[a-z]+$/`',
+    fn(string $message) => expect($message)->toBe('"wpoiur" must not match the pattern `/^[a-z]+$/`')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::regex('/^w+$/')->assert(new stdClass()),
-    '- `stdClass {}` must match the pattern `/^w+$/`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must match the pattern `/^w+$/`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::regex('/^[a-z]+$/i'))->assert('wPoiur'),
-    '- "wPoiur" must not match the pattern `/^[a-z]+$/i`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "wPoiur" must not match the pattern `/^[a-z]+$/i`')
 ));

--- a/tests/feature/Rules/ResourceTypeTest.php
+++ b/tests/feature/Rules/ResourceTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::resourceType()->assert('test'),
-    '"test" must be a resource',
+    fn(string $message) => expect($message)->toBe('"test" must be a resource')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::resourceType())->assert(tmpfile()),
-    '`resource <stream>` must not be a resource',
+    fn(string $message) => expect($message)->toBe('`resource <stream>` must not be a resource')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::resourceType()->assert([]),
-    '- `[]` must be a resource',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be a resource')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::resourceType())->assert(tmpfile()),
-    '- `resource <stream>` must not be a resource',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `resource <stream>` must not be a resource')
 ));

--- a/tests/feature/Rules/RomanTest.php
+++ b/tests/feature/Rules/RomanTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::roman()->assert(1234),
-    '1234 must be a valid Roman numeral',
+    fn(string $message) => expect($message)->toBe('1234 must be a valid Roman numeral')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::roman())->assert('XL'),
-    '"XL" must not be a valid Roman numeral',
+    fn(string $message) => expect($message)->toBe('"XL" must not be a valid Roman numeral')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::roman()->assert('e2'),
-    '- "e2" must be a valid Roman numeral',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e2" must be a valid Roman numeral')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::roman())->assert('IV'),
-    '- "IV" must not be a valid Roman numeral',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "IV" must not be a valid Roman numeral')
 ));

--- a/tests/feature/Rules/ScalarValTest.php
+++ b/tests/feature/Rules/ScalarValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::scalarVal()->assert([]),
-    '`[]` must be a scalar value',
+    fn(string $message) => expect($message)->toBe('`[]` must be a scalar value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::scalarVal())->assert(true),
-    '`true` must not be a scalar value',
+    fn(string $message) => expect($message)->toBe('`true` must not be a scalar value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::scalarVal()->assert(new stdClass()),
-    '- `stdClass {}` must be a scalar value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a scalar value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::scalarVal())->assert(42),
-    '- 42 must not be a scalar value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a scalar value')
 ));

--- a/tests/feature/Rules/SizeTest.php
+++ b/tests/feature/Rules/SizeTest.php
@@ -22,52 +22,58 @@ beforeEach(function (): void {
         ->at($this->root);
 });
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::size('KB', v::lessThan(2))->assert($this->file2Kb->url()),
-    'The size in kilobytes of "vfs://root/2kb.txt" must be less than 2',
-    '- The size in kilobytes of "vfs://root/2kb.txt" must be less than 2',
-    ['sizeLessThan' => 'The size in kilobytes of "vfs://root/2kb.txt" must be less than 2'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The size in kilobytes of "vfs://root/2kb.txt" must be less than 2')
+        ->and($fullMessage)->toBe('- The size in kilobytes of "vfs://root/2kb.txt" must be less than 2')
+        ->and($messages)->toBe(['sizeLessThan' => 'The size in kilobytes of "vfs://root/2kb.txt" must be less than 2'])
 ));
 
-test('Wrong type', expectAll(
+test('Wrong type', catchAll(
     fn() => v::size('KB', v::lessThan(2))->assert(new stdClass()),
-    '`stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface',
-    '- `stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface',
-    ['sizeLessThan' => '`stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface')
+        ->and($fullMessage)->toBe('- `stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface')
+        ->and($messages)->toBe(['sizeLessThan' => '`stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::size('MB', v::not(v::equals(3)))->assert($this->file2Mb->url()),
-    'The size in megabytes of "vfs://root/3mb.txt" must not be equal to 3',
-    '- The size in megabytes of "vfs://root/3mb.txt" must not be equal to 3',
-    ['sizeNotEquals' => 'The size in megabytes of "vfs://root/3mb.txt" must not be equal to 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The size in megabytes of "vfs://root/3mb.txt" must not be equal to 3')
+        ->and($fullMessage)->toBe('- The size in megabytes of "vfs://root/3mb.txt" must not be equal to 3')
+        ->and($messages)->toBe(['sizeNotEquals' => 'The size in megabytes of "vfs://root/3mb.txt" must not be equal to 3'])
 ));
 
-test('Wrapped with name', expectAll(
+test('Wrapped with name', catchAll(
     fn() => v::size('KB', v::lessThan(2)->setName('Wrapped'))->assert($this->file2Kb->url()),
-    'The size in kilobytes of Wrapped must be less than 2',
-    '- The size in kilobytes of Wrapped must be less than 2',
-    ['sizeLessThan' => 'The size in kilobytes of Wrapped must be less than 2'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The size in kilobytes of Wrapped must be less than 2')
+        ->and($fullMessage)->toBe('- The size in kilobytes of Wrapped must be less than 2')
+        ->and($messages)->toBe(['sizeLessThan' => 'The size in kilobytes of Wrapped must be less than 2'])
 ));
 
-test('Wrapper with name', expectAll(
+test('Wrapper with name', catchAll(
     fn() => v::size('KB', v::lessThan(2))->setName('Wrapper')->assert($this->file2Kb->url()),
-    'The size in kilobytes of Wrapper must be less than 2',
-    '- The size in kilobytes of Wrapper must be less than 2',
-    ['sizeLessThan' => 'The size in kilobytes of Wrapper must be less than 2'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The size in kilobytes of Wrapper must be less than 2')
+        ->and($fullMessage)->toBe('- The size in kilobytes of Wrapper must be less than 2')
+        ->and($messages)->toBe(['sizeLessThan' => 'The size in kilobytes of Wrapper must be less than 2'])
 ));
 
-test('Chained wrapped rule', expectAll(
+test('Chained wrapped rule', catchAll(
     fn() => v::size('KB', v::between(5, 7)->odd())->assert($this->file2Kb->url()),
-    'The size in kilobytes of "vfs://root/2kb.txt" must be between 5 and 7',
-    <<<'FULL_MESSAGE'
-    - "vfs://root/2kb.txt" must pass all the rules
-      - The size in kilobytes of "vfs://root/2kb.txt" must be between 5 and 7
-      - The size in kilobytes of "vfs://root/2kb.txt" must be an odd number
-    FULL_MESSAGE,
-    [
-        '__root__' => '"vfs://root/2kb.txt" must pass all the rules',
-        'sizeBetween' => 'The size in kilobytes of "vfs://root/2kb.txt" must be between 5 and 7',
-        'sizeOdd' => 'The size in kilobytes of "vfs://root/2kb.txt" must be an odd number',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The size in kilobytes of "vfs://root/2kb.txt" must be between 5 and 7')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - "vfs://root/2kb.txt" must pass all the rules
+          - The size in kilobytes of "vfs://root/2kb.txt" must be between 5 and 7
+          - The size in kilobytes of "vfs://root/2kb.txt" must be an odd number
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '"vfs://root/2kb.txt" must pass all the rules',
+            'sizeBetween' => 'The size in kilobytes of "vfs://root/2kb.txt" must be between 5 and 7',
+            'sizeOdd' => 'The size in kilobytes of "vfs://root/2kb.txt" must be an odd number',
+        ])
 ));

--- a/tests/feature/Rules/SlugTest.php
+++ b/tests/feature/Rules/SlugTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::slug()->assert('my-Slug'),
-    '"my-Slug" must be a valid slug',
+    fn(string $message) => expect($message)->toBe('"my-Slug" must be a valid slug')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::slug())->assert('my-slug'),
-    '"my-slug" must not be a valid slug',
+    fn(string $message) => expect($message)->toBe('"my-slug" must not be a valid slug')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::slug()->assert('my-Slug'),
-    '- "my-Slug" must be a valid slug',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "my-Slug" must be a valid slug')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::slug())->assert('my-slug'),
-    '- "my-slug" must not be a valid slug',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "my-slug" must not be a valid slug')
 ));

--- a/tests/feature/Rules/SortedTest.php
+++ b/tests/feature/Rules/SortedTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::sorted('ASC')->assert([1, 3, 2]),
-    '`[1, 3, 2]` must be sorted in ascending order',
+    fn(string $message) => expect($message)->toBe('`[1, 3, 2]` must be sorted in ascending order')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::sorted('DESC')->assert([1, 2, 3]),
-    '`[1, 2, 3]` must be sorted in descending order',
+    fn(string $message) => expect($message)->toBe('`[1, 2, 3]` must be sorted in descending order')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::sorted('ASC'))->assert([1, 2, 3]),
-    '`[1, 2, 3]` must not be sorted in ascending order',
+    fn(string $message) => expect($message)->toBe('`[1, 2, 3]` must not be sorted in ascending order')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::sorted('DESC'))->assert([3, 2, 1]),
-    '`[3, 2, 1]` must not be sorted in descending order',
+    fn(string $message) => expect($message)->toBe('`[3, 2, 1]` must not be sorted in descending order')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::sorted('ASC')->assert([3, 2, 1]),
-    '- `[3, 2, 1]` must be sorted in ascending order',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[3, 2, 1]` must be sorted in ascending order')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::sorted('DESC')->assert([1, 2, 3]),
-    '- `[1, 2, 3]` must be sorted in descending order',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[1, 2, 3]` must be sorted in descending order')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::sorted('ASC'))->assert([1, 2, 3]),
-    '- `[1, 2, 3]` must not be sorted in ascending order',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[1, 2, 3]` must not be sorted in ascending order')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::sorted('DESC'))->assert([3, 2, 1]),
-    '- `[3, 2, 1]` must not be sorted in descending order',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[3, 2, 1]` must not be sorted in descending order')
 ));

--- a/tests/feature/Rules/SpaceTest.php
+++ b/tests/feature/Rules/SpaceTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::space()->assert('ab'),
-    '"ab" must contain only space characters',
+    fn(string $message) => expect($message)->toBe('"ab" must contain only space characters')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::space('c')->assert('cd'),
-    '"cd" must contain only space characters and "c"',
+    fn(string $message) => expect($message)->toBe('"cd" must contain only space characters and "c"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::space())->assert("\t"),
-    '"\\t" must not contain space characters',
+    fn(string $message) => expect($message)->toBe('"\\t" must not contain space characters')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::space('def'))->assert("\r"),
-    '"\\r" must not contain space characters or "def"',
+    fn(string $message) => expect($message)->toBe('"\\r" must not contain space characters or "def"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::space()->assert('ef'),
-    '- "ef" must contain only space characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ef" must contain only space characters')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::space('e')->assert('gh'),
-    '- "gh" must contain only space characters and "e"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "gh" must contain only space characters and "e"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::space())->assert("\n"),
-    '- "\\n" must not contain space characters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "\\n" must not contain space characters')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::space('yk'))->assert(' k'),
-    '- " k" must not contain space characters or "yk"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- " k" must not contain space characters or "yk"')
 ));

--- a/tests/feature/Rules/StartsWithTest.php
+++ b/tests/feature/Rules/StartsWithTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::startsWith('b')->assert(['a', 'b']),
-    '`["a", "b"]` must start with "b"',
+    fn(string $message) => expect($message)->toBe('`["a", "b"]` must start with "b"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::startsWith(1.1))->assert([1.1, 2.2]),
-    '`[1.1, 2.2]` must not start with 1.1',
+    fn(string $message) => expect($message)->toBe('`[1.1, 2.2]` must not start with 1.1')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::startsWith('3.3', true)->assert([3.3, 4.4]),
-    '- `[3.3, 4.4]` must start with "3.3"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[3.3, 4.4]` must start with "3.3"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::startsWith('c'))->assert(['c', 'd']),
-    '- `["c", "d"]` must not start with "c"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["c", "d"]` must not start with "c"')
 ));

--- a/tests/feature/Rules/StringTypeTest.php
+++ b/tests/feature/Rules/StringTypeTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::stringType()->assert(42),
-    '42 must be a string',
+    fn(string $message) => expect($message)->toBe('42 must be a string')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::stringType())->assert('foo'),
-    '"foo" must not be a string',
+    fn(string $message) => expect($message)->toBe('"foo" must not be a string')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::stringType()->assert(true),
-    '- `true` must be a string',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be a string')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::stringType())->assert('bar'),
-    '- "bar" must not be a string',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bar" must not be a string')
 ));

--- a/tests/feature/Rules/StringValTest.php
+++ b/tests/feature/Rules/StringValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::stringVal()->assert([]),
-    '`[]` must be a string value',
+    fn(string $message) => expect($message)->toBe('`[]` must be a string value')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::stringVal())->assert(true),
-    '`true` must not be a string value',
+    fn(string $message) => expect($message)->toBe('`true` must not be a string value')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::stringVal()->assert(new stdClass()),
-    '- `stdClass {}` must be a string value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a string value')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::stringVal())->assert(42),
-    '- 42 must not be a string value',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a string value')
 ));

--- a/tests/feature/Rules/SubsetTest.php
+++ b/tests/feature/Rules/SubsetTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::subset([1, 2])->assert([1, 2, 3]),
-    '`[1, 2, 3]` must be subset of `[1, 2]`',
+    fn(string $message) => expect($message)->toBe('`[1, 2, 3]` must be subset of `[1, 2]`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::subset([1, 2, 3]))->assert([1, 2]),
-    '`[1, 2]` must not be subset of `[1, 2, 3]`',
+    fn(string $message) => expect($message)->toBe('`[1, 2]` must not be subset of `[1, 2, 3]`')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::subset(['A', 'B'])->assert(['B', 'C']),
-    '- `["B", "C"]` must be subset of `["A", "B"]`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["B", "C"]` must be subset of `["A", "B"]`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::subset(['A']))->assert(['A']),
-    '- `["A"]` must not be subset of `["A"]`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["A"]` must not be subset of `["A"]`')
 ));

--- a/tests/feature/Rules/SymbolicLinkTest.php
+++ b/tests/feature/Rules/SymbolicLinkTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::symbolicLink()->assert('tests/fixtures/fake-filename'),
-    '"tests/fixtures/fake-filename" must be a symbolic link',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/fake-filename" must be a symbolic link')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::symbolicLink())->assert('tests/fixtures/symbolic-link'),
-    '"tests/fixtures/symbolic-link" must not be a symbolic link',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/symbolic-link" must not be a symbolic link')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::symbolicLink()->assert('tests/fixtures/fake-filename'),
-    '- "tests/fixtures/fake-filename" must be a symbolic link',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/fake-filename" must be a symbolic link')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::symbolicLink())->assert('tests/fixtures/symbolic-link'),
-    '- "tests/fixtures/symbolic-link" must not be a symbolic link',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/symbolic-link" must not be a symbolic link')
 ));

--- a/tests/feature/Rules/TemplatedTest.php
+++ b/tests/feature/Rules/TemplatedTest.php
@@ -7,46 +7,52 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::templated(v::stringType(), 'Template in "Templated"')->assert(12),
-    'Template in "Templated"',
-    '- Template in "Templated"',
-    ['stringType' => 'Template in "Templated"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template in "Templated"')
+        ->and($fullMessage)->toBe('- Template in "Templated"')
+        ->and($messages)->toBe(['stringType' => 'Template in "Templated"'])
 ));
 
-test('With parameters', expectAll(
+test('With parameters', catchAll(
     fn() => v::templated(v::stringType(), 'Template in {{source}}', ['source' => 'Templated'])->assert(12),
-    'Template in "Templated"',
-    '- Template in "Templated"',
-    ['stringType' => 'Template in "Templated"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template in "Templated"')
+        ->and($fullMessage)->toBe('- Template in "Templated"')
+        ->and($messages)->toBe(['stringType' => 'Template in "Templated"'])
 ));
 
-test('Inverted', expectAll(
+test('Inverted', catchAll(
     fn() => v::not(v::templated(v::intType(), 'Template in "Templated"'))->assert(12),
-    'Template in "Templated"',
-    '- Template in "Templated"',
-    ['notIntType' => 'Template in "Templated"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template in "Templated"')
+        ->and($fullMessage)->toBe('- Template in "Templated"')
+        ->and($messages)->toBe(['notIntType' => 'Template in "Templated"'])
 ));
 
-test('Template in Validator', expectAll(
+test('Template in Validator', catchAll(
     fn() => v::templated(v::stringType(), 'Template in "Templated"')
         ->setTemplate('Template in "Validator"')
         ->assert(12),
-    'Template in "Templated"',
-    '- Template in "Templated"',
-    ['stringType' => 'Template in "Templated"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template in "Templated"')
+        ->and($fullMessage)->toBe('- Template in "Templated"')
+        ->and($messages)->toBe(['stringType' => 'Template in "Templated"'])
 ));
 
-test('Template passed to Validator::assert()', expectAll(
+test('Template passed to Validator::assert()', catchAll(
     fn() => v::templated(v::stringType(), 'Template in "Templated"')->assert(10, 'Template in "Validator::assert"'),
-    'Template in "Templated"',
-    '- Template in "Templated"',
-    ['stringType' => 'Template in "Templated"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template in "Templated"')
+        ->and($fullMessage)->toBe('- Template in "Templated"')
+        ->and($messages)->toBe(['stringType' => 'Template in "Templated"'])
 ));
 
-test('With bound', expectAll(
+test('With bound', catchAll(
     fn() => v::templated(v::attributes(), 'Template in "Templated"')->assert(null),
-    'Template in "Templated"',
-    '- Template in "Templated"',
-    ['attributes' => 'Template in "Templated"'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Template in "Templated"')
+        ->and($fullMessage)->toBe('- Template in "Templated"')
+        ->and($messages)->toBe(['attributes' => 'Template in "Templated"'])
 ));

--- a/tests/feature/Rules/TimeTest.php
+++ b/tests/feature/Rules/TimeTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::time()->assert('2018-01-30'),
-    '"2018-01-30" must be a valid time in the format "23:59:59"',
+    fn(string $message) => expect($message)->toBe('"2018-01-30" must be a valid time in the format "23:59:59"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::time())->assert('09:25:46'),
-    '"09:25:46" must not be a valid time in the format "23:59:59"',
+    fn(string $message) => expect($message)->toBe('"09:25:46" must not be a valid time in the format "23:59:59"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::time()->assert('2018-01-30'),
-    '- "2018-01-30" must be a valid time in the format "23:59:59"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-01-30" must be a valid time in the format "23:59:59"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::time('g:i A'))->assert('8:13 AM'),
-    '- "8:13 AM" must not be a valid time in the format "11:59 PM"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "8:13 AM" must not be a valid time in the format "11:59 PM"')
 ));

--- a/tests/feature/Rules/TldTest.php
+++ b/tests/feature/Rules/TldTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::tld()->assert('42'),
-    '"42" must be a valid top-level domain name',
+    fn(string $message) => expect($message)->toBe('"42" must be a valid top-level domain name')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::tld())->assert('com'),
-    '"com" must not be a valid top-level domain name',
+    fn(string $message) => expect($message)->toBe('"com" must not be a valid top-level domain name')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::tld()->assert('1984'),
-    '- "1984" must be a valid top-level domain name',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1984" must be a valid top-level domain name')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::tld())->assert('com'),
-    '- "com" must not be a valid top-level domain name',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "com" must not be a valid top-level domain name')
 ));

--- a/tests/feature/Rules/TrueValTest.php
+++ b/tests/feature/Rules/TrueValTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::trueVal()->assert(false),
-    '`false` must evaluate to `true`',
+    fn(string $message) => expect($message)->toBe('`false` must evaluate to `true`')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::trueVal())->assert(1),
-    '1 must not evaluate to `true`',
+    fn(string $message) => expect($message)->toBe('1 must not evaluate to `true`')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::trueVal()->assert(0),
-    '- 0 must evaluate to `true`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0 must evaluate to `true`')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::trueVal())->assert('true'),
-    '- "true" must not evaluate to `true`',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "true" must not evaluate to `true`')
 ));

--- a/tests/feature/Rules/UndefOrTest.php
+++ b/tests/feature/Rules/UndefOrTest.php
@@ -7,105 +7,117 @@
 
 declare(strict_types=1);
 
-test('Default', expectAll(
+test('Default', catchAll(
     fn() => v::undefOr(v::alpha())->assert(1234),
-    '1234 must contain only letters (a-z) or must be undefined',
-    '- 1234 must contain only letters (a-z) or must be undefined',
-    ['undefOrAlpha' => '1234 must contain only letters (a-z) or must be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('1234 must contain only letters (a-z) or must be undefined')
+        ->and($fullMessage)->toBe('- 1234 must contain only letters (a-z) or must be undefined')
+        ->and($messages)->toBe(['undefOrAlpha' => '1234 must contain only letters (a-z) or must be undefined'])
 ));
 
-test('Inverted wrapper', expectAll(
+test('Inverted wrapper', catchAll(
     fn() => v::not(v::undefOr(v::alpha()))->assert('alpha'),
-    '"alpha" must not contain letters (a-z) and must not be undefined',
-    '- "alpha" must not contain letters (a-z) and must not be undefined',
-    ['notUndefOrAlpha' => '"alpha" must not contain letters (a-z) and must not be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"alpha" must not contain letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => '"alpha" must not contain letters (a-z) and must not be undefined'])
 ));
 
-test('Inverted wrapped', expectAll(
+test('Inverted wrapped', catchAll(
     fn() => v::undefOr(v::not(v::alpha()))->assert('alpha'),
-    '"alpha" must not contain letters (a-z) or must be undefined',
-    '- "alpha" must not contain letters (a-z) or must be undefined',
-    ['undefOrNotAlpha' => '"alpha" must not contain letters (a-z) or must be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"alpha" must not contain letters (a-z) or must be undefined')
+        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) or must be undefined')
+        ->and($messages)->toBe(['undefOrNotAlpha' => '"alpha" must not contain letters (a-z) or must be undefined'])
 ));
 
-test('Inverted undefined', expectAll(
+test('Inverted undefined', catchAll(
     fn() => v::not(v::undefOr(v::alpha()))->assert(null),
-    '`null` must not contain letters (a-z) and must not be undefined',
-    '- `null` must not contain letters (a-z) and must not be undefined',
-    ['notUndefOrAlpha' => '`null` must not contain letters (a-z) and must not be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`null` must not contain letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- `null` must not contain letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => '`null` must not contain letters (a-z) and must not be undefined'])
 ));
 
-test('Inverted undefined, wrapped name', expectAll(
+test('Inverted undefined, wrapped name', catchAll(
     fn() => v::not(v::undefOr(v::alpha()->setName('Wrapped')))->assert(null),
-    'Wrapped must not contain letters (a-z) and must not be undefined',
-    '- Wrapped must not contain letters (a-z) and must not be undefined',
-    ['notUndefOrAlpha' => 'Wrapped must not contain letters (a-z) and must not be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapped must not contain letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- Wrapped must not contain letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Wrapped must not contain letters (a-z) and must not be undefined'])
 ));
 
-test('Inverted undefined, wrapper name', expectAll(
+test('Inverted undefined, wrapper name', catchAll(
     fn() => v::not(v::undefOr(v::alpha())->setName('Wrapper'))->assert(null),
-    'Wrapper must not contain letters (a-z) and must not be undefined',
-    '- Wrapper must not contain letters (a-z) and must not be undefined',
-    ['notUndefOrAlpha' => 'Wrapper must not contain letters (a-z) and must not be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Wrapper must not contain letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- Wrapper must not contain letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Wrapper must not contain letters (a-z) and must not be undefined'])
 ));
 
-test('Inverted undefined, not name', expectAll(
+test('Inverted undefined, not name', catchAll(
     fn() => v::not(v::undefOr(v::alpha()))->setName('Not')->assert(null),
-    'Not must not contain letters (a-z) and must not be undefined',
-    '- Not must not contain letters (a-z) and must not be undefined',
-    ['notUndefOrAlpha' => 'Not must not contain letters (a-z) and must not be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not must not contain letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- Not must not contain letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Not must not contain letters (a-z) and must not be undefined'])
 ));
 
-test('With template', expectAll(
+test('With template', catchAll(
     fn() => v::undefOr(v::alpha())->assert(123, 'Underneath the undulating umbrella'),
-    'Underneath the undulating umbrella',
-    '- Underneath the undulating umbrella',
-    ['undefOrAlpha' => 'Underneath the undulating umbrella'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Underneath the undulating umbrella')
+        ->and($fullMessage)->toBe('- Underneath the undulating umbrella')
+        ->and($messages)->toBe(['undefOrAlpha' => 'Underneath the undulating umbrella'])
 ));
 
-test('With array template', expectAll(
+test('With array template', catchAll(
     fn() => v::undefOr(v::alpha())->assert(123, ['undefOrAlpha' => 'Undefined number of unique unicorns']),
-    'Undefined number of unique unicorns',
-    '- Undefined number of unique unicorns',
-    ['undefOrAlpha' => 'Undefined number of unique unicorns'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Undefined number of unique unicorns')
+        ->and($fullMessage)->toBe('- Undefined number of unique unicorns')
+        ->and($messages)->toBe(['undefOrAlpha' => 'Undefined number of unique unicorns'])
 ));
 
-test('Inverted undefined with template', expectAll(
+test('Inverted undefined with template', catchAll(
     fn() => v::not(v::undefOr(v::alpha()))->assert('', ['notUndefOrAlpha' => 'Should not be undefined or alpha']),
-    'Should not be undefined or alpha',
-    '- Should not be undefined or alpha',
-    ['notUndefOrAlpha' => 'Should not be undefined or alpha'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Should not be undefined or alpha')
+        ->and($fullMessage)->toBe('- Should not be undefined or alpha')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Should not be undefined or alpha'])
 ));
 
-test('Without adjacent result', expectAll(
+test('Without adjacent result', catchAll(
     fn() => v::undefOr(v::alpha()->stringType())->assert(1234),
-    '1234 must contain only letters (a-z) or must be undefined',
-    <<<'FULL_MESSAGE'
-    - 1234 must pass all the rules
-      - 1234 must contain only letters (a-z) or must be undefined
-      - 1234 must be a string or must be undefined
-    FULL_MESSAGE,
-    [
-        '__root__' => '1234 must pass all the rules',
-        'undefOrAlpha' => '1234 must contain only letters (a-z) or must be undefined',
-        'undefOrStringType' => '1234 must be a string or must be undefined',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('1234 must contain only letters (a-z) or must be undefined')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - 1234 must pass all the rules
+          - 1234 must contain only letters (a-z) or must be undefined
+          - 1234 must be a string or must be undefined
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '1234 must pass all the rules',
+            'undefOrAlpha' => '1234 must contain only letters (a-z) or must be undefined',
+            'undefOrStringType' => '1234 must be a string or must be undefined',
+        ])
 ));
 
-test('Without adjacent result with templates', expectAll(
+test('Without adjacent result with templates', catchAll(
     fn() => v::undefOr(v::alpha()->stringType())->assert(1234, [
         'undefOrAlpha' => 'Should be nul or alpha',
         'undefOrStringType' => 'Should be nul or string type',
     ]),
-    'Should be nul or alpha',
-    <<<'FULL_MESSAGE'
-    - 1234 must pass all the rules
-      - Should be nul or alpha
-      - Should be nul or string type
-    FULL_MESSAGE,
-    [
-        '__root__' => '1234 must pass all the rules',
-        'undefOrAlpha' => 'Should be nul or alpha',
-        'undefOrStringType' => 'Should be nul or string type',
-    ],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Should be nul or alpha')
+        ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - 1234 must pass all the rules
+          - Should be nul or alpha
+          - Should be nul or string type
+        FULL_MESSAGE)
+        ->and($messages)->toBe([
+            '__root__' => '1234 must pass all the rules',
+            'undefOrAlpha' => 'Should be nul or alpha',
+            'undefOrStringType' => 'Should be nul or string type',
+        ])
 ));

--- a/tests/feature/Rules/UniqueTest.php
+++ b/tests/feature/Rules/UniqueTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::unique()->assert([1, 2, 2, 3]),
-    '`[1, 2, 2, 3]` must not contain duplicates',
+    fn(string $message) => expect($message)->toBe('`[1, 2, 2, 3]` must not contain duplicates')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::unique())->assert([1, 2, 3, 4]),
-    '`[1, 2, 3, 4]` must contain duplicates',
+    fn(string $message) => expect($message)->toBe('`[1, 2, 3, 4]` must contain duplicates')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::unique()->assert('test'),
-    '- "test" must not contain duplicates',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "test" must not contain duplicates')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::unique())->assert(['a', 'b', 'c']),
-    '- `["a", "b", "c"]` must contain duplicates',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `["a", "b", "c"]` must contain duplicates')
 ));

--- a/tests/feature/Rules/UploadedTest.php
+++ b/tests/feature/Rules/UploadedTest.php
@@ -7,34 +7,26 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
-    function (): void {
-        uopz_set_return('is_uploaded_file', false);
-        v::uploaded()->assert('filename');
-    },
-    '"filename" must be an uploaded file',
-))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #1', catchMessage(function (): void {
+    uopz_set_return('is_uploaded_file', false);
+    v::uploaded()->assert('filename');
+},
+fn(string $message) => expect($message)->toBe('"filename" must be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
 
-test('Scenario #2', expectMessage(
-    function (): void {
-        uopz_set_return('is_uploaded_file', true);
-        v::not(v::uploaded())->assert('filename');
-    },
-    '"filename" must not be an uploaded file',
-))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #2', catchMessage(function (): void {
+    uopz_set_return('is_uploaded_file', true);
+    v::not(v::uploaded())->assert('filename');
+},
+fn(string $message) => expect($message)->toBe('"filename" must not be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
 
-test('Scenario #3', expectFullMessage(
-    function (): void {
-        uopz_set_return('is_uploaded_file', false);
-        v::uploaded()->assert('filename');
-    },
-    '- "filename" must be an uploaded file',
-))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #3', catchFullMessage(function (): void {
+    uopz_set_return('is_uploaded_file', false);
+    v::uploaded()->assert('filename');
+},
+fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename" must be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
 
-test('Scenario #4', expectFullMessage(
-    function (): void {
-        uopz_set_return('is_uploaded_file', true);
-        v::not(v::uploaded())->assert('filename');
-    },
-    '- "filename" must not be an uploaded file',
-))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #4', catchFullMessage(function (): void {
+    uopz_set_return('is_uploaded_file', true);
+    v::not(v::uploaded())->assert('filename');
+},
+fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename" must not be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');

--- a/tests/feature/Rules/UppercaseTest.php
+++ b/tests/feature/Rules/UppercaseTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::uppercase()->assert('lowercase'),
-    '"lowercase" must contain only uppercase letters',
+    fn(string $message) => expect($message)->toBe('"lowercase" must contain only uppercase letters')
 ));
 
-test('Scenario #2', expectFullMessage(
+test('Scenario #2', catchFullMessage(
     fn() => v::uppercase()->assert('lowercase'),
-    '- "lowercase" must contain only uppercase letters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "lowercase" must contain only uppercase letters')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::uppercase())->assert('UPPERCASE'),
-    '"UPPERCASE" must not contain only uppercase letters',
+    fn(string $message) => expect($message)->toBe('"UPPERCASE" must not contain only uppercase letters')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::uppercase())->assert('UPPERCASE'),
-    '- "UPPERCASE" must not contain only uppercase letters',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "UPPERCASE" must not contain only uppercase letters')
 ));

--- a/tests/feature/Rules/UrlTest.php
+++ b/tests/feature/Rules/UrlTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::url()->assert('example.com'),
-    '"example.com" must be a URL',
+    fn(string $message) => expect($message)->toBe('"example.com" must be a URL')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::url())->assert('http://example.com'),
-    '"http://example.com" must not be a URL',
+    fn(string $message) => expect($message)->toBe('"http://example.com" must not be a URL')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::url()->assert('example.com'),
-    '- "example.com" must be a URL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a URL')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::url())->assert('http://example.com'),
-    '- "http://example.com" must not be a URL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "http://example.com" must not be a URL')
 ));

--- a/tests/feature/Rules/UuidTest.php
+++ b/tests/feature/Rules/UuidTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::uuid()->assert('g71a18f4-3a13-11e7-a919-92ebcb67fe33'),
-    '"g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID',
+    fn(string $message) => expect($message)->toBe('"g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::uuid(1)->assert('e0b5ffb9-9caf-2a34-9673-8fc91db78be6'),
-    '"e0b5ffb9-9caf-2a34-9673-8fc91db78be6" must be a valid UUID version 1',
+    fn(string $message) => expect($message)->toBe('"e0b5ffb9-9caf-2a34-9673-8fc91db78be6" must be a valid UUID version 1')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::uuid())->assert('fb3a7909-8034-59f5-8f38-21adbc168db7'),
-    '"fb3a7909-8034-59f5-8f38-21adbc168db7" must not be a valid UUID',
+    fn(string $message) => expect($message)->toBe('"fb3a7909-8034-59f5-8f38-21adbc168db7" must not be a valid UUID')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::uuid(3))->assert('11a38b9a-b3da-360f-9353-a5a725514269'),
-    '"11a38b9a-b3da-360f-9353-a5a725514269" must not be a valid UUID version 3',
+    fn(string $message) => expect($message)->toBe('"11a38b9a-b3da-360f-9353-a5a725514269" must not be a valid UUID version 3')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::uuid()->assert('g71a18f4-3a13-11e7-a919-92ebcb67fe33'),
-    '- "g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::uuid(4)->assert('a71a18f4-3a13-11e7-a919-92ebcb67fe33'),
-    '- "a71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID version 4',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID version 4')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::uuid())->assert('e0b5ffb9-9caf-4a34-9673-8fc91db78be6'),
-    '- "e0b5ffb9-9caf-4a34-9673-8fc91db78be6" must not be a valid UUID',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e0b5ffb9-9caf-4a34-9673-8fc91db78be6" must not be a valid UUID')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::uuid(5))->assert('c4a760a8-dbcf-5254-a0d9-6a4474bd1b62'),
-    '- "c4a760a8-dbcf-5254-a0d9-6a4474bd1b62" must not be a valid UUID version 5',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "c4a760a8-dbcf-5254-a0d9-6a4474bd1b62" must not be a valid UUID version 5')
 ));

--- a/tests/feature/Rules/VersionTest.php
+++ b/tests/feature/Rules/VersionTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::version()->assert('1.3.7--'),
-    '"1.3.7--" must be a version',
+    fn(string $message) => expect($message)->toBe('"1.3.7--" must be a version')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::version())->assert('1.0.0-alpha'),
-    '"1.0.0-alpha" must not be a version',
+    fn(string $message) => expect($message)->toBe('"1.0.0-alpha" must not be a version')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::version()->assert('1.2.3.4-beta'),
-    '- "1.2.3.4-beta" must be a version',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1.2.3.4-beta" must be a version')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::version())->assert('1.3.7-rc.1'),
-    '- "1.3.7-rc.1" must not be a version',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1.3.7-rc.1" must not be a version')
 ));

--- a/tests/feature/Rules/VideoUrlTest.php
+++ b/tests/feature/Rules/VideoUrlTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::videoUrl()->assert('example.com'),
-    '"example.com" must be a valid video URL',
+    fn(string $message) => expect($message)->toBe('"example.com" must be a valid video URL')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::videoUrl('YouTube')->assert('example.com'),
-    '"example.com" must be a valid YouTube video URL',
+    fn(string $message) => expect($message)->toBe('"example.com" must be a valid YouTube video URL')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::videoUrl())->assert('https://player.vimeo.com/video/7178746722'),
-    '"https://player.vimeo.com/video/7178746722" must not be a valid video URL',
+    fn(string $message) => expect($message)->toBe('"https://player.vimeo.com/video/7178746722" must not be a valid video URL')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::videoUrl('YouTube'))->assert('https://www.youtube.com/embed/netHLn9TScY'),
-    '"https://www.youtube.com/embed/netHLn9TScY" must not be a valid YouTube video URL',
+    fn(string $message) => expect($message)->toBe('"https://www.youtube.com/embed/netHLn9TScY" must not be a valid YouTube video URL')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::videoUrl()->assert('example.com'),
-    '- "example.com" must be a valid video URL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a valid video URL')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::videoUrl('Vimeo')->assert('example.com'),
-    '- "example.com" must be a valid Vimeo video URL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a valid Vimeo video URL')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::videoUrl())->assert('https://youtu.be/netHLn9TScY'),
-    '- "https://youtu.be/netHLn9TScY" must not be a valid video URL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "https://youtu.be/netHLn9TScY" must not be a valid video URL')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::videoUrl('Vimeo'))->assert('https://vimeo.com/71787467'),
-    '- "https://vimeo.com/71787467" must not be a valid Vimeo video URL',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "https://vimeo.com/71787467" must not be a valid Vimeo video URL')
 ));

--- a/tests/feature/Rules/VowelTest.php
+++ b/tests/feature/Rules/VowelTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::vowel()->assert('b'),
-    '"b" must consist of vowels only',
+    fn(string $message) => expect($message)->toBe('"b" must consist of vowels only')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::vowel('c')->assert('d'),
-    '"d" must consist of vowels and "c"',
+    fn(string $message) => expect($message)->toBe('"d" must consist of vowels and "c"')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::vowel())->assert('a'),
-    '"a" must not consist of vowels only',
+    fn(string $message) => expect($message)->toBe('"a" must not consist of vowels only')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::vowel('f'))->assert('e'),
-    '"e" must not consist of vowels or "f"',
+    fn(string $message) => expect($message)->toBe('"e" must not consist of vowels or "f"')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::vowel()->assert('g'),
-    '- "g" must consist of vowels only',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g" must consist of vowels only')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::vowel('h')->assert('j'),
-    '- "j" must consist of vowels and "h"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "j" must consist of vowels and "h"')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::not(v::vowel())->assert('i'),
-    '- "i" must not consist of vowels only',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "i" must not consist of vowels only')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::vowel('k'))->assert('o'),
-    '- "o" must not consist of vowels or "k"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "o" must not consist of vowels or "k"')
 ));

--- a/tests/feature/Rules/WhenTest.php
+++ b/tests/feature/Rules/WhenTest.php
@@ -7,50 +7,56 @@
 
 declare(strict_types=1);
 
-test('When valid use "then"', expectAll(
+test('When valid use "then"', catchAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert(-1),
-    '-1 must be a positive number',
-    '- -1 must be a positive number',
-    ['positive' => '-1 must be a positive number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('-1 must be a positive number')
+        ->and($fullMessage)->toBe('- -1 must be a positive number')
+        ->and($messages)->toBe(['positive' => '-1 must be a positive number'])
 ));
 
-test('When invalid use "else"', expectAll(
+test('When invalid use "else"', catchAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert(''),
-    '"" must not be empty',
-    '- "" must not be empty',
-    ['notEmpty' => '"" must not be empty'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"" must not be empty')
+        ->and($fullMessage)->toBe('- "" must not be empty')
+        ->and($messages)->toBe(['notEmpty' => '"" must not be empty'])
 ));
 
-test('When valid use "then" using single template', expectAll(
+test('When valid use "then" using single template', catchAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert(-1, 'That did not go as planned'),
-    'That did not go as planned',
-    '- That did not go as planned',
-    ['positive' => 'That did not go as planned'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('That did not go as planned')
+        ->and($fullMessage)->toBe('- That did not go as planned')
+        ->and($messages)->toBe(['positive' => 'That did not go as planned'])
 ));
 
-test('When invalid use "else" using single template', expectAll(
+test('When invalid use "else" using single template', catchAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert('', 'That could have been better'),
-    'That could have been better',
-    '- That could have been better',
-    ['notEmpty' => 'That could have been better'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('That could have been better')
+        ->and($fullMessage)->toBe('- That could have been better')
+        ->and($messages)->toBe(['notEmpty' => 'That could have been better'])
 ));
 
-test('When valid use "then" using array template', expectAll(
+test('When valid use "then" using array template', catchAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert(-1, [
         'notEmpty' => '--Never shown--',
         'positive' => 'Not positive',
     ]),
-    'Not positive',
-    '- Not positive',
-    ['positive' => 'Not positive'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not positive')
+        ->and($fullMessage)->toBe('- Not positive')
+        ->and($messages)->toBe(['positive' => 'Not positive'])
 ));
 
-test('When invalid use "else" using array template', expectAll(
+test('When invalid use "else" using array template', catchAll(
     fn() => v::when(v::intVal(), v::positive(), v::notEmpty())->assert('', [
         'notEmpty' => 'Not empty',
         'positive' => '--Never shown--',
     ]),
-    'Not empty',
-    '- Not empty',
-    ['notEmpty' => 'Not empty'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Not empty')
+        ->and($fullMessage)->toBe('- Not empty')
+        ->and($messages)->toBe(['notEmpty' => 'Not empty'])
 ));

--- a/tests/feature/Rules/WritableTest.php
+++ b/tests/feature/Rules/WritableTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::writable()->assert('/path/of/a/valid/writable/file.txt'),
-    '"/path/of/a/valid/writable/file.txt" must be writable',
+    fn(string $message) => expect($message)->toBe('"/path/of/a/valid/writable/file.txt" must be writable')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::not(v::writable())->assert('tests/fixtures/valid-image.png'),
-    '"tests/fixtures/valid-image.png" must not be writable',
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be writable')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::writable()->assert([]),
-    '- `[]` must be writable',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be writable')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::not(v::writable())->assert('tests/fixtures/invalid-image.png'),
-    '- "tests/fixtures/invalid-image.png" must not be writable',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must not be writable')
 ));

--- a/tests/feature/Rules/XdigitTest.php
+++ b/tests/feature/Rules/XdigitTest.php
@@ -7,42 +7,42 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::xdigit()->assert('aaa%a'),
-    '"aaa%a" must only contain hexadecimal digits',
+    fn(string $message) => expect($message)->toBe('"aaa%a" must only contain hexadecimal digits')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::xdigit(' ')->assert('bbb%b'),
-    '"bbb%b" must contain hexadecimal digits and " "',
+    fn(string $message) => expect($message)->toBe('"bbb%b" must contain hexadecimal digits and " "')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::not(v::xdigit())->assert('ccccc'),
-    '"ccccc" must not only contain hexadecimal digits',
+    fn(string $message) => expect($message)->toBe('"ccccc" must not only contain hexadecimal digits')
 ));
 
-test('Scenario #4', expectMessage(
+test('Scenario #4', catchMessage(
     fn() => v::not(v::xdigit('% '))->assert('ddd%d'),
-    '"ddd%d" must not contain hexadecimal digits or "% "',
+    fn(string $message) => expect($message)->toBe('"ddd%d" must not contain hexadecimal digits or "% "')
 ));
 
-test('Scenario #5', expectFullMessage(
+test('Scenario #5', catchFullMessage(
     fn() => v::xdigit()->assert('eee^e'),
-    '- "eee^e" must only contain hexadecimal digits',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "eee^e" must only contain hexadecimal digits')
 ));
 
-test('Scenario #6', expectFullMessage(
+test('Scenario #6', catchFullMessage(
     fn() => v::not(v::xdigit())->assert('fffff'),
-    '- "fffff" must not only contain hexadecimal digits',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "fffff" must not only contain hexadecimal digits')
 ));
 
-test('Scenario #7', expectFullMessage(
+test('Scenario #7', catchFullMessage(
     fn() => v::xdigit('* &%')->assert('000^0'),
-    '- "000^0" must contain hexadecimal digits and "* &%"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "000^0" must contain hexadecimal digits and "* &%"')
 ));
 
-test('Scenario #8', expectFullMessage(
+test('Scenario #8', catchFullMessage(
     fn() => v::not(v::xdigit('^'))->assert('111^1'),
-    '- "111^1" must not contain hexadecimal digits or "^"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "111^1" must not contain hexadecimal digits or "^"')
 ));

--- a/tests/feature/Rules/YesTest.php
+++ b/tests/feature/Rules/YesTest.php
@@ -7,22 +7,22 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::not(v::yes())->assert('Yes'),
-    '"Yes" must not be similar to "Yes"',
+    fn(string $message) => expect($message)->toBe('"Yes" must not be similar to "Yes"')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::yes()->assert('si'),
-    '"si" must be similar to "Yes"',
+    fn(string $message) => expect($message)->toBe('"si" must be similar to "Yes"')
 ));
 
-test('Scenario #3', expectFullMessage(
+test('Scenario #3', catchFullMessage(
     fn() => v::not(v::yes())->assert('Yes'),
-    '- "Yes" must not be similar to "Yes"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Yes" must not be similar to "Yes"')
 ));
 
-test('Scenario #4', expectFullMessage(
+test('Scenario #4', catchFullMessage(
     fn() => v::yes()->assert('si'),
-    '- "si" must be similar to "Yes"',
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "si" must be similar to "Yes"')
 ));

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageTest.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 use Respect\Validation\Validator;
 
-test('Scenario #1', expectFullMessage(
-    function (): void {
-        Validator::callback('is_string')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
-    },
-    '- "something" is not tasty',
-));
+test('Scenario #1', catchFullMessage(function (): void {
+    Validator::callback('is_string')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
+},
+fn(string $fullMessage) => expect($fullMessage)->toBe('- "something" is not tasty')));

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 use Respect\Validation\Validator;
 
-test('Scenario #1', expectMessage(
-    function (): void {
-        Validator::callback('is_int')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
-    },
-    '"something" is not tasty',
-));
+test('Scenario #1', catchMessage(function (): void {
+    Validator::callback('is_int')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
+},
+fn(string $message) => expect($message)->toBe('"something" is not tasty')));

--- a/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 use Respect\Validation\Validator;
 
-test('Scenario', expectMessage(
+test('Scenario', catchMessage(
     fn() => Validator::callback('is_int')->setTemplate('{{name}} is not tasty')->assert('something'),
-    '"something" is not tasty',
+    fn(string $message) => expect($message)->toBe('"something" is not tasty')
 ));

--- a/tests/feature/ShouldNotOverwriteDefinedNamesTest.php
+++ b/tests/feature/ShouldNotOverwriteDefinedNamesTest.php
@@ -9,17 +9,17 @@ declare(strict_types=1);
 
 $input = ['email' => 'not an email'];
 
-test('Scenario #1', expectMessage(
+test('Scenario #1', catchMessage(
     fn() => v::key('email', v::email()->setName('Email'))->setName('Foo')->assert($input),
-    'Email must be a valid email address',
+    fn(string $message) => expect($message)->toBe('Email must be a valid email address')
 ));
 
-test('Scenario #2', expectMessage(
+test('Scenario #2', catchMessage(
     fn() => v::key('email', v::email())->setName('Email')->assert($input),
-    'Email must be a valid email address',
+    fn(string $message) => expect($message)->toBe('Email must be a valid email address')
 ));
 
-test('Scenario #3', expectMessage(
+test('Scenario #3', catchMessage(
     fn() => v::key('email', v::email())->assert($input),
-    '`.email` must be a valid email address',
+    fn(string $message) => expect($message)->toBe('`.email` must be a valid email address')
 ));

--- a/tests/feature/Transformers/AliasesTest.php
+++ b/tests/feature/Transformers/AliasesTest.php
@@ -9,9 +9,10 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-test('Optional', expectAll(
+test('Optional', catchAll(
     fn() => v::optional(v::scalarVal())->assert([]),
-    '`[]` must be a scalar value or must be undefined',
-    '- `[]` must be a scalar value or must be undefined',
-    ['undefOrScalarVal' => '`[]` must be a scalar value or must be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`[]` must be a scalar value or must be undefined')
+        ->and($fullMessage)->toBe('- `[]` must be a scalar value or must be undefined')
+        ->and($messages)->toBe(['undefOrScalarVal' => '`[]` must be a scalar value or must be undefined'])
 ));

--- a/tests/feature/Transformers/PrefixTest.php
+++ b/tests/feature/Transformers/PrefixTest.php
@@ -9,58 +9,66 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
-test('Key', expectAll(
+test('Key', catchAll(
     fn() => v::keyEquals('foo', 12)->assert(['foo' => 10]),
-    '`.foo` must be equal to 12',
-    '- `.foo` must be equal to 12',
-    ['foo' => '`.foo` must be equal to 12'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be equal to 12')
+        ->and($fullMessage)->toBe('- `.foo` must be equal to 12')
+        ->and($messages)->toBe(['foo' => '`.foo` must be equal to 12'])
 ));
 
-test('Length', expectAll(
+test('Length', catchAll(
     fn() => v::lengthGreaterThan(3)->assert('foo'),
-    'The length of "foo" must be greater than 3',
-    '- The length of "foo" must be greater than 3',
-    ['lengthGreaterThan' => 'The length of "foo" must be greater than 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The length of "foo" must be greater than 3')
+        ->and($fullMessage)->toBe('- The length of "foo" must be greater than 3')
+        ->and($messages)->toBe(['lengthGreaterThan' => 'The length of "foo" must be greater than 3'])
 ));
 
-test('Max', expectAll(
+test('Max', catchAll(
     fn() => v::maxOdd()->assert([1, 2, 3, 4]),
-    'The maximum of `[1, 2, 3, 4]` must be an odd number',
-    '- The maximum of `[1, 2, 3, 4]` must be an odd number',
-    ['maxOdd' => 'The maximum of `[1, 2, 3, 4]` must be an odd number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The maximum of `[1, 2, 3, 4]` must be an odd number')
+        ->and($fullMessage)->toBe('- The maximum of `[1, 2, 3, 4]` must be an odd number')
+        ->and($messages)->toBe(['maxOdd' => 'The maximum of `[1, 2, 3, 4]` must be an odd number'])
 ));
 
-test('Min', expectAll(
+test('Min', catchAll(
     fn() => v::minEven()->assert([1, 2, 3]),
-    'The minimum of `[1, 2, 3]` must be an even number',
-    '- The minimum of `[1, 2, 3]` must be an even number',
-    ['minEven' => 'The minimum of `[1, 2, 3]` must be an even number'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('The minimum of `[1, 2, 3]` must be an even number')
+        ->and($fullMessage)->toBe('- The minimum of `[1, 2, 3]` must be an even number')
+        ->and($messages)->toBe(['minEven' => 'The minimum of `[1, 2, 3]` must be an even number'])
 ));
 
-test('Not', expectAll(
+test('Not', catchAll(
     fn() => v::notBetween(1, 3)->assert(2),
-    '2 must not be between 1 and 3',
-    '- 2 must not be between 1 and 3',
-    ['notBetween' => '2 must not be between 1 and 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('2 must not be between 1 and 3')
+        ->and($fullMessage)->toBe('- 2 must not be between 1 and 3')
+        ->and($messages)->toBe(['notBetween' => '2 must not be between 1 and 3'])
 ));
 
-test('NullOr', expectAll(
+test('NullOr', catchAll(
     fn() => v::nullOrBoolType()->assert('string'),
-    '"string" must be a boolean or must be null',
-    '- "string" must be a boolean or must be null',
-    ['nullOrBoolType' => '"string" must be a boolean or must be null'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be a boolean or must be null')
+        ->and($fullMessage)->toBe('- "string" must be a boolean or must be null')
+        ->and($messages)->toBe(['nullOrBoolType' => '"string" must be a boolean or must be null'])
 ));
 
-test('Property', expectAll(
+test('Property', catchAll(
     fn() => v::propertyBetween('foo', 1, 3)->assert((object) ['foo' => 5]),
-    '`.foo` must be between 1 and 3',
-    '- `.foo` must be between 1 and 3',
-    ['foo' => '`.foo` must be between 1 and 3'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.foo` must be between 1 and 3')
+        ->and($fullMessage)->toBe('- `.foo` must be between 1 and 3')
+        ->and($messages)->toBe(['foo' => '`.foo` must be between 1 and 3'])
 ));
 
-test('UndefOr', expectAll(
+test('UndefOr', catchAll(
     fn() => v::undefOrUrl()->assert('string'),
-    '"string" must be a URL or must be undefined',
-    '- "string" must be a URL or must be undefined',
-    ['undefOrUrl' => '"string" must be a URL or must be undefined'],
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"string" must be a URL or must be undefined')
+        ->and($fullMessage)->toBe('- "string" must be a URL or must be undefined')
+        ->and($messages)->toBe(['undefOrUrl' => '"string" must be a URL or must be undefined'])
 ));

--- a/tests/feature/TranslatorTest.php
+++ b/tests/feature/TranslatorTest.php
@@ -11,7 +11,7 @@ use Respect\Validation\Message\Translator\ArrayTranslator;
 use Respect\Validation\Validator;
 use Respect\Validation\ValidatorDefaults;
 
-test('Various translations', expectFullMessage(
+test('Various translations', catchFullMessage(
     function (): void {
         ValidatorDefaults::setTranslator(new ArrayTranslator([
             '{{name}} must pass all the rules' => 'Todas as regras requeridas devem passar para {{name}}',
@@ -24,15 +24,15 @@ test('Various translations', expectFullMessage(
 
         Validator::stringType()->lengthBetween(2, 15)->phone('US')->assert([]);
     },
-    <<<'FULL_MESSAGE'
-    - Todas as regras requeridas devem passar para `[]`
-      - `[]` deve ser uma string
-      - O comprimento de `[]` deve possuir de 2 a 15 caracteres
-      - `[]` deve ser um número de telefone válido para o país Estados Unidos
-    FULL_MESSAGE,
+    fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
+        - Todas as regras requeridas devem passar para `[]`
+          - `[]` deve ser uma string
+          - O comprimento de `[]` deve possuir de 2 a 15 caracteres
+          - `[]` deve ser um número de telefone válido para o país Estados Unidos
+        FULL_MESSAGE)
 ));
 
-test('DateTimeDiff', expectMessage(
+test('DateTimeDiff', catchMessage(
     function (): void {
         ValidatorDefaults::setTranslator(new ArrayTranslator([
             'years' => 'anos',
@@ -42,10 +42,10 @@ test('DateTimeDiff', expectMessage(
 
         v::dateTimeDiff('years', v::equals(2))->assert('1972-02-09');
     },
-    'O número de anos entre agora e "1972-02-09" deve ser igual a 2',
+    fn(string $message) => expect($message)->toBe('O número de anos entre agora e "1972-02-09" deve ser igual a 2')
 ));
 
-test('Using "listOr"', expectMessage(
+test('Using "listOr"', catchMessage(
     function (): void {
         ValidatorDefaults::setTranslator(new ArrayTranslator([
             'Your name must be {{haystack|listOr}}' => 'Seu nome deve ser {{haystack|listOr}}',
@@ -54,10 +54,10 @@ test('Using "listOr"', expectMessage(
 
         v::templated(v::in(['Respect', 'Validation']), 'Your name must be {{haystack|listOr}}')->assert('');
     },
-    'Seu nome deve ser "Respect" ou "Validation"',
+    fn(string $message) => expect($message)->toBe('Seu nome deve ser "Respect" ou "Validation"')
 ));
 
-test('Using "listAnd"', expectMessage(
+test('Using "listAnd"', catchMessage(
     function (): void {
         ValidatorDefaults::setTranslator(new ArrayTranslator([
             '{{haystack|listAnd}} are the only possible names' => '{{haystack|listAnd}} são os únicos nomes possíveis',
@@ -66,5 +66,5 @@ test('Using "listAnd"', expectMessage(
 
         v::templated(v::in(['Respect', 'Validation']), '{{haystack|listAnd}} are the only possible names')->assert('');
     },
-    '"Respect" e "Validation" são os únicos nomes possíveis',
+    fn(string $message) => expect($message)->toBe('"Respect" e "Validation" são os únicos nomes possíveis')
 ));


### PR DESCRIPTION
The problem with the current approach is that the "expect()" calls happen inside "tests/Pest.php". That means that when something fails, we can't easily know which exact expectation has failed.

This commit will change the helper functions, and will make the tests more verbose, but event with that, the developer experience is better.