### PR TITLE
Replace placeholder "name" with "subject"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,20 +16,21 @@ learn that just by looking at other rules. Pick the simple ones like `ArrayType`
 to begin.
 
 Before writing anything, feature or bug fix:
+
 - Check if there is already an issue related to it (opened or closed) and if
   someone is already working on that;
-    - If there is not, [open an issue][] and notify everybody that you're going
-      to work on that;
-    - If there is, create a comment to notify everybody that you're going to
-      work on that.
+  - If there is not, [open an issue][] and notify everybody that you're going
+    to work on that;
+  - If there is, create a comment to notify everybody that you're going to
+    work on that.
 - Make sure that what you need is not done yet
 
 ## Adding a new validator
 
 A common validator (rule) on Respect\Validation is composed of three classes:
 
-  * `library/Rules/YourRuleName.php`: the rule itself
-  * `tests/unit/Rules/YourRuleNameTest.php`: tests for the rule
+- `library/Rules/YourRuleName.php`: the rule itself
+- `tests/unit/Rules/YourRuleNameTest.php`: tests for the rule
 
 The classes are pretty straightforward. In the sample below, we're going to
 create a validator that validates if a string is equal to "Hello World".
@@ -65,8 +66,8 @@ use Respect\Validation\Message\Template;
 use Respect\Validation\Rules\Core\Simple;
 
 #[Template(
