### PR TITLE
Create named constructor to create `Result`

### DIFF
--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -46,6 +46,6 @@ final class AllOf extends Composite
             $template = self::TEMPLATE_ALL;
         }
 
-        return (new Result($valid, $input, $this, [], $template))->withChildren(...$children);
+        return Result::of($valid, $input, $this, [], $template)->withChildren(...$children);
     }
 }

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -34,6 +34,6 @@ final class AnyOf extends Composite
             false,
         );
 
-        return (new Result($valid, $input, $this))->withChildren(...$children);
+        return Result::of($valid, $input, $this)->withChildren(...$children);
     }
 }

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -38,7 +38,7 @@ final readonly class Base implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result(
+        return Result::of(
             (bool) preg_match('@^[' . mb_substr($this->chars, 0, $this->base) . ']+$@', (string) $input),
             $input,
             $this,

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -47,7 +47,7 @@ final readonly class Charset implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result(
+        return Result::of(
             in_array(mb_detect_encoding($input, $this->charset, true), $this->charset),
             $input,
             $this,

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -37,14 +37,14 @@ final readonly class Contains implements Rule
     {
         $parameters = ['containsValue' => $this->containsValue];
         if (is_array($input)) {
-            return new Result(in_array($this->containsValue, $input, $this->identical), $input, $this, $parameters);
+            return Result::of(in_array($this->containsValue, $input, $this->identical), $input, $this, $parameters);
         }
 
         if (!is_scalar($input) || !is_scalar($this->containsValue)) {
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result(
+        return Result::of(
             $this->validateString((string) $input, (string) $this->containsValue),
             $input,
             $this,

--- a/library/Rules/Core/Comparison.php
+++ b/library/Rules/Core/Comparison.php
@@ -33,7 +33,7 @@ abstract class Comparison implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result($this->compare($left, $right), $input, $this, $parameters);
+        return Result::of($this->compare($left, $right), $input, $this, $parameters);
     }
 
     abstract protected function compare(mixed $left, mixed $right): bool;

--- a/library/Rules/Core/Envelope.php
+++ b/library/Rules/Core/Envelope.php
@@ -23,6 +23,6 @@ abstract class Envelope implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result($this->rule->evaluate($input)->hasPassed, $input, $this, $this->parameters);
+        return Result::of($this->rule->evaluate($input)->hasPassed, $input, $this, $this->parameters);
     }
 }

--- a/library/Rules/Core/FilteredString.php
+++ b/library/Rules/Core/FilteredString.php
@@ -44,7 +44,7 @@ abstract class FilteredString implements Rule
         $filteredInput = $this->filter($stringInput);
         $isValid = $filteredInput === '' || $this->isValid($filteredInput);
 
-        return new Result($isValid, $input, $this, $parameters, $template);
+        return Result::of($isValid, $input, $this, $parameters, $template);
     }
 
     abstract protected function isValid(string $input): bool;

--- a/library/Rules/Core/Simple.php
+++ b/library/Rules/Core/Simple.php
@@ -18,6 +18,6 @@ abstract class Simple implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result($this->isValid($input), $input, $this);
+        return Result::of($this->isValid($input), $input, $this);
     }
 }

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -79,7 +79,7 @@ final readonly class CreditCard implements Rule
             return Result::failed($input, $this, $parameters, $template);
         }
 
-        return new Result(
+        return Result::of(
             preg_match(self::BRAND_REGEX_LIST[$this->brand], $filteredInput) > 0,
             $input,
             $this,

--- a/library/Rules/CurrencyCode.php
+++ b/library/Rules/CurrencyCode.php
@@ -61,6 +61,6 @@ final readonly class CurrencyCode implements Rule
             'numeric' => $this->currencies->getByNumericCode($input),
         };
 
-        return new Result($currency !== null, $input, $this);
+        return Result::of($currency !== null, $input, $this);
     }
 }

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -45,6 +45,6 @@ final readonly class Date implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result($this->isDateTime($this->format, (string) $input), $input, $this, $parameters);
+        return Result::of($this->isDateTime($this->format, (string) $input), $input, $this, $parameters);
     }
 }

--- a/library/Rules/DateTime.php
+++ b/library/Rules/DateTime.php
@@ -47,7 +47,7 @@ final class DateTime implements Rule
         $template = $this->format !== null ? self::TEMPLATE_FORMAT : self::TEMPLATE_STANDARD;
         $parameters = ['sample' => date($this->format ?: 'c', strtotime('2005-12-30 01:02:03'))];
         if ($input instanceof DateTimeInterface) {
-            return new Result($this->format === null, $input, $this, $parameters, $template);
+            return Result::of($this->format === null, $input, $this, $parameters, $template);
         }
 
         if (!is_scalar($input)) {
@@ -55,9 +55,9 @@ final class DateTime implements Rule
         }
 
         if ($this->format === null) {
-            return new Result(strtotime((string) $input) !== false, $input, $this, $parameters, $template);
+            return Result::of(strtotime((string) $input) !== false, $input, $this, $parameters, $template);
         }
 
