### PR TITLE
Rename `StandardStringifier` to `ValidationStringifier`

### DIFF
--- a/library/Message/InterpolationRenderer.php
+++ b/library/Message/InterpolationRenderer.php
@@ -29,7 +29,7 @@ final class InterpolationRenderer implements Renderer
     private array $templates = [];
 
     public function __construct(
-        private readonly Stringifier $stringifier = new StandardStringifier(),
+        private readonly Stringifier $stringifier = new ValidationStringifier(),
     ) {
     }
 

--- a/library/Message/ValidationStringifier.php
+++ b/library/Message/ValidationStringifier.php
@@ -34,7 +34,7 @@ use Respect\Stringifier\Stringifiers\ThrowableObjectStringifier;
 use Respect\Validation\Message\Stringifier\ListedStringifier;
 use Respect\Validation\Message\Stringifier\QuotedStringifier;
 
-final readonly class StandardStringifier implements Stringifier
+final readonly class ValidationStringifier implements Stringifier
 {
     private const int MAXIMUM_DEPTH = 3;
     private const int MAXIMUM_NUMBER_OF_ITEMS = 5;

--- a/tests/feature/Message/StandardStringifierTest.php
+++ b/tests/feature/Message/StandardStringifierTest.php
@@ -7,13 +7,13 @@
 
 declare(strict_types=1);
 
-use Respect\Validation\Message\StandardStringifier;
+use Respect\Validation\Message\ValidationStringifier;
 
 test('Should return `unknown` when cannot stringify value', function (): void {
     $resource = tmpfile();
     fclose($resource);
 
-    $stringifier = new StandardStringifier();
+    $stringifier = new ValidationStringifier();
 
     expect($stringifier->stringify($resource, 0))->toBe('`unknown`');
 });


### PR DESCRIPTION
The name `StandardStringifier` is ambiguous because it doesn't describe how that stringifier differs from others. Ideally, we'd have a better name for it, something that makes its behaviour explicit, but since this is the stringifier from Validation, naming it as such will make it easier for users to use it if they want.