-    '{{name}} must be a Hello World',
-    '{{name}} must not be a Hello World',
+    '{{subject}} must be a Hello World',
+    '{{subject}} must not be a Hello World',
 )]
 final class HelloWorld extends Simple
 {
@@ -155,6 +156,7 @@ After run `composer install` on the library's root directory you must run PHPUni
 ### Linux
 
 You can test the project using the commands:
+
 ```sh
 $ vendor/bin/phpunit
 ```
@@ -168,6 +170,7 @@ $ composer phpunit
 ### Windows
 
 You can test the project using the commands:
+
 ```sh
 > vendor\bin\phpunit
 ```
@@ -187,5 +190,5 @@ and changing it according to your needs.
 [data provider]: https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers "PHPUnit Data Providers"
 [open an issue]: http://github.com/Respect/Validation/issues
 [PHP-FIG]: http://www.php-fig.org "PHP Framework Interop Group"
-[project documentation]: https://respect-validation.readthedocs.io/ "Respect\Validation documentation"
+[project documentation]: https://respect-validation.readthedocs.io/ "Respect\\Validation documentation"
 [pull requests]: http://help.github.com/pull-requests "GitHub pull requests"

--- a/docs/02-feature-guide.md
+++ b/docs/02-feature-guide.md
@@ -19,6 +19,7 @@ if (v::intType()->positive()->isValid($input)) {
 ```
 
 Note that you can combine multiple rules for a complex validation.
+
 ## Validating using exceptions
 
 The `assert()` method throws an exception when validation fails. You can handle those exceptions with `try/catch` for more robust error handling.
@@ -33,24 +34,24 @@ v::intType()->positive()->assert($input);
 
 Respect\Validation offers over 150 rules, many of which are designed to address common scenarios. Here’s a quick guide to some specific use cases and the rules that make validation straightforward.
 
-* Using rules as **PHP Attributes**: [Attributes](rules/Attributes.md).
-* Validating **Arrays**: [Key](rules/Key.md), [KeyOptional](rules/KeyOptional.md), [KeyExists](rules/KeyExists.md).
-* Validating **Array structures**: [KeySet](rules/KeySet.md).
-* Validating **Object properties**: [Property](rules/Property.md), [PropertyOptional](rules/PropertyOptional.md), [PropertyExists](rules/PropertyExists.md).
-* Using **Conditional validation**: [NullOr](rules/NullOr.md), [UndefOr](rules/UndefOr.md), [When](rules/When.md).
-* Using **Grouped validation**: [AllOf](rules/AllOf.md), [AnyOf](rules/AnyOf.md), [NoneOf](rules/NoneOf.md), [OneOf](rules/OneOf.md)
-* Validating **Each** value in the input: [Each](rules/Each.md).
-* Validating the **Length** of the input: [Length](rules/Length.md).
-* Validating the **Maximum** value in the input: [Max](rules/Max.md).
-* Validating the **Minimum** value in the input: [Min](rules/Min.md).
-* Handling **Special cases**: [Lazy](rules/Lazy.md), [Circuit](rules/Circuit.md), [Call](rules/Call.md).
+- Using rules as **PHP Attributes**: [Attributes](rules/Attributes.md).
+- Validating **Arrays**: [Key](rules/Key.md), [KeyOptional](rules/KeyOptional.md), [KeyExists](rules/KeyExists.md).
+- Validating **Array structures**: [KeySet](rules/KeySet.md).
+- Validating **Object properties**: [Property](rules/Property.md), [PropertyOptional](rules/PropertyOptional.md), [PropertyExists](rules/PropertyExists.md).
+- Using **Conditional validation**: [NullOr](rules/NullOr.md), [UndefOr](rules/UndefOr.md), [When](rules/When.md).
+- Using **Grouped validation**: [AllOf](rules/AllOf.md), [AnyOf](rules/AnyOf.md), [NoneOf](rules/NoneOf.md), [OneOf](rules/OneOf.md)
+- Validating **Each** value in the input: [Each](rules/Each.md).
+- Validating the **Length** of the input: [Length](rules/Length.md).
+- Validating the **Maximum** value in the input: [Max](rules/Max.md).
+- Validating the **Minimum** value in the input: [Min](rules/Min.md).
+- Handling **Special cases**: [Lazy](rules/Lazy.md), [Circuit](rules/Circuit.md), [Call](rules/Call.md).
 
 ### Custom templates
 
 Define your own error message when the validation fails:
 
 ```php
-v::between(1, 256)->assert($input, '{{name}} is not what I was expecting');
+v::between(1, 256)->assert($input, '{{subject}} is not what I was expecting');
 ```
 
 ### Custom templates per rule
@@ -67,6 +68,7 @@ v::alnum()->lowercase()->assert($input, [
 ### Custom exception objects
 
 Integrate your own exception objects when the validation fails:
+
 ```php
 v::alnum()->assert($input, new DomainException('Not a valid username'));
 ```
@@ -87,7 +89,7 @@ v::alnum()->lowercase()->assert(
 
 ## Inverting validation rules
 
-Use the `not` prefix to invert a  validation rule.
+Use the `not` prefix to invert a validation rule.
 
 ```php
 v::notEquals('main')->assert($input);
@@ -109,7 +111,7 @@ $validator->assert('alexandre gaigalas');
 
 ## Customising validator names
 
-Template messages include the placeholder `{{name}}`, which defaults to the input. Use `setName()` to replace it with a more descriptive label.
+Template messages include the placeholder `{{subject}}`, which defaults to the input. Use `setName()` to replace it with a more descriptive label.
 
 ```php
 v::dateTime('Y-m-d')

--- a/docs/03-handling-exceptions.md
+++ b/docs/03-handling-exceptions.md
@@ -1,6 +1,7 @@
 # Handling exceptions
 
 The `Validator::assert()` method simplifies exception handling by throwing `ValidationException` exceptions when validation fails. These exceptions provide detailed feedback on what went wrong.
+
 ## Full exception message
 
 The `getFullMessage()` method will return a full comprehensive explanation of rules that didn't pass in a nested Markdown list format.
@@ -51,6 +52,7 @@ Array
 ```
 
 When validating with [Key](rules/Key.md) or [Property](rules/Property.md) the keys of will correspond to the name of the key or property that failed the validation.
+
 ## Custom templates
 
 You can tailor the messages to better suit your needs.
@@ -100,7 +102,7 @@ use Respect\Validation\Validator as v;
 
 $validator = v::alnum()->lowercase();
 $validator->setTemplates([
-    '__root__' => '{{name}} is not valid',
+    '__root__' => '{{subject}} is not valid',
     'alnum' => 'Usernames must contain only letters and digits',
     'lowercase' => 'Usernames must be lowercase',
 ]);

--- a/docs/05-message-placeholder-conversion.md
+++ b/docs/05-message-placeholder-conversion.md
@@ -7,7 +7,7 @@ to convert them to string.
 We use the `ParameterStringifier` to convert those parameters into a string.
 Our default implementation will convert all parameters with
 [Respect\Stringifier](https://github.com/Respect/Stringifier) unless the
-parameter is called `name` and it is already a string.
+parameter is called `subject` and it is already a string.
 
 It is possible to overwrite that behavior by creating a custom implementation of
 the `ParameterStringifier` and passing it to the `Factory`:

--- a/docs/07-custom-rules.md
+++ b/docs/07-custom-rules.md
@@ -4,7 +4,7 @@ You can also create and use your own rules. To do this, you will need to create
 a rule and an exception to go with the rule.
 
 To create a rule, you need to create a class that implements the `Rule` interface
-and is within the Rules `namespace`. It is  convenient to just extend the `Simple` or
+and is within the Rules `namespace`. It is convenient to just extend the `Simple` or
 `Standard` class. When the rule is called the logic inside the validate method will be
 executed. Here's how the class should look:
 
@@ -15,8 +15,8 @@ use Respect\Validation\Message\Template;
 use Respect\Validation\Rules\Core\Simple;
 
 #[Template(
-    '{{name}} is something',
-    '{{name}} is not something',
+    '{{subject}} is something',
+    '{{subject}} is not something',
 )]
 final class Something extends Simple
 {
@@ -27,7 +27,7 @@ final class Something extends Simple
 }
 ```
 
-The `'{{name}} is not something` message would be used then you call the rule
+The `'{{subject}} is not something` message would be used then you call the rule
 with the `not()`.
 
 All classes in Validation are created by the `Factory` class. If you want

--- a/docs/rules/AllOf.md
+++ b/docs/rules/AllOf.md
@@ -14,25 +14,25 @@ v::allOf(v::intVal(), v::positive())->isValid(15); // true
 
 Used when some rules must be failed.
 
-| Mode       | Template                     |
-|------------|------------------------------|
-| `default`  | {{name}} must pass the rules |
-| `inverted` | {{name}} must pass the rules |
+| Mode       | Template                        |
+| ---------- | ------------------------------- |
+| `default`  | {{subject}} must pass the rules |
+| `inverted` | {{subject}} must pass the rules |
 
 ### `AllOf::TEMPLATE_ALL`
 
 Used when all rules have failed.
 
-| Mode       | Template                         |
-|------------|----------------------------------|
-| `default`  | {{name}} must pass all the rules |
-| `inverted` | {{name}} must pass all the rules |
+| Mode       | Template                            |
+| ---------- | ----------------------------------- |
+| `default`  | {{subject}} must pass all the rules |
+| `inverted` | {{subject}} must pass all the rules |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -42,11 +42,12 @@ Used when all rules have failed.
 ## Changelog
 
 | Version | Description                             |
-|--------:|-----------------------------------------|
+| ------: | --------------------------------------- |
 |   3.0.0 | Require at least two rules to be passed |
 |   0.3.9 | Created                                 |
 
-***
+---
+
 See also:
 
 - [AnyOf](AnyOf.md)

--- a/docs/rules/Alnum.md
+++ b/docs/rules/Alnum.md
@@ -30,24 +30,24 @@ of extra chars passed as the parameter.
 
 ### `Alnum::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                  |
-|------------|-----------------------------------------------------------|
-| `default`  | {{name}} must contain only letters (a-z) and digits (0-9) |
-| `inverted` | {{name}} must not contain letters (a-z) or digits (0-9)   |
+| Mode       | Template                                                     |
+| ---------- | ------------------------------------------------------------ |
+| `default`  | {{subject}} must contain only letters (a-z) and digits (0-9) |
+| `inverted` | {{subject}} must not contain letters (a-z) or digits (0-9)   |
 
 ### `Alnum::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                        |
-|------------|---------------------------------------------------------------------------------|
-| `default`  | {{name}} must contain only letters (a-z), digits (0-9), and {{additionalChars}} |
-| `inverted` | {{name}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}   |
+| Mode       | Template                                                                           |
+| ---------- | ---------------------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain only letters (a-z), digits (0-9), and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -56,11 +56,12 @@ of extra chars passed as the parameter.
 ## Changelog
 
 | Version | Description                               |
-|--------:|-------------------------------------------|
+| ------: | ----------------------------------------- |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.3.9 | Created                                   |
 
-***
+---
+
 See also:
 
 - [Alpha](Alpha.md)

--- a/docs/rules/Alpha.md
+++ b/docs/rules/Alpha.md
@@ -25,24 +25,24 @@ v::alpha()->uppercase()->isValid('example'); // false
 
 ### `Alpha::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must contain only letters (a-z) |
-| `inverted` | {{name}} must not contain letters (a-z)  |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must contain only letters (a-z) |
+| `inverted` | {{subject}} must not contain letters (a-z)  |
 
 ### `Alpha::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                         |
-|------------|------------------------------------------------------------------|
-| `default`  | {{name}} must contain only letters (a-z) and {{additionalChars}} |
-| `inverted` | {{name}} must not contain letters (a-z) or {{additionalChars}}   |
+| Mode       | Template                                                            |
+| ---------- | ------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain only letters (a-z) and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain letters (a-z) or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -51,11 +51,12 @@ v::alpha()->uppercase()->isValid('example'); // false
 ## Changelog
 
 | Version | Description                               |
-|--------:|-------------------------------------------|
+| ------: | ----------------------------------------- |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.3.9 | Created                                   |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/AlwaysInvalid.md
+++ b/docs/rules/AlwaysInvalid.md
@@ -12,23 +12,23 @@ v::alwaysInvalid()->isValid('whatever'); // false
 
 ### `AlwaysInvalid::TEMPLATE_STANDARD`
 
-| Mode       | Template                 |
-|------------|--------------------------|
-| `default`  | {{name}} must be valid   |
-| `inverted` | {{name}} must be invalid |
+| Mode       | Template                    |
+| ---------- | --------------------------- |
+| `default`  | {{subject}} must be valid   |
+| `inverted` | {{subject}} must be invalid |
 
 ### `AlwaysInvalid::TEMPLATE_SIMPLE`
 
-| Mode       | Template            |
-|------------|---------------------|
-| `default`  | {{name}} is invalid |
-| `inverted` | {{name}} is valid   |
+| Mode       | Template               |
+| ---------- | ---------------------- |
+| `default`  | {{subject}} is invalid |
+| `inverted` | {{subject}} is valid   |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,10 +37,11 @@ v::alwaysInvalid()->isValid('whatever'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [AlwaysValid](AlwaysValid.md)

--- a/docs/rules/AlwaysValid.md
+++ b/docs/rules/AlwaysValid.md
@@ -12,16 +12,16 @@ v::alwaysValid()->isValid('whatever'); // true
 
 ### `AlwaysValid::TEMPLATE_STANDARD`
 
-| Mode       | Template                 |
-|------------|--------------------------|
-| `default`  | {{name}} must be valid   |
-| `inverted` | {{name}} must be invalid |
+| Mode       | Template                    |
+| ---------- | --------------------------- |
+| `default`  | {{subject}} must be valid   |
+| `inverted` | {{subject}} must be invalid |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::alwaysValid()->isValid('whatever'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [AlwaysInvalid](AlwaysInvalid.md)

--- a/docs/rules/AnyOf.md
+++ b/docs/rules/AnyOf.md
@@ -17,16 +17,16 @@ so `AnyOf()` returns true.
 
 ### `AnyOf::TEMPLATE_STANDARD`
 
-| Mode       | Template                                     |
-|------------|----------------------------------------------|
-| `default`  | {{name}} must pass at least one of the rules |
-| `inverted` | {{name}} must pass at least one of the rules |
+| Mode       | Template                                        |
+| ---------- | ----------------------------------------------- |
+| `default`  | {{subject}} must pass at least one of the rules |
+| `inverted` | {{subject}} must pass at least one of the rules |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -36,11 +36,12 @@ so `AnyOf()` returns true.
 ## Changelog
 
 | Version | Description                             |
-|--------:|-----------------------------------------|
+| ------: | --------------------------------------- |
 |   3.0.0 | Require at least two rules to be passed |
 |   2.0.0 | Created                                 |
 
-***
+---
+
 See also:
 
 - [AllOf](AllOf.md)

--- a/docs/rules/ArrayType.md
+++ b/docs/rules/ArrayType.md
@@ -14,16 +14,16 @@ v::arrayType()->isValid(new ArrayObject()); // false
 
 ### `ArrayType::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-|------------|-------------------------------|
-| `default`  | {{name}} must be an array     |
-| `inverted` | {{name}} must not be an array |
+| Mode       | Template                         |
+| ---------- | -------------------------------- |
+| `default`  | {{subject}} must be an array     |
+| `inverted` | {{subject}} must not be an array |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::arrayType()->isValid(new ArrayObject()); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayVal](ArrayVal.md)

--- a/docs/rules/ArrayVal.md
+++ b/docs/rules/ArrayVal.md
@@ -15,16 +15,16 @@ v::arrayVal()->isValid(new SimpleXMLElement('<xml></xml>')); // true
 
 ### `ArrayVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-|------------|-------------------------------------|
-| `default`  | {{name}} must be an array value     |
-| `inverted` | {{name}} must not be an array value |
+| Mode       | Template                               |
+| ---------- | -------------------------------------- |
+| `default`  | {{subject}} must be an array value     |
+| `inverted` | {{subject}} must not be an array value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,12 +34,13 @@ v::arrayVal()->isValid(new SimpleXMLElement('<xml></xml>')); // true
 ## Changelog
 
 | Version | Description                                                                                  |
-|--------:|----------------------------------------------------------------------------------------------|
+| ------: | -------------------------------------------------------------------------------------------- |
 |   2.0.0 | `SimpleXMLElement` is also considered as valid                                               |
 |   1.0.0 | Renamed from `Arr` to `ArrayVal` and validate only if the input can be used as an array (#1) |
 |   0.3.9 | Created as `Arr`                                                                             |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Base.md
+++ b/docs/rules/Base.md
@@ -16,17 +16,17 @@ v::base(2)->isValid('0120122001'); // false
 
 ### `Base::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                |
-|------------|---------------------------------------------------------|
-| `default`  | {{name}} must be a number in base {{base&#124;raw}}     |
-| `inverted` | {{name}} must not be a number in base {{base&#124;raw}} |
+| Mode       | Template                                                   |
+| ---------- | ---------------------------------------------------------- |
+| `default`  | {{subject}} must be a number in base {{base&#124;raw}}     |
+| `inverted` | {{subject}} must not be a number in base {{base&#124;raw}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `base`      | The base passed to the constructor of the rule.                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -35,10 +35,11 @@ v::base(2)->isValid('0120122001'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Base64](Base64.md)

--- a/docs/rules/Base64.md
+++ b/docs/rules/Base64.md
@@ -13,16 +13,16 @@ v::base64()->isValid('respect!'); // false
 
 ### `Base64::TEMPLATE_STANDARD`
 
-| Mode       | Template                                     |
-|------------|----------------------------------------------|
-| `default`  | {{name}} must be a base64 encoded string     |
-| `inverted` | {{name}} must not be a base64 encoded string |
+| Mode       | Template                                        |
+| ---------- | ----------------------------------------------- |
+| `default`  | {{subject}} must be a base64 encoded string     |
+| `inverted` | {{subject}} must not be a base64 encoded string |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::base64()->isValid('respect!'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Base](Base.md)

--- a/docs/rules/Between.md
+++ b/docs/rules/Between.md
@@ -19,18 +19,18 @@ Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
 
 ### `Between::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                   |
-|------------|------------------------------------------------------------|
-| `default`  | {{name}} must be between {{minValue}} and {{maxValue}}     |
-| `inverted` | {{name}} must not be between {{minValue}} and {{maxValue}} |
+| Mode       | Template                                                      |
+| ---------- | ------------------------------------------------------------- |
+| `default`  | {{subject}} must be between {{minValue}} and {{maxValue}}     |
+| `inverted` | {{subject}} must not be between {{minValue}} and {{maxValue}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `maxValue`  | The minimum value passed to the rule.                            |
 | `minValue`  | The maximum value passed to the rule.                            |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,12 +39,13 @@ Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
 ## Changelog
 
 | Version | Description                 |
-|--------:|-----------------------------|
+| ------: | --------------------------- |
 |   2.0.0 | Became always inclusive     |
 |   1.0.0 | Became inclusive by default |
 |   0.3.9 | Created                     |
 
-***
+---
+
 See also:
 
 - [BetweenExclusive](BetweenExclusive.md)

--- a/docs/rules/BetweenExclusive.md
+++ b/docs/rules/BetweenExclusive.md
@@ -19,10 +19,10 @@ Validation makes comparison easier, check out our supported [comparable values](
 
 ### `BetweenExclusive::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                                 |
-|------------|--------------------------------------------------------------------------|
-| `default`  | {{name}} must be greater than {{minValue}} and less than {{maxValue}}    |
-| `inverted` | {{name}} must not be greater than {{minValue}} or less than {{maxValue}} |
+| Mode       | Template                                                                    |
+| ---------- | --------------------------------------------------------------------------- |
+| `default`  | {{subject}} must be greater than {{minValue}} and less than {{maxValue}}    |
+| `inverted` | {{subject}} must not be greater than {{minValue}} or less than {{maxValue}} |
 
 ## Template placeholders
 
@@ -30,7 +30,7 @@ Validation makes comparison easier, check out our supported [comparable values](
 | ----------- | ---------------------------------------------------------------- |
 | `maxValue`  | The minimum value passed to the rule.                            |
 | `minValue`  | The maximum value passed to the rule.                            |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,10 +39,11 @@ Validation makes comparison easier, check out our supported [comparable values](
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   3.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/BoolType.md
+++ b/docs/rules/BoolType.md
@@ -13,16 +13,16 @@ v::boolType()->isValid(false); // true
 
 ### `BoolType::TEMPLATE_STANDARD`
 
-| Mode       | Template                       |
-|------------|--------------------------------|
-| `default`  | {{name}} must be a boolean     |
-| `inverted` | {{name}} must not be a boolean |
+| Mode       | Template                          |
+| ---------- | --------------------------------- |
+| `default`  | {{subject}} must be a boolean     |
+| `inverted` | {{subject}} must not be a boolean |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,11 +32,12 @@ v::boolType()->isValid(false); // true
 ## Changelog
 
 | Version | Description                       |
-|--------:|-----------------------------------|
+| ------: | --------------------------------- |
 |   1.0.0 | Renamed from `Bool` to `BoolType` |
 |   0.3.9 | Created as `Bool`                 |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/BoolVal.md
+++ b/docs/rules/BoolVal.md
@@ -17,16 +17,16 @@ v::boolVal()->isValid(0); // true
 
 ### `BoolVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be a boolean value     |
-| `inverted` | {{name}} must not be a boolean value |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be a boolean value     |
+| `inverted` | {{subject}} must not be a boolean value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -36,10 +36,11 @@ v::boolVal()->isValid(0); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [BoolType](BoolType.md)

--- a/docs/rules/Bsn.md
+++ b/docs/rules/Bsn.md
@@ -12,16 +12,16 @@ v::bsn()->isValid('612890053'); // true
 
 ### `Bsn::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-|------------|----------------------------------|
-| `default`  | {{name}} must be a valid BSN     |
-| `inverted` | {{name}} must not be a valid BSN |
+| Mode       | Template                            |
+| ---------- | ----------------------------------- |
+| `default`  | {{subject}} must be a valid BSN     |
+| `inverted` | {{subject}} must not be a valid BSN |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::bsn()->isValid('612890053'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Cnh](Cnh.md)

--- a/docs/rules/Call.md
+++ b/docs/rules/Call.md
@@ -56,7 +56,7 @@ v::call(
 |-------------|------------------------------------------------------------------|
 | `callable`  |                                                                  |
 | `input`     |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/CallableType.md
+++ b/docs/rules/CallableType.md
@@ -14,16 +14,16 @@ v::callableType()->isValid([new DateTime(), 'format']); // true
 
 ### `CallableType::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} must be a callable     |
-| `inverted` | {{name}} must not be a callable |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} must be a callable     |
+| `inverted` | {{subject}} must not be a callable |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::callableType()->isValid([new DateTime(), 'format']); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Callback.md
+++ b/docs/rules/Callback.md
@@ -16,16 +16,16 @@ v::callback(
 
 ### `Callback::TEMPLATE_STANDARD`
 
-| Mode       | Template                 |
-|------------|--------------------------|
-| `default`  | {{name}} must be valid   |
-| `inverted` | {{name}} must be invalid |
+| Mode       | Template                    |
+| ---------- | --------------------------- |
+| `default`  | {{subject}} must be valid   |
+| `inverted` | {{subject}} must be invalid |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ v::callback(
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Call](Call.md)

--- a/docs/rules/Charset.md
+++ b/docs/rules/Charset.md
@@ -16,17 +16,17 @@ The array format is a logic OR, not AND.
 
 ### `Charset::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                                       |
-|------------|--------------------------------------------------------------------------------|
-| `default`  | {{name}} must only contain characters from the {{charset&#124;raw}} charset    |
-| `inverted` | {{name}} must not contain any characters from the {{charset&#124;raw}} charset |
+| Mode       | Template                                                                          |
+| ---------- | --------------------------------------------------------------------------------- |
+| `default`  | {{subject}} must only contain characters from the {{charset&#124;raw}} charset    |
+| `inverted` | {{subject}} must not contain any characters from the {{charset&#124;raw}} charset |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `charset`   |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -35,11 +35,12 @@ The array format is a logic OR, not AND.
 ## Changelog
 
 | Version | Description                                           |
-|--------:|-------------------------------------------------------|
+| ------: | ----------------------------------------------------- |
 |   2.0.0 | Charset supports multiple charsets on its constructor |
 |   0.5.0 | Created                                               |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Cnh.md
+++ b/docs/rules/Cnh.md
@@ -12,16 +12,16 @@ v::cnh()->isValid('02650306461'); // true
 
 ### `Cnh::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must be a valid CNH number     |
-| `inverted` | {{name}} must not be a valid CNH number |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must be a valid CNH number     |
+| `inverted` | {{subject}} must not be a valid CNH number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::cnh()->isValid('02650306461'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Bsn](Bsn.md)

--- a/docs/rules/Cnpj.md
+++ b/docs/rules/Cnpj.md
@@ -9,16 +9,16 @@ Ignores non-digit chars, so use `->digit()` if needed.
 
 ### `Cnpj::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must be a valid CNPJ number     |
-| `inverted` | {{name}} must not be a valid CNPJ number |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must be a valid CNPJ number     |
+| `inverted` | {{subject}} must not be a valid CNPJ number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -27,10 +27,11 @@ Ignores non-digit chars, so use `->digit()` if needed.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Bsn](Bsn.md)

--- a/docs/rules/Consonant.md
+++ b/docs/rules/Consonant.md
@@ -13,24 +13,24 @@ v::consonant()->isValid('xkcd'); // true
 
 ### `Consonant::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must only contain consonants |
-| `inverted` | {{name}} must not contain consonants  |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must only contain consonants |
+| `inverted` | {{subject}} must not contain consonants  |
 
 ### `Consonant::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                      |
-|------------|---------------------------------------------------------------|
-| `default`  | {{name}} must only contain consonants and {{additionalChars}} |
-| `inverted` | {{name}} must not contain consonants or {{additionalChars}}   |
+| Mode       | Template                                                         |
+| ---------- | ---------------------------------------------------------------- |
+| `default`  | {{subject}} must only contain consonants and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain consonants or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,11 +39,12 @@ v::consonant()->isValid('xkcd'); // true
 ## Changelog
 
 | Version | Description                              |
-|--------:|------------------------------------------|
+| ------: | ---------------------------------------- |
 |   0.5.0 | Renamed from `Consonants` to `Consonant` |
 |   0.3.9 | Created as `Consonants`                  |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Contains.md
+++ b/docs/rules/Contains.md
@@ -26,17 +26,17 @@ Message template for this validator includes `{{containsValue}}`.
 
 ### `Contains::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must contain {{containsValue}}     |
-| `inverted` | {{name}} must not contain {{containsValue}} |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must contain {{containsValue}}     |
+| `inverted` | {{subject}} must not contain {{containsValue}} |
 
 ## Template placeholders
 
 | Placeholder     | Description                                                      |
-|-----------------|------------------------------------------------------------------|
+| --------------- | ---------------------------------------------------------------- |
 | `containsValue` |                                                                  |
-| `name`          | The validated input or the custom validator name (if specified). |
+| `subject`       | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -46,10 +46,11 @@ Message template for this validator includes `{{containsValue}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [ContainsAny](ContainsAny.md)

--- a/docs/rules/ContainsAny.md
+++ b/docs/rules/ContainsAny.md
@@ -26,16 +26,16 @@ Message template for this validator includes `{{needles}}`.
 
 ### `ContainsAny::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                  |
-|------------|-----------------------------------------------------------|
-| `default`  | {{name}} must contain at least one value from {{needles}} |
-| `inverted` | {{name}} must not contain any value from {{needles}}      |
+| Mode       | Template                                                     |
+| ---------- | ------------------------------------------------------------ |
+| `default`  | {{subject}} must contain at least one value from {{needles}} |
+| `inverted` | {{subject}} must not contain any value from {{needles}}      |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `needles`   |                                                                  |
 
 ## Categorization
@@ -46,10 +46,11 @@ Message template for this validator includes `{{needles}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [AnyOf](AnyOf.md)

--- a/docs/rules/Control.md
+++ b/docs/rules/Control.md
@@ -14,24 +14,24 @@ v::control()->isValid("\n\r\t"); // true
 
 ### `Control::TEMPLATE_STANDARD`
 
-| Mode       | Template                                      |
-|------------|-----------------------------------------------|
-| `default`  | {{name}} must only contain control characters |
-| `inverted` | {{name}} must not contain control characters  |
+| Mode       | Template                                         |
+| ---------- | ------------------------------------------------ |
+| `default`  | {{subject}} must only contain control characters |
+| `inverted` | {{subject}} must not contain control characters  |
 
 ### `Control::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                              |
-|------------|-----------------------------------------------------------------------|
-| `default`  | {{name}} must only contain control characters and {{additionalChars}} |
-| `inverted` | {{name}} must not contain control characters or {{additionalChars}}   |
+| Mode       | Template                                                                 |
+| ---------- | ------------------------------------------------------------------------ |
+| `default`  | {{subject}} must only contain control characters and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain control characters or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -40,11 +40,12 @@ v::control()->isValid("\n\r\t"); // true
 ## Changelog
 
 | Version | Description                       |
-|--------:|-----------------------------------|
+| ------: | --------------------------------- |
 |   2.0.0 | Renamed from `Cntrl` to `Control` |
 |   0.5.0 | Created                           |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Countable.md
+++ b/docs/rules/Countable.md
@@ -15,16 +15,16 @@ v::countable()->isValid('string'); // false
 
 ### `Countable::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a countable value     |
-| `inverted` | {{name}} must not be a countable value |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a countable value     |
+| `inverted` | {{subject}} must not be a countable value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::countable()->isValid('string'); // false
 ## Changelog
 
 | Version | Description             |
-|--------:|-------------------------|
+| ------: | ----------------------- |
 |   1.0.0 | Created from `ArrayVal` |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/CountryCode.md
+++ b/docs/rules/CountryCode.md
@@ -27,16 +27,16 @@ When no set is defined, the rule uses `'alpha-2'` (`CountryCode::ALPHA2`).
 
 ### `CountryCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-|------------|-------------------------------------------|
-| `default`  | {{name}} must be a valid country code     |
-| `inverted` | {{name}} must not be a valid country code |
+| Mode       | Template                                     |
+| ---------- | -------------------------------------------- |
+| `default`  | {{subject}} must be a valid country code     |
+| `inverted` | {{subject}} must not be a valid country code |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -46,12 +46,13 @@ When no set is defined, the rule uses `'alpha-2'` (`CountryCode::ALPHA2`).
 ## Changelog
 
 | Version | Description                                                       |
-|--------:|-------------------------------------------------------------------|
+| ------: | ----------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   2.0.0 | Became case-sensitive                                             |
 |   0.5.0 | Created                                                           |
 
-***
+---
+
 See also:
 
 - [CurrencyCode](CurrencyCode.md)

--- a/docs/rules/Cpf.md
+++ b/docs/rules/Cpf.md
@@ -25,16 +25,16 @@ v::digit()->cpf()->isValid('11598647644'); // true
 
 ### `Cpf::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must be a valid CPF number     |
-| `inverted` | {{name}} must not be a valid CPF number |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must be a valid CPF number     |
+| `inverted` | {{subject}} must not be a valid CPF number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -43,10 +43,11 @@ v::digit()->cpf()->isValid('11598647644'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Bsn](Bsn.md)

--- a/docs/rules/CreditCard.md
+++ b/docs/rules/CreditCard.md
@@ -40,24 +40,24 @@ v::digit()->creditCard()->isValid('5376747397208720'); // true
 
 ### `CreditCard::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-|------------|-------------------------------------------------|
-| `default`  | {{name}} must be a valid credit card number     |
-| `inverted` | {{name}} must not be a valid credit card number |
+| Mode       | Template                                           |
+| ---------- | -------------------------------------------------- |
+| `default`  | {{subject}} must be a valid credit card number     |
+| `inverted` | {{subject}} must not be a valid credit card number |
 
 ### `CreditCard::TEMPLATE_BRANDED`
 
-| Mode       | Template                                                           |
-|------------|--------------------------------------------------------------------|
-| `default`  | {{name}} must be a valid {{brand&#124;raw}} credit card number     |
-| `inverted` | {{name}} must not be a valid {{brand&#124;raw}} credit card number |
+| Mode       | Template                                                              |
+| ---------- | --------------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid {{brand&#124;raw}} credit card number     |
+| `inverted` | {{subject}} must not be a valid {{brand&#124;raw}} credit card number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `brand`     |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -66,12 +66,13 @@ v::digit()->creditCard()->isValid('5376747397208720'); // true
 ## Changelog
 
 | Version | Description                        |
-|--------:|------------------------------------|
+| ------: | ---------------------------------- |
 |   2.2.4 | RuPay is now supported as a brand  |
 |   1.1.0 | Allow the define credit card brand |
 |   0.3.9 | Created                            |
 
-***
+---
+
 See also:
 
 - [Decimal](Decimal.md)

--- a/docs/rules/CurrencyCode.md
+++ b/docs/rules/CurrencyCode.md
@@ -20,16 +20,16 @@ This rule supports the two [ISO 4217][] sets:
 
 ### `CurrencyCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-|------------|--------------------------------------------|
-| `default`  | {{name}} must be a valid currency code     |
-| `inverted` | {{name}} must not be a valid currency code |
+| Mode       | Template                                      |
+| ---------- | --------------------------------------------- |
+| `default`  | {{subject}} must be a valid currency code     |
+| `inverted` | {{subject}} must not be a valid currency code |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,12 +39,13 @@ This rule supports the two [ISO 4217][] sets:
 ## Changelog
 
 | Version | Description                                                       |
-|--------:|-------------------------------------------------------------------|
+| ------: | ----------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   2.0.0 | Became case-sensitive                                             |
 |   1.0.0 | Created                                                           |
 
-***
+---
+
 See also:
 
 - [CountryCode](CountryCode.md)

--- a/docs/rules/Date.md
+++ b/docs/rules/Date.md
@@ -6,18 +6,17 @@
 Validates if input is a date. The `$format` argument should be in accordance to
 PHP's [date()](http://php.net/date) function, but only those are allowed:
 
-Format  | Description                                                           | Values
---------|-----------------------------------------------------------------------|-------------------------
-`d`     | Day of the month, 2 digits with leading zeros                         | 01 to 31
-`j`     | Day of the month without leading zeros                                | 1 to 31
-`S`     | English ordinal suffix for the day of the month, 2 characters         | st, nd, rd or th
-`F`     | A full textual representation of a month, such as January or March    | January to December
-`m`     | Numeric representation of a month, with leading zeros                 | 01 to 12
-`M`     | A short textual representation of a month, three letters              | Jan to Dec
-`n`     | Numeric representation of a month, without leading zeros              | 1 to 12
-`Y`     | A full numeric representation of a year, 4 digits                     | Examples: 1988 or 2017
-`y`     | A two digit representation of a year                                  | Examples: 88 or 17
-
+| Format | Description                                                        | Values                 |
+| ------ | ------------------------------------------------------------------ | ---------------------- |
+| `d`    | Day of the month, 2 digits with leading zeros                      | 01 to 31               |
+| `j`    | Day of the month without leading zeros                             | 1 to 31                |
+| `S`    | English ordinal suffix for the day of the month, 2 characters      | st, nd, rd or th       |
+| `F`    | A full textual representation of a month, such as January or March | January to December    |
+| `m`    | Numeric representation of a month, with leading zeros              | 01 to 12               |
+| `M`    | A short textual representation of a month, three letters           | Jan to Dec             |
+| `n`    | Numeric representation of a month, without leading zeros           | 1 to 12                |
+| `Y`    | A full numeric representation of a year, 4 digits                  | Examples: 1988 or 2017 |
+| `y`    | A two digit representation of a year                               | Examples: 88 or 17     |
 
 When a `$format` is not given its default value is `Y-m-d`.
 
@@ -34,16 +33,16 @@ v::date('Ydm')->isValid(20173112); // true
 
 ### `Date::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                   |
-|------------|------------------------------------------------------------|
-| `default`  | {{name}} must be a valid date in the format {{sample}}     |
-| `inverted` | {{name}} must not be a valid date in the format {{sample}} |
+| Mode       | Template                                                      |
+| ---------- | ------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid date in the format {{sample}}     |
+| `inverted` | {{subject}} must not be a valid date in the format {{sample}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `sample`    |                                                                  |
 
 ## Categorization
@@ -53,11 +52,12 @@ v::date('Ydm')->isValid(20173112); // true
 ## Changelog
 
 | Version | Description                    |
-|--------:|--------------------------------|
+| ------: | ------------------------------ |
 |   2.0.0 | Changed to only validate dates |
 |   0.3.9 | Created as `Date`              |
 
-***
+---
+
 See also:
 
 - [DateTime](DateTime.md)

--- a/docs/rules/DateTime.md
+++ b/docs/rules/DateTime.md
@@ -59,23 +59,23 @@ v::dateTime(DateTime::RFC3339_EXTENDED)->isValid($input); // false
 
 ### `DateTime::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a valid date/time     |
-| `inverted` | {{name}} must not be a valid date/time |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a valid date/time     |
+| `inverted` | {{subject}} must not be a valid date/time |
 
 ### `DateTime::TEMPLATE_FORMAT`
 
-| Mode       | Template                                                        |
-|------------|-----------------------------------------------------------------|
-| `default`  | {{name}} must be a valid date/time in the format {{sample}}     |
-| `inverted` | {{name}} must not be a valid date/time in the format {{sample}} |
+| Mode       | Template                                                           |
+| ---------- | ------------------------------------------------------------------ |
+| `default`  | {{subject}} must be a valid date/time in the format {{sample}}     |
+| `inverted` | {{subject}} must not be a valid date/time in the format {{sample}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `sample`    |                                                                  |
 
 ## Categorization
@@ -85,12 +85,13 @@ v::dateTime(DateTime::RFC3339_EXTENDED)->isValid($input); // false
 ## Changelog
 
 | Version | Description                                |
-|--------:|--------------------------------------------|
+| ------: | ------------------------------------------ |
 |   2.3.0 | Validation became a lot stricter           |
 |   2.2.4 | `v::dateTime('z')` is no longer supported. |
 |   2.0.0 | Created                                    |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/DateTimeDiff.md
+++ b/docs/rules/DateTimeDiff.md
@@ -21,13 +21,13 @@ v::dateTimeDiff('months', v::between(1, 18))->isValid('5 months ago'); // true
 
 The supported types are:
 
-* `years`
-* `months`
-* `days`
-* `hours`
-* `minutes`
-* `seconds`
-* `microseconds`
+- `years`
+- `months`
+- `days`
+- `hours`
+- `minutes`
+- `seconds`
+- `microseconds`
 
 ## Templates
 
@@ -46,7 +46,7 @@ v::not(v::dateTimeDiff('years', v::lessThan(8)))->assert('7 year ago')
 Used when `$format` and `$now` are not defined.
 
 | Mode       | Template                                          |
-|------------|---------------------------------------------------|
+| ---------- | ------------------------------------------------- |
 | `default`  | The number of {{type&#124;trans}} between now and |
 | `inverted` | The number of {{type&#124;trans}} between now and |
 
@@ -55,7 +55,7 @@ Used when `$format` and `$now` are not defined.
 Used when `$format` or `$now` are defined.
 
 | Mode       | Template                                                       |
-|------------|----------------------------------------------------------------|
+| ---------- | -------------------------------------------------------------- |
 | `default`  | The number of {{type&#124;trans}} between {{now&#124;raw}} and |
 | `inverted` | The number of {{type&#124;trans}} between {{now&#124;raw}} and |
 
@@ -63,16 +63,16 @@ Used when `$format` or `$now` are defined.
 
 Used when the input cannot be parsed with the given format.
 
-| Mode       | Template                                                                                                      |
-|------------|---------------------------------------------------------------------------------------------------------------|
-| `default`  | For comparison with {{now&#124;raw}}, {{name}} must be a valid datetime in the format {{sample&#124;raw}}     |
-| `inverted` | For comparison with {{now&#124;raw}}, {{name}} must not be a valid datetime in the format {{sample&#124;raw}} |
+| Mode       | Template                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| `default`  | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime in the format {{sample&#124;raw}}     |
+| `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a valid datetime in the format {{sample&#124;raw}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `now`       | The date and time that is considered as now.                     |
 | `sample`    | A sample of the datetime.                                        |
 | `type`      | The type of interval (years, months, etc.).                      |
@@ -95,10 +95,11 @@ v::dateTimeDiff('years', v::equals(2))->assert('1 year ago', [
 ## Changelog
 
 | Version | Description                                |
-|--------:|--------------------------------------------|
+| ------: | ------------------------------------------ |
 |   3.0.0 | Created from `Age`, `MinAge`, and `MaxAge` |
 
-***
+---
+
 See also:
 
 - [Date](Date.md)

--- a/docs/rules/Decimal.md
+++ b/docs/rules/Decimal.md
@@ -24,17 +24,17 @@ v::decimal(1)->isValid(1.50); // true
 
 ### `Decimal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                     |
-|------------|----------------------------------------------|
-| `default`  | {{name}} must have {{decimals}} decimals     |
-| `inverted` | {{name}} must not have {{decimals}} decimals |
+| Mode       | Template                                        |
+| ---------- | ----------------------------------------------- |
+| `default`  | {{subject}} must have {{decimals}} decimals     |
+| `inverted` | {{subject}} must not have {{decimals}} decimals |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `decimals`  |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -43,11 +43,12 @@ v::decimal(1)->isValid(1.50); // true
 ## Changelog
 
 | Version | Description                                     |
-|--------:|-------------------------------------------------|
+| ------: | ----------------------------------------------- |
 |   2.2.4 | Float values with trailing zeroes are now valid |
 |   2.0.0 | Created                                         |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Digit.md
+++ b/docs/rules/Digit.md
@@ -16,24 +16,24 @@ v::digit('.', '-')->isValid('172.655.537-21'); // true
 
 ### `Digit::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must contain only digits (0-9) |
-| `inverted` | {{name}} must not contain digits (0-9)  |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must contain only digits (0-9) |
+| `inverted` | {{subject}} must not contain digits (0-9)  |
 
 ### `Digit::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                        |
-|------------|-----------------------------------------------------------------|
-| `default`  | {{name}} must contain only digits (0-9) and {{additionalChars}} |
-| `inverted` | {{name}} must not contain digits (0-9) and {{additionalChars}}  |
+| Mode       | Template                                                           |
+| ---------- | ------------------------------------------------------------------ |
+| `default`  | {{subject}} must contain only digits (0-9) and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain digits (0-9) and {{additionalChars}}  |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -43,12 +43,13 @@ v::digit('.', '-')->isValid('172.655.537-21'); // true
 ## Changelog
 
 | Version | Description                               |
-|--------:|-------------------------------------------|
+| ------: | ----------------------------------------- |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.5.0 | Renamed from `Digits` to `Digit`          |
 |   0.3.9 | Created as `Digits`                       |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Directory.md
+++ b/docs/rules/Directory.md
@@ -20,16 +20,16 @@ v::directory()->isValid(dir('/'));
 
 ### `Directory::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-|------------|----------------------------------|
-| `default`  | {{name}} must be a directory     |
-| `inverted` | {{name}} must not be a directory |
+| Mode       | Template                            |
+| ---------- | ----------------------------------- |
+| `default`  | {{subject}} must be a directory     |
+| `inverted` | {{subject}} must not be a directory |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -38,11 +38,12 @@ v::directory()->isValid(dir('/'));
 ## Changelog
 
 | Version | Description                       |
-|--------:|-----------------------------------|
+| ------: | --------------------------------- |
 |   2.0.0 | Validates PHP's `Directory` class |
 |   0.4.4 | Created                           |
 
-***
+---
+
 See also:
 
 - [Executable](Executable.md)

--- a/docs/rules/Domain.md
+++ b/docs/rules/Domain.md
@@ -9,7 +9,7 @@ Validates whether the input is a valid domain name or not.
 v::domain()->isValid('google.com');
 ```
 
-You can skip *top level domain* (TLD) checks to validate internal
+You can skip _top level domain_ (TLD) checks to validate internal
 domain names:
 
 ```php
@@ -33,16 +33,16 @@ Messages for this validator will reflect rules above.
 
 ### `Domain::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-|------------|-------------------------------------|
-| `default`  | {{name}} must be a valid domain     |
-| `inverted` | {{name}} must not be a valid domain |
+| Mode       | Template                               |
+| ---------- | -------------------------------------- |
+| `default`  | {{subject}} must be a valid domain     |
+| `inverted` | {{subject}} must not be a valid domain |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -51,11 +51,12 @@ Messages for this validator will reflect rules above.
 ## Changelog
 
 | Version | Description             |
-|--------:|-------------------------|
+| ------: | ----------------------- |
 |   0.6.0 | Allow to skip TLD check |
 |   0.3.9 | Created                 |
 
-***
+---
+
 See also:
 
 - [Ip](Ip.md)

--- a/docs/rules/Each.md
+++ b/docs/rules/Each.md
@@ -29,16 +29,16 @@ empty, the validation will fail.
 
 ### `Each::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | Each item in {{name}} must be valid   |
-| `inverted` | Each item in {{name}} must be invalid |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | Each item in {{subject}} must be valid   |
+| `inverted` | Each item in {{subject}} must be invalid |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -49,12 +49,13 @@ empty, the validation will fail.
 ## Changelog
 
 | Version | Description                                                 |
-|--------:|-------------------------------------------------------------|
+| ------: | ----------------------------------------------------------- |
 |   3.0.0 | Rejected `stdClass`, non-iterable. or empty iterable values |
 |   2.0.0 | Remove support for key validation                           |
 |   0.3.9 | Created                                                     |
 
-***
+---
+
 See also:
 
 - [ArrayVal](ArrayVal.md)

--- a/docs/rules/Email.md
+++ b/docs/rules/Email.md
@@ -8,22 +8,20 @@ Validates an email address.
 v::email()->isValid('alganet@gmail.com'); // true
 ```
 
-
-
 ## Templates
 
 ### `Email::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a valid email address |
-| `inverted` | {{name}} must not be an email address  |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a valid email address |
+| `inverted` | {{subject}} must not be an email address  |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,12 +30,13 @@ v::email()->isValid('alganet@gmail.com'); // true
 ## Changelog
 
 | Version | Description                                       |
-|--------:|---------------------------------------------------|
+| ------: | ------------------------------------------------- |
 |   2.3.0 | Use "egulias/emailvalidator" version 4.0          |
 |   0.9.0 | Use "egulias/emailvalidator" for email validation |
 |   0.3.9 | Created                                           |
 
-***
+---
+
 See also:
 
 - [Json](Json.md)

--- a/docs/rules/EndsWith.md
+++ b/docs/rules/EndsWith.md
@@ -27,17 +27,17 @@ Message template for this validator includes `{{endValue}}`.
 
 ### `EndsWith::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must end with {{endValue}}     |
-| `inverted` | {{name}} must not end with {{endValue}} |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must end with {{endValue}}     |
+| `inverted` | {{subject}} must not end with {{endValue}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `endValue`  |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -47,10 +47,11 @@ Message template for this validator includes `{{endValue}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Contains](Contains.md)

--- a/docs/rules/Equals.md
+++ b/docs/rules/Equals.md
@@ -14,17 +14,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `Equals::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must be equal to {{compareTo}}     |
-| `inverted` | {{name}} must not be equal to {{compareTo}} |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must be equal to {{compareTo}}     |
+| `inverted` | {{subject}} must not be equal to {{compareTo}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,11 +33,12 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description                                                |
-|--------:|------------------------------------------------------------|
+| ------: | ---------------------------------------------------------- |
 |   1.0.0 | Removed identical checking (see [Identical](Identical.md)) |
 |   0.3.9 | Created                                                    |
 
-***
+---
+
 See also:
 
 - [Contains](Contains.md)

--- a/docs/rules/Equivalent.md
+++ b/docs/rules/Equivalent.md
@@ -19,17 +19,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `Equivalent::TEMPLATE_STANDARD`
 
-| Mode       | Template                                         |
-|------------|--------------------------------------------------|
-| `default`  | {{name}} must be equivalent to {{compareTo}}     |
-| `inverted` | {{name}} must not be equivalent to {{compareTo}} |
+| Mode       | Template                                            |
+| ---------- | --------------------------------------------------- |
+| `default`  | {{subject}} must be equivalent to {{compareTo}}     |
+| `inverted` | {{subject}} must not be equivalent to {{compareTo}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -38,10 +38,11 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Contains](Contains.md)

--- a/docs/rules/Even.md
+++ b/docs/rules/Even.md
@@ -14,16 +14,16 @@ Using `int()` before `even()` is a best practice.
 
 ### `Even::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} must be an even number |
-| `inverted` | {{name}} must be an odd number  |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} must be an even number |
+| `inverted` | {{subject}} must be an odd number  |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ Using `int()` before `even()` is a best practice.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Multiple](Multiple.md)

--- a/docs/rules/Executable.md
+++ b/docs/rules/Executable.md
@@ -12,16 +12,16 @@ v::executable()->isValid('script.sh'); // true
 
 ### `Executable::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must be an executable file     |
-| `inverted` | {{name}} must not be an executable file |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must be an executable file     |
+| `inverted` | {{subject}} must not be an executable file |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::executable()->isValid('script.sh'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.7.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Exists.md
+++ b/docs/rules/Exists.md
@@ -19,16 +19,16 @@ v::exists()->isValid(new SplFileInfo('file.txt'));
 
 ### `Exists::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must be an existing file     |
-| `inverted` | {{name}} must not be an existing file |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must be an existing file     |
+| `inverted` | {{subject}} must not be an existing file |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,10 +37,11 @@ v::exists()->isValid(new SplFileInfo('file.txt'));
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Extension.md
+++ b/docs/rules/Extension.md
@@ -14,17 +14,17 @@ This rule is case-sensitive.
 
 ### `Extension::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-|------------|------------------------------------------------|
-| `default`  | {{name}} must have {{extension}} extension     |
-| `inverted` | {{name}} must not have {{extension}} extension |
+| Mode       | Template                                          |
+| ---------- | ------------------------------------------------- |
+| `default`  | {{subject}} must have {{extension}} extension     |
+| `inverted` | {{subject}} must not have {{extension}} extension |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `extension` |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ This rule is case-sensitive.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Factor.md
+++ b/docs/rules/Factor.md
@@ -14,17 +14,17 @@ v::factor(4)->isValid(3); // false
 
 ### `Factor::TEMPLATE_STANDARD`
 
-| Mode       | Template                                               |
-|------------|--------------------------------------------------------|
-| `default`  | {{name}} must be a factor of {{dividend&#124;raw}}     |
-| `inverted` | {{name}} must not be a factor of {{dividend&#124;raw}} |
+| Mode       | Template                                                  |
+| ---------- | --------------------------------------------------------- |
+| `default`  | {{subject}} must be a factor of {{dividend&#124;raw}}     |
+| `inverted` | {{subject}} must not be a factor of {{dividend&#124;raw}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `dividend`  |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ v::factor(4)->isValid(3); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Decimal](Decimal.md)

--- a/docs/rules/FalseVal.md
+++ b/docs/rules/FalseVal.md
@@ -19,16 +19,16 @@ v::falseVal()->isValid('2'); // false
 
 ### `FalseVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must evaluate to `false`     |
-| `inverted` | {{name}} must not evaluate to `false` |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must evaluate to `false`     |
+| `inverted` | {{subject}} must not evaluate to `false` |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,11 +37,12 @@ v::falseVal()->isValid('2'); // false
 ## Changelog
 
 | Version | Description                        |
-|--------:|------------------------------------|
+| ------: | ---------------------------------- |
 |   1.0.0 | Renamed from `False` to `FalseVal` |
 |   0.8.0 | Created as `False`                 |
 
-***
+---
+
 See also:
 
 - [TrueVal](TrueVal.md)

--- a/docs/rules/Fibonacci.md
+++ b/docs/rules/Fibonacci.md
@@ -14,16 +14,16 @@ v::fibonacci()->isValid(6); // false
 
 ### `Fibonacci::TEMPLATE_STANDARD`
 
-| Mode       | Template                                      |
-|------------|-----------------------------------------------|
-| `default`  | {{name}} must be a valid Fibonacci number     |
-| `inverted` | {{name}} must not be a valid Fibonacci number |
+| Mode       | Template                                         |
+| ---------- | ------------------------------------------------ |
+| `default`  | {{subject}} must be a valid Fibonacci number     |
+| `inverted` | {{subject}} must not be a valid Fibonacci number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::fibonacci()->isValid(6); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.1.0 | Created     |
 
-***
+---
+
 See also:
 
 - [PerfectSquare](PerfectSquare.md)

--- a/docs/rules/File.md
+++ b/docs/rules/File.md
@@ -19,16 +19,16 @@ v::file()->isValid(new SplFileInfo('file.txt'));
 
 ### `File::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-|------------|----------------------------------|
-| `default`  | {{name}} must be a valid file    |
-| `inverted` | {{name}} must be an invalid file |
+| Mode       | Template                            |
+| ---------- | ----------------------------------- |
+| `default`  | {{subject}} must be a valid file    |
+| `inverted` | {{subject}} must be an invalid file |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,10 +37,11 @@ v::file()->isValid(new SplFileInfo('file.txt'));
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/FilterVar.md
+++ b/docs/rules/FilterVar.md
@@ -18,16 +18,16 @@ v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->isValid('@local'); /
 
 ### `FilterVar::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must be valid     |
-| `inverted` | {{name}} must not be valid |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must be valid     |
+| `inverted` | {{subject}} must not be valid |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -36,12 +36,13 @@ v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->isValid('@local'); /
 ## Changelog
 
 | Version | Description                                                        |
-|--------:|--------------------------------------------------------------------|
+| ------: | ------------------------------------------------------------------ |
 |   2.3.0 | `v::filterVar(FILTER_VALIDATE_INT)->isValid(0)` is no longer false |
 |  2.0.15 | Allow validating domains                                           |
 |   0.8.0 | Created                                                            |
 
-***
+---
+
 See also:
 
 - [Callback](Callback.md)

--- a/docs/rules/Finite.md
+++ b/docs/rules/Finite.md
@@ -13,16 +13,16 @@ v::finite()->isValid(10); // true
 
 ### `Finite::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be a finite number     |
-| `inverted` | {{name}} must not be a finite number |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be a finite number     |
+| `inverted` | {{subject}} must not be a finite number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::finite()->isValid(10); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Decimal](Decimal.md)

--- a/docs/rules/FloatType.md
+++ b/docs/rules/FloatType.md
@@ -14,16 +14,16 @@ v::floatType()->isValid(0e5); // true
 
 ### `FloatType::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must be float     |
-| `inverted` | {{name}} must not be float |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must be float     |
+| `inverted` | {{subject}} must not be float |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::floatType()->isValid(0e5); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/FloatVal.md
+++ b/docs/rules/FloatVal.md
@@ -13,16 +13,16 @@ v::floatVal()->isValid('1e5'); // true
 
 ### `FloatVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-|------------|------------------------------------|
-| `default`  | {{name}} must be a float value     |
-| `inverted` | {{name}} must not be a float value |
+| Mode       | Template                              |
+| ---------- | ------------------------------------- |
+| `default`  | {{subject}} must be a float value     |
+| `inverted` | {{subject}} must not be a float value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::floatVal()->isValid('1e5'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [BoolType](BoolType.md)

--- a/docs/rules/Graph.md
+++ b/docs/rules/Graph.md
@@ -14,24 +14,24 @@ v::graph()->isValid('LKM@#$%4;'); // true
 
 ### `Graph::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-|------------|-------------------------------------------------|
-| `default`  | {{name}} must contain only graphical characters |
-| `inverted` | {{name}} must not contain graphical characters  |
+| Mode       | Template                                           |
+| ---------- | -------------------------------------------------- |
+| `default`  | {{subject}} must contain only graphical characters |
+| `inverted` | {{subject}} must not contain graphical characters  |
 
 ### `Graph::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                |
-|------------|-------------------------------------------------------------------------|
-| `default`  | {{name}} must contain only graphical characters and {{additionalChars}} |
-| `inverted` | {{name}} must not contain graphical characters or {{additionalChars}}   |
+| Mode       | Template                                                                   |
+| ---------- | -------------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain only graphical characters and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain graphical characters or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -40,10 +40,11 @@ v::graph()->isValid('LKM@#$%4;'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Printable](Printable.md)

--- a/docs/rules/GreaterThan.md
+++ b/docs/rules/GreaterThan.md
@@ -18,17 +18,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `GreaterThan::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-|------------|-------------------------------------------------|
-| `default`  | {{name}} must be greater than {{compareTo}}     |
-| `inverted` | {{name}} must not be greater than {{compareTo}} |
+| Mode       | Template                                           |
+| ---------- | -------------------------------------------------- |
+| `default`  | {{subject}} must be greater than {{compareTo}}     |
+| `inverted` | {{subject}} must not be greater than {{compareTo}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,10 +37,11 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/GreaterThanOrEqual.md
+++ b/docs/rules/GreaterThanOrEqual.md
@@ -19,17 +19,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `GreaterThanOrEqual::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                |
-|------------|---------------------------------------------------------|
-| `default`  | {{name}} must be greater than or equal to {{compareTo}} |
-| `inverted` | {{name}} must be less than {{compareTo}}                |
+| Mode       | Template                                                   |
+| ---------- | ---------------------------------------------------------- |
+| `default`  | {{subject}} must be greater than or equal to {{compareTo}} |
+| `inverted` | {{subject}} must be less than {{compareTo}}                |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -38,13 +38,14 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description                                |
-|--------:|--------------------------------------------|
+| ------: | ------------------------------------------ |
 |   3.0.0 | Renamed from "Min" to "GreaterThanOrEqual" |
 |   2.0.0 | Became always inclusive                    |
 |   1.0.0 | Became inclusive by default                |
 |   0.3.9 | Created                                    |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/Hetu.md
+++ b/docs/rules/Hetu.md
@@ -18,16 +18,16 @@ The validation is case-sensitive.
 
 ### `Hetu::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                    |
-|------------|-------------------------------------------------------------|
-| `default`  | {{name}} must be a valid Finnish personal identity code     |
-| `inverted` | {{name}} must not be a valid Finnish personal identity code |
+| Mode       | Template                                                       |
+| ---------- | -------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid Finnish personal identity code     |
+| `inverted` | {{subject}} must not be a valid Finnish personal identity code |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -36,10 +36,11 @@ The validation is case-sensitive.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   3.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Cnh](Cnh.md)

--- a/docs/rules/HexRgbColor.md
+++ b/docs/rules/HexRgbColor.md
@@ -15,16 +15,16 @@ v::hexRgbColor()->isValid('FCD'); // true
 
 ### `HexRgbColor::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be a hex RGB color     |
-| `inverted` | {{name}} must not be a hex RGB color |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be a hex RGB color     |
+| `inverted` | {{subject}} must not be a hex RGB color |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,12 +33,13 @@ v::hexRgbColor()->isValid('FCD'); // true
 ## Changelog
 
 | Version | Description                                 |
-|--------:|---------------------------------------------|
+| ------: | ------------------------------------------- |
 |   2.1.0 | Allow hex RGB colors to be case-insensitive |
 |   2.0.0 | Allow hex RGB colors with 3 integers        |
 |   0.7.0 | Created                                     |
 
-***
+---
+
 See also:
 
 - [Xdigit](Xdigit.md)

--- a/docs/rules/Iban.md
+++ b/docs/rules/Iban.md
@@ -18,16 +18,16 @@ v::iban()->isValid(''); // false
 
 ### `Iban::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-|------------|-----------------------------------|
-| `default`  | {{name}} must be a valid IBAN     |
-| `inverted` | {{name}} must not be a valid IBAN |
+| Mode       | Template                             |
+| ---------- | ------------------------------------ |
+| `default`  | {{subject}} must be a valid IBAN     |
+| `inverted` | {{subject}} must not be a valid IBAN |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -36,10 +36,11 @@ v::iban()->isValid(''); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [CreditCard](CreditCard.md)

--- a/docs/rules/Identical.md
+++ b/docs/rules/Identical.md
@@ -15,17 +15,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `Identical::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-|------------|-------------------------------------------------|
-| `default`  | {{name}} must be identical to {{compareTo}}     |
-| `inverted` | {{name}} must not be identical to {{compareTo}} |
+| Mode       | Template                                           |
+| ---------- | -------------------------------------------------- |
+| `default`  | {{subject}} must be identical to {{compareTo}}     |
+| `inverted` | {{subject}} must not be identical to {{compareTo}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Contains](Contains.md)

--- a/docs/rules/Image.md
+++ b/docs/rules/Image.md
@@ -20,16 +20,16 @@ This rule relies on [fileinfo](http://php.net/fileinfo) PHP extension.
 
 ### `Image::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must be a valid image file     |
-| `inverted` | {{name}} must not be a valid image file |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must be a valid image file     |
+| `inverted` | {{subject}} must not be a valid image file |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -38,10 +38,11 @@ This rule relies on [fileinfo](http://php.net/fileinfo) PHP extension.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.1.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Imei.md
+++ b/docs/rules/Imei.md
@@ -13,16 +13,16 @@ v::imei()->isValid('490154203237518'); // true
 
 ### `Imei::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must be a valid IMEI number     |
-| `inverted` | {{name}} must not be a valid IMEI number |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must be a valid IMEI number     |
+| `inverted` | {{subject}} must not be a valid IMEI number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::imei()->isValid('490154203237518'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Bsn](Bsn.md)

--- a/docs/rules/In.md
+++ b/docs/rules/In.md
@@ -26,17 +26,17 @@ Message template for this validator includes `{{haystack}}`.
 
 ### `In::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be in {{haystack}}     |
-| `inverted` | {{name}} must not be in {{haystack}} |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be in {{haystack}}     |
+| `inverted` | {{subject}} must not be in {{haystack}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `haystack`  |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -47,10 +47,11 @@ Message template for this validator includes `{{haystack}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Contains](Contains.md)

--- a/docs/rules/Infinite.md
+++ b/docs/rules/Infinite.md
@@ -12,16 +12,16 @@ v::infinite()->isValid(INF); // true
 
 ### `Infinite::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must be an infinite number     |
-| `inverted` | {{name}} must not be an infinite number |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must be an infinite number     |
+| `inverted` | {{subject}} must not be an infinite number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::infinite()->isValid(INF); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Decimal](Decimal.md)

--- a/docs/rules/Instance.md
+++ b/docs/rules/Instance.md
@@ -15,17 +15,17 @@ Message template for this validator includes `{{instanceName}}`.
 
 ### `Instance::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                 |
-|------------|----------------------------------------------------------|
-| `default`  | {{name}} must be an instance of `{{class&#124;raw}}`     |
-| `inverted` | {{name}} must not be an instance of `{{class&#124;raw}}` |
+| Mode       | Template                                                    |
+| ---------- | ----------------------------------------------------------- |
+| `default`  | {{subject}} must be an instance of `{{class&#124;raw}}`     |
+| `inverted` | {{subject}} must not be an instance of `{{class&#124;raw}}` |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `class`     |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ Message template for this validator includes `{{instanceName}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Countable](Countable.md)

--- a/docs/rules/IntType.md
+++ b/docs/rules/IntType.md
@@ -13,16 +13,16 @@ v::intType()->isValid('10'); // false
 
 ### `IntType::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} must be an integer     |
-| `inverted` | {{name}} must not be an integer |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} must be an integer     |
+| `inverted` | {{subject}} must not be an integer |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::intType()->isValid('10'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/IntVal.md
+++ b/docs/rules/IntVal.md
@@ -28,16 +28,16 @@ consider them as valid.
 
 ### `IntVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must be an integer value     |
-| `inverted` | {{name}} must not be an integer value |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must be an integer value     |
+| `inverted` | {{subject}} must not be an integer value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -47,13 +47,14 @@ consider them as valid.
 ## Changelog
 
 | Version | Description                                               |
-|--------:|-----------------------------------------------------------|
+| ------: | --------------------------------------------------------- |
 |   2.2.4 | Improved support for negative values with trailing zeroes |
 |  2.0.14 | Allow leading zeros                                       |
 |   1.0.0 | Renamed from `Int` to `IntVal`                            |
 |   0.3.9 | Created as `Int`                                          |
 
-***
+---
+
 See also:
 
 - [Decimal](Decimal.md)

--- a/docs/rules/Ip.md
+++ b/docs/rules/Ip.md
@@ -37,23 +37,23 @@ v::ip('*', FILTER_FLAG_IPV6)->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334')
 
 ### `Ip::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-|------------|------------------------------------|
-| `default`  | {{name}} must be an IP address     |
-| `inverted` | {{name}} must not be an IP address |
+| Mode       | Template                              |
+| ---------- | ------------------------------------- |
+| `default`  | {{subject}} must be an IP address     |
+| `inverted` | {{subject}} must not be an IP address |
 
 ### `Ip::TEMPLATE_NETWORK_RANGE`
 
-| Mode       | Template                                                           |
-|------------|--------------------------------------------------------------------|
-| `default`  | {{name}} must be an IP address in the {{range&#124;raw}} range     |
-| `inverted` | {{name}} must not be an IP address in the {{range&#124;raw}} range |
+| Mode       | Template                                                              |
+| ---------- | --------------------------------------------------------------------- |
+| `default`  | {{subject}} must be an IP address in the {{range&#124;raw}} range     |
+| `inverted` | {{subject}} must not be an IP address in the {{range&#124;raw}} range |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `range`     |                                                                  |
 
 ## Categorization
@@ -63,12 +63,13 @@ v::ip('*', FILTER_FLAG_IPV6)->isValid('2001:0db8:85a3:08d3:1319:8a2e:0370:7334')
 ## Changelog
 
 | Version | Description                                            |
-|--------:|--------------------------------------------------------|
+| ------: | ------------------------------------------------------ |
 |   2.0.0 | Allow to define range and options to the same instance |
 |   0.5.0 | Implemented IP range validation                        |
 |   0.3.9 | Created                                                |
 
-***
+---
+
 See also:
 
 - [Domain](Domain.md)

--- a/docs/rules/Isbn.md
+++ b/docs/rules/Isbn.md
@@ -15,16 +15,16 @@ v::isbn()->isValid('978 10 596 52068 7'); // false
 
 ### `Isbn::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-|------------|-----------------------------------|
-| `default`  | {{name}} must be a valid ISBN     |
-| `inverted` | {{name}} must not be a valid ISBN |
+| Mode       | Template                             |
+| ---------- | ------------------------------------ |
+| `default`  | {{subject}} must be a valid ISBN     |
+| `inverted` | {{subject}} must not be a valid ISBN |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::isbn()->isValid('978 10 596 52068 7'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Imei](Imei.md)

--- a/docs/rules/IterableType.md
+++ b/docs/rules/IterableType.md
@@ -16,16 +16,16 @@ v::iterableType()->isValid('string'); // false
 
 ### `IterableType::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must be iterable  |
-| `inverted` | {{name}} must not iterable |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must be iterable  |
+| `inverted` | {{subject}} must not iterable |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,12 +34,13 @@ v::iterableType()->isValid('string'); // false
 ## Changelog
 
 | Version | Description                               |
-|--------:|-------------------------------------------|
+| ------: | ----------------------------------------- |
 |   3.0.0 | Rejected `stdClass` as iterable           |
 |   1.0.8 | Renamed from `Iterable` to `IterableType` |
 |   1.0.0 | Created as `Iterable`                     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/IterableVal.md
+++ b/docs/rules/IterableVal.md
@@ -2,7 +2,7 @@
 
 - `IterableVal()`
 
-Validates whether the input is an iterable value, in other words,  if you can iterate over it with the [foreach][] language construct.
+Validates whether the input is an iterable value, in other words, if you can iterate over it with the [foreach][] language construct.
 
 ```php
 v::iterableVal()->isValid([]); // true
@@ -19,16 +19,16 @@ This rule doesn't behave as PHP's [is_iterable() function because it considers t
 
 ### `IterableVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be an iterable value     |
-| `inverted` | {{name}} must not be an iterable value |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be an iterable value     |
+| `inverted` | {{subject}} must not be an iterable value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,12 +37,13 @@ This rule doesn't behave as PHP's [is_iterable() function because it considers t
 ## Changelog
 
 | Version | Description                                  |
-|--------:|----------------------------------------------|
+| ------: | -------------------------------------------- |
 |   3.0.0 | Renamed from `IterableType` to `IterableVal` |
 |   1.0.8 | Renamed from `Iterable` to `IterableType`    |
 |   1.0.0 | Created as `Iterable`                        |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Json.md
+++ b/docs/rules/Json.md
@@ -12,16 +12,16 @@ v::json()->isValid('{"foo":"bar"}'); // true
 
 ### `Json::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must be a valid JSON string     |
-| `inverted` | {{name}} must not be a valid JSON string |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must be a valid JSON string     |
+| `inverted` | {{subject}} must not be a valid JSON string |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::json()->isValid('{"foo":"bar"}'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Domain](Domain.md)

--- a/docs/rules/Key.md
+++ b/docs/rules/Key.md
@@ -46,7 +46,7 @@ v::key('email', v::email())->assert(['email' => 'not email']);
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/KeyExists.md
+++ b/docs/rules/KeyExists.md
@@ -17,23 +17,23 @@ v::keyExists(5)->isValid(new ArrayObject(['a', 'b', 'c'])); // false
 
 ## Notes
 
-* To validate an array against a given rule if the key exists, use [KeyOptional](KeyOptional.md) instead.
-* To validate an array against a given rule requiring the key to exist, use [Key](Key.md) instead.
+- To validate an array against a given rule if the key exists, use [KeyOptional](KeyOptional.md) instead.
+- To validate an array against a given rule requiring the key to exist, use [Key](Key.md) instead.
 
 ## Templates
 
 ### `KeyExists::TEMPLATE_STANDARD`
 
-| Mode       | Template                     |
-|------------|------------------------------|
-| `default`  | {{name}} must be present     |
-| `inverted` | {{name}} must not be present |
+| Mode       | Template                        |
+| ---------- | ------------------------------- |
+| `default`  | {{subject}} must be present     |
+| `inverted` | {{subject}} must not be present |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Caveats
 
@@ -64,10 +64,11 @@ v::key('foo', v::alwaysValid()->setName('Custom name'))->assert([]);
 ## Changelog
 
 | Version | Description                |
-|--------:|----------------------------|
+| ------: | -------------------------- |
 |   3.0.0 | Created from [Key](Key.md) |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/KeyOptional.md
+++ b/docs/rules/KeyOptional.md
@@ -42,7 +42,7 @@ Below are some other rules that are tightly related to `KeyOptional`:
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/KeySet.md
+++ b/docs/rules/KeySet.md
@@ -12,6 +12,7 @@ v::keySet(
 ```
 
 It will validate the keys in the array with the rules passed in the constructor.
+
 ```php
 v::keySet(
     v::key('foo', v::intVal())
@@ -23,6 +24,7 @@ v::keySet(
 ```
 
 Extra keys are not allowed:
+
 ```php
 v::keySet(
     v::key('foo', v::intVal())
@@ -30,6 +32,7 @@ v::keySet(
 ```
 
 Missing required keys are not allowed:
+
 ```php
 v::keySet(
     v::key('foo', v::intVal()),
@@ -39,6 +42,7 @@ v::keySet(
 ```
 
 Missing non-required keys are allowed:
+
 ```php
 v::keySet(
     v::key('foo', v::intVal()),
@@ -48,6 +52,7 @@ v::keySet(
 ```
 
 Alternatively, you can pass a chain of key-related rules to `keySet()`:
+
 ```php
 v::keySet(
     v::create()
@@ -65,37 +70,37 @@ The keys' order is not considered in the validation.
 
 ### `KeySet::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} validation failed |
-| `inverted` | {{name}} validation passed |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} validation failed |
+| `inverted` | {{subject}} validation passed |
 
 ### `KeySet::TEMPLATE_BOTH`
 
-| Mode       | Template                                      |
-|------------|-----------------------------------------------|
-| `default`  | {{name}} contains both missing and extra keys |
-| `inverted` | {{name}} contains no missing or extra keys.   |
+| Mode       | Template                                         |
+| ---------- | ------------------------------------------------ |
+| `default`  | {{subject}} contains both missing and extra keys |
+| `inverted` | {{subject}} contains no missing or extra keys.   |
 
 ### `KeySet::TEMPLATE_EXTRA_KEYS`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} contains extra keys    |
-| `inverted` | {{name}} contains no extra keys |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} contains extra keys    |
+| `inverted` | {{subject}} contains no extra keys |
 
 ### `KeySet::TEMPLATE_MISSING_KEYS`
 
-| Mode       | Template                          |
-|------------|-----------------------------------|
-| `default`  | {{name}} contains missing keys    |
-| `inverted` | {{name}} contains no missing keys |
+| Mode       | Template                             |
+| ---------- | ------------------------------------ |
+| `default`  | {{subject}} contains missing keys    |
+| `inverted` | {{subject}} contains no missing keys |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -106,12 +111,13 @@ The keys' order is not considered in the validation.
 ## Changelog
 
 | Version | Description                                           |
-|--------:|-------------------------------------------------------|
+| ------: | ----------------------------------------------------- |
 |   3.0.0 | Requires at least one key-related rule                |
 |   2.3.0 | KeySet is NonNegatable, fixed message with extra keys |
 |   1.0.0 | Created                                               |
 
-***
+---
+
 See also:
 
 - [ArrayVal](ArrayVal.md)

--- a/docs/rules/LanguageCode.md
+++ b/docs/rules/LanguageCode.md
@@ -24,16 +24,16 @@ This rule supports the two[ISO 639][] sets:
 
 ### `LanguageCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-|------------|--------------------------------------------|
-| `default`  | {{name}} must be a valid language code     |
-| `inverted` | {{name}} must not be a valid language code |
+| Mode       | Template                                      |
+| ---------- | --------------------------------------------- |
+| `default`  | {{subject}} must be a valid language code     |
+| `inverted` | {{subject}} must not be a valid language code |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -43,11 +43,12 @@ This rule supports the two[ISO 639][] sets:
 ## Changelog
 
 | Version | Description                                                       |
-|--------:|-------------------------------------------------------------------|
+| ------: | ----------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   1.1.0 | Created                                                           |
 
-***
+---
+
 See also:
 
 - [CountryCode](CountryCode.md)

--- a/docs/rules/Lazy.md
+++ b/docs/rules/Lazy.md
@@ -29,7 +29,7 @@ on the input itself (`$_POST`), but it will use any input that’s given to the 
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/LeapDate.md
+++ b/docs/rules/LeapDate.md
@@ -15,16 +15,16 @@ parameter is mandatory.
 
 ### `LeapDate::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-|------------|------------------------------------|
-| `default`  | {{name}} must be a valid leap date |
-| `inverted` | {{name}} must not be a leap date   |
+| Mode       | Template                              |
+| ---------- | ------------------------------------- |
+| `default`  | {{subject}} must be a valid leap date |
+| `inverted` | {{subject}} must not be a leap date   |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ parameter is mandatory.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Date](Date.md)

--- a/docs/rules/LeapYear.md
+++ b/docs/rules/LeapYear.md
@@ -14,16 +14,16 @@ This validator accepts DateTime instances as well.
 
 ### `LeapYear::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-|------------|------------------------------------|
-| `default`  | {{name}} must be a valid leap year |
-| `inverted` | {{name}} must not be a leap year   |
+| Mode       | Template                              |
+| ---------- | ------------------------------------- |
+| `default`  | {{subject}} must be a valid leap year |
+| `inverted` | {{subject}} must not be a leap year   |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ This validator accepts DateTime instances as well.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Date](Date.md)

--- a/docs/rules/Length.md
+++ b/docs/rules/Length.md
@@ -27,7 +27,7 @@ v::length(v::equals(0))->isValid(new SplPriorityQueue()); // true
 Used when it's possible to get the length of the input.
 
 | Mode       | Template      |
-|------------|---------------|
+| ---------- | ------------- |
 | `default`  | The length of |
 | `inverted` | The length of |
 
@@ -45,16 +45,16 @@ v::not(v::length(v::equals(4)))->assert('rose');
 
 Used when it's impossible to get the length of the input.
 
-| Mode       | Template                                           |
-|------------|----------------------------------------------------|
-| `default`  | {{name}} must be a countable value or a string     |
-| `inverted` | {{name}} must not be a countable value or a string |
+| Mode       | Template                                              |
+| ---------- | ----------------------------------------------------- |
+| `default`  | {{subject}} must be a countable value or a string     |
+| `inverted` | {{subject}} must not be a countable value or a string |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -64,11 +64,12 @@ Used when it's impossible to get the length of the input.
 ## Changelog
 
 | Version | Description             |
-|--------:|-------------------------|
+| ------: | ----------------------- |
 |   3.0.0 | Became a transformation |
 |   0.3.9 | Created                 |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/LessThan.md
+++ b/docs/rules/LessThan.md
@@ -18,17 +18,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `LessThan::TEMPLATE_STANDARD`
 
-| Mode       | Template                                     |
-|------------|----------------------------------------------|
-| `default`  | {{name}} must be less than {{compareTo}}     |
-| `inverted` | {{name}} must not be less than {{compareTo}} |
+| Mode       | Template                                        |
+| ---------- | ----------------------------------------------- |
+| `default`  | {{subject}} must be less than {{compareTo}}     |
+| `inverted` | {{subject}} must not be less than {{compareTo}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,10 +37,11 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/LessThanOrEqual.md
+++ b/docs/rules/LessThanOrEqual.md
@@ -19,17 +19,17 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `LessThanOrEqual::TEMPLATE_STANDARD`
 
-| Mode       | Template                                             |
-|------------|------------------------------------------------------|
-| `default`  | {{name}} must be less than or equal to {{compareTo}} |
-| `inverted` | {{name}} must be greater than {{compareTo}}          |
+| Mode       | Template                                                |
+| ---------- | ------------------------------------------------------- |
+| `default`  | {{subject}} must be less than or equal to {{compareTo}} |
+| `inverted` | {{subject}} must be greater than {{compareTo}}          |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `compareTo` | Value to be compared against the input.                          |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -38,13 +38,14 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description                             |
-|--------:|-----------------------------------------|
+| ------: | --------------------------------------- |
 |   3.0.0 | Renamed from "Max" to "LessThanOrEqual" |
 |   2.0.0 | Became always inclusive                 |
 |   1.0.0 | Became inclusive by default             |
 |   0.3.9 | Created                                 |
 
-***
+---
+
 See also:
 
 - [Between](Between.md)

--- a/docs/rules/Lowercase.md
+++ b/docs/rules/Lowercase.md
@@ -12,16 +12,16 @@ v::stringType()->lowercase()->isValid('xkcd'); // true
 
 ### `Lowercase::TEMPLATE_STANDARD`
 
-| Mode       | Template                                         |
-|------------|--------------------------------------------------|
-| `default`  | {{name}} must contain only lowercase letters     |
-| `inverted` | {{name}} must not contain only lowercase letters |
+| Mode       | Template                                            |
+| ---------- | --------------------------------------------------- |
+| `default`  | {{subject}} must contain only lowercase letters     |
+| `inverted` | {{subject}} must not contain only lowercase letters |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::stringType()->lowercase()->isValid('xkcd'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Luhn.md
+++ b/docs/rules/Luhn.md
@@ -13,16 +13,16 @@ v::luhn()->isValid('respect!'); // false
 
 ### `Luhn::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must be a valid Luhn number     |
-| `inverted` | {{name}} must not be a valid Luhn number |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must be a valid Luhn number     |
+| `inverted` | {{subject}} must not be a valid Luhn number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::luhn()->isValid('respect!'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [CreditCard](CreditCard.md)

--- a/docs/rules/MacAddress.md
+++ b/docs/rules/MacAddress.md
@@ -13,16 +13,16 @@ v::macAddress()->isValid('af-AA-22-33-44-55'); // true
 
 ### `MacAddress::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must be a valid MAC address     |
-| `inverted` | {{name}} must not be a valid MAC address |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must be a valid MAC address     |
+| `inverted` | {{subject}} must not be a valid MAC address |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::macAddress()->isValid('af-AA-22-33-44-55'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Domain](Domain.md)

--- a/docs/rules/Max.md
+++ b/docs/rules/Max.md
@@ -34,7 +34,7 @@ empty, the validation will fail.
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/Mimetype.md
+++ b/docs/rules/Mimetype.md
@@ -15,17 +15,17 @@ This rule is case-sensitive and requires [fileinfo](http://php.net/fileinfo) PHP
 
 ### `Mimetype::TEMPLATE_STANDARD`
 
-| Mode       | Template                                          |
-|------------|---------------------------------------------------|
-| `default`  | {{name}} must have the {{mimetype}} MIME type     |
-| `inverted` | {{name}} must not have the {{mimetype}} MIME type |
+| Mode       | Template                                             |
+| ---------- | ---------------------------------------------------- |
+| `default`  | {{subject}} must have the {{mimetype}} MIME type     |
+| `inverted` | {{subject}} must not have the {{mimetype}} MIME type |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
+| ----------- | ---------------------------------------------------------------- |
 | `mimetype`  |                                                                  |
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ This rule is case-sensitive and requires [fileinfo](http://php.net/fileinfo) PHP
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Min.md
+++ b/docs/rules/Min.md
@@ -33,7 +33,7 @@ empty, the validation will fail.
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/Multiple.md
+++ b/docs/rules/Multiple.md
@@ -12,17 +12,17 @@ v::intVal()->multiple(3)->isValid(9); // true
 
 ### `Multiple::TEMPLATE_STANDARD`
 
-| Mode       | Template                                          |
-|------------|---------------------------------------------------|
-| `default`  | {{name}} must be a multiple of {{multipleOf}}     |
-| `inverted` | {{name}} must not be a multiple of {{multipleOf}} |
+| Mode       | Template                                             |
+| ---------- | ---------------------------------------------------- |
+| `default`  | {{subject}} must be a multiple of {{multipleOf}}     |
+| `inverted` | {{subject}} must not be a multiple of {{multipleOf}} |
 
 ## Template placeholders
 
 | Placeholder  | Description                                                      |
-|--------------|------------------------------------------------------------------|
+| ------------ | ---------------------------------------------------------------- |
 | `multipleOf` |                                                                  |
-| `name`       | The validated input or the custom validator name (if specified). |
+| `subject`    | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::intVal()->multiple(3)->isValid(9); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Even](Even.md)

--- a/docs/rules/Named.md
+++ b/docs/rules/Named.md
@@ -26,7 +26,7 @@ This rule does not have any templates, as it will use the template of the given 
 
 | Placeholder | Description                           |
 |-------------|---------------------------------------|
-| `name`      | The value that you define as `$name`. |
+| `subject`      | The value that you define as `$name`. |
 
 ## Categorization
 

--- a/docs/rules/Negative.md
+++ b/docs/rules/Negative.md
@@ -12,16 +12,16 @@ v::numericVal()->negative()->isValid(-15); // true
 
 ### `Negative::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a negative number     |
-| `inverted` | {{name}} must not be a negative number |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a negative number     |
+| `inverted` | {{subject}} must not be a negative number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,11 +31,12 @@ v::numericVal()->negative()->isValid(-15); // true
 ## Changelog
 
 | Version | Description                          |
-|--------:|--------------------------------------|
+| ------: | ------------------------------------ |
 |   2.0.0 | Does not validate non-numeric values |
 |   0.3.9 | Created                              |
 
-***
+---
+
 See also:
 
 - [Positive](Positive.md)

--- a/docs/rules/NfeAccessKey.md
+++ b/docs/rules/NfeAccessKey.md
@@ -12,16 +12,16 @@ v::nfeAccessKey()->isValid('31841136830118868211870485416765268625116906'); // t
 
 ### `NfeAccessKey::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must be a valid NFe access key     |
-| `inverted` | {{name}} must not be a valid NFe access key |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must be a valid NFe access key     |
+| `inverted` | {{subject}} must not be a valid NFe access key |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::nfeAccessKey()->isValid('31841136830118868211870485416765268625116906'); // t
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.6.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Cnh](Cnh.md)

--- a/docs/rules/Nif.md
+++ b/docs/rules/Nif.md
@@ -13,16 +13,16 @@ v::nif()->isValid('P6437358A'); // false
 
 ### `Nif::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-|------------|----------------------------------|
-| `default`  | {{name}} must be a valid NIF     |
-| `inverted` | {{name}} must not be a valid NIF |
+| Mode       | Template                            |
+| ---------- | ----------------------------------- |
+| `default`  | {{subject}} must be a valid NIF     |
+| `inverted` | {{subject}} must not be a valid NIF |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::nif()->isValid('P6437358A'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.2.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Bsn](Bsn.md)

--- a/docs/rules/Nip.md
+++ b/docs/rules/Nip.md
@@ -16,16 +16,16 @@ v::nip()->isValid('164-58-65-777'); // false
 
 ### `Nip::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                      |
-|------------|---------------------------------------------------------------|
-| `default`  | {{name}} must be a valid Polish VAT identification number     |
-| `inverted` | {{name}} must not be a valid Polish VAT identification number |
+| Mode       | Template                                                         |
+| ---------- | ---------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid Polish VAT identification number     |
+| `inverted` | {{subject}} must not be a valid Polish VAT identification number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ v::nip()->isValid('164-58-65-777'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Pesel](Pesel.md)

--- a/docs/rules/No.md
+++ b/docs/rules/No.md
@@ -30,7 +30,7 @@ Be careful when using `$locale` as `TRUE` because the it's very permissive:
 v::no(true)->isValid('Never gonna give you up 🎵'); // true
 ```
 
-Besides that, with `$locale` as  `TRUE` it will consider any character starting
+Besides that, with `$locale` as `TRUE` it will consider any character starting
 with "N" as valid:
 
 ```php
@@ -42,16 +42,16 @@ v::no(true)->isValid('Yes'); // true
 
 ### `No::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be similar to "No"     |
-| `inverted` | {{name}} must not be similar to "No" |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be similar to "No"     |
+| `inverted` | {{subject}} must not be similar to "No" |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -60,10 +60,11 @@ v::no(true)->isValid('Yes'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.7.0 | Created     |
 
-***
+---
+
 See also:
 
 - [BoolType](BoolType.md)

--- a/docs/rules/NoWhitespace.md
+++ b/docs/rules/NoWhitespace.md
@@ -15,16 +15,16 @@ This is most useful when chaining with other validators such as `Alnum()`
 
 ### `NoWhitespace::TEMPLATE_STANDARD`
 
-| Mode       | Template                                      |
-|------------|-----------------------------------------------|
-| `default`  | {{name}} must not contain whitespaces         |
-| `inverted` | {{name}} must contain at least one whitespace |
+| Mode       | Template                                         |
+| ---------- | ------------------------------------------------ |
+| `default`  | {{subject}} must not contain whitespaces         |
+| `inverted` | {{subject}} must contain at least one whitespace |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ This is most useful when chaining with other validators such as `Alnum()`
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/NoneOf.md
+++ b/docs/rules/NoneOf.md
@@ -19,25 +19,25 @@ In the sample above, 'foo' isn't a integer nor a float, so noneOf returns true.
 
 Used when some rules have passed.
 
-| Mode       | Template                     |
-|------------|------------------------------|
-| `default`  | {{name}} must pass the rules |
-| `inverted` | {{name}} must pass the rules |
+| Mode       | Template                        |
+| ---------- | ------------------------------- |
+| `default`  | {{subject}} must pass the rules |
+| `inverted` | {{subject}} must pass the rules |
 
 ### `NoneOf::TEMPLATE_ALL`
 
 Used when all rules have passed.
 
-| Mode       | Template                         |
-|------------|----------------------------------|
-| `default`  | {{name}} must pass all the rules |
-| `inverted` | {{name}} must pass all the rules |
+| Mode       | Template                            |
+| ---------- | ----------------------------------- |
+| `default`  | {{subject}} must pass all the rules |
+| `inverted` | {{subject}} must pass all the rules |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -47,11 +47,12 @@ Used when all rules have passed.
 ## Changelog
 
 | Version | Description                             |
-|--------:|-----------------------------------------|
+| ------: | --------------------------------------- |
 |   3.0.0 | Require at least two rules to be passed |
 |   0.3.9 | Created                                 |
 
-***
+---
+
 See also:
 
 - [AllOf](AllOf.md)

--- a/docs/rules/Not.md
+++ b/docs/rules/Not.md
@@ -24,7 +24,7 @@ Each other validation has custom messages for negated rules.
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/NotBlank.md
+++ b/docs/rules/NotBlank.md
@@ -30,16 +30,16 @@ It's similar to [NotEmpty](NotEmpty.md) but it's way more strict.
 
 ### `NotBlank::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must not be blank |
-| `inverted` | {{name}} must be blank     |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must not be blank |
+| `inverted` | {{subject}} must be blank     |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -48,10 +48,11 @@ It's similar to [NotEmpty](NotEmpty.md) but it's way more strict.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [NoWhitespace](NoWhitespace.md)

--- a/docs/rules/NotEmoji.md
+++ b/docs/rules/NotEmoji.md
@@ -18,24 +18,24 @@ means the longer the text the longer it takes to perform the check.
 However, the validator will break the execution as soon as it finds the
 first emoji or until it checks the whole text.
 
-*Note: this validator will check the Emoji as they are defined in
+_Note: this validator will check the Emoji as they are defined in
 Unicode V11 check the following link for more details
-[Unicode v11](https://unicode.org/emoji/charts/full-emoji-list.html)*
+[Unicode v11](https://unicode.org/emoji/charts/full-emoji-list.html)_
 
 ## Templates
 
 ### `NotEmoji::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-|------------|------------------------------------|
-| `default`  | {{name}} must not contain an emoji |
-| `inverted` | {{name}} must contain an emoji     |
+| Mode       | Template                              |
+| ---------- | ------------------------------------- |
+| `default`  | {{subject}} must not contain an emoji |
+| `inverted` | {{subject}} must contain an emoji     |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -44,10 +44,11 @@ Unicode V11 check the following link for more details
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/NotEmpty.md
+++ b/docs/rules/NotEmpty.md
@@ -39,16 +39,16 @@ v::stringType()->notEmpty()->isValid("\t \n \r");  //false
 
 ### `NotEmpty::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must not be empty |
-| `inverted` | {{name}} must be empty     |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must not be empty |
+| `inverted` | {{subject}} must be empty     |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -57,10 +57,11 @@ v::stringType()->notEmpty()->isValid("\t \n \r");  //false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Each](Each.md)

--- a/docs/rules/NotUndef.md
+++ b/docs/rules/NotUndef.md
@@ -33,16 +33,16 @@ v::notUndef()->isValid(new stdClass()); // true
 
 ### `NotUndef::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must be defined   |
-| `inverted` | {{name}} must be undefined |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must be defined   |
+| `inverted` | {{subject}} must be undefined |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -51,11 +51,12 @@ v::notUndef()->isValid(new stdClass()); // true
 ## Changelog
 
 | Version | Description                              |
-|--------:|------------------------------------------|
+| ------: | ---------------------------------------- |
 |   3.0.0 | Renamed from "NotOptional" to "NotUndef" |
 |   1.0.0 | Created                                  |
 
-***
+---
+
 See also:
 
 - [NoWhitespace](NoWhitespace.md)

--- a/docs/rules/NullOr.md
+++ b/docs/rules/NullOr.md
@@ -44,7 +44,7 @@ v::not(v::nullOr(v::alpha()))->assert("alpha");
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/NullType.md
+++ b/docs/rules/NullType.md
@@ -12,16 +12,16 @@ v::nullType()->isValid(null); // true
 
 ### `NullType::TEMPLATE_STANDARD`
 
-| Mode       | Template                  |
-|------------|---------------------------|
-| `default`  | {{name}} must be null     |
-| `inverted` | {{name}} must not be null |
+| Mode       | Template                     |
+| ---------- | ---------------------------- |
+| `default`  | {{subject}} must be null     |
+| `inverted` | {{subject}} must not be null |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,11 +30,12 @@ v::nullType()->isValid(null); // true
 ## Changelog
 
 | Version | Description                            |
-|--------:|----------------------------------------|
+| ------: | -------------------------------------- |
 |   1.0.0 | Renamed from `NullValue` to `NullType` |
 |   0.3.9 | Created as `NullValue`                 |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Number.md
+++ b/docs/rules/Number.md
@@ -17,16 +17,16 @@ v::number()->isValid(acos(8)); // false
 
 ### `Number::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} must be a valid number |
-| `inverted` | {{name}} must not be a number   |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} must be a valid number |
+| `inverted` | {{subject}} must not be a number   |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -35,10 +35,11 @@ v::number()->isValid(acos(8)); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [BoolType](BoolType.md)

--- a/docs/rules/NumericVal.md
+++ b/docs/rules/NumericVal.md
@@ -16,16 +16,16 @@ purpose use the [Number](Number.md) rule.
 
 ### `NumericVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be a numeric value     |
-| `inverted` | {{name}} must not be a numeric value |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be a numeric value     |
+| `inverted` | {{subject}} must not be a numeric value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -35,11 +35,12 @@ purpose use the [Number](Number.md) rule.
 ## Changelog
 
 | Version | Description                            |
-|--------:|----------------------------------------|
+| ------: | -------------------------------------- |
 |   2.0.0 | Renamed from `Numeric` to `NumericVal` |
 |   0.3.9 | Created as `Numeric`                   |
 
-***
+---
+
 See also:
 
 - [Decimal](Decimal.md)

--- a/docs/rules/ObjectType.md
+++ b/docs/rules/ObjectType.md
@@ -12,16 +12,16 @@ v::objectType()->isValid(new stdClass); // true
 
 ### `ObjectType::TEMPLATE_STANDARD`
 
-| Mode       | Template                       |
-|------------|--------------------------------|
-| `default`  | {{name}} must be an object     |
-| `inverted` | {{name}} must not be an object |
+| Mode       | Template                          |
+| ---------- | --------------------------------- |
+| `default`  | {{subject}} must be an object     |
+| `inverted` | {{subject}} must not be an object |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,11 +31,12 @@ v::objectType()->isValid(new stdClass); // true
 ## Changelog
 
 | Version | Description                           |
-|--------:|---------------------------------------|
+| ------: | ------------------------------------- |
 |   1.0.0 | Renamed from `Object` to `ObjectType` |
 |   0.3.9 | Created as `Object`                   |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Odd.md
+++ b/docs/rules/Odd.md
@@ -15,16 +15,16 @@ Using `intVal()` before `odd()` is a best practice.
 
 ### `Odd::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} must be an odd number  |
-| `inverted` | {{name}} must be an even number |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} must be an odd number  |
+| `inverted` | {{subject}} must be an even number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,11 +33,12 @@ Using `intVal()` before `odd()` is a best practice.
 ## Changelog
 
 | Version | Description             |
-|--------:|-------------------------|
+| ------: | ----------------------- |
 |   2.0.0 | Only validates integers |
 |   0.3.9 | Created                 |
 
-***
+---
+
 See also:
 
 - [Even](Even.md)

--- a/docs/rules/OneOf.md
+++ b/docs/rules/OneOf.md
@@ -20,25 +20,25 @@ character, one or the other, but not neither nor both.
 
 Used when none of the rules have passed.
 
-| Mode       | Template                            |
-|------------|-------------------------------------|
-| `default`  | {{name}} must pass one of the rules |
-| `inverted` | {{name}} must pass one of the rules |
+| Mode       | Template                               |
+| ---------- | -------------------------------------- |
+| `default`  | {{subject}} must pass one of the rules |
+| `inverted` | {{subject}} must pass one of the rules |
 
 ### `OneOf::TEMPLATE_MORE_THAN_ONE`
 
 Used when more than one rule has passed.
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must pass only one of the rules |
-| `inverted` | {{name}} must pass only one of the rules |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must pass only one of the rules |
+| `inverted` | {{subject}} must pass only one of the rules |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -48,11 +48,12 @@ Used when more than one rule has passed.
 ## Changelog
 
 | Version | Description                             |
-|--------:|-----------------------------------------|
+| ------: | --------------------------------------- |
 |   3.0.0 | Require at least two rules to be passed |
 |   0.3.9 | Created                                 |
 
-***
+---
+
 See also:
 
 - [AllOf](AllOf.md)

--- a/docs/rules/PerfectSquare.md
+++ b/docs/rules/PerfectSquare.md
@@ -13,16 +13,16 @@ v::perfectSquare()->isValid(9); // true (3*3)
 
 ### `PerfectSquare::TEMPLATE_STANDARD`
 
-| Mode       | Template                                     |
-|------------|----------------------------------------------|
-| `default`  | {{name}} must be a perfect square number     |
-| `inverted` | {{name}} must not be a perfect square number |
+| Mode       | Template                                        |
+| ---------- | ----------------------------------------------- |
+| `default`  | {{subject}} must be a perfect square number     |
+| `inverted` | {{subject}} must not be a perfect square number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::perfectSquare()->isValid(9); // true (3*3)
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Factor](Factor.md)

--- a/docs/rules/Pesel.md
+++ b/docs/rules/Pesel.md
@@ -15,16 +15,16 @@ v::pesel()->isValid('PESEL123456'); // false
 
 ### `Pesel::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-|------------|------------------------------------|
-| `default`  | {{name}} must be a valid PESEL     |
-| `inverted` | {{name}} must not be a valid PESEL |
+| Mode       | Template                              |
+| ---------- | ------------------------------------- |
+| `default`  | {{subject}} must be a valid PESEL     |
+| `inverted` | {{subject}} must not be a valid PESEL |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::pesel()->isValid('PESEL123456'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.1.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Nip](Nip.md)

--- a/docs/rules/Phone.md
+++ b/docs/rules/Phone.md
@@ -5,7 +5,6 @@
 Validates whether the input is a valid phone number. This rule requires
 the `giggsey/libphonenumber-for-php-lite` package.
 
-
 ```php
 v::phone()->isValid('+1 650 253 00 00'); // true
 v::phone('BR')->isValid('+55 11 91111 1111'); // true
@@ -16,24 +15,24 @@ v::phone('BR')->isValid('11 91111 1111'); // false
 
 ### `Phone::TEMPLATE_INTERNATIONAL`
 
-| Mode       | Template                                      |
-|------------|-----------------------------------------------|
-| `default`  | {{name}} must be a valid telephone number     |
-| `inverted` | {{name}} must not be a valid telephone number |
+| Mode       | Template                                         |
+| ---------- | ------------------------------------------------ |
+| `default`  | {{subject}} must be a valid telephone number     |
+| `inverted` | {{subject}} must not be a valid telephone number |
 
 ### `Phone::TEMPLATE_FOR_COUNTRY`
 
-| Mode       | Template                                                                             |
-|------------|--------------------------------------------------------------------------------------|
-| `default`  | {{name}} must be a valid telephone number for country {{countryName&#124;trans}}     |
-| `inverted` | {{name}} must not be a valid telephone number for country {{countryName&#124;trans}} |
+| Mode       | Template                                                                                |
+| ---------- | --------------------------------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid telephone number for country {{countryName&#124;trans}}     |
+| `inverted` | {{subject}} must not be a valid telephone number for country {{countryName&#124;trans}} |
 
 ## Template placeholders
 
 | Placeholder   | Description                                                      |
-|---------------|------------------------------------------------------------------|
+| ------------- | ---------------------------------------------------------------- |
 | `countryName` |                                                                  |
-| `name`        | The validated input or the custom validator name (if specified). |
+| `subject`     | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -42,11 +41,12 @@ v::phone('BR')->isValid('11 91111 1111'); // false
 ## Changelog
 
 | Version | Description                       |
-|--------:|-----------------------------------|
+| ------: | --------------------------------- |
 |   2.3.0 | Updated to use external validator |
 |   0.5.0 | Created                           |
 
-***
+---
+
 See also:
 
 - [Email](Email.md)

--- a/docs/rules/PhpLabel.md
+++ b/docs/rules/PhpLabel.md
@@ -3,7 +3,7 @@
 - `PhpLabel()`
 
 Validates if a value is considered a valid PHP Label,
-so that it can be used as a *variable*, *function* or *class* name, for example.
+so that it can be used as a _variable_, _function_ or _class_ name, for example.
 
 Reference:
 http://php.net/manual/en/language.variables.basics.php
@@ -18,16 +18,16 @@ v::phpLabel()->isValid('4ccess'); //false
 
 ### `PhpLabel::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a valid PHP label     |
-| `inverted` | {{name}} must not be a valid PHP label |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a valid PHP label     |
+| `inverted` | {{subject}} must not be a valid PHP label |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -36,10 +36,11 @@ v::phpLabel()->isValid('4ccess'); //false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.1.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Charset](Charset.md)

--- a/docs/rules/Pis.md
+++ b/docs/rules/Pis.md
@@ -16,16 +16,16 @@ v::pis()->isValid('12003406788'); // true
 
 ### `Pis::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-|------------|-----------------------------------------|
-| `default`  | {{name}} must be a valid PIS number     |
-| `inverted` | {{name}} must not be a valid PIS number |
+| Mode       | Template                                   |
+| ---------- | ------------------------------------------ |
+| `default`  | {{subject}} must be a valid PIS number     |
+| `inverted` | {{subject}} must not be a valid PIS number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ v::pis()->isValid('12003406788'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Cnh](Cnh.md)

--- a/docs/rules/PolishIdCard.md
+++ b/docs/rules/PolishIdCard.md
@@ -15,16 +15,16 @@ v::polishIdCard()->isValid('AYW036731'); // false
 
 ### `PolishIdCard::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                 |
-|------------|----------------------------------------------------------|
-| `default`  | {{name}} must be a valid Polish Identity Card number     |
-| `inverted` | {{name}} must not be a valid Polish Identity Card number |
+| Mode       | Template                                                    |
+| ---------- | ----------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid Polish Identity Card number     |
+| `inverted` | {{subject}} must not be a valid Polish Identity Card number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::polishIdCard()->isValid('AYW036731'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Nip](Nip.md)

--- a/docs/rules/PortugueseNif.md
+++ b/docs/rules/PortugueseNif.md
@@ -13,16 +13,16 @@ v::portugueseNif()->isValid('220005245'); // false
 
 ### `PortugueseNif::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must be a Portuguese NIF     |
-| `inverted` | {{name}} must not be a Portuguese NIF |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must be a Portuguese NIF     |
+| `inverted` | {{subject}} must not be a Portuguese NIF |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::portugueseNif()->isValid('220005245'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.2.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Bsn](Bsn.md)

--- a/docs/rules/Positive.md
+++ b/docs/rules/Positive.md
@@ -14,16 +14,16 @@ v::positive()->isValid(-15); // false
 
 ### `Positive::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a positive number     |
-| `inverted` | {{name}} must not be a positive number |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a positive number     |
+| `inverted` | {{subject}} must not be a positive number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,11 +33,12 @@ v::positive()->isValid(-15); // false
 ## Changelog
 
 | Version | Description                          |
-|--------:|--------------------------------------|
+| ------: | ------------------------------------ |
 |   2.0.0 | Does not validate non-numeric values |
 |   0.3.9 | Created                              |
 
-***
+---
+
 See also:
 
 - [Negative](Negative.md)

--- a/docs/rules/PostalCode.md
+++ b/docs/rules/PostalCode.md
@@ -14,7 +14,6 @@ v::postalCode('PL')->isValid('99-300'); // true
 
 By default, `PostalCode` won't validate the format (puncts, spaces), unless you pass `$formatted = true`:
 
-
 ```php
 v::postalCode('BR', true)->isValid('02179000'); // false
 v::postalCode('BR', true)->isValid('02179-000'); // true
@@ -28,17 +27,17 @@ Extracted from [GeoNames](http://www.geonames.org/).
 
 ### `PostalCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                    |
-|------------|-------------------------------------------------------------|
-| `default`  | {{name}} must be a valid postal code on {{countryCode}}     |
-| `inverted` | {{name}} must not be a valid postal code on {{countryCode}} |
+| Mode       | Template                                                       |
+| ---------- | -------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid postal code on {{countryCode}}     |
+| `inverted` | {{subject}} must not be a valid postal code on {{countryCode}} |
 
 ## Template placeholders
 
 | Placeholder   | Description                                                      |
-|---------------|------------------------------------------------------------------|
+| ------------- | ---------------------------------------------------------------- |
 | `countryCode` |                                                                  |
-| `name`        | The validated input or the custom validator name (if specified). |
+| `subject`     | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -48,12 +47,13 @@ Extracted from [GeoNames](http://www.geonames.org/).
 ## Changelog
 
 | Version | Description                                       |
-|--------:|---------------------------------------------------|
+| ------: | ------------------------------------------------- |
 |   2.3.0 | Add option to validate formatting                 |
 |   2.2.4 | Cambodian postal codes now support 5 and 6 digits |
 |   0.7.0 | Created                                           |
 
-***
+---
+
 See also:
 
 - [CountryCode](CountryCode.md)

--- a/docs/rules/PrimeNumber.md
+++ b/docs/rules/PrimeNumber.md
@@ -12,16 +12,16 @@ v::primeNumber()->isValid(7); // true
 
 ### `PrimeNumber::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-|------------|-------------------------------------|
-| `default`  | {{name}} must be a prime number     |
-| `inverted` | {{name}} must not be a prime number |
+| Mode       | Template                               |
+| ---------- | -------------------------------------- |
+| `default`  | {{subject}} must be a prime number     |
+| `inverted` | {{subject}} must not be a prime number |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::primeNumber()->isValid(7); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Factor](Factor.md)

--- a/docs/rules/Printable.md
+++ b/docs/rules/Printable.md
@@ -13,24 +13,24 @@ v::printable()->isValid('LMKA0$% _123'); // true
 
 ### `Printable::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-|------------|-------------------------------------------------|
-| `default`  | {{name}} must contain only printable characters |
-| `inverted` | {{name}} must not contain printable characters  |
+| Mode       | Template                                           |
+| ---------- | -------------------------------------------------- |
+| `default`  | {{subject}} must contain only printable characters |
+| `inverted` | {{subject}} must not contain printable characters  |
 
 ### `Printable::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                |
-|------------|-------------------------------------------------------------------------|
-| `default`  | {{name}} must contain only printable characters and {{additionalChars}} |
-| `inverted` | {{name}} must not contain printable characters or {{additionalChars}}   |
+| Mode       | Template                                                                   |
+| ---------- | -------------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain only printable characters and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain printable characters or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,10 +39,11 @@ v::printable()->isValid('LMKA0$% _123'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Control](Control.md)

--- a/docs/rules/Property.md
+++ b/docs/rules/Property.md
@@ -51,7 +51,7 @@ This rule will validate public, private, protected, uninitialised, and static pr
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/PropertyExists.md
+++ b/docs/rules/PropertyExists.md
@@ -18,23 +18,23 @@ v::propertyExists('website')->isValid($object); // false
 
 This rule will validate public, private, protected, uninitialised, and static properties.
 
-* To validate a property against a given rule requiring the property to exist, use [Property](Property.md) instead.
-* To validate a property against a given rule only if the property exists, use [PropertyOptional](PropertyOptional.md) instead.
+- To validate a property against a given rule requiring the property to exist, use [Property](Property.md) instead.
+- To validate a property against a given rule only if the property exists, use [PropertyOptional](PropertyOptional.md) instead.
 
 ## Templates
 
 ### `PropertyExists::TEMPLATE_STANDARD`
 
-| Mode       | Template                     |
-|------------|------------------------------|
-| `default`  | {{name}} must be present     |
-| `inverted` | {{name}} must not be present |
+| Mode       | Template                        |
+| ---------- | ------------------------------- |
+| `default`  | {{subject}} must be present     |
+| `inverted` | {{subject}} must not be present |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Caveats
 
@@ -65,10 +65,11 @@ v::property('foo', v::alwaysValid()->setName('Custom name'))->assert([]);
 ## Changelog
 
 | Version | Description                          |
-|--------:|--------------------------------------|
+| ------: | ------------------------------------ |
 |   3.0.0 | Created from [Property](Property.md) |
 
-***
+---
+
 See also:
 
 - [Attributes](Attributes.md)

--- a/docs/rules/PropertyOptional.md
+++ b/docs/rules/PropertyOptional.md
@@ -45,7 +45,7 @@ v::objectType()->propertyOptional('name', v::notEmpty())->isValid('Not an object
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/PublicDomainSuffix.md
+++ b/docs/rules/PublicDomainSuffix.md
@@ -11,7 +11,7 @@ v::publicDomainSuffix->isValid('nom.br'); // true
 v::publicDomainSuffix->isValid('invalid.com'); // false
 ```
 
-This rule will not match top level domains such as `tk`. 
+This rule will not match top level domains such as `tk`.
 If you want to match either, use a combination with `Tld`:
 
 ```php
@@ -22,16 +22,16 @@ v::oneOf(v::tld(), v::publicDomainSuffix())->isValid('tk'); // true
 
 ### `PublicDomainSuffix::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must be a public domain suffix     |
-| `inverted` | {{name}} must not be a public domain suffix |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must be a public domain suffix     |
+| `inverted` | {{subject}} must not be a public domain suffix |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -40,10 +40,11 @@ v::oneOf(v::tld(), v::publicDomainSuffix())->isValid('tk'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.3.0 | Created     |
 
-***
+---
+
 See also:
 
 - [CountryCode](CountryCode.md)

--- a/docs/rules/Punct.md
+++ b/docs/rules/Punct.md
@@ -13,24 +13,24 @@ v::punct()->isValid('&,.;[]'); // true
 
 ### `Punct::TEMPLATE_STANDARD`
 
-| Mode       | Template                                          |
-|------------|---------------------------------------------------|
-| `default`  | {{name}} must contain only punctuation characters |
-| `inverted` | {{name}} must not contain punctuation characters  |
+| Mode       | Template                                             |
+| ---------- | ---------------------------------------------------- |
+| `default`  | {{subject}} must contain only punctuation characters |
+| `inverted` | {{subject}} must not contain punctuation characters  |
 
 ### `Punct::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                  |
-|------------|---------------------------------------------------------------------------|
-| `default`  | {{name}} must contain only punctuation characters and {{additionalChars}} |
-| `inverted` | {{name}} must not contain punctuation characters or {{additionalChars}}   |
+| Mode       | Template                                                                     |
+| ---------- | ---------------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain only punctuation characters and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain punctuation characters or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,10 +39,11 @@ v::punct()->isValid('&,.;[]'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Control](Control.md)

--- a/docs/rules/Readable.md
+++ b/docs/rules/Readable.md
@@ -12,16 +12,16 @@ v::readable()->isValid('file.txt'); // true
 
 ### `Readable::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-|------------|-------------------------------|
-| `default`  | {{name}} must be readable     |
-| `inverted` | {{name}} must not be readable |
+| Mode       | Template                         |
+| ---------- | -------------------------------- |
+| `default`  | {{subject}} must be readable     |
+| `inverted` | {{subject}} must not be readable |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,11 +30,12 @@ v::readable()->isValid('file.txt'); // true
 ## Changelog
 
 | Version | Description       |
-|--------:|-------------------|
+| ------: | ----------------- |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Regex.md
+++ b/docs/rules/Regex.md
@@ -14,16 +14,16 @@ Message template for this validator includes `{{regex}}`.
 
 ### `Regex::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                 |
-|------------|----------------------------------------------------------|
-| `default`  | {{name}} must match the pattern `{{regex&#124;raw}}`     |
-| `inverted` | {{name}} must not match the pattern `{{regex&#124;raw}}` |
+| Mode       | Template                                                    |
+| ---------- | ----------------------------------------------------------- |
+| `default`  | {{subject}} must match the pattern `{{regex&#124;raw}}`     |
+| `inverted` | {{subject}} must not match the pattern `{{regex&#124;raw}}` |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `regex`     |                                                                  |
 
 ## Categorization
@@ -33,10 +33,11 @@ Message template for this validator includes `{{regex}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/ResourceType.md
+++ b/docs/rules/ResourceType.md
@@ -12,16 +12,16 @@ v::resourceType()->isValid(fopen('/path/to/file.txt', 'w')); // true
 
 ### `ResourceType::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-|------------|---------------------------------|
-| `default`  | {{name}} must be a resource     |
-| `inverted` | {{name}} must not be a resource |
+| Mode       | Template                           |
+| ---------- | ---------------------------------- |
+| `default`  | {{subject}} must be a resource     |
+| `inverted` | {{subject}} must not be a resource |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::resourceType()->isValid(fopen('/path/to/file.txt', 'w')); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Roman.md
+++ b/docs/rules/Roman.md
@@ -12,16 +12,16 @@ v::roman()->isValid('IV'); // true
 
 ### `Roman::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-|------------|--------------------------------------------|
-| `default`  | {{name}} must be a valid Roman numeral     |
-| `inverted` | {{name}} must not be a valid Roman numeral |
+| Mode       | Template                                      |
+| ---------- | --------------------------------------------- |
+| `default`  | {{subject}} must be a valid Roman numeral     |
+| `inverted` | {{subject}} must not be a valid Roman numeral |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,12 +30,13 @@ v::roman()->isValid('IV'); // true
 ## Changelog
 
 | Version | Description                                                       |
-|--------:|-------------------------------------------------------------------|
+| ------: | ----------------------------------------------------------------- |
 |   2.0.0 | Exception message refers to Roman "numerals" instead of "numbers" |
 |   2.0.0 | Do not consider empty strings as valid                            |
 |   0.3.9 | Created                                                           |
 
-***
+---
+
 See also:
 
 - [In](In.md)

--- a/docs/rules/ScalarVal.md
+++ b/docs/rules/ScalarVal.md
@@ -13,16 +13,16 @@ v::scalarVal()->isValid(135.0); // true
 
 ### `ScalarVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-|------------|-------------------------------------|
-| `default`  | {{name}} must be a scalar value     |
-| `inverted` | {{name}} must not be a scalar value |
+| Mode       | Template                               |
+| ---------- | -------------------------------------- |
+| `default`  | {{subject}} must be a scalar value     |
+| `inverted` | {{subject}} must not be a scalar value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,10 +31,11 @@ v::scalarVal()->isValid(135.0); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayVal](ArrayVal.md)

--- a/docs/rules/Size.md
+++ b/docs/rules/Size.md
@@ -14,17 +14,17 @@ Accepted data storage units are `B`, `KB`, `MB`, `GB`, `TB`, `PB`, `EB`, `ZB`, a
 
 This validator will accept:
 
-* `string` file paths
-* `SplFileInfo` objects (see [SplFileInfo][])
-* `Psr\Http\Message\UploadedFileInterface` objects (see [PSR-7][])
-* `Psr\Http\Message\StreamInterface` objects (see [PSR-7][])
+- `string` file paths
+- `SplFileInfo` objects (see [SplFileInfo][])
+- `Psr\Http\Message\UploadedFileInterface` objects (see [PSR-7][])
+- `Psr\Http\Message\StreamInterface` objects (see [PSR-7][])
 
 ## Templates
 
 ### `Size::TEMPLATE_STANDARD`
 
 | Mode       | Template                           |
-|------------|------------------------------------|
+| ---------- | ---------------------------------- |
 | `default`  | The size in {{unit&#124;trans}} of |
 | `inverted` | The size in {{unit&#124;trans}} of |
 
@@ -42,16 +42,16 @@ v::size('KB', v::not(v::equals(56)))->assert('filename.txt')
 
 Used when the input is not a valid file path, a `SplFileInfo` object, or a PSR-7 interface.
 
-| Mode       | Template                                                                           |
-|------------|------------------------------------------------------------------------------------|
-| `default`  | {{name}} must be a filename or an instance of SplFileInfo or a PSR-7 interface     |
-| `inverted` | {{name}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface |
+| Mode       | Template                                                                              |
+| ---------- | ------------------------------------------------------------------------------------- |
+| `default`  | {{subject}} must be a filename or an instance of SplFileInfo or a PSR-7 interface     |
+| `inverted` | {{subject}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `unit`      | The name of the storage unit (bytes, kilobytes, etc.)            |
 
 ## Categorization
@@ -62,12 +62,13 @@ Used when the input is not a valid file path, a `SplFileInfo` object, or a PSR-7
 ## Changelog
 
 | Version | Description             |
-|--------:|-------------------------|
+| ------: | ----------------------- |
 |   3.0.0 | Became a transformation |
 |   2.1.0 | Add [PSR-7][] support   |
 |   1.0.0 | Created                 |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Slug.md
+++ b/docs/rules/Slug.md
@@ -14,16 +14,16 @@ v::slug()->isValid('my-wordpress-title-'); // false
 
 ### `Slug::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-|------------|-----------------------------------|
-| `default`  | {{name}} must be a valid slug     |
-| `inverted` | {{name}} must not be a valid slug |
+| Mode       | Template                             |
+| ---------- | ------------------------------------ |
+| `default`  | {{subject}} must be a valid slug     |
+| `inverted` | {{subject}} must not be a valid slug |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::slug()->isValid('my-wordpress-title-'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [PhpLabel](PhpLabel.md)

--- a/docs/rules/Sorted.md
+++ b/docs/rules/Sorted.md
@@ -35,23 +35,23 @@ v::call('iterator_to_array', v::sorted())->isValid(new ArrayIterator([1, 7, 4]))
 
 ### `Sorted::TEMPLATE_ASCENDING`
 
-| Mode       | Template                                       |
-|------------|------------------------------------------------|
-| `default`  | {{name}} must be sorted in ascending order     |
-| `inverted` | {{name}} must not be sorted in ascending order |
+| Mode       | Template                                          |
+| ---------- | ------------------------------------------------- |
+| `default`  | {{subject}} must be sorted in ascending order     |
+| `inverted` | {{subject}} must not be sorted in ascending order |
 
 ### `Sorted::TEMPLATE_DESCENDING`
 
-| Mode       | Template                                        |
-|------------|-------------------------------------------------|
-| `default`  | {{name}} must be sorted in descending order     |
-| `inverted` | {{name}} must not be sorted in descending order |
+| Mode       | Template                                           |
+| ---------- | -------------------------------------------------- |
+| `default`  | {{subject}} must be sorted in descending order     |
+| `inverted` | {{subject}} must not be sorted in descending order |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -61,14 +61,15 @@ v::call('iterator_to_array', v::sorted())->isValid(new ArrayIterator([1, 7, 4]))
 ## Changelog
 
 | Version | Description                                    |
-|--------:|------------------------------------------------|
+| ------: | ---------------------------------------------- |
 |   2.0.0 | Add support for strings                        |
 |   2.0.0 | Do not use array keys to sort                  |
 |   2.0.0 | Use sorting direction instead of boolean value |
 |   2.0.0 | Do not accept callback in the constructor      |
 |   1.1.1 | Created                                        |
 
-***
+---
+
 See also:
 
 - [ArrayVal](ArrayVal.md)

--- a/docs/rules/Space.md
+++ b/docs/rules/Space.md
@@ -13,24 +13,24 @@ v::space()->isValid('    '); // true
 
 ### `Space::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must contain only space characters |
-| `inverted` | {{name}} must not contain space characters  |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must contain only space characters |
+| `inverted` | {{subject}} must not contain space characters  |
 
 ### `Space::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                            |
-|------------|---------------------------------------------------------------------|
-| `default`  | {{name}} must contain only space characters and {{additionalChars}} |
-| `inverted` | {{name}} must not contain space characters or {{additionalChars}}   |
+| Mode       | Template                                                               |
+| ---------- | ---------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain only space characters and {{additionalChars}} |
+| `inverted` | {{subject}} must not contain space characters or {{additionalChars}}   |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,10 +39,11 @@ v::space()->isValid('    '); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Control](Control.md)

--- a/docs/rules/StartsWith.md
+++ b/docs/rules/StartsWith.md
@@ -29,16 +29,16 @@ Message template for this validator includes `{{startValue}}`.
 
 ### `StartsWith::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must start with {{startValue}}     |
-| `inverted` | {{name}} must not start with {{startValue}} |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must start with {{startValue}}     |
+| `inverted` | {{subject}} must not start with {{startValue}} |
 
 ## Template placeholders
 
 | Placeholder  | Description                                                      |
-|--------------|------------------------------------------------------------------|
-| `name`       | The validated input or the custom validator name (if specified). |
+| ------------ | ---------------------------------------------------------------- |
+| `subject`    | The validated input or the custom validator name (if specified). |
 | `startValue` |                                                                  |
 
 ## Categorization
@@ -49,10 +49,11 @@ Message template for this validator includes `{{startValue}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Contains](Contains.md)

--- a/docs/rules/StringType.md
+++ b/docs/rules/StringType.md
@@ -12,16 +12,16 @@ v::stringType()->isValid('hi'); // true
 
 ### `StringType::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-|------------|-------------------------------|
-| `default`  | {{name}} must be a string     |
-| `inverted` | {{name}} must not be a string |
+| Mode       | Template                         |
+| ---------- | -------------------------------- |
+| `default`  | {{subject}} must be a string     |
+| `inverted` | {{subject}} must not be a string |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -31,11 +31,12 @@ v::stringType()->isValid('hi'); // true
 ## Changelog
 
 | Version | Description                           |
-|--------:|---------------------------------------|
+| ------: | ------------------------------------- |
 |   1.0.0 | Renamed from `String` to `StringType` |
 |   0.3.9 | Created as `String`                   |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/StringVal.md
+++ b/docs/rules/StringVal.md
@@ -18,16 +18,16 @@ v::stringVal()->isValid(new ClassWithToString()); // true if ClassWithToString i
 
 ### `StringVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-|------------|-------------------------------------|
-| `default`  | {{name}} must be a string value     |
-| `inverted` | {{name}} must not be a string value |
+| Mode       | Template                               |
+| ---------- | -------------------------------------- |
+| `default`  | {{subject}} must be a string value     |
+| `inverted` | {{subject}} must not be a string value |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,10 +37,11 @@ v::stringVal()->isValid(new ClassWithToString()); // true if ClassWithToString i
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/SubdivisionCode.md
+++ b/docs/rules/SubdivisionCode.md
@@ -17,17 +17,17 @@ v::subdivisionCode('US')->isValid('CA'); // true
 
 ### `SubdivisionCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                              |
-|------------|-----------------------------------------------------------------------|
-| `default`  | {{name}} must be a subdivision code of {{countryName&#124;trans}}     |
-| `inverted` | {{name}} must not be a subdivision code of {{countryName&#124;trans}} |
+| Mode       | Template                                                                 |
+| ---------- | ------------------------------------------------------------------------ |
+| `default`  | {{subject}} must be a subdivision code of {{countryName&#124;trans}}     |
+| `inverted` | {{subject}} must not be a subdivision code of {{countryName&#124;trans}} |
 
 ## Template placeholders
 
 | Placeholder   | Description                                                      |
-|---------------|------------------------------------------------------------------|
+| ------------- | ---------------------------------------------------------------- |
 | `countryName` |                                                                  |
-| `name`        | The validated input or the custom validator name (if specified). |
+| `subject`     | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,11 +37,12 @@ v::subdivisionCode('US')->isValid('CA'); // true
 ## Changelog
 
 | Version | Description                                                       |
-|--------:|-------------------------------------------------------------------|
+| ------: | ----------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   1.0.0 | Created                                                           |
 
-***
+---
+
 See also:
 
 - [Circuit](Circuit.md)

--- a/docs/rules/Subset.md
+++ b/docs/rules/Subset.md
@@ -13,16 +13,16 @@ v::subset([1, 2])->isValid([1, 2, 3]); // false
 
 ### `Subset::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-|------------|---------------------------------------------|
-| `default`  | {{name}} must be subset of {{superset}}     |
-| `inverted` | {{name}} must not be subset of {{superset}} |
+| Mode       | Template                                       |
+| ---------- | ---------------------------------------------- |
+| `default`  | {{subject}} must be subset of {{superset}}     |
+| `inverted` | {{subject}} must not be subset of {{superset}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `superset`  |                                                                  |
 
 ## Categorization
@@ -32,10 +32,11 @@ v::subset([1, 2])->isValid([1, 2, 3]); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/SymbolicLink.md
+++ b/docs/rules/SymbolicLink.md
@@ -14,16 +14,16 @@ v::symbolicLink()->isValid(new SplFileObject('/path/of/valid/symbolic/link')); /
 
 ### `SymbolicLink::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must be a symbolic link     |
-| `inverted` | {{name}} must not be a symbolic link |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must be a symbolic link     |
+| `inverted` | {{subject}} must not be a symbolic link |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -32,10 +32,11 @@ v::symbolicLink()->isValid(new SplFileObject('/path/of/valid/symbolic/link')); /
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Templated.md
+++ b/docs/rules/Templated.md
@@ -27,7 +27,7 @@ This rule does not have any templates, as you must define the templates yourself
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 
 ## Categorization

--- a/docs/rules/Time.md
+++ b/docs/rules/Time.md
@@ -7,18 +7,18 @@ Validates whether an input is a time or not. The `$format` argument should be in
 accordance to PHP's [date()](http://php.net/date) function, but only those are
 allowed:
 
-Format  | Description                                        | Values
---------|----------------------------------------------------|--------
-`g`     | 12-hour format of an hour without leading zeros    | 1 through 12
-`G`     | 24-hour format of an hour without leading zeros    | 0 through 23
-`h`     | 12-hour format of an hour with leading zeros       | 01 through 12
-`H`     | 24-hour format of an hour with leading zeros       | 00 through 23
-`i`     | Minutes with leading zeros                         | 00 to 59
-`s`     | Seconds, with leading zeros                        | 00 through 59
-`u`     | Microseconds                                       | 000000 through 999999
-`v`     | Milliseconds                                       | 000 through 999
-`a`     | Lowercase Ante meridiem and Post meridiem          | am or pm
-`A`     | Uppercase Ante meridiem and Post meridiem          | AM or PM
+| Format | Description                                     | Values                |
+| ------ | ----------------------------------------------- | --------------------- |
+| `g`    | 12-hour format of an hour without leading zeros | 1 through 12          |
+| `G`    | 24-hour format of an hour without leading zeros | 0 through 23          |
+| `h`    | 12-hour format of an hour with leading zeros    | 01 through 12         |
+| `H`    | 24-hour format of an hour with leading zeros    | 00 through 23         |
+| `i`    | Minutes with leading zeros                      | 00 to 59              |
+| `s`    | Seconds, with leading zeros                     | 00 through 59         |
+| `u`    | Microseconds                                    | 000000 through 999999 |
+| `v`    | Milliseconds                                    | 000 through 999       |
+| `a`    | Lowercase Ante meridiem and Post meridiem       | am or pm              |
+| `A`    | Uppercase Ante meridiem and Post meridiem       | AM or PM              |
 
 When a `$format` is not given its default value is `H:i:s`.
 
@@ -38,16 +38,16 @@ v::time()->isValid(new DateTimeImmutable()); // false
 
 ### `Time::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                   |
-|------------|------------------------------------------------------------|
-| `default`  | {{name}} must be a valid time in the format {{sample}}     |
-| `inverted` | {{name}} must not be a valid time in the format {{sample}} |
+| Mode       | Template                                                      |
+| ---------- | ------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid time in the format {{sample}}     |
+| `inverted` | {{subject}} must not be a valid time in the format {{sample}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `sample`    |                                                                  |
 
 ## Categorization
@@ -57,10 +57,11 @@ v::time()->isValid(new DateTimeImmutable()); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Date](Date.md)

--- a/docs/rules/Tld.md
+++ b/docs/rules/Tld.md
@@ -15,16 +15,16 @@ v::tld()->isValid('COM'); // true
 
 ### `Tld::TEMPLATE_STANDARD`
 
-| Mode       | Template                                           |
-|------------|----------------------------------------------------|
-| `default`  | {{name}} must be a valid top-level domain name     |
-| `inverted` | {{name}} must not be a valid top-level domain name |
+| Mode       | Template                                              |
+| ---------- | ----------------------------------------------------- |
+| `default`  | {{subject}} must be a valid top-level domain name     |
+| `inverted` | {{subject}} must not be a valid top-level domain name |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::tld()->isValid('COM'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [CountryCode](CountryCode.md)

--- a/docs/rules/TrueVal.md
+++ b/docs/rules/TrueVal.md
@@ -19,16 +19,16 @@ v::trueVal()->isValid('2'); // false
 
 ### `TrueVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must evaluate to `true`     |
-| `inverted` | {{name}} must not evaluate to `true` |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must evaluate to `true`     |
+| `inverted` | {{subject}} must not evaluate to `true` |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -37,11 +37,12 @@ v::trueVal()->isValid('2'); // false
 ## Changelog
 
 | Version | Description                      |
-|--------:|----------------------------------|
+| ------: | -------------------------------- |
 |   1.0.0 | Renamed from `True` to `TrueVal` |
 |   0.8.0 | Created as `True`                |
 
-***
+---
+
 See also:
 
 - [BoolType](BoolType.md)

--- a/docs/rules/UndefOr.md
+++ b/docs/rules/UndefOr.md
@@ -48,7 +48,7 @@ v::not(v::undefOr(v::alpha()))->assert("alpha");
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/Unique.md
+++ b/docs/rules/Unique.md
@@ -15,16 +15,16 @@ v::unique()->isValid([1, 2, 3, 1]); // false
 
 ### `Unique::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-|------------|--------------------------------------|
-| `default`  | {{name}} must not contain duplicates |
-| `inverted` | {{name}} must contain duplicates     |
+| Mode       | Template                                |
+| ---------- | --------------------------------------- |
+| `default`  | {{subject}} must not contain duplicates |
+| `inverted` | {{subject}} must contain duplicates     |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -33,10 +33,11 @@ v::unique()->isValid([1, 2, 3, 1]); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   2.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [ArrayType](ArrayType.md)

--- a/docs/rules/Uploaded.md
+++ b/docs/rules/Uploaded.md
@@ -12,16 +12,16 @@ v::uploaded()->isValid('/path/of/an/uploaded/file'); // true
 
 ### `Uploaded::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must be an uploaded file     |
-| `inverted` | {{name}} must not be an uploaded file |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must be an uploaded file     |
+| `inverted` | {{subject}} must not be an uploaded file |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,11 +30,12 @@ v::uploaded()->isValid('/path/of/an/uploaded/file'); // true
 ## Changelog
 
 | Version | Description       |
-|--------:|-------------------|
+| ------: | ----------------- |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Uppercase.md
+++ b/docs/rules/Uppercase.md
@@ -22,16 +22,16 @@ v::not(v::numericVal())->alnum()->uppercase()->isValid('W3C'); // true
 
 ### `Uppercase::TEMPLATE_STANDARD`
 
-| Mode       | Template                                         |
-|------------|--------------------------------------------------|
-| `default`  | {{name}} must contain only uppercase letters     |
-| `inverted` | {{name}} must not contain only uppercase letters |
+| Mode       | Template                                            |
+| ---------- | --------------------------------------------------- |
+| `default`  | {{subject}} must contain only uppercase letters     |
+| `inverted` | {{subject}} must not contain only uppercase letters |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -40,10 +40,11 @@ v::not(v::numericVal())->alnum()->uppercase()->isValid('W3C'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Url.md
+++ b/docs/rules/Url.md
@@ -16,16 +16,16 @@ v::url()->isValid('news:new.example.com'); // true
 
 ### `Url::TEMPLATE_STANDARD`
 
-| Mode       | Template                   |
-|------------|----------------------------|
-| `default`  | {{name}} must be a URL     |
-| `inverted` | {{name}} must not be a URL |
+| Mode       | Template                      |
+| ---------- | ----------------------------- |
+| `default`  | {{subject}} must be a URL     |
+| `inverted` | {{subject}} must not be a URL |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -34,10 +34,11 @@ v::url()->isValid('news:new.example.com'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.8.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Domain](Domain.md)

--- a/docs/rules/Uuid.md
+++ b/docs/rules/Uuid.md
@@ -20,23 +20,23 @@ v::uuid(4)->isValid(new \Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2
 
 ### `Uuid::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-|------------|-----------------------------------|
-| `default`  | {{name}} must be a valid UUID     |
-| `inverted` | {{name}} must not be a valid UUID |
+| Mode       | Template                             |
+| ---------- | ------------------------------------ |
+| `default`  | {{subject}} must be a valid UUID     |
+| `inverted` | {{subject}} must not be a valid UUID |
 
 ### `Uuid::TEMPLATE_VERSION`
 
-| Mode       | Template                                                       |
-|------------|----------------------------------------------------------------|
-| `default`  | {{name}} must be a valid UUID version {{version&#124;raw}}     |
-| `inverted` | {{name}} must not be a valid UUID version {{version&#124;raw}} |
+| Mode       | Template                                                          |
+| ---------- | ----------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid UUID version {{version&#124;raw}}     |
+| `inverted` | {{subject}} must not be a valid UUID version {{version&#124;raw}} |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `version`   | The version of the expected UUID.                                |
 
 ## Categorization
@@ -46,11 +46,12 @@ v::uuid(4)->isValid(new \Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2
 ## Changelog
 
 | Version | Description            |
-|--------:|------------------------|
+| ------: | ---------------------- |
 |   3.0.0 | Requires `ramsey/uuid` |
 |   2.0.0 | Created                |
 
-***
+---
+
 See also:
 
 - [Base](Base.md)

--- a/docs/rules/Version.md
+++ b/docs/rules/Version.md
@@ -12,16 +12,16 @@ v::version()->isValid('1.0.0');
 
 ### `Version::TEMPLATE_STANDARD`
 
-| Mode       | Template                       |
-|------------|--------------------------------|
-| `default`  | {{name}} must be a version     |
-| `inverted` | {{name}} must not be a version |
+| Mode       | Template                          |
+| ---------- | --------------------------------- |
+| `default`  | {{subject}} must be a version     |
+| `inverted` | {{subject}} must not be a version |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,10 +30,11 @@ v::version()->isValid('1.0.0');
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.3.9 | Created     |
 
-***
+---
+
 See also:
 
 - [Equals](Equals.md)

--- a/docs/rules/VideoUrl.md
+++ b/docs/rules/VideoUrl.md
@@ -39,23 +39,23 @@ Message template for this validator includes `{{service}}`.
 
 ### `VideoUrl::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-|------------|----------------------------------------|
-| `default`  | {{name}} must be a valid video URL     |
-| `inverted` | {{name}} must not be a valid video URL |
+| Mode       | Template                                  |
+| ---------- | ----------------------------------------- |
+| `default`  | {{subject}} must be a valid video URL     |
+| `inverted` | {{subject}} must not be a valid video URL |
 
 ### `VideoUrl::TEMPLATE_SERVICE`
 
-| Mode       | Template                                                    |
-|------------|-------------------------------------------------------------|
-| `default`  | {{name}} must be a valid {{service&#124;raw}} video URL     |
-| `inverted` | {{name}} must not be a valid {{service&#124;raw}} video URL |
+| Mode       | Template                                                       |
+| ---------- | -------------------------------------------------------------- |
+| `default`  | {{subject}} must be a valid {{service&#124;raw}} video URL     |
+| `inverted` | {{subject}} must not be a valid {{service&#124;raw}} video URL |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 | `service`   |                                                                  |
 
 ## Categorization
@@ -65,10 +65,11 @@ Message template for this validator includes `{{service}}`.
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   1.0.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Email](Email.md)

--- a/docs/rules/Vowel.md
+++ b/docs/rules/Vowel.md
@@ -13,24 +13,24 @@ v::vowel()->isValid('aei'); // true
 
 ### `Vowel::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-|------------|------------------------------------------|
-| `default`  | {{name}} must consist of vowels only     |
-| `inverted` | {{name}} must not consist of vowels only |
+| Mode       | Template                                    |
+| ---------- | ------------------------------------------- |
+| `default`  | {{subject}} must consist of vowels only     |
+| `inverted` | {{subject}} must not consist of vowels only |
 
 ### `Vowel::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                   |
-|------------|------------------------------------------------------------|
-| `default`  | {{name}} must consist of vowels and {{additionalChars}}    |
-| `inverted` | {{name}} must not consist of vowels or {{additionalChars}} |
+| Mode       | Template                                                      |
+| ---------- | ------------------------------------------------------------- |
+| `default`  | {{subject}} must consist of vowels and {{additionalChars}}    |
+| `inverted` | {{subject}} must not consist of vowels or {{additionalChars}} |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -39,12 +39,13 @@ v::vowel()->isValid('aei'); // true
 ## Changelog
 
 | Version | Description                          |
-|--------:|--------------------------------------|
+| ------: | ------------------------------------ |
 |   2.0.0 | Do not consider whitespaces as valid |
 |   0.5.0 | Renamed from `Vowels` to `Vowel`     |
 |   0.3.9 | Created as `Vowels`                  |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/When.md
+++ b/docs/rules/When.md
@@ -26,7 +26,7 @@ When `$else` is not defined use [AlwaysInvalid](AlwaysInvalid.md)
 
 | Placeholder | Description                                                      |
 |-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| `subject`      | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 

--- a/docs/rules/Writable.md
+++ b/docs/rules/Writable.md
@@ -12,16 +12,16 @@ v::writable()->isValid('file.txt'); // true
 
 ### `Writable::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-|------------|-------------------------------|
-| `default`  | {{name}} must be writable     |
-| `inverted` | {{name}} must not be writable |
+| Mode       | Template                         |
+| ---------- | -------------------------------- |
+| `default`  | {{subject}} must be writable     |
+| `inverted` | {{subject}} must not be writable |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -30,11 +30,12 @@ v::writable()->isValid('file.txt'); // true
 ## Changelog
 
 | Version | Description       |
-|--------:|-------------------|
+| ------: | ----------------- |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 
-***
+---
+
 See also:
 
 - [Directory](Directory.md)

--- a/docs/rules/Xdigit.md
+++ b/docs/rules/Xdigit.md
@@ -19,24 +19,24 @@ v::xdigit()->isValid('0x1f'); // false
 
 ### `Xdigit::TEMPLATE_STANDARD`
 
-| Mode       | Template                                          |
-|------------|---------------------------------------------------|
-| `default`  | {{name}} must only contain hexadecimal digits     |
-| `inverted` | {{name}} must not only contain hexadecimal digits |
+| Mode       | Template                                             |
+| ---------- | ---------------------------------------------------- |
+| `default`  | {{subject}} must only contain hexadecimal digits     |
+| `inverted` | {{subject}} must not only contain hexadecimal digits |
 
 ### `Xdigit::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                            |
-|------------|---------------------------------------------------------------------|
-| `default`  | {{name}} must contain hexadecimal digits and {{additionalChars}}    |
-| `inverted` | {{name}} must not contain hexadecimal digits or {{additionalChars}} |
+| Mode       | Template                                                               |
+| ---------- | ---------------------------------------------------------------------- |
+| `default`  | {{subject}} must contain hexadecimal digits and {{additionalChars}}    |
+| `inverted` | {{subject}} must not contain hexadecimal digits or {{additionalChars}} |
 
 ## Template placeholders
 
 | Placeholder       | Description                                                      |
-|-------------------|------------------------------------------------------------------|
+| ----------------- | ---------------------------------------------------------------- |
 | `additionalChars` | Additional characters that are considered valid.                 |
-| `name`            | The validated input or the custom validator name (if specified). |
+| `subject`         | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -45,10 +45,11 @@ v::xdigit()->isValid('0x1f'); // false
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.5.0 | Created     |
 
-***
+---
+
 See also:
 
 - [Alnum](Alnum.md)

--- a/docs/rules/Yes.md
+++ b/docs/rules/Yes.md
@@ -29,7 +29,7 @@ Be careful when using `$locale` as `TRUE` because the it's very permissive:
 v::yes(true)->isValid('Yydoesnotmatter'); // true
 ```
 
-Besides that, with `$locale` as  `TRUE` it will consider any character starting
+Besides that, with `$locale` as `TRUE` it will consider any character starting
 with "Y" as valid:
 
 ```php
@@ -41,16 +41,16 @@ v::yes(true)->isValid('Yes'); // true
 
 ### `Yes::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-|------------|---------------------------------------|
-| `default`  | {{name}} must be similar to "Yes"     |
-| `inverted` | {{name}} must not be similar to "Yes" |
+| Mode       | Template                                 |
+| ---------- | ---------------------------------------- |
+| `default`  | {{subject}} must be similar to "Yes"     |
+| `inverted` | {{subject}} must not be similar to "Yes" |
 
 ## Template placeholders
 
 | Placeholder | Description                                                      |
-|-------------|------------------------------------------------------------------|
-| `name`      | The validated input or the custom validator name (if specified). |
+| ----------- | ---------------------------------------------------------------- |
+| `subject`   | The validated input or the custom validator name (if specified). |
 
 ## Categorization
 
@@ -59,10 +59,11 @@ v::yes(true)->isValid('Yes'); // true
 ## Changelog
 
 | Version | Description |
-|--------:|-------------|
+| ------: | ----------- |
 |   0.7.0 | Created     |
 
-***
+---
+
 See also:
 
 - [BoolType](BoolType.md)

--- a/library/Message/InterpolationRenderer.php
+++ b/library/Message/InterpolationRenderer.php
@@ -36,7 +36,7 @@ final readonly class InterpolationRenderer implements Renderer
     /** @param array<string|int, mixed> $templates */
     public function render(Result $result, array $templates): string
     {
-        $parameters = ['path' => $result->path, 'input' => $result->input, 'name' => $this->getName($result)];
+        $parameters = ['path' => $result->path, 'input' => $result->input, 'subject' => $this->getName($result)];
         $parameters += $result->parameters;
 
         $givenTemplate = $this->templateResolver->getGivenTemplate($result, $templates);

--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -22,13 +22,13 @@ use function count;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must pass the rules',
-    '{{name}} must pass the rules',
+    '{{subject}} must pass the rules',
+    '{{subject}} must pass the rules',
     self::TEMPLATE_SOME,
 )]
 #[Template(
-    '{{name}} must pass all the rules',
-    '{{name}} must pass all the rules',
+    '{{subject}} must pass all the rules',
+    '{{subject}} must pass all the rules',
     self::TEMPLATE_ALL,
 )]
 final class AllOf extends Composite

--- a/library/Rules/Alnum.php
+++ b/library/Rules/Alnum.php
@@ -17,13 +17,13 @@ use function ctype_alnum;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only letters (a-z) and digits (0-9)',
-    '{{name}} must not contain letters (a-z) or digits (0-9)',
+    '{{subject}} must contain only letters (a-z) and digits (0-9)',
+    '{{subject}} must not contain letters (a-z) or digits (0-9)',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only letters (a-z), digits (0-9), and {{additionalChars}}',
-    '{{name}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}',
+    '{{subject}} must contain only letters (a-z), digits (0-9), and {{additionalChars}}',
+    '{{subject}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Alnum extends FilteredString

--- a/library/Rules/Alpha.php
+++ b/library/Rules/Alpha.php
@@ -17,13 +17,13 @@ use function ctype_alpha;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only letters (a-z)',
-    '{{name}} must not contain letters (a-z)',
+    '{{subject}} must contain only letters (a-z)',
+    '{{subject}} must not contain letters (a-z)',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only letters (a-z) and {{additionalChars}}',
-    '{{name}} must not contain letters (a-z) or {{additionalChars}}',
+    '{{subject}} must contain only letters (a-z) and {{additionalChars}}',
+    '{{subject}} must not contain letters (a-z) or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Alpha extends FilteredString

--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -15,13 +15,13 @@ use Respect\Validation\Rules\Core\Simple;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be valid',
-    '{{name}} must be invalid',
+    '{{subject}} must be valid',
+    '{{subject}} must be invalid',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} is invalid',
-    '{{name}} is valid',
+    '{{subject}} is invalid',
+    '{{subject}} is valid',
     self::TEMPLATE_SIMPLE,
 )]
 final class AlwaysInvalid extends Simple

--- a/library/Rules/AlwaysValid.php
+++ b/library/Rules/AlwaysValid.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Simple;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be valid',
-    '{{name}} must be invalid',
+    '{{subject}} must be valid',
+    '{{subject}} must be invalid',
 )]
 final class AlwaysValid extends Simple
 {

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -20,8 +20,8 @@ use function array_reduce;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must pass at least one of the rules',
-    '{{name}} must pass at least one of the rules',
+    '{{subject}} must pass at least one of the rules',
+    '{{subject}} must pass at least one of the rules',
 )]
 final class AnyOf extends Composite
 {

--- a/library/Rules/ArrayType.php
+++ b/library/Rules/ArrayType.php
@@ -17,8 +17,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an array',
-    '{{name}} must not be an array',
+    '{{subject}} must be an array',
+    '{{subject}} must not be an array',
 )]
 final class ArrayType extends Simple
 {

--- a/library/Rules/ArrayVal.php
+++ b/library/Rules/ArrayVal.php
@@ -19,8 +19,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an array value',
-    '{{name}} must not be an array value',
+    '{{subject}} must be an array value',
+    '{{subject}} must not be an array value',
 )]
 final class ArrayVal extends Simple
 {

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -21,8 +21,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a number in base {{base|raw}}',
-    '{{name}} must not be a number in base {{base|raw}}',
+    '{{subject}} must be a number in base {{base|raw}}',
+    '{{subject}} must not be a number in base {{base|raw}}',
 )]
 final readonly class Base implements Rule
 {

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -19,8 +19,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a base64 encoded string',
-    '{{name}} must not be a base64 encoded string',
+    '{{subject}} must be a base64 encoded string',
+    '{{subject}} must not be a base64 encoded string',
 )]
 final class Base64 extends Simple
 {

--- a/library/Rules/Between.php
+++ b/library/Rules/Between.php
@@ -17,8 +17,8 @@ use Respect\Validation\Rules\Core\Envelope;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be between {{minValue}} and {{maxValue}}',
-    '{{name}} must not be between {{minValue}} and {{maxValue}}',
+    '{{subject}} must be between {{minValue}} and {{maxValue}}',
+    '{{subject}} must not be between {{minValue}} and {{maxValue}}',
 )]
 final class Between extends Envelope
 {

--- a/library/Rules/BetweenExclusive.php
+++ b/library/Rules/BetweenExclusive.php
@@ -17,8 +17,8 @@ use Respect\Validation\Rules\Core\Envelope;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be greater than {{minValue}} and less than {{maxValue}}',
-    '{{name}} must not be greater than {{minValue}} or less than {{maxValue}}',
+    '{{subject}} must be greater than {{minValue}} and less than {{maxValue}}',
+    '{{subject}} must not be greater than {{minValue}} or less than {{maxValue}}',
 )]
 final class BetweenExclusive extends Envelope
 {

--- a/library/Rules/BoolType.php
+++ b/library/Rules/BoolType.php
@@ -17,8 +17,8 @@ use function is_bool;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a boolean',
-    '{{name}} must not be a boolean',
+    '{{subject}} must be a boolean',
+    '{{subject}} must not be a boolean',
 )]
 final class BoolType extends Simple
 {

--- a/library/Rules/BoolVal.php
+++ b/library/Rules/BoolVal.php
@@ -21,8 +21,8 @@ use const FILTER_VALIDATE_BOOLEAN;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a boolean value',
-    '{{name}} must not be a boolean value',
+    '{{subject}} must be a boolean value',
+    '{{subject}} must not be a boolean value',
 )]
 final class BoolVal extends Simple
 {

--- a/library/Rules/Bsn.php
+++ b/library/Rules/Bsn.php
@@ -22,8 +22,8 @@ use function strval;
 /** @see https://nl.wikipedia.org/wiki/Burgerservicenummer */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid BSN',
-    '{{name}} must not be a valid BSN',
+    '{{subject}} must be a valid BSN',
+    '{{subject}} must not be a valid BSN',
 )]
 final class Bsn extends Simple
 {

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -17,8 +17,8 @@ use function is_callable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a callable',
-    '{{name}} must not be a callable',
+    '{{subject}} must be a callable',
+    '{{subject}} must not be a callable',
 )]
 final class CallableType extends Simple
 {

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -19,8 +19,8 @@ use function count;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be valid',
-    '{{name}} must be invalid',
+    '{{subject}} must be valid',
+    '{{subject}} must be invalid',
 )]
 final class Callback extends Simple
 {

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -25,8 +25,8 @@ use function mb_list_encodings;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must only contain characters from the {{charset|raw}} charset',
-    '{{name}} must not contain any characters from the {{charset|raw}} charset',
+    '{{subject}} must only contain characters from the {{charset|raw}} charset',
+    '{{subject}} must not contain any characters from the {{charset|raw}} charset',
 )]
 final readonly class Charset implements Rule
 {

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -20,8 +20,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid CNH number',
-    '{{name}} must not be a valid CNH number',
+    '{{subject}} must be a valid CNH number',
+    '{{subject}} must not be a valid CNH number',
 )]
 final class Cnh extends Simple
 {

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -22,8 +22,8 @@ use function str_split;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid CNPJ number',
-    '{{name}} must not be a valid CNPJ number',
+    '{{subject}} must be a valid CNPJ number',
+    '{{subject}} must not be a valid CNPJ number',
 )]
 final class Cnpj extends Simple
 {

--- a/library/Rules/Consonant.php
+++ b/library/Rules/Consonant.php
@@ -17,13 +17,13 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must only contain consonants',
-    '{{name}} must not contain consonants',
+    '{{subject}} must only contain consonants',
+    '{{subject}} must not contain consonants',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must only contain consonants and {{additionalChars}}',
-    '{{name}} must not contain consonants or {{additionalChars}}',
+    '{{subject}} must only contain consonants and {{additionalChars}}',
+    '{{subject}} must not contain consonants or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Consonant extends FilteredString

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -22,8 +22,8 @@ use function mb_strpos;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain {{containsValue}}',
-    '{{name}} must not contain {{containsValue}}',
+    '{{subject}} must contain {{containsValue}}',
+    '{{subject}} must not contain {{containsValue}}',
 )]
 final readonly class Contains implements Rule
 {

--- a/library/Rules/ContainsAny.php
+++ b/library/Rules/ContainsAny.php
@@ -19,8 +19,8 @@ use function count;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain at least one value from {{needles}}',
-    '{{name}} must not contain any value from {{needles}}',
+    '{{subject}} must contain at least one value from {{needles}}',
+    '{{subject}} must not contain any value from {{needles}}',
 )]
 final class ContainsAny extends Envelope
 {

--- a/library/Rules/Control.php
+++ b/library/Rules/Control.php
@@ -17,13 +17,13 @@ use function ctype_cntrl;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must only contain control characters',
-    '{{name}} must not contain control characters',
+    '{{subject}} must only contain control characters',
+    '{{subject}} must not contain control characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must only contain control characters and {{additionalChars}}',
-    '{{name}} must not contain control characters or {{additionalChars}}',
+    '{{subject}} must only contain control characters and {{additionalChars}}',
+    '{{subject}} must not contain control characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Control extends FilteredString

--- a/library/Rules/Countable.php
+++ b/library/Rules/Countable.php
@@ -18,8 +18,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a countable value',
-    '{{name}} must not be a countable value',
+    '{{subject}} must be a countable value',
+    '{{subject}} must not be a countable value',
 )]
 final class Countable extends Simple
 {

--- a/library/Rules/CountryCode.php
+++ b/library/Rules/CountryCode.php
@@ -23,8 +23,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid country code',
-    '{{name}} must not be a valid country code',
+    '{{subject}} must be a valid country code',
+    '{{subject}} must not be a valid country code',
 )]
 final readonly class CountryCode implements Rule
 {

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -20,8 +20,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid CPF number',
-    '{{name}} must not be a valid CPF number',
+    '{{subject}} must be a valid CPF number',
+    '{{subject}} must not be a valid CPF number',
 )]
 final class Cpf extends Simple
 {

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -22,13 +22,13 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid credit card number',
-    '{{name}} must not be a valid credit card number',
+    '{{subject}} must be a valid credit card number',
+    '{{subject}} must not be a valid credit card number',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be a valid {{brand|raw}} credit card number',
-    '{{name}} must not be a valid {{brand|raw}} credit card number',
+    '{{subject}} must be a valid {{brand|raw}} credit card number',
+    '{{subject}} must not be a valid {{brand|raw}} credit card number',
     self::TEMPLATE_BRANDED,
 )]
 final readonly class CreditCard implements Rule

--- a/library/Rules/CurrencyCode.php
+++ b/library/Rules/CurrencyCode.php
@@ -22,8 +22,8 @@ use function in_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid currency code',
-    '{{name}} must not be a valid currency code',
+    '{{subject}} must be a valid currency code',
+    '{{subject}} must not be a valid currency code',
 )]
 final readonly class CurrencyCode implements Rule
 {

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -23,8 +23,8 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid date in the format {{sample}}',
-    '{{name}} must not be a valid date in the format {{sample}}',
+    '{{subject}} must be a valid date in the format {{sample}}',
+    '{{subject}} must not be a valid date in the format {{sample}}',
 )]
 final readonly class Date implements Rule
 {

--- a/library/Rules/DateTime.php
+++ b/library/Rules/DateTime.php
@@ -22,13 +22,13 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid date/time',
-    '{{name}} must not be a valid date/time',
+    '{{subject}} must be a valid date/time',
+    '{{subject}} must not be a valid date/time',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be a valid date/time in the format {{sample}}',
-    '{{name}} must not be a valid date/time in the format {{sample}}',
+    '{{subject}} must be a valid date/time in the format {{sample}}',
+    '{{subject}} must not be a valid date/time in the format {{sample}}',
     self::TEMPLATE_FORMAT,
 )]
 final class DateTime implements Rule

--- a/library/Rules/DateTimeDiff.php
+++ b/library/Rules/DateTimeDiff.php
@@ -33,13 +33,13 @@ use function in_array;
     self::TEMPLATE_CUSTOMIZED,
 )]
 #[Template(
-    'For comparison with {{now|raw}}, {{name}} must be a valid datetime',
-    'For comparison with {{now|raw}}, {{name}} must not be a valid datetime',
+    'For comparison with {{now|raw}}, {{subject}} must be a valid datetime',
+    'For comparison with {{now|raw}}, {{subject}} must not be a valid datetime',
     self::TEMPLATE_NOT_A_DATE,
 )]
 #[Template(
-    'For comparison with {{now|raw}}, {{name}} must be a valid datetime in the format {{sample|raw}}',
-    'For comparison with {{now|raw}}, {{name}} must not be a valid datetime in the format {{sample|raw}}',
+    'For comparison with {{now|raw}}, {{subject}} must be a valid datetime in the format {{sample|raw}}',
+    'For comparison with {{now|raw}}, {{subject}} must not be a valid datetime in the format {{sample|raw}}',
     self::TEMPLATE_WRONG_FORMAT,
 )]
 final readonly class DateTimeDiff implements Rule

--- a/library/Rules/Decimal.php
+++ b/library/Rules/Decimal.php
@@ -22,8 +22,8 @@ use function var_export;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must have {{decimals}} decimals',
-    '{{name}} must not have {{decimals}} decimals',
+    '{{subject}} must have {{decimals}} decimals',
+    '{{subject}} must not have {{decimals}} decimals',
 )]
 final readonly class Decimal implements Rule
 {

--- a/library/Rules/Digit.php
+++ b/library/Rules/Digit.php
@@ -17,13 +17,13 @@ use function ctype_digit;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only digits (0-9)',
-    '{{name}} must not contain digits (0-9)',
+    '{{subject}} must contain only digits (0-9)',
+    '{{subject}} must not contain digits (0-9)',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only digits (0-9) and {{additionalChars}}',
-    '{{name}} must not contain digits (0-9) and {{additionalChars}}',
+    '{{subject}} must contain only digits (0-9) and {{additionalChars}}',
+    '{{subject}} must not contain digits (0-9) and {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Digit extends FilteredString

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -20,8 +20,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a directory',
-    '{{name}} must not be a directory',
+    '{{subject}} must be a directory',
+    '{{subject}} must not be a directory',
 )]
 final class Directory extends Simple
 {

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -21,8 +21,8 @@ use function mb_substr_count;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid domain',
-    '{{name}} must not be a valid domain',
+    '{{subject}} must be a valid domain',
+    '{{subject}} must not be a valid domain',
 )]
 final class Domain implements Rule
 {

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -19,8 +19,8 @@ use function array_reduce;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    'Each item in {{name}} must be valid',
-    'Each item in {{name}} must be invalid',
+    'Each item in {{subject}} must be valid',
+    'Each item in {{subject}} must be invalid',
 )]
 final class Each extends FilteredNonEmptyArray
 {

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -24,8 +24,8 @@ use const FILTER_VALIDATE_EMAIL;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid email address',
-    '{{name}} must not be an email address',
+    '{{subject}} must be a valid email address',
+    '{{subject}} must not be an email address',
 )]
 final class Email extends Simple
 {

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -22,8 +22,8 @@ use function mb_strrpos;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must end with {{endValue}}',
-    '{{name}} must not end with {{endValue}}',
+    '{{subject}} must end with {{endValue}}',
+    '{{subject}} must not end with {{endValue}}',
 )]
 final readonly class EndsWith implements Rule
 {

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -18,8 +18,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be equal to {{compareTo}}',
-    '{{name}} must not be equal to {{compareTo}}',
+    '{{subject}} must be equal to {{compareTo}}',
+    '{{subject}} must not be equal to {{compareTo}}',
 )]
 final readonly class Equals implements Rule
 {

--- a/library/Rules/Equivalent.php
+++ b/library/Rules/Equivalent.php
@@ -18,8 +18,8 @@ use function mb_strtoupper;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be equivalent to {{compareTo}}',
-    '{{name}} must not be equivalent to {{compareTo}}',
+    '{{subject}} must be equivalent to {{compareTo}}',
+    '{{subject}} must not be equivalent to {{compareTo}}',
 )]
 final class Equivalent extends Comparison
 {

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -19,8 +19,8 @@ use const FILTER_VALIDATE_INT;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an even number',
-    '{{name}} must be an odd number',
+    '{{subject}} must be an even number',
+    '{{subject}} must be an odd number',
 )]
 final class Even extends Simple
 {

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -19,8 +19,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an executable file',
-    '{{name}} must not be an executable file',
+    '{{subject}} must be an executable file',
+    '{{subject}} must not be an executable file',
 )]
 final class Executable extends Simple
 {

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -19,8 +19,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an existing file',
-    '{{name}} must not be an existing file',
+    '{{subject}} must be an existing file',
+    '{{subject}} must not be an existing file',
 )]
 final class Exists extends Simple
 {

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -22,8 +22,8 @@ use const PATHINFO_EXTENSION;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must have {{extension}} extension',
-    '{{name}} must not have {{extension}} extension',
+    '{{subject}} must have {{extension}} extension',
+    '{{subject}} must not have {{extension}} extension',
 )]
 final readonly class Extension implements Rule
 {

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -21,8 +21,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a factor of {{dividend|raw}}',
-    '{{name}} must not be a factor of {{dividend|raw}}',
+    '{{subject}} must be a factor of {{dividend|raw}}',
+    '{{subject}} must not be a factor of {{dividend|raw}}',
 )]
 final readonly class Factor implements Rule
 {

--- a/library/Rules/FalseVal.php
+++ b/library/Rules/FalseVal.php
@@ -20,8 +20,8 @@ use const FILTER_VALIDATE_BOOLEAN;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must evaluate to `false`',
-    '{{name}} must not evaluate to `false`',
+    '{{subject}} must evaluate to `false`',
+    '{{subject}} must not evaluate to `false`',
 )]
 final class FalseVal extends Simple
 {

--- a/library/Rules/Fibonacci.php
+++ b/library/Rules/Fibonacci.php
@@ -17,8 +17,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid Fibonacci number',
-    '{{name}} must not be a valid Fibonacci number',
+    '{{subject}} must be a valid Fibonacci number',
+    '{{subject}} must not be a valid Fibonacci number',
 )]
 final class Fibonacci extends Simple
 {

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -19,8 +19,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid file',
-    '{{name}} must be an invalid file',
+    '{{subject}} must be a valid file',
+    '{{subject}} must be an invalid file',
 )]
 final class File extends Simple
 {

--- a/library/Rules/FilterVar.php
+++ b/library/Rules/FilterVar.php
@@ -30,8 +30,8 @@ use const FILTER_VALIDATE_URL;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be valid',
-    '{{name}} must not be valid',
+    '{{subject}} must be valid',
+    '{{subject}} must not be valid',
 )]
 final class FilterVar extends Envelope
 {

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -18,8 +18,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a finite number',
-    '{{name}} must not be a finite number',
+    '{{subject}} must be a finite number',
+    '{{subject}} must not be a finite number',
 )]
 final class Finite extends Simple
 {

--- a/library/Rules/FloatType.php
+++ b/library/Rules/FloatType.php
@@ -17,8 +17,8 @@ use function is_float;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be float',
-    '{{name}} must not be float',
+    '{{subject}} must be float',
+    '{{subject}} must not be float',
 )]
 final class FloatType extends Simple
 {

--- a/library/Rules/FloatVal.php
+++ b/library/Rules/FloatVal.php
@@ -20,8 +20,8 @@ use const FILTER_VALIDATE_FLOAT;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a float value',
-    '{{name}} must not be a float value',
+    '{{subject}} must be a float value',
+    '{{subject}} must not be a float value',
 )]
 final class FloatVal extends Simple
 {

--- a/library/Rules/Graph.php
+++ b/library/Rules/Graph.php
@@ -17,13 +17,13 @@ use function ctype_graph;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only graphical characters',
-    '{{name}} must not contain graphical characters',
+    '{{subject}} must contain only graphical characters',
+    '{{subject}} must not contain graphical characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only graphical characters and {{additionalChars}}',
-    '{{name}} must not contain graphical characters or {{additionalChars}}',
+    '{{subject}} must contain only graphical characters and {{additionalChars}}',
+    '{{subject}} must not contain graphical characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Graph extends FilteredString

--- a/library/Rules/GreaterThan.php
+++ b/library/Rules/GreaterThan.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Comparison;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be greater than {{compareTo}}',
-    '{{name}} must not be greater than {{compareTo}}',
+    '{{subject}} must be greater than {{compareTo}}',
+    '{{subject}} must not be greater than {{compareTo}}',
 )]
 final class GreaterThan extends Comparison
 {

--- a/library/Rules/GreaterThanOrEqual.php
+++ b/library/Rules/GreaterThanOrEqual.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Comparison;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be greater than or equal to {{compareTo}}',
-    '{{name}} must be less than {{compareTo}}',
+    '{{subject}} must be greater than or equal to {{compareTo}}',
+    '{{subject}} must be less than {{compareTo}}',
 )]
 final class GreaterThanOrEqual extends Comparison
 {

--- a/library/Rules/Hetu.php
+++ b/library/Rules/Hetu.php
@@ -21,8 +21,8 @@ use function str_split;
 /** @see https://en.wikipedia.org/wiki/National_identification_number#Finland */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid Finnish personal identity code',
-    '{{name}} must not be a valid Finnish personal identity code',
+    '{{subject}} must be a valid Finnish personal identity code',
+    '{{subject}} must not be a valid Finnish personal identity code',
 )]
 final class Hetu extends Simple
 {

--- a/library/Rules/HexRgbColor.php
+++ b/library/Rules/HexRgbColor.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Envelope;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a hex RGB color',
-    '{{name}} must not be a hex RGB color',
+    '{{subject}} must be a hex RGB color',
+    '{{subject}} must not be a hex RGB color',
 )]
 final class HexRgbColor extends Envelope
 {

--- a/library/Rules/Iban.php
+++ b/library/Rules/Iban.php
@@ -25,8 +25,8 @@ use function substr;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid IBAN',
-    '{{name}} must not be a valid IBAN',
+    '{{subject}} must be a valid IBAN',
+    '{{subject}} must not be a valid IBAN',
 )]
 final class Iban extends Simple
 {

--- a/library/Rules/Identical.php
+++ b/library/Rules/Identical.php
@@ -16,8 +16,8 @@ use Respect\Validation\Rule;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be identical to {{compareTo}}',
-    '{{name}} must not be identical to {{compareTo}}',
+    '{{subject}} must be identical to {{compareTo}}',
+    '{{subject}} must not be identical to {{compareTo}}',
 )]
 final readonly class Identical implements Rule
 {

--- a/library/Rules/Image.php
+++ b/library/Rules/Image.php
@@ -23,8 +23,8 @@ use const FILEINFO_MIME_TYPE;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid image file',
-    '{{name}} must not be a valid image file',
+    '{{subject}} must be a valid image file',
+    '{{subject}} must not be a valid image file',
 )]
 final class Image extends Simple
 {

--- a/library/Rules/Imei.php
+++ b/library/Rules/Imei.php
@@ -19,8 +19,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid IMEI number',
-    '{{name}} must not be a valid IMEI number',
+    '{{subject}} must be a valid IMEI number',
+    '{{subject}} must not be a valid IMEI number',
 )]
 final class Imei extends Simple
 {

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -21,8 +21,8 @@ use function mb_strpos;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be in {{haystack}}',
-    '{{name}} must not be in {{haystack}}',
+    '{{subject}} must be in {{haystack}}',
+    '{{subject}} must not be in {{haystack}}',
 )]
 final readonly class In implements Rule
 {

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -18,8 +18,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an infinite number',
-    '{{name}} must not be an infinite number',
+    '{{subject}} must be an infinite number',
+    '{{subject}} must not be an infinite number',
 )]
 final class Infinite extends Simple
 {

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -16,8 +16,8 @@ use Respect\Validation\Rule;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an instance of {{class|quote}}',
-    '{{name}} must not be an instance of {{class|quote}}',
+    '{{subject}} must be an instance of {{class|quote}}',
+    '{{subject}} must not be an instance of {{class|quote}}',
 )]
 final readonly class Instance implements Rule
 {

--- a/library/Rules/IntType.php
+++ b/library/Rules/IntType.php
@@ -17,8 +17,8 @@ use function is_int;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an integer',
-    '{{name}} must not be an integer',
+    '{{subject}} must be an integer',
+    '{{subject}} must not be an integer',
 )]
 final class IntType extends Simple
 {

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -19,8 +19,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an integer value',
-    '{{name}} must not be an integer value',
+    '{{subject}} must be an integer value',
+    '{{subject}} must not be an integer value',
 )]
 final class IntVal extends Simple
 {

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -34,13 +34,13 @@ use const PHP_INT_MAX;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an IP address',
-    '{{name}} must not be an IP address',
+    '{{subject}} must be an IP address',
+    '{{subject}} must not be an IP address',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be an IP address in the {{range|raw}} range',
-    '{{name}} must not be an IP address in the {{range|raw}} range',
+    '{{subject}} must be an IP address in the {{range|raw}} range',
+    '{{subject}} must not be an IP address in the {{range|raw}} range',
     self::TEMPLATE_NETWORK_RANGE,
 )]
 final class Ip implements Rule

--- a/library/Rules/Isbn.php
+++ b/library/Rules/Isbn.php
@@ -20,8 +20,8 @@ use function sprintf;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid ISBN',
-    '{{name}} must not be a valid ISBN',
+    '{{subject}} must be a valid ISBN',
+    '{{subject}} must not be a valid ISBN',
 )]
 final class Isbn extends Simple
 {

--- a/library/Rules/IterableType.php
+++ b/library/Rules/IterableType.php
@@ -17,8 +17,8 @@ use function is_iterable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be iterable',
-    '{{name}} must not iterable',
+    '{{subject}} must be iterable',
+    '{{subject}} must not iterable',
 )]
 final class IterableType extends Simple
 {

--- a/library/Rules/IterableVal.php
+++ b/library/Rules/IterableVal.php
@@ -16,8 +16,8 @@ use Respect\Validation\Rules\Core\Simple;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an iterable value',
-    '{{name}} must not be an iterable value',
+    '{{subject}} must be an iterable value',
+    '{{subject}} must not be an iterable value',
 )]
 final class IterableVal extends Simple
 {

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -23,8 +23,8 @@ use const JSON_ERROR_NONE;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid JSON string',
-    '{{name}} must not be a valid JSON string',
+    '{{subject}} must be a valid JSON string',
+    '{{subject}} must not be a valid JSON string',
 )]
 final class Json extends Simple
 {

--- a/library/Rules/KeyExists.php
+++ b/library/Rules/KeyExists.php
@@ -22,8 +22,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be present',
-    '{{name}} must not be present',
+    '{{subject}} must be present',
+    '{{subject}} must not be present',
 )]
 final class KeyExists implements Rule, KeyRelated
 {

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -27,22 +27,22 @@ use function array_slice;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} validation failed',
-    '{{name}} validation passed',
+    '{{subject}} validation failed',
+    '{{subject}} validation passed',
 )]
 #[Template(
-    '{{name}} contains both missing and extra keys',
-    '{{name}} contains no missing or extra keys.',
+    '{{subject}} contains both missing and extra keys',
+    '{{subject}} contains no missing or extra keys.',
     self::TEMPLATE_BOTH,
 )]
 #[Template(
-    '{{name}} contains extra keys',
-    '{{name}} contains no extra keys',
+    '{{subject}} contains extra keys',
+    '{{subject}} contains no extra keys',
     self::TEMPLATE_EXTRA_KEYS,
 )]
 #[Template(
-    '{{name}} contains missing keys',
-    '{{name}} contains no missing keys',
+    '{{subject}} contains missing keys',
+    '{{subject}} contains no missing keys',
     self::TEMPLATE_MISSING_KEYS,
 )]
 final readonly class KeySet implements Rule

--- a/library/Rules/LanguageCode.php
+++ b/library/Rules/LanguageCode.php
@@ -24,8 +24,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid language code',
-    '{{name}} must not be a valid language code',
+    '{{subject}} must be a valid language code',
+    '{{subject}} must not be a valid language code',
 )]
 final readonly class LanguageCode implements Rule
 {

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -19,8 +19,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid leap date',
-    '{{name}} must not be a leap date',
+    '{{subject}} must be a valid leap date',
+    '{{subject}} must not be a leap date',
 )]
 final class LeapDate extends Simple
 {

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -22,8 +22,8 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid leap year',
-    '{{name}} must not be a leap year',
+    '{{subject}} must be a valid leap year',
+    '{{subject}} must not be a leap year',
 )]
 final class LeapYear extends Simple
 {

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -27,8 +27,8 @@ use function mb_strlen;
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be a countable value or a string',
-    '{{name}} must not be a countable value or a string',
+    '{{subject}} must be a countable value or a string',
+    '{{subject}} must not be a countable value or a string',
     self::TEMPLATE_WRONG_TYPE,
 )]
 final class Length extends Wrapper

--- a/library/Rules/LessThan.php
+++ b/library/Rules/LessThan.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Comparison;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be less than {{compareTo}}',
-    '{{name}} must not be less than {{compareTo}}',
+    '{{subject}} must be less than {{compareTo}}',
+    '{{subject}} must not be less than {{compareTo}}',
 )]
 final class LessThan extends Comparison
 {

--- a/library/Rules/LessThanOrEqual.php
+++ b/library/Rules/LessThanOrEqual.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Comparison;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be less than or equal to {{compareTo}}',
-    '{{name}} must be greater than {{compareTo}}',
+    '{{subject}} must be less than or equal to {{compareTo}}',
+    '{{subject}} must be greater than {{compareTo}}',
 )]
 final class LessThanOrEqual extends Comparison
 {

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -18,8 +18,8 @@ use function mb_strtolower;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only lowercase letters',
-    '{{name}} must not contain only lowercase letters',
+    '{{subject}} must contain only lowercase letters',
+    '{{subject}} must not contain only lowercase letters',
 )]
 final class Lowercase extends Simple
 {

--- a/library/Rules/Luhn.php
+++ b/library/Rules/Luhn.php
@@ -20,8 +20,8 @@ use function str_split;
 /** @see https://en.wikipedia.org/wiki/Luhn_algorithm */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid Luhn number',
-    '{{name}} must not be a valid Luhn number',
+    '{{subject}} must be a valid Luhn number',
+    '{{subject}} must not be a valid Luhn number',
 )]
 final class Luhn extends Simple
 {

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -18,8 +18,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid MAC address',
-    '{{name}} must not be a valid MAC address',
+    '{{subject}} must be a valid MAC address',
+    '{{subject}} must not be a valid MAC address',
 )]
 final class MacAddress extends Simple
 {

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -23,8 +23,8 @@ use const FILEINFO_MIME_TYPE;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must have the {{mimetype}} MIME type',
-    '{{name}} must not have the {{mimetype}} MIME type',
+    '{{subject}} must have the {{mimetype}} MIME type',
+    '{{subject}} must not have the {{mimetype}} MIME type',
 )]
 final readonly class Mimetype implements Rule
 {

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -16,8 +16,8 @@ use Respect\Validation\Rule;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a multiple of {{multipleOf}}',
-    '{{name}} must not be a multiple of {{multipleOf}}',
+    '{{subject}} must be a multiple of {{multipleOf}}',
+    '{{subject}} must not be a multiple of {{multipleOf}}',
 )]
 final readonly class Multiple implements Rule
 {

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -17,8 +17,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a negative number',
-    '{{name}} must not be a negative number',
+    '{{subject}} must be a negative number',
+    '{{subject}} must not be a negative number',
 )]
 final class Negative extends Simple
 {

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -21,8 +21,8 @@ use function str_split;
 /** @see (pt-br) Manual de Integração do Contribuinte v4.0.1 em http://www.nfe.fazenda.gov.br */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid NFe access key',
-    '{{name}} must not be a valid NFe access key',
+    '{{subject}} must be a valid NFe access key',
+    '{{subject}} must not be a valid NFe access key',
 )]
 final class NfeAccessKey extends Simple
 {

--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -24,8 +24,8 @@ use function str_split;
 /** @see https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid NIF',
-    '{{name}} must not be a valid NIF',
+    '{{subject}} must be a valid NIF',
+    '{{subject}} must not be a valid NIF',
 )]
 final class Nif extends Simple
 {

--- a/library/Rules/Nip.php
+++ b/library/Rules/Nip.php
@@ -21,8 +21,8 @@ use function str_split;
 /** @see https://en.wikipedia.org/wiki/VAT_identification_number */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid Polish VAT identification number',
-    '{{name}} must not be a valid Polish VAT identification number',
+    '{{subject}} must be a valid Polish VAT identification number',
+    '{{subject}} must not be a valid Polish VAT identification number',
 )]
 final class Nip extends Simple
 {

--- a/library/Rules/No.php
+++ b/library/Rules/No.php
@@ -19,8 +19,8 @@ use const NOEXPR;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be similar to "No"',
-    '{{name}} must not be similar to "No"',
+    '{{subject}} must be similar to "No"',
+    '{{subject}} must not be similar to "No"',
 )]
 final class No extends Envelope
 {

--- a/library/Rules/NoWhitespace.php
+++ b/library/Rules/NoWhitespace.php
@@ -18,8 +18,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must not contain whitespaces',
-    '{{name}} must contain at least one whitespace',
+    '{{subject}} must not contain whitespaces',
+    '{{subject}} must contain at least one whitespace',
 )]
 final class NoWhitespace extends Simple
 {

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -22,13 +22,13 @@ use function count;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must pass the rules',
-    '{{name}} must pass the rules',
+    '{{subject}} must pass the rules',
+    '{{subject}} must pass the rules',
     self::TEMPLATE_SOME,
 )]
 #[Template(
-    '{{name}} must pass all the rules',
-    '{{name}} must pass all the rules',
+    '{{subject}} must pass all the rules',
+    '{{subject}} must pass all the rules',
     self::TEMPLATE_ALL,
 )]
 final class NoneOf extends Composite

