### PR TITLE
Do not overwrite existing names

### DIFF
--- a/docs/rules/KeyExists.md
+++ b/docs/rules/KeyExists.md
@@ -35,6 +35,27 @@ v::keyExists(5)->isValid(new ArrayObject(['a', 'b', 'c'])); // false
 |-------------|------------------------------------------------------------------|
 | `name`      | The validated input or the custom validator name (if specified). |
 
+## Caveats
+
+`KeyExists` defines the given `$key` as the path, and because it is a standalone rule without children, it's not possible to display a fully custom name with it.
+
+When no custom name is set, the path is displayed as `{{name}}`. When a custom name is set, the validation engine prepends the path to the custom name:
+
+```php
+v::keyExists('foo')->assert([]);
+// Message: `.foo` must be present
+
+v::keyExists('foo')->setName('Custom name')->assert([]);
+// Message: `.foo` (<- Custom name) must be present
+```
+
+If you want to display only a custom name while checking if a key exists, use [Key](Key.md) with [AlwaysValid](AlwaysValid.md):
+
+```php
+v::key('foo', v::alwaysValid()->setName('Custom name'))->assert([]);
+// Message: Custom name must be present
+```
+
 ## Categorization
 
 - Arrays

--- a/docs/rules/PropertyExists.md
+++ b/docs/rules/PropertyExists.md
@@ -36,6 +36,27 @@ This rule will validate public, private, protected, uninitialised, and static pr
 |-------------|------------------------------------------------------------------|
 | `name`      | The validated input or the custom validator name (if specified). |
 
+## Caveats
+
+`PropertyExists` defines the given `$propertyName` as the path, and because it is a standalone rule without children, it's not possible to display a fully custom name with it.
+
+When no custom name is set, the path is displayed as `{{name}}`. When a custom name is set, the validation engine prepends the path to the custom name:
+
+```php
+v::propertyExists('foo')->assert([]);
+// Message: `.foo` must be present
+
+v::propertyExists('foo')->setName('Custom name')->assert([]);
+// Message: `.foo` (<- Custom name) must be present
+```
+
+If you want to display only a custom name while checking if a property exists, use [Property](Property.md) with [AlwaysValid](AlwaysValid.md):
+
+```php
+v::property('foo', v::alwaysValid()->setName('Custom name'))->assert([]);
+// Message: Custom name must be present
+```
+
 ## Categorization
 
 - Objects

--- a/library/Message/Formatter/FirstResultStringFormatter.php
+++ b/library/Message/Formatter/FirstResultStringFormatter.php
@@ -11,6 +11,7 @@ namespace Respect\Validation\Message\Formatter;
 
 use Respect\Validation\Message\Renderer;
 use Respect\Validation\Message\StringFormatter;
+use Respect\Validation\Name;
 use Respect\Validation\Result;
 
 final readonly class FirstResultStringFormatter implements StringFormatter
