### PR TITLE
Change the contract of the formatters

### DIFF
--- a/library/ContainerRegistry.php
+++ b/library/ContainerRegistry.php
@@ -51,10 +51,10 @@ final class ContainerRegistry
             'respect.validation.ignored_backtrace_paths' => [__DIR__ . '/Validator.php'],
             Validator::class => factory(static fn(Container $container) => new Validator(
                 $container->get(Factory::class),
+                $container->get(Renderer::class),
                 $container->get('respect.validation.formatter.message'),
                 $container->get('respect.validation.formatter.full_message'),
                 $container->get('respect.validation.formatter.messages'),
-                $container->get(Translator::class),
                 $container->get(ResultFilter::class),
                 $container->get('respect.validation.ignored_backtrace_paths'),
             )),

--- a/library/Message/ArrayFormatter.php
+++ b/library/Message/ArrayFormatter.php
@@ -18,5 +18,5 @@ interface ArrayFormatter
      *
      * @return array<string, mixed>
      */
-    public function format(Result $result, array $templates, Translator $translator): array;
+    public function format(Result $result, Renderer $renderer, array $templates): array;
 }

--- a/library/Message/Formatter/FirstResultStringFormatter.php
+++ b/library/Message/Formatter/FirstResultStringFormatter.php
@@ -11,31 +11,25 @@ namespace Respect\Validation\Message\Formatter;
 
 use Respect\Validation\Message\Renderer;
 use Respect\Validation\Message\StringFormatter;
-use Respect\Validation\Message\Translator;
 use Respect\Validation\Result;
 
 final readonly class FirstResultStringFormatter implements StringFormatter
 {
     public function __construct(
-        private Renderer $renderer,
         private TemplateResolver $templateResolver,
     ) {
     }
 
     /** @param array<string|int, mixed> $templates */
-    public function format(Result $result, array $templates, Translator $translator): string
+    public function format(Result $result, Renderer $renderer, array $templates): string
     {
         $matchedTemplates = $this->templateResolver->selectMatches($result, $templates);
         if (!$this->templateResolver->hasMatch($result, $matchedTemplates)) {
             foreach ($result->children as $child) {
-                return $this->format(
-                    $child,
-                    $matchedTemplates,
-                    $translator,
-                );
+                return $this->format($child, $renderer, $matchedTemplates);
             }
         }
 
-        return $this->renderer->render($this->templateResolver->resolve($result, $matchedTemplates), $translator);
+        return $renderer->render($this->templateResolver->resolve($result, $matchedTemplates));
     }
 }

--- a/library/Message/Renderer.php
+++ b/library/Message/Renderer.php
@@ -13,5 +13,5 @@ use Respect\Validation\Result;
 
 interface Renderer
 {
-    public function render(Result $result, Translator $translator): string;
+    public function render(Result $result): string;
 }

--- a/library/Message/StringFormatter.php
+++ b/library/Message/StringFormatter.php
@@ -14,5 +14,5 @@ use Respect\Validation\Result;
 interface StringFormatter
 {
     /** @param array<string, mixed> $templates */
-    public function format(Result $result, array $templates, Translator $translator): string;
+    public function format(Result $result, Renderer $renderer, array $templates): string;
 }

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -11,8 +11,8 @@ namespace Respect\Validation;
 
 use Respect\Validation\Exceptions\ValidationException;
 use Respect\Validation\Message\ArrayFormatter;
+use Respect\Validation\Message\Renderer;
 use Respect\Validation\Message\StringFormatter;
-use Respect\Validation\Message\Translator;
 use Respect\Validation\Mixins\Builder;
 use Respect\Validation\Rules\Core\Nameable;
 use Respect\Validation\Rules\Core\Reducer;