--- a/library/Rules/NotBlank.php
+++ b/library/Rules/NotBlank.php
@@ -23,8 +23,8 @@ use function trim;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must not be blank',
-    '{{name}} must be blank',
+    '{{subject}} must not be blank',
+    '{{subject}} must be blank',
 )]
 final class NotBlank implements Rule
 {

--- a/library/Rules/NotEmoji.php
+++ b/library/Rules/NotEmoji.php
@@ -19,8 +19,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must not contain an emoji',
-    '{{name}} must contain an emoji',
+    '{{subject}} must not contain an emoji',
+    '{{subject}} must contain an emoji',
 )]
 final class NotEmoji extends Simple
 {

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -19,8 +19,8 @@ use function trim;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must not be empty',
-    '{{name}} must be empty',
+    '{{subject}} must not be empty',
+    '{{subject}} must be empty',
 )]
 final class NotEmpty implements Rule
 {

--- a/library/Rules/NotUndef.php
+++ b/library/Rules/NotUndef.php
@@ -17,8 +17,8 @@ use Respect\Validation\Rule;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be defined',
-    '{{name}} must be undefined',
+    '{{subject}} must be defined',
+    '{{subject}} must be undefined',
 )]
 final class NotUndef implements Rule
 {

--- a/library/Rules/NullType.php
+++ b/library/Rules/NullType.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Simple;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be null',
-    '{{name}} must not be null',
+    '{{subject}} must be null',
+    '{{subject}} must not be null',
 )]
 final class NullType extends Simple
 {

--- a/library/Rules/Number.php
+++ b/library/Rules/Number.php
@@ -18,8 +18,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid number',
-    '{{name}} must not be a number',
+    '{{subject}} must be a valid number',
+    '{{subject}} must not be a number',
 )]
 final class Number extends Simple
 {

--- a/library/Rules/NumericVal.php
+++ b/library/Rules/NumericVal.php
@@ -17,8 +17,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a numeric value',
-    '{{name}} must not be a numeric value',
+    '{{subject}} must be a numeric value',
+    '{{subject}} must not be a numeric value',
 )]
 final class NumericVal extends Simple
 {

--- a/library/Rules/ObjectType.php
+++ b/library/Rules/ObjectType.php
@@ -17,8 +17,8 @@ use function is_object;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an object',
-    '{{name}} must not be an object',
+    '{{subject}} must be an object',
+    '{{subject}} must not be an object',
 )]
 final class ObjectType extends Simple
 {

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -20,8 +20,8 @@ use const FILTER_VALIDATE_INT;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an odd number',
-    '{{name}} must be an even number',
+    '{{subject}} must be an odd number',
+    '{{subject}} must be an even number',
 )]
 final class Odd extends Simple
 {

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -23,13 +23,13 @@ use function usort;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must pass one of the rules',
-    '{{name}} must pass one of the rules',
+    '{{subject}} must pass one of the rules',
+    '{{subject}} must pass one of the rules',
     self::TEMPLATE_NONE,
 )]
 #[Template(
