### PR TITLE
Create `All` rule and `all` prefix

### DIFF
--- a/bin/create-mixin
+++ b/bin/create-mixin
@@ -8,6 +8,8 @@ require __DIR__ . '/../vendor/autoload.php';
 use Nette\PhpGenerator\InterfaceType;
 use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\Printer;
+use Respect\Validation\Mixins\AllBuilder;
+use Respect\Validation\Mixins\AllChain;
 use Respect\Validation\Mixins\Chain;
 use Respect\Validation\Mixins\KeyBuilder;
 use Respect\Validation\Mixins\KeyChain;
@@ -168,6 +170,7 @@ function overwriteFile(string $content, string $basename): void
     ];
 
     $mixins = [
+        ['All', 'all', [], ['All', ...$structureRelatedRules]],
         ['Key', 'key', [], $structureRelatedRules],
         ['Length', 'length', $numberRelatedRules, []],
         ['Max', 'max', $numberRelatedRules, []],
@@ -207,6 +210,7 @@ function overwriteFile(string $content, string $basename): void
 
         if ($name === '') {
             $chainedInterface->addExtend(Rule::class);
+            $chainedInterface->addExtend(AllChain::class);
             $chainedInterface->addExtend(KeyChain::class);
             $chainedInterface->addExtend(LengthChain::class);
             $chainedInterface->addExtend(MaxChain::class);
@@ -217,6 +221,7 @@ function overwriteFile(string $content, string $basename): void
             $chainedInterface->addExtend(UndefOrChain::class);
             $chainedInterface->addComment('@mixin \\' . Validator::class);
 
+            $staticInterface->addExtend(AllBuilder::class);
             $staticInterface->addExtend(KeyBuilder::class);
             $staticInterface->addExtend(LengthBuilder::class);
             $staticInterface->addExtend(MaxBuilder::class);

--- a/docs/09-list-of-rules-by-category.md
+++ b/docs/09-list-of-rules-by-category.md
@@ -43,6 +43,7 @@
 
 ## Comparisons
 
+- [All](rules/All.md)
 - [Between](rules/Between.md)
 - [BetweenExclusive](rules/BetweenExclusive.md)
 - [Equals](rules/Equals.md)
@@ -270,6 +271,7 @@
 
 ## Transformations
 
+- [All](rules/All.md)
 - [Call](rules/Call.md)
 - [Each](rules/Each.md)
 - [Length](rules/Length.md)
@@ -302,6 +304,7 @@
 
 ## Alphabetically
 
+- [All](rules/All.md)
 - [AllOf](rules/AllOf.md)
 - [Alnum](rules/Alnum.md)
 - [Alpha](rules/Alpha.md)

--- a/docs/rules/All.md
+++ b/docs/rules/All.md
@@ -1,0 +1,55 @@
+# All
+
+- `All(Rule $rule)`
+
+Validates all items of the input against a given rule.
+
+```php
+v::all(v::intType())->isValid([1, 2, 3]); // true
+v::all(v::intType())->isValid([1, 2, '3']); // false
+```
+
+This rule is similar to [Each](Each.md), but as opposed to the former, it displays a single message when asserting an input.
+
+## Note
+
+This rule uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail.
+
+## Templates
+
+### `All::TEMPLATE_STANDARD`
+
+| Mode       | Template      |
+| ---------- | ------------- |
+| `default`  | Every item in |
+| `inverted` | Every item in |
+
+This template serve as message prefixes.:
+
+```php
+v::all(v::floatType())->assert([1.5, 2]);
+// Message: Every item in `[1.5, 2]` must be float
+
+v::not(v::all(v::intType()))->assert([1, 2, -3]);
+// Message: Every item in `[1, 2, -3]` must not be an integer
+```
+
+## Categorization
+
+- Comparisons
+- Transformations
+
+## Changelog
+
+| Version | Description |
+| ------: | ----------- |
+|   3.0.0 | Created     |
+
+---
+
+See also:
+
+- [Each](Each.md)
+- [Length](Length.md)
+- [Max](Max.md)
+- [Min](Min.md)

--- a/docs/rules/Each.md
+++ b/docs/rules/Each.md
@@ -22,7 +22,7 @@ v::call('array_keys', v::each(v::stringType()))->isValid($releaseDates); // true
 
 ## Note
 
-This rule uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail. 
+This rule uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail.
 
 ## Templates
 
@@ -57,6 +57,7 @@ This rule uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally
 
 See also:
 
+- [All](All.md)
 - [ArrayVal](ArrayVal.md)
 - [Call](Call.md)
 - [Falsy](Falsy.md)
@@ -65,5 +66,6 @@ See also:
 - [Key](Key.md)
 - [KeyExists](KeyExists.md)
 - [KeyOptional](KeyOptional.md)
+- [Length](Length.md)
 - [Min](Min.md)
 - [Unique](Unique.md)

--- a/docs/rules/Length.md
+++ b/docs/rules/Length.md
@@ -72,8 +72,10 @@ Used when it's impossible to get the length of the input.
 
 See also:
 
+- [All](All.md)
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)
+- [Each](Each.md)
 - [GreaterThan](GreaterThan.md)
 - [GreaterThanOrEqual](GreaterThanOrEqual.md)
 - [LessThan](LessThan.md)

--- a/docs/rules/Max.md
+++ b/docs/rules/Max.md
@@ -52,6 +52,7 @@ This rule uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally
 
 See also:
 
+- [All](All.md)
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)
 - [DateTimeDiff](DateTimeDiff.md)

