### PR TITLE
Fix date overflow when parsing year-month format without day

### DIFF
--- a/library/Helpers/CanValidateDateTime.php
+++ b/library/Helpers/CanValidateDateTime.php
@@ -11,7 +11,6 @@ namespace Respect\Validation\Helpers;
 
 use DateTime;
 use DateTimeZone;
-
 use function checkdate;
 use function date_default_timezone_get;
 use function date_parse_from_format;
@@ -33,7 +32,7 @@ trait CanValidateDateTime
 
         if ($this->isDateFormat($format)) {
             $formattedDate = DateTime::createFromFormat(
-                '!'.$format,
+                '!' . $format,
                 $value,
                 new DateTimeZone(date_default_timezone_get()),
             );
@@ -63,7 +62,7 @@ trait CanValidateDateTime
     private function isDateInformation(array $info): bool
     {
         if ($info['day']) {
-            return checkdate((int) $info['month'], $info['day'], (int) $info['year']);
+            return checkdate((int)$info['month'], $info['day'], (int)$info['year']);
         }
 
         return checkdate($info['month'] ?: 1, 1, $info['year'] ?: 1);


### PR DESCRIPTION
When parsing date formats like "2026-02" that don't specify a day, DateTime::createFromFormat() was using the current day (29th) from the system date. This caused February 2026 to overflow to March 1st since February 2026 only has 28 days.

Adding the '!' prefix resets all date components to Unix Epoch before parsing, ensuring the day defaults to 1 instead of using the current day.