-    '{{name}} must pass only one of the rules',
-    '{{name}} must pass only one of the rules',
+    '{{subject}} must pass only one of the rules',
+    '{{subject}} must pass only one of the rules',
     self::TEMPLATE_MORE_THAN_ONE,
 )]
 final class OneOf extends Composite

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -19,8 +19,8 @@ use function sqrt;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a perfect square number',
-    '{{name}} must not be a perfect square number',
+    '{{subject}} must be a perfect square number',
+    '{{subject}} must not be a perfect square number',
 )]
 final class PerfectSquare extends Simple
 {

--- a/library/Rules/Pesel.php
+++ b/library/Rules/Pesel.php
@@ -18,8 +18,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid PESEL',
-    '{{name}} must not be a valid PESEL',
+    '{{subject}} must be a valid PESEL',
+    '{{subject}} must not be a valid PESEL',
 )]
 final class Pesel extends Simple
 {

--- a/library/Rules/Phone.php
+++ b/library/Rules/Phone.php
@@ -24,13 +24,13 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid telephone number',
-    '{{name}} must not be a valid telephone number',
+    '{{subject}} must be a valid telephone number',
+    '{{subject}} must not be a valid telephone number',
     self::TEMPLATE_INTERNATIONAL,
 )]
 #[Template(