-        return new Result($this->isDateTime($this->format, (string) $input), $input, $this, $parameters, $template);
+        return Result::of($this->isDateTime($this->format, (string) $input), $input, $this, $parameters, $template);
     }
 }

--- a/library/Rules/DateTimeDiff.php
+++ b/library/Rules/DateTimeDiff.php
@@ -81,13 +81,17 @@ final readonly class DateTimeDiff implements Rule
 
         $nowPlaceholder = $this->nowParameter($now);
 
-        return Result::fromAdjacent(
-            $input,
+        $result = $this->rule->evaluate($this->comparisonValue($now, $compareTo));
+
+        return $result->asAdjacentOf(
+            Result::of(
+                $result->hasPassed,
+                $input,
+                $this,
+                ['type' => $this->type, 'now' => $nowPlaceholder],
+                $nowPlaceholder === 'now' ? self::TEMPLATE_STANDARD : self::TEMPLATE_CUSTOMIZED,
+            ),
             'dateTimeDiff',
-            $this,
-            $this->rule->evaluate($this->comparisonValue($now, $compareTo)),
-            ['type' => $this->type, 'now' => $nowPlaceholder],
-            $nowPlaceholder === 'now' ? self::TEMPLATE_STANDARD : self::TEMPLATE_CUSTOMIZED,
         );
     }
 

--- a/library/Rules/Decimal.php
+++ b/library/Rules/Decimal.php
@@ -39,7 +39,7 @@ final readonly class Decimal implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result($this->isValidDecimal($input), $input, $this, $parameters);
+        return Result::of($this->isValidDecimal($input), $input, $this, $parameters);
     }
 
     private function isValidDecimal(mixed $input): bool

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -54,7 +54,7 @@ final class Domain implements Rule
             }
         }
 
-        return new Result($this->partsRule->evaluate($parts)->hasPassed, $input, $this);
+        return Result::of($this->partsRule->evaluate($parts)->hasPassed, $input, $this);
     }
 
     private function createGenericRule(): Circuit

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -38,8 +38,6 @@ final class Each extends FilteredNonEmptyArray
             true,
         );
 
-        return (new Result($hasPassed, $input, $this))
-            ->withChildren(...$children)
-            ->withNameFrom($this->rule);
+        return Result::of($hasPassed, $input, $this)->withChildren(...$children)->withNameFrom($this->rule);
     }
 }

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -37,10 +37,10 @@ final readonly class EndsWith implements Rule
     {
         $parameters = ['endValue' => $this->endValue];
         if ($this->identical) {
-            return new Result($this->validateIdentical($input), $input, $this, $parameters);
+            return Result::of($this->validateIdentical($input), $input, $this, $parameters);
         }
 
-        return new Result($this->validateEquals($input), $input, $this, $parameters);
+        return Result::of($this->validateEquals($input), $input, $this, $parameters);
     }
 
     private function validateEquals(mixed $input): bool

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -32,7 +32,7 @@ final readonly class Equals implements Rule
     {
         $parameters = ['compareTo' => $this->compareTo];
         if (is_scalar($input) === is_scalar($this->compareTo)) {
-            return new Result($input == $this->compareTo, $input, $this, $parameters);
+            return Result::of($input == $this->compareTo, $input, $this, $parameters);
         }
 
         return Result::failed($input, $this, $parameters);

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -36,13 +36,13 @@ final readonly class Extension implements Rule
     {
         $parameters = ['extension' => $this->extension];
         if ($input instanceof SplFileInfo) {
-            return new Result($this->extension === $input->getExtension(), $input, $this, $parameters);
+            return Result::of($this->extension === $input->getExtension(), $input, $this, $parameters);
         }
 
         if (!is_string($input)) {
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result($this->extension === pathinfo($input, PATHINFO_EXTENSION), $input, $this, $parameters);
+        return Result::of($this->extension === pathinfo($input, PATHINFO_EXTENSION), $input, $this, $parameters);
     }
 }

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -50,6 +50,6 @@ final readonly class Factor implements Rule
 
         // The dividend divided by the input must be an integer if input is a
         // factor of the dividend.
-        return new Result(is_int($dividend / $input), $input, $this, $parameters);
+        return Result::of(is_int($dividend / $input), $input, $this, $parameters);
     }
 }