@@ -38,10 +38,10 @@ final class Validator implements Rule, Nameable
     /** @param array<string> $ignoredBacktracePaths */
     public function __construct(
         private readonly Factory $factory,
+        private readonly Renderer $renderer,
         private readonly StringFormatter $mainMessageFormatter,
         private readonly StringFormatter $fullMessageFormatter,
         private readonly ArrayFormatter $messagesFormatter,
-        private readonly Translator $translator,
         private readonly ResultFilter $resultFilter,
         private readonly array $ignoredBacktracePaths,
     ) {
@@ -89,9 +89,9 @@ final class Validator implements Rule, Nameable
         $failedResult = $this->resultFilter->filter($result);
 
         $exception = new ValidationException(
-            $this->mainMessageFormatter->format($failedResult, $templates, $this->translator),
-            $this->fullMessageFormatter->format($failedResult, $templates, $this->translator),
-            $this->messagesFormatter->format($failedResult, $templates, $this->translator),
+            $this->mainMessageFormatter->format($failedResult, $this->renderer, $templates),
+            $this->fullMessageFormatter->format($failedResult, $this->renderer, $templates),
+            $this->messagesFormatter->format($failedResult, $this->renderer, $templates),
             $this->ignoredBacktracePaths,
         );
 

--- a/tests/library/Message/TestingMessageRenderer.php
+++ b/tests/library/Message/TestingMessageRenderer.php
@@ -10,12 +10,11 @@ declare(strict_types=1);
 namespace Respect\Validation\Test\Message;
 
 use Respect\Validation\Message\Renderer;
-use Respect\Validation\Message\Translator;
 use Respect\Validation\Result;
 
 final class TestingMessageRenderer implements Renderer
 {
-    public function render(Result $result, Translator $translator): string
+    public function render(Result $result): string
     {
         return $result->template;
     }

--- a/tests/unit/Message/Formatter/FirstResultStringFormatterTest.php
+++ b/tests/unit/Message/Formatter/FirstResultStringFormatterTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Message\StandardFormatter\ResultCreator;
-use Respect\Validation\Message\Translator\DummyTranslator;
 use Respect\Validation\Result;
 use Respect\Validation\Rule;
 use Respect\Validation\Test\Builders\ResultBuilder;
@@ -35,21 +34,17 @@ final class FirstResultStringFormatterTest extends TestCase
     #[DataProvider('provideForMain')]
     public function itShouldFormatMainMessage(Result $result, string $expected, array $templates = []): void
     {
-        $formatter = new FirstResultStringFormatter(
-            renderer: new TestingMessageRenderer(),
-            templateResolver: new TemplateResolver(),
-        );
+        $renderer = new TestingMessageRenderer();
+        $formatter = new FirstResultStringFormatter(new TemplateResolver());
 
-        self::assertSame($expected, $formatter->format($result, $templates, new DummyTranslator()));
+        self::assertSame($expected, $formatter->format($result, $renderer, $templates));
     }
 
     #[Test]
     public function itShouldThrowAnExceptionWhenTryingToFormatAndTemplateIsInvalid(): void
     {
-        $formatter = new FirstResultStringFormatter(
-            renderer: new TestingMessageRenderer(),
-            templateResolver: new TemplateResolver(),
-        );
+        $renderer = new TestingMessageRenderer();
+        $formatter = new FirstResultStringFormatter(new TemplateResolver());
         $result = (new ResultBuilder())->id('foo')->build();
 
         $template = new stdClass();
@@ -57,7 +52,7 @@ final class FirstResultStringFormatterTest extends TestCase
         $this->expectException(ComponentException::class);
         $this->expectExceptionMessage(sprintf('Template for "foo" must be a string, %s given', stringify($template)));
 
-        $formatter->format($result, ['foo' => $template], new DummyTranslator());
+        $formatter->format($result, $renderer, ['foo' => $template]);
     }
 
     /** @return array<string, array{0: Result, 1: string, 2?: array<string, mixed>}> */

--- a/tests/unit/Message/Formatter/NestedArrayFormatterTest.php
+++ b/tests/unit/Message/Formatter/NestedArrayFormatterTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Message\StandardFormatter\ResultCreator;
-use Respect\Validation\Message\Translator\DummyTranslator;
 use Respect\Validation\Result;
 use Respect\Validation\Test\Builders\ResultBuilder;
 use Respect\Validation\Test\Message\TestingMessageRenderer;
@@ -37,21 +36,17 @@ final class NestedArrayFormatterTest extends TestCase
     #[DataProvider('provideForArray')]
     public function itShouldFormatArrayMessage(Result $result, array $expected, array $templates = []): void
     {
-        $formatter = new NestedArrayFormatter(
-            renderer: new TestingMessageRenderer(),
-            templateResolver: new TemplateResolver(),
-        );
+        $renderer = new TestingMessageRenderer();
+        $formatter = new NestedArrayFormatter(new TemplateResolver());
 
-        self::assertSame($expected, $formatter->format($result, $templates, new DummyTranslator()));
+        self::assertSame($expected, $formatter->format($result, $renderer, $templates));
     }
 
     #[Test]
     public function itShouldThrowAnExceptionWhenTryingToFormatAndTemplateIsInvalid(): void
     {
-        $formatter = new NestedArrayFormatter(
-            renderer: new TestingMessageRenderer(),
-            templateResolver: new TemplateResolver(),
-        );
+        $renderer = new TestingMessageRenderer();
+        $formatter = new NestedArrayFormatter(new TemplateResolver());
         $result = (new ResultBuilder())->id('foo')->build();
 
         $template = new stdClass();
@@ -59,7 +54,7 @@ final class NestedArrayFormatterTest extends TestCase
         $this->expectException(ComponentException::class);
         $this->expectExceptionMessage(sprintf('Template for "foo" must be a string, %s given', stringify($template)));
 
-        $formatter->format($result, ['foo' => $template], new DummyTranslator());
+        $formatter->format($result, $renderer, ['foo' => $template]);
     }
 
     /** @return array<string, array{0: Result, 1: array<string, mixed>, 2?: array<string, mixed>}> */

--- a/tests/unit/Message/Formatter/NestedListStringFormatterTest.php
+++ b/tests/unit/Message/Formatter/NestedListStringFormatterTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Exceptions\ComponentException;
 use Respect\Validation\Message\StandardFormatter\ResultCreator;
-use Respect\Validation\Message\Translator\DummyTranslator;
 use Respect\Validation\Result;
 use Respect\Validation\Test\Builders\ResultBuilder;
 use Respect\Validation\Test\Message\TestingMessageRenderer;
@@ -34,21 +33,17 @@ final class NestedListStringFormatterTest extends TestCase
     #[DataProvider('provideForFull')]
     public function itShouldFormatFullMessage(Result $result, string $expected, array $templates = []): void
     {
-        $formatter = new NestedListStringFormatter(
-            renderer: new TestingMessageRenderer(),
-            templateResolver: new TemplateResolver(),
-        );
+        $renderer = new TestingMessageRenderer();
+        $formatter = new NestedListStringFormatter(new TemplateResolver());
 
-        self::assertSame($expected, $formatter->format($result, $templates, new DummyTranslator()));
+        self::assertSame($expected, $formatter->format($result, $renderer, $templates));
     }
 
     #[Test]
     public function itShouldThrowAnExceptionWhenTryingToFormatAndTemplateIsInvalid(): void
     {
-        $formatter = new NestedListStringFormatter(
-            renderer: new TestingMessageRenderer(),
-            templateResolver: new TemplateResolver(),
-        );
+        $renderer = new TestingMessageRenderer();
+        $formatter = new NestedListStringFormatter(new TemplateResolver());
         $result = (new ResultBuilder())->id('foo')->build();
 
         $template = new stdClass();
@@ -56,7 +51,7 @@ final class NestedListStringFormatterTest extends TestCase
         $this->expectException(ComponentException::class);
         $this->expectExceptionMessage(sprintf('Template for "foo" must be a string, %s given', stringify($template)));
 
-        $formatter->format($result, ['foo' => $template], new DummyTranslator());
+        $formatter->format($result, $renderer, ['foo' => $template]);
     }
 
     /** @return array<string, array{0: Result, 1: string, 2?: array<string, mixed>}> */

--- a/tests/unit/Message/InterpolationRendererTest.php
+++ b/tests/unit/Message/InterpolationRendererTest.php
@@ -26,11 +26,11 @@ final class InterpolationRendererTest extends TestCase
     #[Test]
     public function itShouldRenderResultWithCustomTemplate(): void
     {
-        $renderer = new InterpolationRenderer(new TestingStringifier());
+        $renderer = new InterpolationRenderer(new DummyTranslator(), new TestingStringifier());
 
         $result = (new ResultBuilder())->template('This is my template')->build();
 
-        self::assertSame($result->template, $renderer->render($result, new DummyTranslator()));
+        self::assertSame($result->template, $renderer->render($result));
     }
 
     #[Test]
@@ -38,7 +38,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $key = 'foo';
         $value = true;
@@ -50,7 +50,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             'Will replace ' . $stringifier->stringify($value, 0),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -59,7 +59,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $key = 'foo';
         $value = 0.1;
@@ -71,7 +71,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s and 0.1', $stringifier->stringify($value, 0)),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -80,7 +80,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $key = 'foo';
         $value = false;
@@ -92,20 +92,19 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s and 0', $stringifier->stringify($value, 0)),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
     #[Test]
     public function itShouldRenderResultProcessingTranslatableParametersInTheTemplate(): void
     {
-        $stringifier = new TestingStringifier();
-
-        $renderer = new InterpolationRenderer($stringifier);
-
         $key = 'foo';
         $value = 'original';
         $translation = 'translated';
+
+        $stringifier = new TestingStringifier();
+        $renderer = new InterpolationRenderer(new ArrayTranslator([$value => $translation]), $stringifier);
 
         $result = (new ResultBuilder())
             ->template(sprintf('Will replace {{%1$s}} and {{%1$s|trans}}', $key))
@@ -114,7 +113,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s and %s', $stringifier->stringify($value, 0), $translation),
-            $renderer->render($result, new ArrayTranslator([$value => $translation])),
+            $renderer->render($result),
         );
     }
 
@@ -123,7 +122,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $value = 'original';
 
@@ -134,7 +133,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s', $stringifier->stringify(new Name($value), 0) ?? 'FAILED'),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -143,7 +142,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $value = true;
 
@@ -157,7 +156,7 @@ final class InterpolationRendererTest extends TestCase
                 'Will replace %s',
                 $stringifier->stringify(new Name((string) $stringifier->stringify($value, 0)), 0),
             ),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -165,7 +164,7 @@ final class InterpolationRendererTest extends TestCase
     public function itShouldRenderResultProcessingNameAsSomeParameterInTheTemplate(): void
     {
         $stringifier = new TestingStringifier();
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $name = 'my name';
 
@@ -176,7 +175,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             'Will replace ' . $stringifier->stringify(new Name($name), 0),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -185,7 +184,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $input = 42;
 
@@ -199,7 +198,7 @@ final class InterpolationRendererTest extends TestCase
                 'Will replace %s',
                 $stringifier->stringify(new Name((string) $stringifier->stringify($input, 0)), 0),
             ),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -208,7 +207,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $input = 42;
 