-    '{{name}} must be a valid telephone number for country {{countryName|trans}}',
-    '{{name}} must not be a valid telephone number for country {{countryName|trans}}',
+    '{{subject}} must be a valid telephone number for country {{countryName|trans}}',
+    '{{subject}} must not be a valid telephone number for country {{countryName|trans}}',
     self::TEMPLATE_FOR_COUNTRY,
 )]
 final class Phone implements Rule

--- a/library/Rules/PhpLabel.php
+++ b/library/Rules/PhpLabel.php
@@ -18,8 +18,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid PHP label',
-    '{{name}} must not be a valid PHP label',
+    '{{subject}} must be a valid PHP label',
+    '{{subject}} must not be a valid PHP label',
 )]
 final class PhpLabel extends Simple
 {

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -20,8 +20,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid PIS number',
-    '{{name}} must not be a valid PIS number',
+    '{{subject}} must be a valid PIS number',
+    '{{subject}} must not be a valid PIS number',
 )]
 final class Pis extends Simple
 {

--- a/library/Rules/PolishIdCard.php
+++ b/library/Rules/PolishIdCard.php
@@ -20,8 +20,8 @@ use function preg_match;
 /** @see https://en.wikipedia.org/wiki/Polish_identity_card */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid Polish Identity Card number',
-    '{{name}} must not be a valid Polish Identity Card number',
+    '{{subject}} must be a valid Polish Identity Card number',
+    '{{subject}} must not be a valid Polish Identity Card number',
 )]
 final class PolishIdCard extends Simple
 {

--- a/library/Rules/PortugueseNif.php
+++ b/library/Rules/PortugueseNif.php
@@ -26,8 +26,8 @@ use function strlen;
 /** @see https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a Portuguese NIF',
-    '{{name}} must not be a Portuguese NIF',
+    '{{subject}} must be a Portuguese NIF',
+    '{{subject}} must not be a Portuguese NIF',
 )]
 final class PortugueseNif extends Simple
 {

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -17,8 +17,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a positive number',
-    '{{name}} must not be a positive number',
+    '{{subject}} must be a positive number',
+    '{{subject}} must not be a positive number',
 )]
 final class Positive extends Simple
 {

--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -17,8 +17,8 @@ use Respect\Validation\Rules\Core\Envelope;
 /** @see http://download.geonames.org/export/dump/countryInfo.txt */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid postal code on {{countryCode}}',
-    '{{name}} must not be a valid postal code on {{countryCode}}',
+    '{{subject}} must be a valid postal code on {{countryCode}}',
+    '{{subject}} must not be a valid postal code on {{countryCode}}',
 )]
 final class PostalCode extends Envelope
 {

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -19,8 +19,8 @@ use function sqrt;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a prime number',
-    '{{name}} must not be a prime number',
+    '{{subject}} must be a prime number',
+    '{{subject}} must not be a prime number',
 )]
 final class PrimeNumber extends Simple
 {

--- a/library/Rules/Printable.php
+++ b/library/Rules/Printable.php
@@ -17,13 +17,13 @@ use function ctype_print;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only printable characters',
-    '{{name}} must not contain printable characters',
+    '{{subject}} must contain only printable characters',
+    '{{subject}} must not contain printable characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only printable characters and {{additionalChars}}',
-    '{{name}} must not contain printable characters or {{additionalChars}}',
+    '{{subject}} must contain only printable characters and {{additionalChars}}',
+    '{{subject}} must not contain printable characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Printable extends FilteredString

--- a/library/Rules/PropertyExists.php
+++ b/library/Rules/PropertyExists.php
@@ -21,8 +21,8 @@ use function is_object;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be present',
-    '{{name}} must not be present',
+    '{{subject}} must be present',
+    '{{subject}} must not be present',
 )]
 final readonly class PropertyExists implements Rule
 {

--- a/library/Rules/PublicDomainSuffix.php
+++ b/library/Rules/PublicDomainSuffix.php
@@ -23,8 +23,8 @@ use function strtoupper;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a public domain suffix',
-    '{{name}} must not be a public domain suffix',
+    '{{subject}} must be a public domain suffix',
+    '{{subject}} must not be a public domain suffix',
 )]
 final class PublicDomainSuffix extends Simple
 {

--- a/library/Rules/Punct.php
+++ b/library/Rules/Punct.php
@@ -17,13 +17,13 @@ use function ctype_punct;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only punctuation characters',
-    '{{name}} must not contain punctuation characters',
+    '{{subject}} must contain only punctuation characters',
+    '{{subject}} must not contain punctuation characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only punctuation characters and {{additionalChars}}',
-    '{{name}} must not contain punctuation characters or {{additionalChars}}',
+    '{{subject}} must contain only punctuation characters and {{additionalChars}}',
+    '{{subject}} must not contain punctuation characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Punct extends FilteredString

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -20,8 +20,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be readable',
-    '{{name}} must not be readable',
+    '{{subject}} must be readable',
+    '{{subject}} must not be readable',
 )]
 final class Readable extends Simple
 {

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -19,8 +19,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must match the pattern {{regex|quote}}',
-    '{{name}} must not match the pattern {{regex|quote}}',
+    '{{subject}} must match the pattern {{regex|quote}}',
+    '{{subject}} must not match the pattern {{regex|quote}}',
 )]
 final readonly class Regex implements Rule
 {

--- a/library/Rules/ResourceType.php
+++ b/library/Rules/ResourceType.php
@@ -17,8 +17,8 @@ use function is_resource;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a resource',
-    '{{name}} must not be a resource',
+    '{{subject}} must be a resource',
+    '{{subject}} must not be a resource',
 )]
 final class ResourceType extends Simple
 {

--- a/library/Rules/Roman.php
+++ b/library/Rules/Roman.php
@@ -15,8 +15,8 @@ use Respect\Validation\Rules\Core\Envelope;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid Roman numeral',
-    '{{name}} must not be a valid Roman numeral',
+    '{{subject}} must be a valid Roman numeral',
+    '{{subject}} must not be a valid Roman numeral',
 )]
 final class Roman extends Envelope
 {

--- a/library/Rules/ScalarVal.php
+++ b/library/Rules/ScalarVal.php
@@ -17,8 +17,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a scalar value',
-    '{{name}} must not be a scalar value',
+    '{{subject}} must be a scalar value',
+    '{{subject}} must not be a scalar value',
 )]
 final class ScalarVal extends Simple
 {

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -29,8 +29,8 @@ use function is_string;
     Size::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be a filename or an instance of SplFileInfo or a PSR-7 interface',
-    '{{name}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface',
+    '{{subject}} must be a filename or an instance of SplFileInfo or a PSR-7 interface',
+    '{{subject}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface',
     self::TEMPLATE_WRONG_TYPE,
 )]
 final class Size extends Wrapper

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -19,8 +19,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid slug',
-    '{{name}} must not be a valid slug',
+    '{{subject}} must be a valid slug',
+    '{{subject}} must not be a valid slug',
 )]
 final class Slug extends Simple
 {

--- a/library/Rules/Sorted.php
+++ b/library/Rules/Sorted.php
@@ -23,13 +23,13 @@ use function str_split;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be sorted in ascending order',
-    '{{name}} must not be sorted in ascending order',
+    '{{subject}} must be sorted in ascending order',
+    '{{subject}} must not be sorted in ascending order',
     self::TEMPLATE_ASCENDING,
 )]
 #[Template(