--- a/library/Rules/Identical.php
+++ b/library/Rules/Identical.php
@@ -28,6 +28,6 @@ final readonly class Identical implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result($input === $this->compareTo, $input, $this, ['compareTo' => $this->compareTo]);
+        return Result::of($input === $this->compareTo, $input, $this, ['compareTo' => $this->compareTo]);
     }
 }

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -36,10 +36,10 @@ final readonly class In implements Rule
     {
         $parameters = ['haystack' => $this->haystack];
         if ($this->compareIdentical) {
-            return new Result($this->validateIdentical($input), $input, $this, $parameters);
+            return Result::of($this->validateIdentical($input), $input, $this, $parameters);
         }
 
-        return new Result($this->validateEquals($input), $input, $this, $parameters);
+        return Result::of($this->validateEquals($input), $input, $this, $parameters);
     }
 
     private function validateEquals(mixed $input): bool

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -29,6 +29,6 @@ final readonly class Instance implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result($input instanceof $this->class, $input, $this, ['class' => $this->class]);
+        return Result::of($input instanceof $this->class, $input, $this, ['class' => $this->class]);
     }
 }

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -74,11 +74,11 @@ final class Ip implements Rule
         }
 
         if ($this->mask) {
-            return new Result($this->belongsToSubnet($input), $input, $this, $parameters, $template);
+            return Result::of($this->belongsToSubnet($input), $input, $this, $parameters, $template);
         }
 
         if ($this->startAddress && $this->endAddress) {
-            return new Result($this->verifyNetwork($input), $input, $this, $parameters, $template);
+            return Result::of($this->verifyNetwork($input), $input, $this, $parameters, $template);
         }
 
         return Result::passed($input, $this, $parameters, $template);

--- a/library/Rules/KeyExists.php
+++ b/library/Rules/KeyExists.php
@@ -39,7 +39,7 @@ final class KeyExists implements Rule, KeyRelated
 
     public function evaluate(mixed $input): Result
     {
-        return new Result($this->hasKey($input), $input, $this, path: new Path($this->key));
+        return Result::of($this->hasKey($input), $input, $this)->withPath(new Path($this->key));
     }
 
     private function hasKey(mixed $input): bool

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -85,7 +85,9 @@ final readonly class KeySet implements Rule
         )));
         $keysResult = $keys->evaluate($input);
 
-        return (new Result($keysResult->hasPassed, $input, $this, [], $this->getTemplateFromKeys(array_keys($input))))
+        $template = $this->getTemplateFromKeys(array_keys($input));
+
+        return Result::of($keysResult->hasPassed, $input, $this, [], $template)
             ->withChildren(...($keysResult->children === [] ? [$keysResult] : $keysResult->children));
     }
 

--- a/library/Rules/LanguageCode.php
+++ b/library/Rules/LanguageCode.php
@@ -67,6 +67,6 @@ final readonly class LanguageCode implements Rule
             'alpha-3' => $this->languages->getByAlpha3($input),
         };
 
-        return new Result($currency !== null, $input, $this);
+        return Result::of($currency !== null, $input, $this);
     }
 }

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -43,7 +43,12 @@ final class Length extends Wrapper
                 ->withId($this->rule->evaluate($input)->id->withPrefix('length'));
         }
 
-        return Result::fromAdjacent($input, 'length', $this, $this->rule->evaluate($length));
+        $result = $this->rule->evaluate($length);
+
+        return $result->asAdjacentOf(
+            Result::of($result->hasPassed, $input, $this),
+            'length',
+        );
     }
 
     private function extractLength(mixed $input): int|null

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -23,6 +23,11 @@ final class Max extends FilteredNonEmptyArray
     /** @param non-empty-array<mixed> $input */
     protected function evaluateNonEmptyArray(array $input): Result
     {
-        return Result::fromAdjacent($input, 'max', $this, $this->rule->evaluate(max($input)));
+        $result = $this->rule->evaluate(max($input));
+
+        return $result->asAdjacentOf(
+            Result::of($result->hasPassed, $input, $this),
+            'max',
+        );
     }
 }

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -49,7 +49,7 @@ final readonly class Mimetype implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result(
+        return Result::of(
             $this->mimetype === $this->fileInfo->file($input, FILEINFO_MIME_TYPE),
             $input,
             $this,

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -23,6 +23,11 @@ final class Min extends FilteredNonEmptyArray
     /** @param non-empty-array<mixed> $input */
     protected function evaluateNonEmptyArray(array $input): Result
     {
-        return Result::fromAdjacent($input, 'min', $this, $this->rule->evaluate(min($input)));
+        $result = $this->rule->evaluate(min($input));
+
+        return $result->asAdjacentOf(
+            Result::of($result->hasPassed, $input, $this),
+            'min',
+        );
     }
 }

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -30,9 +30,9 @@ final readonly class Multiple implements Rule
     {
         $parameters = ['multipleOf' => $this->multipleOf];
         if ($this->multipleOf == 0) {
-            return new Result($input == 0, $input, $this, $parameters);
+            return Result::of($input == 0, $input, $this, $parameters);
         }
 
-        return new Result($input % $this->multipleOf == 0, $input, $this, $parameters);
+        return Result::of($input % $this->multipleOf == 0, $input, $this, $parameters);
     }
 }

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -49,6 +49,6 @@ final class NoneOf extends Composite
             $template = self::TEMPLATE_ALL;
         }
 