--- a/docs/rules/Min.md
+++ b/docs/rules/Min.md
@@ -52,6 +52,7 @@ This rule uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally
 
 See also:
 
+- [All](All.md)
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)
 - [DateTimeDiff](DateTimeDiff.md)

--- a/library/Mixins/AllBuilder.php
+++ b/library/Mixins/AllBuilder.php
@@ -1,0 +1,329 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Mixins;
+
+use DateTimeImmutable;
+use Respect\Validation\Rule;
+
+interface AllBuilder
+{
+    public static function allAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public static function allAlnum(string ...$additionalChars): Chain;
+
+    public static function allAlpha(string ...$additionalChars): Chain;
+
+    public static function allAlwaysInvalid(): Chain;
+
+    public static function allAlwaysValid(): Chain;
+
+    public static function allAnyOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public static function allArrayType(): Chain;
+
+    public static function allArrayVal(): Chain;
+
+    public static function allBase(
+        int $base,
+        string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    ): Chain;
+
+    public static function allBase64(): Chain;
+
+    public static function allBetween(mixed $minValue, mixed $maxValue): Chain;
+
+    public static function allBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
+
+    public static function allBlank(): Chain;
+
+    public static function allBoolType(): Chain;
+
+    public static function allBoolVal(): Chain;
+
+    public static function allBsn(): Chain;
+
+    public static function allCall(callable $callable, Rule $rule): Chain;
+
+    public static function allCallableType(): Chain;
+
+    public static function allCallback(callable $callback, mixed ...$arguments): Chain;
+
+    public static function allCharset(string $charset, string ...$charsets): Chain;
+
+    public static function allCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public static function allCnh(): Chain;
+
+    public static function allCnpj(): Chain;
+
+    public static function allConsonant(string ...$additionalChars): Chain;
+
+    public static function allContains(mixed $containsValue, bool $identical = false): Chain;
+
+    /** @param non-empty-array<mixed> $needles */
+    public static function allContainsAny(array $needles, bool $identical = false): Chain;
+
+    public static function allControl(string ...$additionalChars): Chain;
+
+    public static function allCountable(): Chain;
+
+    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    public static function allCountryCode(string $set = 'alpha-2'): Chain;
+
+    public static function allCpf(): Chain;
+
+    public static function allCreditCard(string $brand = 'Any'): Chain;
+
+    /** @param "alpha-3"|"numeric" $set */
+    public static function allCurrencyCode(string $set = 'alpha-3'): Chain;
+
+    public static function allDate(string $format = 'Y-m-d'): Chain;
+
+    public static function allDateTime(string|null $format = null): Chain;
+
+    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    public static function allDateTimeDiff(
+        string $type,
+        Rule $rule,
+        string|null $format = null,
+        DateTimeImmutable|null $now = null,
+    ): Chain;
+
+    public static function allDecimal(int $decimals): Chain;
+
+    public static function allDigit(string ...$additionalChars): Chain;
+
+    public static function allDirectory(): Chain;
+
+    public static function allDomain(bool $tldCheck = true): Chain;
+
+    public static function allEach(Rule $rule): Chain;
+
+    public static function allEmail(): Chain;
+
+    public static function allEmoji(): Chain;
+
+    public static function allEndsWith(mixed $endValue, bool $identical = false): Chain;
+
+    public static function allEquals(mixed $compareTo): Chain;
+
+    public static function allEquivalent(mixed $compareTo): Chain;
+
+    public static function allEven(): Chain;
+
+    public static function allExecutable(): Chain;
+
+    public static function allExtension(string $extension): Chain;
+
+    public static function allFactor(int $dividend): Chain;
+
+    public static function allFalseVal(): Chain;
+
+    public static function allFalsy(): Chain;
+
+    public static function allFibonacci(): Chain;
+
+    public static function allFile(): Chain;
+
+    public static function allFilterVar(int $filter, mixed $options = null): Chain;
+
+    public static function allFinite(): Chain;
+
+    public static function allFloatType(): Chain;
+
+    public static function allFloatVal(): Chain;
+
+    public static function allGraph(string ...$additionalChars): Chain;
+
+    public static function allGreaterThan(mixed $compareTo): Chain;
+
+    public static function allGreaterThanOrEqual(mixed $compareTo): Chain;
+
+    public static function allHetu(): Chain;
+
+    public static function allHexRgbColor(): Chain;
+
+    public static function allIban(): Chain;
+
+    public static function allIdentical(mixed $compareTo): Chain;
+
+    public static function allImage(): Chain;
+
+    public static function allImei(): Chain;
+
+    public static function allIn(mixed $haystack, bool $compareIdentical = false): Chain;
+
+    public static function allInfinite(): Chain;
+
+    /** @param class-string $class */
+    public static function allInstance(string $class): Chain;
+
+    public static function allIntType(): Chain;
+
+    public static function allIntVal(): Chain;
+
+    public static function allIp(string $range = '*', int|null $options = null): Chain;
+
+    public static function allIsbn(): Chain;
+
+    public static function allIterableType(): Chain;
+
+    public static function allIterableVal(): Chain;
+
+    public static function allJson(): Chain;
+
+    /** @param "alpha-2"|"alpha-3" $set */
+    public static function allLanguageCode(string $set = 'alpha-2'): Chain;
+
+    /** @param callable(mixed): Rule $ruleCreator */
+    public static function allLazy(callable $ruleCreator): Chain;
+
+    public static function allLeapDate(string $format): Chain;
+
+    public static function allLeapYear(): Chain;
+
+    public static function allLength(Rule $rule): Chain;
+
+    public static function allLessThan(mixed $compareTo): Chain;
+
+    public static function allLessThanOrEqual(mixed $compareTo): Chain;
+
+    public static function allLowercase(): Chain;
+
+    public static function allLuhn(): Chain;
+
+    public static function allMacAddress(): Chain;
+
+    public static function allMax(Rule $rule): Chain;
+
+    public static function allMimetype(string $mimetype): Chain;
+
+    public static function allMin(Rule $rule): Chain;
+
+    public static function allMultiple(int $multipleOf): Chain;
+
+    public static function allNegative(): Chain;
+
+    public static function allNfeAccessKey(): Chain;
+
+    public static function allNif(): Chain;
+
+    public static function allNip(): Chain;
+
+    public static function allNo(bool $useLocale = false): Chain;
+
+    public static function allNoneOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public static function allNot(Rule $rule): Chain;
+
+    public static function allNullType(): Chain;
+
+    public static function allNumber(): Chain;
+
+    public static function allNumericVal(): Chain;
+
+    public static function allObjectType(): Chain;
+
+    public static function allOdd(): Chain;
+
+    public static function allOneOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public static function allPerfectSquare(): Chain;
+
+    public static function allPesel(): Chain;
+
+    public static function allPhone(string|null $countryCode = null): Chain;
+
+    public static function allPhpLabel(): Chain;
+
+    public static function allPis(): Chain;
+
+    public static function allPolishIdCard(): Chain;
+
+    public static function allPortugueseNif(): Chain;
+
+    public static function allPositive(): Chain;
+
+    public static function allPostalCode(string $countryCode, bool $formatted = false): Chain;
+
+    public static function allPrimeNumber(): Chain;
+
+    public static function allPrintable(string ...$additionalChars): Chain;
+
+    public static function allPublicDomainSuffix(): Chain;
+
+    public static function allPunct(string ...$additionalChars): Chain;
+
+    public static function allReadable(): Chain;
+
+    public static function allRegex(string $regex): Chain;
+
+    public static function allResourceType(): Chain;
+
+    public static function allRoman(): Chain;
+
+    public static function allScalarVal(): Chain;
+
+    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    public static function allSize(string $unit, Rule $rule): Chain;
+
+    public static function allSlug(): Chain;
+
+    public static function allSorted(string $direction): Chain;
+
+    public static function allSpace(string ...$additionalChars): Chain;
+
+    public static function allSpaced(): Chain;
+
+    public static function allStartsWith(mixed $startValue, bool $identical = false): Chain;
+
+    public static function allStringType(): Chain;
+
+    public static function allStringVal(): Chain;
+
+    public static function allSubdivisionCode(string $countryCode): Chain;
+
+    /** @param mixed[] $superset */
+    public static function allSubset(array $superset): Chain;
+
+    public static function allSymbolicLink(): Chain;
+
+    public static function allTime(string $format = 'H:i:s'): Chain;
+
+    public static function allTld(): Chain;
+
+    public static function allTrueVal(): Chain;
+
+    public static function allUndef(): Chain;
+
+    public static function allUnique(): Chain;
+
+    public static function allUploaded(): Chain;
+
+    public static function allUppercase(): Chain;
+
+    public static function allUrl(): Chain;
+
+    public static function allUuid(int|null $version = null): Chain;
+
+    public static function allVersion(): Chain;
+
+    public static function allVideoUrl(string|null $service = null): Chain;
+
+    public static function allVowel(string ...$additionalChars): Chain;
+
+    public static function allWhen(Rule $when, Rule $then, Rule|null $else = null): Chain;
+
+    public static function allWritable(): Chain;
+
+    public static function allXdigit(string ...$additionalChars): Chain;
+
+    public static function allYes(bool $useLocale = false): Chain;
+}