-    '{{name}} must be sorted in descending order',
-    '{{name}} must not be sorted in descending order',
+    '{{subject}} must be sorted in descending order',
+    '{{subject}} must not be sorted in descending order',
     self::TEMPLATE_DESCENDING,
 )]
 final readonly class Sorted implements Rule

--- a/library/Rules/Space.php
+++ b/library/Rules/Space.php
@@ -17,13 +17,13 @@ use function ctype_space;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only space characters',
-    '{{name}} must not contain space characters',
+    '{{subject}} must contain only space characters',
+    '{{subject}} must not contain space characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain only space characters and {{additionalChars}}',
-    '{{name}} must not contain space characters or {{additionalChars}}',
+    '{{subject}} must contain only space characters and {{additionalChars}}',
+    '{{subject}} must not contain space characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Space extends FilteredString

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -22,8 +22,8 @@ use function reset;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must start with {{startValue}}',
-    '{{name}} must not start with {{startValue}}',
+    '{{subject}} must start with {{startValue}}',
+    '{{subject}} must not start with {{startValue}}',
 )]
 final readonly class StartsWith implements Rule
 {

--- a/library/Rules/StringType.php
+++ b/library/Rules/StringType.php
@@ -17,8 +17,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a string',
-    '{{name}} must not be a string',
+    '{{subject}} must be a string',
+    '{{subject}} must not be a string',
 )]
 final class StringType extends Simple
 {

--- a/library/Rules/StringVal.php
+++ b/library/Rules/StringVal.php
@@ -19,8 +19,8 @@ use function method_exists;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a string value',
-    '{{name}} must not be a string value',
+    '{{subject}} must be a string value',
+    '{{subject}} must not be a string value',
 )]
 final class StringVal extends Simple
 {

--- a/library/Rules/SubdivisionCode.php
+++ b/library/Rules/SubdivisionCode.php
@@ -23,8 +23,8 @@ use function class_exists;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a subdivision code of {{countryName|trans}}',
-    '{{name}} must not be a subdivision code of {{countryName|trans}}',
+    '{{subject}} must be a subdivision code of {{countryName|trans}}',
+    '{{subject}} must not be a subdivision code of {{countryName|trans}}',
 )]
 final readonly class SubdivisionCode implements Rule
 {

--- a/library/Rules/Subset.php
+++ b/library/Rules/Subset.php
@@ -19,8 +19,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be subset of {{superset}}',
-    '{{name}} must not be subset of {{superset}}',
+    '{{subject}} must be subset of {{superset}}',
+    '{{subject}} must not be subset of {{superset}}',
 )]
 final readonly class Subset implements Rule
 {

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -19,8 +19,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a symbolic link',
-    '{{name}} must not be a symbolic link',
+    '{{subject}} must be a symbolic link',
+    '{{subject}} must not be a symbolic link',
 )]
 final class SymbolicLink extends Simple
 {

--- a/library/Rules/Time.php
+++ b/library/Rules/Time.php
@@ -23,8 +23,8 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid time in the format {{sample}}',
-    '{{name}} must not be a valid time in the format {{sample}}',
+    '{{subject}} must be a valid time in the format {{sample}}',
+    '{{subject}} must not be a valid time in the format {{sample}}',
 )]
 final readonly class Time implements Rule
 {

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -19,8 +19,8 @@ use function mb_strtoupper;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid top-level domain name',
-    '{{name}} must not be a valid top-level domain name',
+    '{{subject}} must be a valid top-level domain name',
+    '{{subject}} must not be a valid top-level domain name',
 )]
 final class Tld extends Simple
 {

--- a/library/Rules/TrueVal.php
+++ b/library/Rules/TrueVal.php
@@ -20,8 +20,8 @@ use const FILTER_VALIDATE_BOOLEAN;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must evaluate to `true`',
-    '{{name}} must not evaluate to `true`',
+    '{{subject}} must evaluate to `true`',
+    '{{subject}} must not evaluate to `true`',
 )]
 final class TrueVal extends Simple
 {

--- a/library/Rules/Unique.php
+++ b/library/Rules/Unique.php
@@ -20,8 +20,8 @@ use const SORT_REGULAR;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must not contain duplicates',
-    '{{name}} must contain duplicates',
+    '{{subject}} must not contain duplicates',
+    '{{subject}} must contain duplicates',
 )]
 final class Unique extends Simple
 {

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -21,8 +21,8 @@ use function is_uploaded_file;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be an uploaded file',
-    '{{name}} must not be an uploaded file',
+    '{{subject}} must be an uploaded file',
+    '{{subject}} must not be an uploaded file',
 )]
 final class Uploaded extends Simple
 {

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -18,8 +18,8 @@ use function mb_strtoupper;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must contain only uppercase letters',
-    '{{name}} must not contain only uppercase letters',
+    '{{subject}} must contain only uppercase letters',
+    '{{subject}} must not contain only uppercase letters',
 )]
 final class Uppercase extends Simple
 {

--- a/library/Rules/Url.php
+++ b/library/Rules/Url.php
@@ -17,8 +17,8 @@ use const FILTER_VALIDATE_URL;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a URL',
-    '{{name}} must not be a URL',
+    '{{subject}} must be a URL',
+    '{{subject}} must not be a URL',
 )]
 final class Url extends Envelope
 {

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -25,13 +25,13 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid UUID',
-    '{{name}} must not be a valid UUID',
+    '{{subject}} must be a valid UUID',
+    '{{subject}} must not be a valid UUID',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be a valid UUID version {{version|raw}}',
-    '{{name}} must not be a valid UUID version {{version|raw}}',
+    '{{subject}} must be a valid UUID version {{version|raw}}',
+    '{{subject}} must not be a valid UUID version {{version|raw}}',
     self::TEMPLATE_VERSION,
 )]
 final class Uuid implements Rule

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -19,8 +19,8 @@ use function preg_match;
 /** @see http://semver.org/ */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a version',
