### PR TITLE
Remove "uopz" as a dependency to run tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
-          extensions: uopz
-          tools: pecl
 
       - name: Install Localisation Files
         run: |
@@ -65,8 +63,6 @@ jobs:
         with:
           php-version: 8.1
           coverage: pcov
-          extensions: uopz
-          tools: pecl
 
       - name: Install Localisation Files
         run: |

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -15,6 +15,7 @@ use Respect\Validation\Message\Template;
 use Respect\Validation\Rules\Core\Simple;
 use SplFileInfo;
 
+use function function_exists;
 use function is_scalar;
 use function is_uploaded_file;
 
@@ -37,6 +38,10 @@ final class Uploaded extends Simple
 
         if (!is_scalar($input)) {
             return false;
+        }
+
+        if (function_exists('mock_is_uploaded_file')) {
+            return mock_is_uploaded_file((string) $input);
         }
 
         return is_uploaded_file((string) $input);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,4 +30,5 @@
             </property>
         </properties>
     </rule>
+    <exclude-pattern>tests/bootstrap.php</exclude-pattern>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          backupGlobals="false"
          processIsolation="false"
          stopOnFailure="false"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$mockIsUploadedFileReturn = true;
+
+function mock_is_uploaded_file(string $filename): bool
+{
+    global $mockIsUploadedFileReturn;
+
+    return $mockIsUploadedFileReturn;
+}
+
+function set_mock_is_uploaded_file_return(bool $return): void
+{
+    global $mockIsUploadedFileReturn;
+
+    $mockIsUploadedFileReturn = $return;
+}

--- a/tests/feature/Rules/UploadedTest.php
+++ b/tests/feature/Rules/UploadedTest.php
@@ -7,26 +7,34 @@
 
 declare(strict_types=1);
 
-test('Scenario #1', catchMessage(function (): void {
-    uopz_set_return('is_uploaded_file', false);
-    v::uploaded()->assert('filename');
-},
-fn(string $message) => expect($message)->toBe('"filename" must be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #1', catchMessage(
+    function (): void {
+        set_mock_is_uploaded_file_return(false);
+        v::uploaded()->assert('filename');
+    },
+    fn(string $message) => expect($message)->toBe('"filename" must be an uploaded file')
+));
 
-test('Scenario #2', catchMessage(function (): void {
-    uopz_set_return('is_uploaded_file', true);
-    v::not(v::uploaded())->assert('filename');
-},
-fn(string $message) => expect($message)->toBe('"filename" must not be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #2', catchMessage(
+    function (): void {
+        set_mock_is_uploaded_file_return(true);
+        v::not(v::uploaded())->assert('filename');
+    },
+    fn(string $message) => expect($message)->toBe('"filename" must not be an uploaded file')
+));
 
-test('Scenario #3', catchFullMessage(function (): void {
-    uopz_set_return('is_uploaded_file', false);
-    v::uploaded()->assert('filename');
-},
-fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename" must be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #3', catchFullMessage(
+    function (): void {
+        set_mock_is_uploaded_file_return(false);
+        v::uploaded()->assert('filename');
+    },
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename" must be an uploaded file')
+));
 
-test('Scenario #4', catchFullMessage(function (): void {
-    uopz_set_return('is_uploaded_file', true);
-    v::not(v::uploaded())->assert('filename');
-},
-fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename" must not be an uploaded file')))->skip(extension_loaded('uopz') == false, 'Extension "uopz" is required to test "Uploaded" rule');
+test('Scenario #4', catchFullMessage(
+    function (): void {
+        set_mock_is_uploaded_file_return(true);
+        v::not(v::uploaded())->assert('filename');
+    },
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename" must not be an uploaded file')
+));

--- a/tests/unit/Rules/UploadedTest.php
+++ b/tests/unit/Rules/UploadedTest.php
@@ -11,59 +11,44 @@ namespace Respect\Validation\Rules;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\SkippedWithMessageException;
-use Respect\Validation\Test\RuleTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\Stubs\UploadedFileStub;
+use Respect\Validation\Test\TestCase;
 use SplFileInfo;
-use stdClass;
-
-use function extension_loaded;
-use function uopz_set_return;
 
 #[Group('rule')]
 #[CoversClass(Uploaded::class)]
-final class UploadedTest extends RuleTestCase
+final class UploadedTest extends TestCase
 {
     public const UPLOADED_FILENAME = 'uploaded.ext';
 
-    /** @return iterable<array{Uploaded, mixed}> */
-    public static function providerForValidInput(): iterable
+    #[Test]
+    public function itShouldValidateWhenFileIsUploadedAndTheInputIsString(): void
     {
-        $rule = new Uploaded();
+        set_mock_is_uploaded_file_return(true);
 
-        return [
-            [$rule, self::UPLOADED_FILENAME],
-            [$rule, new SplFileInfo(self::UPLOADED_FILENAME)],
-            [$rule, UploadedFileStub::create()],
-        ];
+        self::assertValidInput(new Uploaded(), self::UPLOADED_FILENAME);
     }
 
-    /** @return iterable<array{Uploaded, mixed}> */
-    public static function providerForInvalidInput(): iterable
+    #[Test]
+    public function itShouldValidateWhenFileIsUploadedAndTheInputIsSplFileInfo(): void
     {
-        $rule = new Uploaded();
+        set_mock_is_uploaded_file_return(true);
 
-        return [
-            [$rule, 'not-uploaded.ext'],
-            [$rule, new SplFileInfo('not-uploaded.ext')],
-            [$rule, []],
-            [$rule, 1],
-            [$rule, new stdClass()],
-        ];
+        self::assertValidInput(new Uploaded(), new SplFileInfo(self::UPLOADED_FILENAME));
     }
 
-    protected function setUp(): void
+    #[Test]
+    public function itShouldValidateWhenFileIsUploadedAndTheInputIsUploadedFile(): void
     {
-        if (!extension_loaded('uopz')) {
-            throw new SkippedWithMessageException('Extension "uopz" is required to test "Uploaded" rule');
-        }
+        self::assertValidInput(new Uploaded(), UploadedFileStub::create());
+    }
 
-        uopz_set_return(
-            'is_uploaded_file',
-            static function (string $filename): bool {
-                return $filename === UploadedTest::UPLOADED_FILENAME;
-            },
-            true
-        );
+    #[Test]
+    public function itShouldInvalidateWhenFileHasNotBeenUploaded(): void
+    {
+        set_mock_is_uploaded_file_return(false);
+
+        self::assertInvalidInput(new Uploaded(), self::UPLOADED_FILENAME);
     }
 }


### PR DESCRIPTION
I'm creating a workaround here, which is not exactly happy with, but adding "uopz" as a dependency to run the tests make it harder for developers, including myself.