-        return (new Result($valid, $input, $this, [], $template))->withChildren(...$children);
+        return Result::of($valid, $input, $this, [], $template)->withChildren(...$children);
     }
 }

--- a/library/Rules/NotBlank.php
+++ b/library/Rules/NotBlank.php
@@ -30,7 +30,7 @@ final class NotBlank implements Rule
 {
     public function evaluate(mixed $input): Result
     {
-        return new Result($this->isBlank($input), $input, $this);
+        return Result::of($this->isBlank($input), $input, $this);
     }
 
     private function isBlank(mixed $input): bool

--- a/library/Rules/NotEmpty.php
+++ b/library/Rules/NotEmpty.php
@@ -30,6 +30,6 @@ final class NotEmpty implements Rule
             $input = trim($input);
         }
 
-        return new Result(!empty($input), $input, $this);
+        return Result::of(!empty($input), $input, $this);
     }
 }

--- a/library/Rules/NotUndef.php
+++ b/library/Rules/NotUndef.php
@@ -26,6 +26,6 @@ final class NotUndef implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result($this->isUndefined($input) === false, $input, $this);
+        return Result::of($this->isUndefined($input) === false, $input, $this);
     }
 }

--- a/library/Rules/NullOr.php
+++ b/library/Rules/NullOr.php
@@ -42,7 +42,7 @@ final class NullOr extends Wrapper
         if ($result->allowsAdjacent()) {
             return $result
                 ->withId($result->id->withPrefix('nullOr'))
-                ->withAdjacent(new Result($result->hasPassed, $result->input, $this));
+                ->withAdjacent(Result::of($result->hasPassed, $result->input, $this));
         }
 
         return $result->withChildren(...array_map(fn(Result $child) => $this->enrichResult($child), $result->children));

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -58,6 +58,6 @@ final class OneOf extends Composite
             );
         }
 
-        return (new Result($valid, $input, $this, [], $template))->withChildren(...$children);
+        return Result::of($valid, $input, $this, [], $template)->withChildren(...$children);
     }
 }

--- a/library/Rules/Phone.php
+++ b/library/Rules/Phone.php
@@ -78,7 +78,7 @@ final class Phone implements Rule
             return Result::failed($input, $this, $parameters, $template);
         }
 
-        return new Result($this->isValidPhone((string) $input), $input, $this, $parameters, $template);
+        return Result::of($this->isValidPhone((string) $input), $input, $this, $parameters, $template);
     }
 
     private function isValidPhone(string $input): bool

--- a/library/Rules/PropertyExists.php
+++ b/library/Rules/PropertyExists.php
@@ -33,12 +33,8 @@ final readonly class PropertyExists implements Rule
 
     public function evaluate(mixed $input): Result
     {
-        return new Result(
-            is_object($input) && $this->hasProperty($input),
-            $input,
-            $this,
-            path: new Path($this->propertyName),
-        );
+        return Result::of(is_object($input) && $this->hasProperty($input), $input, $this)
+            ->withPath(new Path($this->propertyName));
     }
 
     private function hasProperty(object $object): bool

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -36,6 +36,6 @@ final readonly class Regex implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result(preg_match($this->regex, (string) $input) === 1, $input, $this, $parameters);
+        return Result::of(preg_match($this->regex, (string) $input) === 1, $input, $this, $parameters);
     }
 }

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -72,7 +72,10 @@ final class Size extends Wrapper
         $result = $this->rule->evaluate($this->getSize($input) / self::DATA_STORAGE_UNITS[$this->unit]['bytes']);
         $parameters = ['unit' => self::DATA_STORAGE_UNITS[$this->unit]['name']];
 