@@ -219,7 +218,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s', $stringifier->stringify($input, 0)),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -230,7 +229,7 @@ final class InterpolationRendererTest extends TestCase
 
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $result = (new ResultBuilder())
             ->template('Will replace {{name}}')
@@ -240,7 +239,7 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s', $stringifier->stringify(new Name($parameterNameValue), 0)),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -249,7 +248,7 @@ final class InterpolationRendererTest extends TestCase
     {
         $stringifier = new TestingStringifier();
 
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $input = 'real input';
 
@@ -261,20 +260,20 @@ final class InterpolationRendererTest extends TestCase
 
         self::assertSame(
             sprintf('Will replace %s', $stringifier->stringify($input, 0)),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
     #[Test]
     public function itShouldRenderResultProcessingNonExistingParameters(): void
     {
-        $renderer = new InterpolationRenderer(new TestingStringifier());
+        $renderer = new InterpolationRenderer(new DummyTranslator(), new TestingStringifier());
 
         $result = (new ResultBuilder())
             ->template('Will not replace {{unknown}}')
             ->build();
 
-        self::assertSame('Will not replace {{unknown}}', $renderer->render($result, new DummyTranslator()));
+        self::assertSame('Will not replace {{unknown}}', $renderer->render($result));
     }
 
     #[Test]
@@ -283,21 +282,21 @@ final class InterpolationRendererTest extends TestCase
         $template = 'This is my template with {{foo}}';
         $translations = [$template => 'This is my translated template with {{foo}}'];
 
-        $renderer = new InterpolationRenderer(new TestingStringifier());
         $translator = new ArrayTranslator($translations);
+        $renderer = new InterpolationRenderer($translator, new TestingStringifier());
 
         $result = (new ResultBuilder())
             ->template($template)
             ->build();
 
-        self::assertSame($translations[$template], $renderer->render($result, $translator));
+        self::assertSame($translations[$template], $renderer->render($result));
     }
 
     #[Test]
     public function itShouldRenderResultWithNonCustomTemplate(): void
     {
         $stringifier = new TestingStringifier();
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $result = (new ResultBuilder())->build();
 
@@ -306,7 +305,7 @@ final class InterpolationRendererTest extends TestCase
                 '%s must be a valid stub',
                 $stringifier->stringify(new Name((string) $stringifier->stringify($result->input, 0)), 0),
             ),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
@@ -314,7 +313,7 @@ final class InterpolationRendererTest extends TestCase
     public function itShouldRenderResultWithNonCustomTemplateAndInvertedMode(): void
     {
         $stringifier = new TestingStringifier();
-        $renderer = new InterpolationRenderer($stringifier);
+        $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $result = (new ResultBuilder())->hasInvertedMode()->build();
 
@@ -323,27 +322,27 @@ final class InterpolationRendererTest extends TestCase
                 '%s must not be a valid stub',
                 $stringifier->stringify(new Name((string) $stringifier->stringify($result->input, 0)), 0),
             ),
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
     #[Test]
     public function itShouldRenderResultWithNonCustomTemplateWhenCannotFindAttachedTemplate(): void
     {
-        $renderer = new InterpolationRenderer(new TestingStringifier());
+        $renderer = new InterpolationRenderer(new DummyTranslator(), new TestingStringifier());
 
         $result = (new ResultBuilder())->template('__not_standard__')->hasInvertedMode()->build();
 
         self::assertSame(
             $result->template,
-            $renderer->render($result, new DummyTranslator()),
+            $renderer->render($result),
         );
     }
 
     #[Test]
     public function itShouldRenderResultWithItsAdjacentsWhenItHasNoCustomTemplate(): void
     {
-        $renderer = new InterpolationRenderer(new TestingStringifier());
+        $renderer = new InterpolationRenderer(new DummyTranslator(), new TestingStringifier());
 
         $result = (new ResultBuilder())->template('__1st__')
             ->adjacent(
@@ -357,7 +356,7 @@ final class InterpolationRendererTest extends TestCase
 
         $expect = '__1st__ __2nd__ __3rd__';
 
-        self::assertSame($expect, $renderer->render($result, new DummyTranslator()));
+        self::assertSame($expect, $renderer->render($result));
     }
 
     #[Test]
@@ -369,8 +368,8 @@ final class InterpolationRendererTest extends TestCase
             ->adjacent((new ResultBuilder())->template('and this is a adjacent')->build())
             ->build();
 
-        $renderer = new InterpolationRenderer(new TestingStringifier());
+        $renderer = new InterpolationRenderer(new DummyTranslator(), new TestingStringifier());
 
-        self::assertSame($template, $renderer->render($result, new DummyTranslator()));
+        self::assertSame($template, $renderer->render($result));
     }
 }


### PR DESCRIPTION
Both `ArrayFormatter` and `StringFormatter` accept an instance of the `Translator`. Thinking about it a bit better, I realised that a formatter might not always need a `Translator`, but it will surely need a `Renderer`.

Besides, the `InterpolationRenderer` needs to take translation into account, so it seems more natural to me that this is the one that will get an instance of the `Translator`, as other implementations of the `Renderer` might not even deal with translations.