--- a/library/Mixins/AllChain.php
+++ b/library/Mixins/AllChain.php
@@ -1,0 +1,329 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Mixins;
+
+use DateTimeImmutable;
+use Respect\Validation\Rule;
+
+interface AllChain
+{
+    public function allAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public function allAlnum(string ...$additionalChars): Chain;
+
+    public function allAlpha(string ...$additionalChars): Chain;
+
+    public function allAlwaysInvalid(): Chain;
+
+    public function allAlwaysValid(): Chain;
+
+    public function allAnyOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public function allArrayType(): Chain;
+
+    public function allArrayVal(): Chain;
+
+    public function allBase(
+        int $base,
+        string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    ): Chain;
+
+    public function allBase64(): Chain;
+
+    public function allBetween(mixed $minValue, mixed $maxValue): Chain;
+
+    public function allBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
+
+    public function allBlank(): Chain;
+
+    public function allBoolType(): Chain;
+
+    public function allBoolVal(): Chain;
+
+    public function allBsn(): Chain;
+
+    public function allCall(callable $callable, Rule $rule): Chain;
+
+    public function allCallableType(): Chain;
+
+    public function allCallback(callable $callback, mixed ...$arguments): Chain;
+
+    public function allCharset(string $charset, string ...$charsets): Chain;
+
+    public function allCircuit(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public function allCnh(): Chain;
+
+    public function allCnpj(): Chain;
+
+    public function allConsonant(string ...$additionalChars): Chain;
+
+    public function allContains(mixed $containsValue, bool $identical = false): Chain;
+
+    /** @param non-empty-array<mixed> $needles */
+    public function allContainsAny(array $needles, bool $identical = false): Chain;
+
+    public function allControl(string ...$additionalChars): Chain;
+
+    public function allCountable(): Chain;
+
+    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    public function allCountryCode(string $set = 'alpha-2'): Chain;
+
+    public function allCpf(): Chain;
+
+    public function allCreditCard(string $brand = 'Any'): Chain;
+
+    /** @param "alpha-3"|"numeric" $set */
+    public function allCurrencyCode(string $set = 'alpha-3'): Chain;
+
+    public function allDate(string $format = 'Y-m-d'): Chain;
+
+    public function allDateTime(string|null $format = null): Chain;
+
+    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    public function allDateTimeDiff(
+        string $type,
+        Rule $rule,
+        string|null $format = null,
+        DateTimeImmutable|null $now = null,
+    ): Chain;
+
+    public function allDecimal(int $decimals): Chain;
+
+    public function allDigit(string ...$additionalChars): Chain;
+
+    public function allDirectory(): Chain;
+
+    public function allDomain(bool $tldCheck = true): Chain;
+
+    public function allEach(Rule $rule): Chain;
+
+    public function allEmail(): Chain;
+
+    public function allEmoji(): Chain;
+
+    public function allEndsWith(mixed $endValue, bool $identical = false): Chain;
+
+    public function allEquals(mixed $compareTo): Chain;
+
+    public function allEquivalent(mixed $compareTo): Chain;
+
+    public function allEven(): Chain;
+
+    public function allExecutable(): Chain;
+
+    public function allExtension(string $extension): Chain;
+
+    public function allFactor(int $dividend): Chain;
+
+    public function allFalseVal(): Chain;
+
+    public function allFalsy(): Chain;
+
+    public function allFibonacci(): Chain;
+
+    public function allFile(): Chain;
+
+    public function allFilterVar(int $filter, mixed $options = null): Chain;
+
+    public function allFinite(): Chain;
+
+    public function allFloatType(): Chain;
+
+    public function allFloatVal(): Chain;
+
+    public function allGraph(string ...$additionalChars): Chain;
+
+    public function allGreaterThan(mixed $compareTo): Chain;
+
+    public function allGreaterThanOrEqual(mixed $compareTo): Chain;
+
+    public function allHetu(): Chain;
+
+    public function allHexRgbColor(): Chain;
+
+    public function allIban(): Chain;
+
+    public function allIdentical(mixed $compareTo): Chain;
+
+    public function allImage(): Chain;
+
+    public function allImei(): Chain;
+
+    public function allIn(mixed $haystack, bool $compareIdentical = false): Chain;
+
+    public function allInfinite(): Chain;
+
+    /** @param class-string $class */
+    public function allInstance(string $class): Chain;
+
+    public function allIntType(): Chain;
+
+    public function allIntVal(): Chain;
+
+    public function allIp(string $range = '*', int|null $options = null): Chain;
+
+    public function allIsbn(): Chain;
+
+    public function allIterableType(): Chain;
+
+    public function allIterableVal(): Chain;
+
+    public function allJson(): Chain;
+
+    /** @param "alpha-2"|"alpha-3" $set */
+    public function allLanguageCode(string $set = 'alpha-2'): Chain;
+
+    /** @param callable(mixed): Rule $ruleCreator */
+    public function allLazy(callable $ruleCreator): Chain;
+
+    public function allLeapDate(string $format): Chain;
+
+    public function allLeapYear(): Chain;
+
+    public function allLength(Rule $rule): Chain;
+
+    public function allLessThan(mixed $compareTo): Chain;
+
+    public function allLessThanOrEqual(mixed $compareTo): Chain;
+
+    public function allLowercase(): Chain;
+
+    public function allLuhn(): Chain;
+
+    public function allMacAddress(): Chain;
+
+    public function allMax(Rule $rule): Chain;
+
+    public function allMimetype(string $mimetype): Chain;
+
+    public function allMin(Rule $rule): Chain;
+
+    public function allMultiple(int $multipleOf): Chain;
+
+    public function allNegative(): Chain;
+
+    public function allNfeAccessKey(): Chain;
+
+    public function allNif(): Chain;
+
+    public function allNip(): Chain;
+
+    public function allNo(bool $useLocale = false): Chain;
+
+    public function allNoneOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public function allNot(Rule $rule): Chain;
+
+    public function allNullType(): Chain;
+
+    public function allNumber(): Chain;
+
+    public function allNumericVal(): Chain;
+
+    public function allObjectType(): Chain;
+
+    public function allOdd(): Chain;
+
+    public function allOneOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
+
+    public function allPerfectSquare(): Chain;
+
+    public function allPesel(): Chain;
+
+    public function allPhone(string|null $countryCode = null): Chain;
+
+    public function allPhpLabel(): Chain;
+
+    public function allPis(): Chain;
+
+    public function allPolishIdCard(): Chain;
+
+    public function allPortugueseNif(): Chain;
+
+    public function allPositive(): Chain;
+
+    public function allPostalCode(string $countryCode, bool $formatted = false): Chain;
+
+    public function allPrimeNumber(): Chain;
+
+    public function allPrintable(string ...$additionalChars): Chain;
+
+    public function allPublicDomainSuffix(): Chain;
+
+    public function allPunct(string ...$additionalChars): Chain;
+
+    public function allReadable(): Chain;
+
+    public function allRegex(string $regex): Chain;
+
+    public function allResourceType(): Chain;
+
+    public function allRoman(): Chain;
+
+    public function allScalarVal(): Chain;
+
+    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    public function allSize(string $unit, Rule $rule): Chain;
+
+    public function allSlug(): Chain;
+
+    public function allSorted(string $direction): Chain;
+
+    public function allSpace(string ...$additionalChars): Chain;
+
+    public function allSpaced(): Chain;
+
+    public function allStartsWith(mixed $startValue, bool $identical = false): Chain;
+
+    public function allStringType(): Chain;
+
+    public function allStringVal(): Chain;
+
+    public function allSubdivisionCode(string $countryCode): Chain;
+
+    /** @param mixed[] $superset */
+    public function allSubset(array $superset): Chain;
+
+    public function allSymbolicLink(): Chain;
+
+    public function allTime(string $format = 'H:i:s'): Chain;
+
+    public function allTld(): Chain;
+
+    public function allTrueVal(): Chain;
+
+    public function allUndef(): Chain;
+
+    public function allUnique(): Chain;
+
+    public function allUploaded(): Chain;
+
+    public function allUppercase(): Chain;
+
+    public function allUrl(): Chain;
+
+    public function allUuid(int|null $version = null): Chain;
+
+    public function allVersion(): Chain;
+
+    public function allVideoUrl(string|null $service = null): Chain;
+
+    public function allVowel(string ...$additionalChars): Chain;
+
+    public function allWhen(Rule $when, Rule $then, Rule|null $else = null): Chain;
+
+    public function allWritable(): Chain;
+
+    public function allXdigit(string ...$additionalChars): Chain;
+
+    public function allYes(bool $useLocale = false): Chain;
+}

--- a/library/Mixins/Builder.php
+++ b/library/Mixins/Builder.php
@@ -14,6 +14,7 @@ use Respect\Validation\Name;
 use Respect\Validation\Rule;
 
 interface Builder extends
+    AllBuilder,
     KeyBuilder,
     LengthBuilder,
     MaxBuilder,
@@ -23,6 +24,8 @@ interface Builder extends
     PropertyBuilder,
     UndefOrBuilder
 {
+    public static function all(Rule $rule): Chain;
+
     public static function allOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function alnum(string ...$additionalChars): Chain;

--- a/library/Mixins/Chain.php
+++ b/library/Mixins/Chain.php
@@ -17,6 +17,7 @@ use Respect\Validation\Validator;
 /** @mixin Validator */
 interface Chain extends
     Rule,
+    AllChain,
     KeyChain,
     LengthChain,
     MaxChain,
@@ -26,6 +27,8 @@ interface Chain extends
     PropertyChain,
     UndefOrChain
 {
+    public function all(Rule $rule): Chain;
+
     public function allOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function alnum(string ...$additionalChars): Chain;

--- a/library/Mixins/KeyBuilder.php
+++ b/library/Mixins/KeyBuilder.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface KeyBuilder
 {
+    public static function keyAll(int|string $key, Rule $rule): Chain;
+
     public static function keyAllOf(int|string $key, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function keyAlnum(int|string $key, string ...$additionalChars): Chain;

--- a/library/Mixins/KeyChain.php
+++ b/library/Mixins/KeyChain.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface KeyChain
 {
+    public function keyAll(int|string $key, Rule $rule): Chain;
+
     public function keyAllOf(int|string $key, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function keyAlnum(int|string $key, string ...$additionalChars): Chain;

--- a/library/Mixins/NotBuilder.php
+++ b/library/Mixins/NotBuilder.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface NotBuilder
 {
+    public static function notAll(Rule $rule): Chain;
+
     public static function notAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function notAlnum(string ...$additionalChars): Chain;

--- a/library/Mixins/NotChain.php
+++ b/library/Mixins/NotChain.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface NotChain
 {
+    public function notAll(Rule $rule): Chain;
+
     public function notAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function notAlnum(string ...$additionalChars): Chain;

--- a/library/Mixins/NullOrBuilder.php
+++ b/library/Mixins/NullOrBuilder.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface NullOrBuilder
 {
+    public static function nullOrAll(Rule $rule): Chain;
+
     public static function nullOrAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function nullOrAlnum(string ...$additionalChars): Chain;

--- a/library/Mixins/NullOrChain.php
+++ b/library/Mixins/NullOrChain.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface NullOrChain
 {
+    public function nullOrAll(Rule $rule): Chain;
+
     public function nullOrAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function nullOrAlnum(string ...$additionalChars): Chain;

--- a/library/Mixins/PropertyBuilder.php
+++ b/library/Mixins/PropertyBuilder.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface PropertyBuilder
 {
+    public static function propertyAll(string $propertyName, Rule $rule): Chain;
+
     public static function propertyAllOf(string $propertyName, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function propertyAlnum(string $propertyName, string ...$additionalChars): Chain;

--- a/library/Mixins/PropertyChain.php
+++ b/library/Mixins/PropertyChain.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface PropertyChain
 {
+    public function propertyAll(string $propertyName, Rule $rule): Chain;
+
     public function propertyAllOf(string $propertyName, Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function propertyAlnum(string $propertyName, string ...$additionalChars): Chain;

--- a/library/Mixins/UndefOrBuilder.php
+++ b/library/Mixins/UndefOrBuilder.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface UndefOrBuilder
 {
+    public static function undefOrAll(Rule $rule): Chain;
+
     public static function undefOrAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public static function undefOrAlnum(string ...$additionalChars): Chain;

--- a/library/Mixins/UndefOrChain.php
+++ b/library/Mixins/UndefOrChain.php
@@ -14,6 +14,8 @@ use Respect\Validation\Rule;
 
 interface UndefOrChain
 {
+    public function undefOrAll(Rule $rule): Chain;
+
     public function undefOrAllOf(Rule $rule1, Rule $rule2, Rule ...$rules): Chain;
 
     public function undefOrAlnum(string ...$additionalChars): Chain;

--- a/library/Rules/All.php
+++ b/library/Rules/All.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use Attribute;
+use Respect\Validation\Message\Template;
+use Respect\Validation\Result;
+use Respect\Validation\Rules\Core\FilteredNonEmptyArray;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Template('Every item in', 'Every item in')]
+final class All extends FilteredNonEmptyArray
+{
+    /** @param non-empty-array<mixed> $input */
+    protected function evaluateNonEmptyArray(array $input): Result
+    {
+        $result = null;
+        $hasPassed = true;
+        foreach ($input as $value) {
+            $result = $this->rule->evaluate($value);
+            if ($result->hasPassed === false) {
+                $hasPassed = false;
+                break;
+            }
+        }
+
+        return $result->asAdjacentOf(
+            Result::of($hasPassed, $input, $this),
+            'all',
+        );
+    }
+}

--- a/library/Transformers/Prefix.php
+++ b/library/Transformers/Prefix.php
@@ -17,6 +17,8 @@ use function substr;
 final class Prefix implements Transformer
 {
     private const array RULES_TO_SKIP = [
+        'all',
+        'allOf',
         'key',
         'keyExists',
         'keyOptional',
@@ -47,6 +49,10 @@ final class Prefix implements Transformer
             $wrapperArguments = [$ruleSpec->arguments[0]];
 
             return new RuleSpec(substr($ruleSpec->name, 3), $arguments, new RuleSpec('key', $wrapperArguments));
+        }
+
+        if (str_starts_with($ruleSpec->name, 'all')) {
+            return new RuleSpec(substr($ruleSpec->name, 3), $ruleSpec->arguments, new RuleSpec('all'));
         }
 
         if (str_starts_with($ruleSpec->name, 'length')) {

--- a/tests/feature/Rules/AllTest.php
+++ b/tests/feature/Rules/AllTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+test('default template', catchAll(
+    fn() => v::all(v::intType())->assert([1, 2, '3']),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Every item in `[1, 2, "3"]` must be an integer')
+        ->and($fullMessage)->toBe('- Every item in `[1, 2, "3"]` must be an integer')
+        ->and($messages)->toBe(['allIntType' => 'Every item in `[1, 2, "3"]` must be an integer']),
+));
+
+test('inverted template', catchAll(
+    fn() => v::not(v::all(v::intType()))->assert([1, 2, 3]),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Every item in `[1, 2, 3]` must not be an integer')
+        ->and($fullMessage)->toBe('- Every item in `[1, 2, 3]` must not be an integer')
+        ->and($messages)->toBe(['notAllIntType' => 'Every item in `[1, 2, 3]` must not be an integer']),
+));

--- a/tests/feature/Transformers/PrefixTest.php
+++ b/tests/feature/Transformers/PrefixTest.php
@@ -9,6 +9,14 @@ declare(strict_types=1);
 
 date_default_timezone_set('UTC');
 
+test('All', catchAll(
+    fn() => v::allStringType()->assert(['foo', 12, 'bar']),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('Every item in `["foo", 12, "bar"]` must be a string')
+        ->and($fullMessage)->toBe('- Every item in `["foo", 12, "bar"]` must be a string')
+        ->and($messages)->toBe(['allStringType' => 'Every item in `["foo", 12, "bar"]` must be a string']),
+));
+
 test('Key', catchAll(
     fn() => v::keyEquals('foo', 12)->assert(['foo' => 10]),
     fn(string $message, string $fullMessage, array $messages) => expect()

--- a/tests/unit/Rules/AllTest.php
+++ b/tests/unit/Rules/AllTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use ArrayObject;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\Test\Rules\Stub;
+use Respect\Validation\Test\TestCase;
+
+#[Group('rule')]
+#[CoversClass(All::class)]
+final class AllTest extends TestCase
+{
+    /** @return iterable<string, array{Stub, mixed}> */
+    public static function providerForValidInput(): iterable
+    {
+        yield 'all pass with array' => [Stub::pass(3), [1, 2, 3]];
+        yield 'all pass with ArrayObject' => [Stub::pass(3), new ArrayObject([1, 2, 3])];
+        yield 'single element that passes' => [Stub::pass(1), ['value']];
+        yield 'all pass with array of strings' => [Stub::pass(5), ['a', 'b', 'c', 'd', 'e']];
+    }
+
+    /** @return iterable<string, array{Stub, mixed}> */
+    public static function providerForInvalidInput(): iterable
+    {
+        yield 'some fail with array' => [Stub::fail(3), [1, 2, 3]];
+        yield 'all fail with array' => [Stub::fail(3), [1, 2, 3]];
+        yield 'mixed pass/fail with array' => [new Stub(true, false, true), [1, 2, 3]];
+        yield 'some fail with ArrayObject' => [Stub::fail(3), new ArrayObject([1, 2, 3])];
+        yield 'non-array input' => [Stub::daze(), 'not an array'];
+        yield 'string input' => [Stub::daze(), 'string'];
+        yield 'integer input' => [Stub::daze(), 123];
+        yield 'null input' => [Stub::daze(), null];
+        yield 'boolean input' => [Stub::daze(), true];
+        yield 'object input' => [Stub::daze(), (object) ['foo' => 'bar']];
+        yield 'empty array' => [Stub::daze(), []];
+    }
+
+    #[Test]
+    #[DataProvider('providerForValidInput')]
+    public function shouldValidateValidInput(Stub $stub, mixed $input): void
+    {
+        $rule = new All($stub);
+        self::assertValidInput($rule, $input);
+    }
+
+    #[Test]
+    #[DataProvider('providerForInvalidInput')]
+    public function shouldValidateInvalidInput(Stub $stub, mixed $input): void
+    {
+        $rule = new All($stub);
+        self::assertInvalidInput($rule, $input);
+    }
+}


### PR DESCRIPTION
This rule behaves similarly to ``Each, but the difference is that it presents the messages in a simpler manner. This allows users to have a simpler message when validating all items in an array or iterable value.

I’m also introducing the `all` prefix, making it easier for users to apply the `All` rule in combination with other rules.