### PR TITLE
Enable validating private properties of parent classes

### DIFF
--- a/library/Rules/Attributes.php
+++ b/library/Rules/Attributes.php
@@ -11,7 +11,9 @@ namespace Respect\Validation\Rules;
 
 use Attribute;
 use ReflectionAttribute;
+use ReflectionClass;
 use ReflectionObject;
+use ReflectionProperty;
 use Respect\Validation\Id;
 use Respect\Validation\Result;
 use Respect\Validation\Rule;
@@ -28,32 +30,65 @@ final class Attributes implements Rule
             return $objectType->withId($id);
         }
 
-        $rules = [];
         $reflection = new ReflectionObject($input);
-        foreach ($reflection->getAttributes(Rule::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-            $rules[] = $attribute->newInstance();
-        }
-
-        foreach ($reflection->getProperties() as $property) {
-            $childrenRules = [];
-            foreach ($property->getAttributes(Rule::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                $childrenRules[] = $attribute->newInstance();
-            }
-
-            if ($childrenRules === []) {
-                continue;
-            }
-
-            $allowsNull = $property->getType()?->allowsNull() ?? false;
-
-            $childRule = new Reducer(...$childrenRules);
-            $rules[] = new Property($property->getName(), $allowsNull ? new NullOr($childRule) : $childRule);
-        }
-
+        $rules = [...$this->getClassRules($reflection), ...$this->getPropertyRules($reflection)];
         if ($rules === []) {
             return (new AlwaysValid())->evaluate($input)->withId($id);
         }
 
         return (new Reducer(...$rules))->evaluate($input)->withId($id);
+    }
+
+    /** @return array<Rule> */
+    private function getClassRules(ReflectionObject $reflection): array
+    {
+        $rules = [];
+        while ($reflection instanceof ReflectionClass) {
+            foreach ($reflection->getAttributes(Rule::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $rules[] = $attribute->newInstance();
+            }
+
+            $reflection = $reflection->getParentClass();
+        }
+
+        return $rules;
+    }
+
+    /** @return array<Rule> */
+    private function getPropertyRules(ReflectionObject $reflection): array
+    {
+        $rules = [];
+        foreach ($this->getProperties($reflection) as $propertyName => $property) {
+            $propertyRules = [];
+            foreach ($property->getAttributes(Rule::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                $propertyRules[] = $attribute->newInstance();
+            }
+
+            if ($propertyRules === []) {
+                continue;
+            }
+
+            $allowsNull = $property->getType()?->allowsNull() ?? false;
+
+            $childRule = new Reducer(...$propertyRules);
+            $rules[] = new Property($propertyName, $allowsNull ? new NullOr($childRule) : $childRule);
+        }
+
+        return $rules;
+    }
+
+    /** @return array<ReflectionProperty> */
+    private function getProperties(ReflectionObject $reflection): array
+    {
+        $properties = [];
+        while ($reflection instanceof ReflectionClass) {
+            foreach ($reflection->getProperties() as $property) {
+                $properties[$property->name] = $property;
+            }
+
+            $reflection = $reflection->getParentClass();
+        }
+
+        return $properties;
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,8 @@ parameters:
       path: tests/unit/Message/Translator/ArrayTranslatorTest.php
     - message: '/Access to an undefined property PHPUnit\\Framework\\TestCase/'
       path: tests/feature/Rules/SizeTest.php
+    - message: '/Property Respect\\Validation\\Test\\Stubs\\.+::\$[a-zA-Z]+ is never read, only written./'
+      path: tests/library/Stubs
   level: 8
   treatPhpDocTypesAsCertain: false
   paths:

--- a/tests/feature/Rules/AttributesTest.php
+++ b/tests/feature/Rules/AttributesTest.php
@@ -46,20 +46,20 @@ test('Multiple attributes, all failed', catchAll(
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.name` must not be empty')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
-            - `Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" +$email="not an email" +$phone ... }` must pass the rules
+            - `Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" #$phone="not a phone number" + ... }` must pass the rules
               - `.name` must not be empty
               - `.birthdate` must pass all the rules
                 - `.birthdate` must be a valid date in the format "2005-12-30"
                 - For comparison with now, `.birthdate` must be a valid datetime
-              - `.email` must be a valid email address or must be null
               - `.phone` must be a valid telephone number or must be null
+              - `.email` must be a valid email address or must be null
             FULL_MESSAGE)
         ->and($messages)->toBe([
-            '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" +$email="not an email" +$phone ... }` must pass the rules',
+            '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" #$phone="not a phone number" + ... }` must pass the rules',
             'name' => '`.name` must not be empty',
             'birthdate' => 'For comparison with now, `.birthdate` must be a valid datetime',
-            'email' => '`.email` must be a valid email address or must be null',
             'phone' => '`.phone` must be a valid telephone number or must be null',
+            'email' => '`.email` must be a valid email address or must be null',
         ]),
 ));
 
@@ -68,13 +68,13 @@ test('Failed attributes on the class', catchAll(
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.email` must be defined')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
-        - `Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" +$email=null +$phone=n ... }` must pass at least one of the rules
+        - `Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" #$phone=null +$address ... }` must pass at least one of the rules
           - `.email` must be defined
           - `.phone` must be defined
         FULL_MESSAGE)
         ->and($messages)->toBe([
             'anyOf' => [
-                '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" +$email=null +$phone=n ... }` must pass at least one of the rules',
+                '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="John Doe" +$birthdate="2024-06-23" #$phone=null +$address ... }` must pass at least one of the rules',
                 'email' => '`.email` must be defined',
                 'phone' => '`.phone` must be defined',
             ],

--- a/tests/library/Stubs/ParentWithAttributes.php
+++ b/tests/library/Stubs/ParentWithAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Rules as Rule;
+
+abstract class ParentWithAttributes
+{
+    public function __construct(
+        #[Rule\Email]
+        private string|null $email = null,
+        #[Rule\Phone]
+        protected string|null $phone = null,
+        public string|null $address = null,
+    ) {
+    }
+}

--- a/tests/library/Stubs/WithAttributes.php
+++ b/tests/library/Stubs/WithAttributes.php
@@ -15,7 +15,7 @@ use Respect\Validation\Rules as Rule;
     new Rule\Property('email', new Rule\NotUndef()),
     new Rule\Property('phone', new Rule\NotUndef()),
 )]
-final class WithAttributes
+final class WithAttributes extends ParentWithAttributes
 {
     public function __construct(
         #[Rule\NotEmpty]
@@ -23,11 +23,10 @@ final class WithAttributes
         #[Rule\Date('Y-m-d')]
         #[Rule\DateTimeDiff('years', new Rule\LessThanOrEqual(25))]
         public string $birthdate,
-        #[Rule\Email]
-        public string|null $email = null,
-        #[Rule\Phone]
-        public string|null $phone = null,
-        public string|null $address = null,
+        string|null $email = null,
+        string|null $phone = null,
+        string|null $address = null,
     ) {
+        parent::__construct($email, $phone, $address);
     }
 }


### PR DESCRIPTION
All validators related to object properties only consider the properties of the object being validated, not those of its parent object. That's because PHP reflection only gets the properties visible to the current class (public or protected). The problem with that is that when there's a private property in the parent class, we're completely unaware of it.

This commit will modify those rules by retrieving properties from the parent class, ensuring we capture all properties that require validation.