-    '{{name}} must not be a version',
+    '{{subject}} must be a version',
+    '{{subject}} must not be a version',
 )]
 final class Version extends Simple
 {

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -22,13 +22,13 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be a valid video URL',
-    '{{name}} must not be a valid video URL',
+    '{{subject}} must be a valid video URL',
+    '{{subject}} must not be a valid video URL',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must be a valid {{service|raw}} video URL',
-    '{{name}} must not be a valid {{service|raw}} video URL',
+    '{{subject}} must be a valid {{service|raw}} video URL',
+    '{{subject}} must not be a valid {{service|raw}} video URL',
     self::TEMPLATE_SERVICE,
 )]
 final class VideoUrl implements Rule

--- a/library/Rules/Vowel.php
+++ b/library/Rules/Vowel.php
@@ -17,13 +17,13 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must consist of vowels only',
-    '{{name}} must not consist of vowels only',
+    '{{subject}} must consist of vowels only',
+    '{{subject}} must not consist of vowels only',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must consist of vowels and {{additionalChars}}',
-    '{{name}} must not consist of vowels or {{additionalChars}}',
+    '{{subject}} must consist of vowels and {{additionalChars}}',
+    '{{subject}} must not consist of vowels or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Vowel extends FilteredString

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -20,8 +20,8 @@ use function is_writable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be writable',
-    '{{name}} must not be writable',
+    '{{subject}} must be writable',
+    '{{subject}} must not be writable',
 )]
 final class Writable extends Simple
 {

--- a/library/Rules/Xdigit.php
+++ b/library/Rules/Xdigit.php
@@ -17,13 +17,13 @@ use function ctype_xdigit;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must only contain hexadecimal digits',
-    '{{name}} must not only contain hexadecimal digits',
+    '{{subject}} must only contain hexadecimal digits',
+    '{{subject}} must not only contain hexadecimal digits',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{name}} must contain hexadecimal digits and {{additionalChars}}',
-    '{{name}} must not contain hexadecimal digits or {{additionalChars}}',
+    '{{subject}} must contain hexadecimal digits and {{additionalChars}}',
+    '{{subject}} must not contain hexadecimal digits or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Xdigit extends FilteredString