@@ -18,10 +19,20 @@ final readonly class FirstResultStringFormatter implements StringFormatter
     /** @param array<string|int, mixed> $templates */
     public function format(Result $result, Renderer $renderer, array $templates): string
     {
+        return $this->formatResult($result, $renderer, $templates, null);
+    }
+
+    /** @param array<string|int, mixed> $templates */
+    private function formatResult(Result $result, Renderer $renderer, array $templates, Name|null $parentName): string
+    {
         if (!$result->hasCustomTemplate()) {
             foreach ($result->children as $child) {
-                return $this->format($child, $renderer, $templates);
+                return $this->formatResult($child, $renderer, $templates, $result->name ?? $parentName);
             }
+        }
+
+        if ($parentName !== null) {
+            $result = $result->withName($parentName);
         }
 
         return $renderer->render($result, $templates);

--- a/library/Message/InterpolationRenderer.php
+++ b/library/Message/InterpolationRenderer.php
@@ -45,7 +45,7 @@ final readonly class InterpolationRenderer implements Renderer
         $rendered = (string) preg_replace_callback(
             '/{{(\w+)(\|([^}]+))?}}/',
             function (array $matches) use ($parameters) {
-                if (!isset($parameters[$matches[1]])) {
+                if (!array_key_exists($matches[1], $parameters)) {
                     return $matches[0];
                 }
 
@@ -89,24 +89,24 @@ final readonly class InterpolationRenderer implements Renderer
         return $this->stringifier->stringify($value, 0) ?? print_r($value, true);
     }
 
-    private function getName(Result $result): Name
+    private function getName(Result $result): mixed
     {
         if (array_key_exists('name', $result->parameters) && is_string($result->parameters['name'])) {
             return new Name($result->parameters['name']);
         }
 
         if (array_key_exists('name', $result->parameters)) {
-            return new Name((string) $this->stringifier->stringify($result->parameters['name'], 0));
+            return $result->parameters['name'];
         }
 
         if ($result->name !== null) {
-            return $result->path ? $result->name->withPath($result->path) : $result->name;
+            return $result->name;
         }
 
         if ($result->path?->value !== null) {
-            return new Name((string) $this->stringifier->stringify($result->path, 0));
+            return $result->path;
         }
 
-        return new Name((string) $this->stringifier->stringify($result->input, 0));
+        return $result->input;
     }
 }

--- a/library/Message/Stringifier/NameStringifier.php
+++ b/library/Message/Stringifier/NameStringifier.php
@@ -27,7 +27,7 @@ final readonly class NameStringifier implements Stringifier
             return null;
         }
 
-        if ($raw->path === null || $raw->path->isOrphan()) {
+        if ($raw->path === null) {
             return $raw->value;
         }
 

--- a/library/Path.php
+++ b/library/Path.php
@@ -12,24 +12,8 @@ namespace Respect\Validation;
 final class Path
 {
     public function __construct(
-        public int|string $value,
+        public readonly int|string $value,
         public Path|null $parent = null,
     ) {
-    }
-
-    public function isOrphan(): bool
-    {
-        return $this->parent === null;
-    }
-
-    public function withParent(self $parent): self
-    {
-        if ($parent === $this->parent) {
-            return $this;
-        }
-
-        $this->parent = $parent;
-
-        return $this;
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,8 +7,6 @@ parameters:
       # Why: SimpleXMLElement is weird and doesn't implement anything ArrayAccess-like
       message: '/Instanceof between mixed and SimpleXMLElement will always evaluate to false\./'
       path: library/Rules/ArrayVal.php
-    - message: '/Call to an undefined method .+::(skip|throws)\(\)/'
-      path: tests/feature
     - message: '/Call to an undefined method .+::expectException\(\)/'
       path: tests/Pest.php
     - message: '/Undefined variable: \$this/'

--- a/tests/feature/HandlingNamesTest.php
+++ b/tests/feature/HandlingNamesTest.php
@@ -9,17 +9,22 @@ declare(strict_types=1);
 
 $input = ['email' => 'not an email'];
 
-test('Scenario #1', catchMessage(
+test('Results with a defined name cannot be overwritten by another name', catchMessage(
     fn() => v::key('email', v::email()->setName('Email'))->setName('Foo')->assert($input),
     fn(string $message) => expect($message)->toBe('Email must be a valid email address'),
 ));
 
-test('Scenario #2', catchMessage(
+test('Defining a name to a result with a path will add the path to the name', catchMessage(
     fn() => v::key('email', v::email())->setName('Email')->assert($input),
+    fn(string $message) => expect($message)->toBe('`.email` (<- Email) must be a valid email address'),
+));
+
+test('Results with a defined name will not be affected by a path', catchMessage(
+    fn() => v::key('email', v::email()->setName('Email'))->assert($input),
     fn(string $message) => expect($message)->toBe('Email must be a valid email address'),
 ));
 
-test('Scenario #3', catchMessage(
+test('Not defining a name to a result with a path will display the path', catchMessage(
     fn() => v::key('email', v::email())->assert($input),
     fn(string $message) => expect($message)->toBe('`.email` must be a valid email address'),
 ));

--- a/tests/feature/Issues/Issue179Test.php
+++ b/tests/feature/Issues/Issue179Test.php
@@ -35,4 +35,4 @@ test('https://github.com/Respect/Validation/issues/179', catchAll(
             'host' => '`.host` must be a string',
             'user' => '`.user` must be present',
         ]),
-))->skip('This still needs to be fixed in order to pass.');
+));

--- a/tests/feature/Rules/EachTest.php
+++ b/tests/feature/Rules/EachTest.php
@@ -127,7 +127,7 @@ test('With wrapper name, default', catchAll(
             1 => '`.1` must be an integer',
             2 => '`.2` must be an integer',
         ]),
-))->skip('This still needs to be fixed in order to pass.');
+));
 
 test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::each(v::intType())->setName('Wrapper'))->setName('Not')->assert([1, 2, 3]),
@@ -145,7 +145,7 @@ test('With wrapper name, inverted', catchAll(
             1 => '`.1` must not be an integer',
             2 => '`.2` must not be an integer',
         ]),
-))->skip('This still needs to be fixed in order to pass.');
+));
 
 test('With Not name, inverted', catchAll(
     fn() => v::not(v::each(v::intType()))->setName('Not')->assert([1, 2, 3]),
@@ -163,7 +163,7 @@ test('With Not name, inverted', catchAll(
             1 => '`.1` must not be an integer',
             2 => '`.2` must not be an integer',
         ]),
-))->skip('This still needs to be fixed in order to pass.');
+));
 
 test('With template, non-iterable', catchAll(
     fn() => v::each(v::intType())->setTemplate('You should have passed an iterable')->assert(null),

--- a/tests/feature/Rules/KeyExistsTest.php
+++ b/tests/feature/Rules/KeyExistsTest.php
@@ -26,9 +26,9 @@ test('Inverted mode', catchAll(
 test('Custom name', catchAll(
     fn() => v::keyExists('foo')->setName('Custom name')->assert(['bar' => 'baz']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Custom name must be present')
-        ->and($fullMessage)->toBe('- Custom name must be present')
-        ->and($messages)->toBe(['foo' => 'Custom name must be present']),
+        ->and($message)->toBe('`.foo` (<- Custom name) must be present')
+        ->and($fullMessage)->toBe('- `.foo` (<- Custom name) must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Custom name) must be present']),
 ));
 
 test('Custom template', catchAll(

--- a/tests/feature/Rules/KeyOptionalTest.php
+++ b/tests/feature/Rules/KeyOptionalTest.php
@@ -50,25 +50,25 @@ test('With wrapped name, inverted', catchAll(
 test('With wrapper name, default', catchAll(
     fn() => v::keyOptional('foo', v::intType())->setName('Wrapper')->assert(['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must be an integer']),
 ));
 
 test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType())->setName('Wrapper'))->setName('Not')->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must not be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must not be an integer']),
 ));
 
 test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::keyOptional('foo', v::intType()))->setName('Not')->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Not must not be an integer')
-        ->and($fullMessage)->toBe('- Not must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Not must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Not) must not be an integer']),
 ));
 
 test('With template, default', catchAll(

--- a/tests/feature/Rules/KeyTest.php
+++ b/tests/feature/Rules/KeyTest.php
@@ -66,33 +66,33 @@ test('With wrapped name, inverted', catchAll(
 test('With wrapper name, default', catchAll(
     fn() => v::key('foo', v::intType())->setName('Wrapper')->assert(['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must be an integer']),
 ));
 
 test('With wrapper name, missing key', catchAll(
     fn() => v::key('foo', v::intType())->setName('Wrapper')->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must be present')
-        ->and($fullMessage)->toBe('- Wrapper must be present')
-        ->and($messages)->toBe(['foo' => 'Wrapper must be present']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must be present')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must be present']),
 ));
 
 test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType())->setName('Wrapper'))->setName('Not')->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must not be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must not be an integer']),
 ));
 
 test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::key('foo', v::intType()))->setName('Not')->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Not must not be an integer')
