### PR TITLE
Fix date overflow when parsing year-month format without day

### DIFF
--- a/library/Helpers/CanValidateDateTime.php
+++ b/library/Helpers/CanValidateDateTime.php
@@ -44,7 +44,7 @@ trait CanValidateDateTime
 
         if ($this->isDateFormat($format)) {
             $formattedDate = DateTime::createFromFormat(
-                $format,
+                '!'.$format,
                 $value,
                 new DateTimeZone(date_default_timezone_get())
             );


### PR DESCRIPTION
## Summary
- Fixed date parsing overflow issue when using year-month formats (e.g., "2026-02") without specifying a day
- Added the `!` reset prefix to `DateTime::createFromFormat()` to ensure the day defaults to 1 instead of using the current system day

## Problem
When parsing date formats like "2026-02" that don't include a day component, `DateTime::createFromFormat()` was using the current day from the system date. On December 29th, this caused February 2026 (which only has 28 days) to overflow to March 1st.

## Solution
Adding the `!` prefix to the format string resets all date components to Unix Epoch (1970-01-01) before parsing, ensuring unspecified fields default to their minimum values (day = 1) rather than using current date values.

## Test Plan
- [ ] Test parsing "2026-02" format on various days of the month
- [ ] Verify February dates don't overflow to March
- [ ] Ensure existing date validation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)