--- a/library/Rules/Yes.php
+++ b/library/Rules/Yes.php
@@ -21,8 +21,8 @@ use const YESEXPR;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{name}} must be similar to "Yes"',
-    '{{name}} must not be similar to "Yes"',
+    '{{subject}} must be similar to "Yes"',
+    '{{subject}} must not be similar to "Yes"',
 )]
 final class Yes extends Simple
 {

--- a/tests/feature/GetMessagesWithReplacementsTest.php
+++ b/tests/feature/GetMessagesWithReplacementsTest.php
@@ -39,7 +39,7 @@ test('Scenario #1', catchMessages(
             [
                 'mysql' => [
                     'user' => 'Value should be a MySQL username',
-                    'host' => '`{{name}}` should be a MySQL host',
+                    'host' => '`{{subject}}` should be a MySQL host',
                 ],
                 'postgresql' => ['schema' => 'You must provide a valid PostgreSQL schema'],
             ],

--- a/tests/feature/Issues/Issue1477Test.php
+++ b/tests/feature/Issues/Issue1477Test.php
@@ -19,7 +19,7 @@ test('https://github.com/Respect/Validation/issues/1477', catchAll(
                     return false;
                 }
             },
-            '{{name}} is not good!',
+            '{{subject}} is not good!',
         ),
     )->assert(['Address' => 'cvejvn']),
     fn(string $message, string $fullMessage, array $messages) => expect()

--- a/tests/feature/Readme/CustomMessagesTest.php
+++ b/tests/feature/Readme/CustomMessagesTest.php
@@ -12,9 +12,9 @@ test('Scenario #1', catchMessages(
         ->noWhitespace()
         ->length(v::between(1, 15))
         ->assert('really messed up screen#name', [
-            'alnum' => '{{name}} must contain only letters and digits',
-            'noWhitespace' => '{{name}} cannot contain spaces',
-            'length' => '{{name}} must not have more than 15 chars',
+            'alnum' => '{{subject}} must contain only letters and digits',
+            'noWhitespace' => '{{subject}} cannot contain spaces',
+            'length' => '{{subject}} must not have more than 15 chars',
         ]),
     fn(array $messages) => expect($messages)->toBe([
         '__root__' => '"really messed up screen#name" must pass all the rules',

--- a/tests/feature/Rules/KeyExistsTest.php
+++ b/tests/feature/Rules/KeyExistsTest.php
@@ -32,7 +32,7 @@ test('Custom name', catchAll(
 ));
 
 test('Custom template', catchAll(
-    fn() => v::keyExists('foo')->assert(['bar' => 'baz'], 'Custom template for {{name}}'),
+    fn() => v::keyExists('foo')->assert(['bar' => 'baz'], 'Custom template for {{subject}}'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Custom template for `.foo`')
         ->and($fullMessage)->toBe('- Custom template for `.foo`')

--- a/tests/feature/Rules/PropertyExistsTest.php
+++ b/tests/feature/Rules/PropertyExistsTest.php
@@ -32,7 +32,7 @@ test('Custom name', catchAll(
 ));
 
 test('Custom template', catchAll(
-    fn() => v::propertyExists('foo')->assert((object) ['bar' => 'baz'], 'Custom template for {{name}}'),
+    fn() => v::propertyExists('foo')->assert((object) ['bar' => 'baz'], 'Custom template for {{subject}}'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Custom template for `.foo`')
         ->and($fullMessage)->toBe('- Custom template for `.foo`')

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageHeaderTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageHeaderTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(
-    fn() => v::callback('is_string')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something'),
+    fn() => v::callback('is_string')->between(1, 2)->setTemplate('{{subject}} is not tasty')->assert('something'),
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - "something" is not tasty
           - "something" must be between 1 and 2

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 use Respect\Validation\Validator;
 
 test('Scenario #1', catchMessage(function (): void {
-    Validator::callback('is_int')->between(1, 2)->setTemplate('{{name}} is not tasty')->assert('something');
+    Validator::callback('is_int')->between(1, 2)->setTemplate('{{subject}} is not tasty')->assert('something');
 },
 fn(string $message) => expect($message)->toBe('"something" is not tasty')));

--- a/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 use Respect\Validation\Validator;
 
 test('Scenario', catchMessage(
-    fn() => Validator::callback('is_int')->setTemplate('{{name}} is not tasty')->assert('something'),
+    fn() => Validator::callback('is_int')->setTemplate('{{subject}} is not tasty')->assert('something'),
     fn(string $message) => expect($message)->toBe('"something" is not tasty'),
 ));

--- a/tests/feature/TranslatorTest.php
+++ b/tests/feature/TranslatorTest.php
@@ -13,15 +13,15 @@ use Respect\Validation\Message\Translator\ArrayTranslator;
 
 $container = ContainerRegistry::createContainer();
 $container->set(Translator::class, new ArrayTranslator([
-    '{{name}} must pass all the rules' => 'Todas as regras requeridas devem passar para {{name}}',
+    '{{subject}} must pass all the rules' => 'Todas as regras requeridas devem passar para {{subject}}',
     'The length of' => 'O comprimento de',
-    '{{name}} must be a string' => '{{name}} deve ser uma string',
-    '{{name}} must be between {{minValue}} and {{maxValue}}' => '{{name}} deve possuir de {{minValue}} a {{maxValue}} caracteres',
-    '{{name}} must be a valid telephone number for country {{countryName|trans}}' => '{{name}} deve ser um número de telefone válido para o país {{countryName|trans}}',
+    '{{subject}} must be a string' => '{{subject}} deve ser uma string',
+    '{{subject}} must be between {{minValue}} and {{maxValue}}' => '{{subject}} deve possuir de {{minValue}} a {{maxValue}} caracteres',
+    '{{subject}} must be a valid telephone number for country {{countryName|trans}}' => '{{subject}} deve ser um número de telefone válido para o país {{countryName|trans}}',
     'United States' => 'Estados Unidos',
     'years' => 'anos',
     'The number of {{type|trans}} between now and' => 'O número de {{type|trans}} entre agora e',
-    '{{name}} must be equal to {{compareTo}}' => '{{name}} deve ser igual a {{compareTo}}',
+    '{{subject}} must be equal to {{compareTo}}' => '{{subject}} deve ser igual a {{compareTo}}',
     'Your name must be {{haystack|listOr}}' => 'Seu nome deve ser {{haystack|listOr}}',
     'or' => 'ou',
     '{{haystack|listAnd}} are the only possible names' => '{{haystack|listAnd}} são os únicos nomes possíveis',

--- a/tests/library/Rules/Stub.php
+++ b/tests/library/Rules/Stub.php
@@ -19,8 +19,8 @@ use function array_shift;
 use function rand;
 
 #[Template(
-    '{{name}} must be a valid stub',
-    '{{name}} must not be a valid stub',
+    '{{subject}} must be a valid stub',
+    '{{subject}} must not be a valid stub',
 )]
 final class Stub extends Simple
 {

--- a/tests/unit/Message/InterpolationRendererTest.php
+++ b/tests/unit/Message/InterpolationRendererTest.php
@@ -127,7 +127,7 @@ final class InterpolationRendererTest extends TestCase
         $value = 'original';
 
         $result = (new ResultBuilder())
-            ->template('Will replace {{name}}')
+            ->template('Will replace {{subject}}')
             ->parameters(['name' => $value])
             ->build();
 
@@ -147,7 +147,7 @@ final class InterpolationRendererTest extends TestCase
         $value = true;
 
         $result = (new ResultBuilder())
-            ->template('Will replace {{name}}')
+            ->template('Will replace {{subject}}')
             ->parameters(['name' => $value])
             ->build();
 
@@ -169,7 +169,7 @@ final class InterpolationRendererTest extends TestCase
         $name = 'my name';
 
         $result = (new ResultBuilder())
-            ->template('Will replace {{name}}')
+            ->template('Will replace {{subject}}')
             ->name($name)
             ->build();
 
@@ -189,7 +189,7 @@ final class InterpolationRendererTest extends TestCase
         $input = 42;
 
         $result = (new ResultBuilder())
-            ->template('Will replace {{name}}')
+            ->template('Will replace {{subject}}')
             ->input($input)
             ->build();
 
@@ -232,7 +232,7 @@ final class InterpolationRendererTest extends TestCase
         $renderer = new InterpolationRenderer(new DummyTranslator(), $stringifier);
 
         $result = (new ResultBuilder())
-            ->template('Will replace {{name}}')
+            ->template('Will replace {{subject}}')
             ->name('real name')
             ->parameters(['name' => $parameterNameValue])
             ->build();


### PR DESCRIPTION
The `{{name}}` placeholder could represent different things depending on the state of the Result, and referring to it as `{{name}}` seems arbitrary. This commit changes it to `{{subject}}`, which is much more generic and it describes well what that placeholder can mean.