-        ->and($fullMessage)->toBe('- Not must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Not must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Not) must not be an integer']),
 ));
 
 test('With template, default', catchAll(

--- a/tests/feature/Rules/PropertyExistsTest.php
+++ b/tests/feature/Rules/PropertyExistsTest.php
@@ -26,9 +26,9 @@ test('Inverted mode', catchAll(
 test('Custom name', catchAll(
     fn() => v::propertyExists('foo')->setName('Custom name')->assert((object) ['bar' => 'baz']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Custom name must be present')
-        ->and($fullMessage)->toBe('- Custom name must be present')
-        ->and($messages)->toBe(['foo' => 'Custom name must be present']),
+        ->and($message)->toBe('`.foo` (<- Custom name) must be present')
+        ->and($fullMessage)->toBe('- `.foo` (<- Custom name) must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Custom name) must be present']),
 ));
 
 test('Custom template', catchAll(

--- a/tests/feature/Rules/PropertyOptionalTest.php
+++ b/tests/feature/Rules/PropertyOptionalTest.php
@@ -50,25 +50,25 @@ test('With wrapped name, inverted', catchAll(
 test('With wrapper name, default', catchAll(
     fn() => v::propertyOptional('foo', v::intType())->setName('Wrapper')->assert((object) ['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must be an integer']),
 ));
 
 test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType())->setName('Wrapper'))->setName('Not')->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must not be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must not be an integer']),
 ));
 
 test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::propertyOptional('foo', v::intType()))->setName('Not')->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Not must not be an integer')
-        ->and($fullMessage)->toBe('- Not must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Not must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Not) must not be an integer']),
 ));
 
 test('With template, default', catchAll(

--- a/tests/feature/Rules/PropertyTest.php
+++ b/tests/feature/Rules/PropertyTest.php
@@ -70,34 +70,34 @@ test('With wrapped name, inverted', catchAll(
 test('With wrapper name, default', catchAll(
     fn() => v::property('foo', v::intType())->setName('Wrapper')->assert((object) ['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must be an integer']),
 ));
 
 test('With wrapper name, missing property', catchAll(
     fn() => v::property('foo', v::intType())->setName('Wrapper')->assert(new stdClass()),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must be present')
-        ->and($fullMessage)->toBe('- Wrapper must be present')
-        ->and($messages)->toBe(['foo' => 'Wrapper must be present']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must be present')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be present')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must be present']),
 ));
 
 test('With wrapper name, inverted', catchAll(
     fn() => v::not(v::property('foo', v::intType())->setName('Wrapper'))->setName('Not')
             ->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must not be an integer')
-        ->and($fullMessage)->toBe('- Wrapper must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Wrapper must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Wrapper) must not be an integer']),
 ));
 
 test('With "Not" name, inverted', catchAll(
     fn() => v::not(v::property('foo', v::intType()))->setName('Not')->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Not must not be an integer')
-        ->and($fullMessage)->toBe('- Not must not be an integer')
-        ->and($messages)->toBe(['foo' => 'Not must not be an integer']),
+        ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
+        ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')
+        ->and($messages)->toBe(['foo' => '`.foo` (<- Not) must not be an integer']),
 ));
 
 test('With template, default', catchAll(

--- a/tests/unit/Message/InterpolationRendererTest.php
+++ b/tests/unit/Message/InterpolationRendererTest.php
@@ -154,7 +154,7 @@ final class InterpolationRendererTest extends TestCase
         self::assertSame(
             sprintf(
                 'Will replace %s',
-                $stringifier->stringify(new Name((string) $stringifier->stringify($value, 0)), 0),
+                $stringifier->stringify($value, 0),
             ),
             $renderer->render($result, []),
         );
@@ -196,7 +196,7 @@ final class InterpolationRendererTest extends TestCase
         self::assertSame(
             sprintf(
                 'Will replace %s',
-                $stringifier->stringify(new Name((string) $stringifier->stringify($input, 0)), 0),
+                $stringifier->stringify($input, 0),
             ),
             $renderer->render($result, []),
         );
@@ -303,7 +303,7 @@ final class InterpolationRendererTest extends TestCase
         self::assertSame(
             sprintf(
                 '%s must be a valid stub',
-                $stringifier->stringify(new Name((string) $stringifier->stringify($result->input, 0)), 0),
+                $stringifier->stringify($result->input, 0),
             ),
             $renderer->render($result, []),
         );
@@ -320,7 +320,7 @@ final class InterpolationRendererTest extends TestCase
         self::assertSame(
             sprintf(
                 '%s must not be a valid stub',
-                $stringifier->stringify(new Name((string) $stringifier->stringify($result->input, 0)), 0),
+                $stringifier->stringify($result->input, 0),
             ),
             $renderer->render($result, []),
         );


### PR DESCRIPTION
This commit addresses the skipped tests by modifying certain core concepts in the library. The way names work has always been somewhat confusing, even to me. I’ve established that existing names will never be overwritten, and if a path is already defined, we will change the name to also include the path.

I’m not very happy with how I’m solving this problem, because the `FirstResultStringFormatter` is changing some behaviour in the results that seems to be something that should always happen before. But, for the moment, I will keep it as is.