-        return Result::fromAdjacent($input, 'size', $this, $result, $parameters);
+        return $result->asAdjacentOf(
+            Result::of($result->hasPassed, $input, $this, $parameters),
+            'size',
+        );
     }
 
     private function getSize(mixed $input): int|null

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -37,10 +37,10 @@ final readonly class StartsWith implements Rule
     {
         $parameters = ['startValue' => $this->startValue];
         if ($this->identical) {
-            return new Result($this->validateIdentical($input), $input, $this, $parameters);
+            return Result::of($this->validateIdentical($input), $input, $this, $parameters);
         }
 
-        return new Result($this->validateEquals($input), $input, $this, $parameters);
+        return Result::of($this->validateEquals($input), $input, $this, $parameters);
     }
 
     protected function validateEquals(mixed $input): bool

--- a/library/Rules/SubdivisionCode.php
+++ b/library/Rules/SubdivisionCode.php
@@ -65,6 +65,6 @@ final readonly class SubdivisionCode implements Rule
             return Result::passed($input, $this, $parameters);
         }
 
-        return new Result($subdivision !== null, $input, $this, $parameters);
+        return Result::of($subdivision !== null, $input, $this, $parameters);
     }
 }

--- a/library/Rules/Subset.php
+++ b/library/Rules/Subset.php
@@ -37,6 +37,6 @@ final readonly class Subset implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result(array_diff($input, $this->superset) === [], $input, $this, $parameters);
+        return Result::of(array_diff($input, $this->superset) === [], $input, $this, $parameters);
     }
 }

--- a/library/Rules/Time.php
+++ b/library/Rules/Time.php
@@ -45,6 +45,6 @@ final readonly class Time implements Rule
             return Result::failed($input, $this, $parameters);
         }
 
-        return new Result($this->isDateTime($this->format, (string) $input), $input, $this, $parameters);
+        return Result::of($this->isDateTime($this->format, (string) $input), $input, $this, $parameters);
     }
 }

--- a/library/Rules/UndefOr.php
+++ b/library/Rules/UndefOr.php
@@ -45,7 +45,7 @@ final class UndefOr extends Wrapper
         if ($result->allowsAdjacent()) {
             return $result
                 ->withId($result->id->withPrefix('undefOr'))
-                ->withAdjacent(new Result($result->hasPassed, $result->input, $this));
+                ->withAdjacent(Result::of($result->hasPassed, $result->input, $this));
         }
 
         return $result->withChildren(...array_map(fn(Result $child) => $this->enrichResult($child), $result->children));

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -73,7 +73,7 @@ final class Uuid implements Rule
 
         $hasPassed = $this->version ? $uuidVersion === $this->version : $uuidVersion !== null;
 
-        return new Result($hasPassed, $input, $this, $parameters, $template);
+        return Result::of($hasPassed, $input, $this, $parameters, $template);
     }
 
     private function isSupportedVersion(int $version): bool

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -60,7 +60,7 @@ final class VideoUrl implements Rule
         }
 
         if ($this->service !== null) {
-            return new Result($this->isValid($this->service, $input), $input, $this, $parameters, $template);
+            return Result::of($this->isValid($this->service, $input), $input, $this, $parameters, $template);
         }
 
         foreach (array_keys(self::SERVICES) as $service) {

--- a/tests/library/Builders/ResultBuilder.php
+++ b/tests/library/Builders/ResultBuilder.php
@@ -31,7 +31,7 @@ final class ResultBuilder
 
     private Name|null $name = null;
 
-    private Id|null $id = null;
+    private Id $id;
 
     private Rule $rule;
 
@@ -45,6 +45,7 @@ final class ResultBuilder
     public function __construct()
     {
         $this->rule = Stub::daze();
+        $this->id = Id::fromRule($this->rule);
     }
 
     public function build(): Result
@@ -53,11 +54,11 @@ final class ResultBuilder
             $this->hasPassed,
             $this->input,
             $this->rule,
+            $this->id,
             $this->parameters,
             $this->template,
             $this->hasInvertedMode,
             $this->name,
-            $this->id,
             $this->adjacent,
             $this->path,
             ...$this->children,


### PR DESCRIPTION
The constructor of `Result` has many arguments, but that's not the primary reason why I'm making this change. I want to change the constructor, and it will become more complicated, so having this named constructor will be useful in the next refactoring.

With this change, I also made the `id` mandatory. That made the constructor look neater and most to promote almost all properties to the constructor.

Another change was removing the `fromAdjacent` method, which was quite confusing. I created the `asAdjacentOf` method, which is a bit clearer. If anything, it makes all static methods named constructors. It will be a bit more verbose, but more intuitive.