### PR TITLE
Refactor the `Factory` class

### DIFF
--- a/library/ContainerRegistry.php
+++ b/library/ContainerRegistry.php
@@ -45,7 +45,6 @@ final class ContainerRegistry
     {
         return new Container([
             Transformer::class => create(Prefix::class),
-            Factory::class => autowire(Factory::class),
             TemplateResolver::class => create(TemplateResolver::class),
             Quoter::class => create(StandardQuoter::class)->constructor(ValidationStringifier::MAXIMUM_LENGTH),
             Stringifier::class => create(ValidationStringifier::class),
@@ -56,6 +55,11 @@ final class ContainerRegistry
             'respect.validation.formatter.full_message' => autowire(NestedListStringFormatter::class),
             'respect.validation.formatter.messages' => autowire(NestedArrayFormatter::class),
             'respect.validation.ignored_backtrace_paths' => [__DIR__ . '/Validator.php'],
+            'respect.validation.rule_factory.namespaces' => ['Respect\\Validation\\Rules'],
+            RuleFactory::class => factory(static fn(Container $container) => new NamespacedRuleFactory(
+                $container->get(Transformer::class),
+                $container->get('respect.validation.rule_factory.namespaces'),
+            )),
             Modifier::class => factory(static fn(Container $container) => new TransModifier(
                 $container->get(Translator::class),
                 new ListOrModifier(
@@ -71,7 +75,7 @@ final class ContainerRegistry
                 ),
             )),
             Validator::class => factory(static fn(Container $container) => new Validator(
-                $container->get(Factory::class),
+                $container->get(RuleFactory::class),
                 $container->get(Renderer::class),
                 $container->get('respect.validation.formatter.message'),
                 $container->get('respect.validation.formatter.full_message'),

--- a/library/RuleFactory.php
+++ b/library/RuleFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation;
+
+interface RuleFactory
+{
+    /** @param array<int, mixed> $arguments */
+    public function create(string $ruleName, array $arguments = []): Rule;
+}

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -37,7 +37,7 @@ final class Validator implements Rule, Nameable
 
     /** @param array<string> $ignoredBacktracePaths */
     public function __construct(
-        private readonly Factory $factory,
+        private readonly RuleFactory $ruleFactory,
         private readonly Renderer $renderer,
         private readonly StringFormatter $mainMessageFormatter,
         private readonly StringFormatter $fullMessageFormatter,
@@ -186,6 +186,6 @@ final class Validator implements Rule, Nameable
     /** @param mixed[] $arguments */
     public function __call(string $ruleName, array $arguments): self
     {
-        return $this->addRule($this->factory->rule($ruleName, $arguments));
+        return $this->addRule($this->ruleFactory->create($ruleName, $arguments));
     }
 }

--- a/tests/unit/NamespacedRuleFactoryTest.php
+++ b/tests/unit/NamespacedRuleFactoryTest.php
@@ -19,33 +19,32 @@ use Respect\Validation\Test\Rules\MyAbstractClass;
 use Respect\Validation\Test\Rules\Stub;
 use Respect\Validation\Test\Rules\Valid;
 use Respect\Validation\Test\TestCase;
+use Respect\Validation\Test\Transformers\StubTransformer;
 
 use function assert;
 use function sprintf;
 
 #[Group('core')]
-#[CoversClass(Factory::class)]
-final class FactoryTest extends TestCase
+#[CoversClass(NamespacedRuleFactory::class)]
+final class NamespacedRuleFactoryTest extends TestCase
 {
     private const string TEST_RULES_NAMESPACE = 'Respect\\Validation\\Test\\Rules';
 
     #[Test]
     public function shouldCreateRuleByNameBasedOnNamespace(): void
     {
-        $factory = (new Factory())
-            ->withRuleNamespace(self::TEST_RULES_NAMESPACE);
+        $factory = new NamespacedRuleFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);
 
-        self::assertInstanceOf(Valid::class, $factory->rule('valid'));
+        self::assertInstanceOf(Valid::class, $factory->create('valid'));
     }
 
     #[Test]
     public function shouldLookUpToAllNamespacesUntilRuleIsFound(): void
     {
-        $factory = (new Factory())
-            ->withRuleNamespace(__NAMESPACE__)
-            ->withRuleNamespace(self::TEST_RULES_NAMESPACE);
+        $factory = (new NamespacedRuleFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]))
+            ->withRuleNamespace(__NAMESPACE__);
 
-        self::assertInstanceOf(Valid::class, $factory->rule('valid'));
+        self::assertInstanceOf(Valid::class, $factory->create('valid'));
     }
 
     #[Test]
@@ -53,8 +52,8 @@ final class FactoryTest extends TestCase
     {
         $constructorArguments = [true, false, true, false];
 
-        $factory = (new Factory())->withRuleNamespace(self::TEST_RULES_NAMESPACE);
-        $rule = $factory->rule('stub', $constructorArguments);
+        $factory = new NamespacedRuleFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);
+        $rule = $factory->create('stub', $constructorArguments);
         assert($rule instanceof Stub);
 
         self::assertSame($constructorArguments, $rule->validations);
@@ -63,33 +62,33 @@ final class FactoryTest extends TestCase
     #[Test]
     public function shouldThrowsAnExceptionWhenRuleIsInvalid(): void
     {
-        $factory = (new Factory())->withRuleNamespace(self::TEST_RULES_NAMESPACE);
+        $factory = new NamespacedRuleFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);
 
         $this->expectException(InvalidClassException::class);
         $this->expectExceptionMessage(sprintf('"%s" must be an instance of "%s"', Invalid::class, Rule::class));
 
-        $factory->rule('invalid');
+        $factory->create('invalid');
     }
 
     #[Test]
     public function shouldThrowsAnExceptionWhenRuleIsNotInstantiable(): void
     {
-        $factory = (new Factory())->withRuleNamespace(self::TEST_RULES_NAMESPACE);
+        $factory = new NamespacedRuleFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);
 
         $this->expectException(InvalidClassException::class);
         $this->expectExceptionMessage(sprintf('"%s" must be instantiable', MyAbstractClass::class));
 
-        $factory->rule('myAbstractClass');
+        $factory->create('myAbstractClass');
     }
 
     #[Test]
     public function shouldThrowsAnExceptionWhenRuleIsNotFound(): void
     {
-        $factory = (new Factory())->withRuleNamespace(self::TEST_RULES_NAMESPACE);
+        $factory = new NamespacedRuleFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);
 
         $this->expectException(ComponentException::class);
         $this->expectExceptionMessage('"nonExistingRule" is not a valid rule name');
 
-        $factory->rule('nonExistingRule');
+        $factory->create('nonExistingRule');
     }
 }


### PR DESCRIPTION
The class was called `Factory` because we used to use it to create rules and exceptions. Since we don’t have more exceptions per rule, the name `RuleFactory` makes more sense, as it accurately describes its purpose.

I’ve turned that class into an interface, and copied the implementation to a new class, `NamespacedRuleFactory`, which describes more of what that specific implementation does.