### PR TITLE
Remove docheaders from all files

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,4 +1,0 @@
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,9 +96,6 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist
 
-      - name: Run DocHeader
-        run: vendor/bin/docheader check library/ tests/
-
       - name: Run PHP_CodeSniffer
         run: vendor/bin/phpcs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,6 @@ and will natively have support for chaining and everything else.
 ```php
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;
@@ -94,11 +89,6 @@ first item of the arrays:
 
 ```php
 <?php
-
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
 
 declare(strict_types=1);
 

--- a/aliases.php
+++ b/aliases.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Validator;

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "require-dev": {
         "egulias/email-validator": "^4.0",
         "giggsey/libphonenumber-for-php-lite": "^8.13",
-        "malukenho/docheader": "^1.0",
         "mikey179/vfsstream": "^1.6",
         "nette/php-generator": "^4.1",
         "pestphp/pest": "^4.2",
@@ -69,13 +68,11 @@
         }
     },
     "scripts": {
-        "docheader": "vendor/bin/docheader check library/ tests/",
         "phpcs": "vendor/bin/phpcs",
         "phpstan": "vendor/bin/phpstan analyze",
         "phpunit": "vendor/bin/phpunit --testsuite=unit",
         "pest": "vendor/bin/pest --testsuite=feature --compact",
         "qa": [
-            "@docheader",
             "@phpcs",
             "@phpstan",
             "@phpunit",

--- a/library/CloneValidatorFactory.php
+++ b/library/CloneValidatorFactory.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/ContainerRegistry.php
+++ b/library/ContainerRegistry.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/Exceptions/ComponentException.php
+++ b/library/Exceptions/ComponentException.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/library/Exceptions/Exception.php
+++ b/library/Exceptions/Exception.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/library/Exceptions/InvalidClassException.php
+++ b/library/Exceptions/InvalidClassException.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/library/Exceptions/InvalidRuleConstructorException.php
+++ b/library/Exceptions/InvalidRuleConstructorException.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/library/Exceptions/MissingComposerDependencyException.php
+++ b/library/Exceptions/MissingComposerDependencyException.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/library/Exceptions/ValidationException.php
+++ b/library/Exceptions/ValidationException.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/library/Helpers/CanCompareValues.php
+++ b/library/Helpers/CanCompareValues.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/library/Helpers/CanValidateDateTime.php
+++ b/library/Helpers/CanValidateDateTime.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/library/Helpers/CanValidateIterable.php
+++ b/library/Helpers/CanValidateIterable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/library/Helpers/CanValidateUndefined.php
+++ b/library/Helpers/CanValidateUndefined.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/library/Helpers/DomainInfo.php
+++ b/library/Helpers/DomainInfo.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/library/Id.php
+++ b/library/Id.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/Message/ArrayFormatter.php
+++ b/library/Message/ArrayFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/Formatter/FirstResultStringFormatter.php
+++ b/library/Message/Formatter/FirstResultStringFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/library/Message/Formatter/NestedArrayFormatter.php
+++ b/library/Message/Formatter/NestedArrayFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/library/Message/Formatter/NestedListStringFormatter.php
+++ b/library/Message/Formatter/NestedListStringFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/library/Message/Formatter/TemplateResolver.php
+++ b/library/Message/Formatter/TemplateResolver.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/library/Message/InterpolationRenderer.php
+++ b/library/Message/InterpolationRenderer.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/Modifier.php
+++ b/library/Message/Modifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/Modifier/ListAndModifier.php
+++ b/library/Message/Modifier/ListAndModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/library/Message/Modifier/ListOrModifier.php
+++ b/library/Message/Modifier/ListOrModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/library/Message/Modifier/QuoteModifier.php
+++ b/library/Message/Modifier/QuoteModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/library/Message/Modifier/RawModifier.php
+++ b/library/Message/Modifier/RawModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/library/Message/Modifier/StringifyModifier.php
+++ b/library/Message/Modifier/StringifyModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/library/Message/Modifier/TransModifier.php
+++ b/library/Message/Modifier/TransModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/library/Message/Placeholder/Listed.php
+++ b/library/Message/Placeholder/Listed.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Placeholder;

--- a/library/Message/Placeholder/Quoted.php
+++ b/library/Message/Placeholder/Quoted.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Placeholder;

--- a/library/Message/Renderer.php
+++ b/library/Message/Renderer.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/StringFormatter.php
+++ b/library/Message/StringFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/Stringifier/ListedStringifier.php
+++ b/library/Message/Stringifier/ListedStringifier.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 namespace Respect\Validation\Message\Stringifier;
 
 use Respect\Stringifier\Stringifier;

--- a/library/Message/Stringifier/NameStringifier.php
+++ b/library/Message/Stringifier/NameStringifier.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 namespace Respect\Validation\Message\Stringifier;
 
 use Respect\Stringifier\Stringifier;

--- a/library/Message/Stringifier/PathStringifier.php
+++ b/library/Message/Stringifier/PathStringifier.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 namespace Respect\Validation\Message\Stringifier;
 
 use Respect\Stringifier\Quoter;

--- a/library/Message/Stringifier/QuotedStringifier.php
+++ b/library/Message/Stringifier/QuotedStringifier.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 namespace Respect\Validation\Message\Stringifier;
 
 use Respect\Stringifier\Quoter;

--- a/library/Message/Template.php
+++ b/library/Message/Template.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/Translator.php
+++ b/library/Message/Translator.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Message/Translator/ArrayTranslator.php
+++ b/library/Message/Translator/ArrayTranslator.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Translator;

--- a/library/Message/Translator/DummyTranslator.php
+++ b/library/Message/Translator/DummyTranslator.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 namespace Respect\Validation\Message\Translator;
 
 use Respect\Validation\Message\Translator;

--- a/library/Message/Translator/GettextTranslator.php
+++ b/library/Message/Translator/GettextTranslator.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Translator;

--- a/library/Message/ValidationStringifier.php
+++ b/library/Message/ValidationStringifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/library/Mixins/Builder.php
+++ b/library/Mixins/Builder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/Chain.php
+++ b/library/Mixins/Chain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/KeyBuilder.php
+++ b/library/Mixins/KeyBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/KeyChain.php
+++ b/library/Mixins/KeyChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/LengthBuilder.php
+++ b/library/Mixins/LengthBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/LengthChain.php
+++ b/library/Mixins/LengthChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/MaxBuilder.php
+++ b/library/Mixins/MaxBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/MaxChain.php
+++ b/library/Mixins/MaxChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/MinBuilder.php
+++ b/library/Mixins/MinBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/MinChain.php
+++ b/library/Mixins/MinChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/NotBuilder.php
+++ b/library/Mixins/NotBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/NotChain.php
+++ b/library/Mixins/NotChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/NullOrBuilder.php
+++ b/library/Mixins/NullOrBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/NullOrChain.php
+++ b/library/Mixins/NullOrChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/PropertyBuilder.php
+++ b/library/Mixins/PropertyBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/PropertyChain.php
+++ b/library/Mixins/PropertyChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/UndefOrBuilder.php
+++ b/library/Mixins/UndefOrBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Mixins/UndefOrChain.php
+++ b/library/Mixins/UndefOrChain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Mixins;

--- a/library/Name.php
+++ b/library/Name.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/NamespacedRuleFactory.php
+++ b/library/NamespacedRuleFactory.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/OnlyFailedChildrenResultFilter.php
+++ b/library/OnlyFailedChildrenResultFilter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/Path.php
+++ b/library/Path.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/Result.php
+++ b/library/Result.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/ResultFilter.php
+++ b/library/ResultFilter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/ResultQuery.php
+++ b/library/ResultQuery.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 namespace Respect\Validation;
 
 use Respect\Validation\Message\ArrayFormatter;

--- a/library/Rule.php
+++ b/library/Rule.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/RuleFactory.php
+++ b/library/RuleFactory.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/Rules/AllOf.php
+++ b/library/Rules/AllOf.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Alnum.php
+++ b/library/Rules/Alnum.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Alpha.php
+++ b/library/Rules/Alpha.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/AlwaysInvalid.php
+++ b/library/Rules/AlwaysInvalid.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/AlwaysValid.php
+++ b/library/Rules/AlwaysValid.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/AnyOf.php
+++ b/library/Rules/AnyOf.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/ArrayType.php
+++ b/library/Rules/ArrayType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/ArrayVal.php
+++ b/library/Rules/ArrayVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Attributes.php
+++ b/library/Rules/Attributes.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Base.php
+++ b/library/Rules/Base.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Base64.php
+++ b/library/Rules/Base64.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Between.php
+++ b/library/Rules/Between.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/BetweenExclusive.php
+++ b/library/Rules/BetweenExclusive.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Blank.php
+++ b/library/Rules/Blank.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/BoolType.php
+++ b/library/Rules/BoolType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/BoolVal.php
+++ b/library/Rules/BoolVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Bsn.php
+++ b/library/Rules/Bsn.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Call.php
+++ b/library/Rules/Call.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/CallableType.php
+++ b/library/Rules/CallableType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Callback.php
+++ b/library/Rules/Callback.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Charset.php
+++ b/library/Rules/Charset.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Circuit.php
+++ b/library/Rules/Circuit.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Cnh.php
+++ b/library/Rules/Cnh.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Cnpj.php
+++ b/library/Rules/Cnpj.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Consonant.php
+++ b/library/Rules/Consonant.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Contains.php
+++ b/library/Rules/Contains.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/ContainsAny.php
+++ b/library/Rules/ContainsAny.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Control.php
+++ b/library/Rules/Control.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Core/Comparison.php
+++ b/library/Rules/Core/Comparison.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/Composite.php
+++ b/library/Rules/Core/Composite.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/Envelope.php
+++ b/library/Rules/Core/Envelope.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/FilteredNonEmptyArray.php
+++ b/library/Rules/Core/FilteredNonEmptyArray.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/FilteredString.php
+++ b/library/Rules/Core/FilteredString.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/KeyRelated.php
+++ b/library/Rules/Core/KeyRelated.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/Nameable.php
+++ b/library/Rules/Core/Nameable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/Reducer.php
+++ b/library/Rules/Core/Reducer.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/Simple.php
+++ b/library/Rules/Core/Simple.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Core/Wrapper.php
+++ b/library/Rules/Core/Wrapper.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/library/Rules/Countable.php
+++ b/library/Rules/Countable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/CountryCode.php
+++ b/library/Rules/CountryCode.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Cpf.php
+++ b/library/Rules/Cpf.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/CreditCard.php
+++ b/library/Rules/CreditCard.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/CurrencyCode.php
+++ b/library/Rules/CurrencyCode.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Date.php
+++ b/library/Rules/Date.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/DateTime.php
+++ b/library/Rules/DateTime.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/DateTimeDiff.php
+++ b/library/Rules/DateTimeDiff.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Decimal.php
+++ b/library/Rules/Decimal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Digit.php
+++ b/library/Rules/Digit.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Directory.php
+++ b/library/Rules/Directory.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Domain.php
+++ b/library/Rules/Domain.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Each.php
+++ b/library/Rules/Each.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Email.php
+++ b/library/Rules/Email.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Emoji.php
+++ b/library/Rules/Emoji.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/EndsWith.php
+++ b/library/Rules/EndsWith.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Equals.php
+++ b/library/Rules/Equals.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Equivalent.php
+++ b/library/Rules/Equivalent.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Even.php
+++ b/library/Rules/Even.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Executable.php
+++ b/library/Rules/Executable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Exists.php
+++ b/library/Rules/Exists.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Extension.php
+++ b/library/Rules/Extension.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Factor.php
+++ b/library/Rules/Factor.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/FalseVal.php
+++ b/library/Rules/FalseVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Falsy.php
+++ b/library/Rules/Falsy.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Fibonacci.php
+++ b/library/Rules/Fibonacci.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/File.php
+++ b/library/Rules/File.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/FilterVar.php
+++ b/library/Rules/FilterVar.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Finite.php
+++ b/library/Rules/Finite.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/FloatType.php
+++ b/library/Rules/FloatType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/FloatVal.php
+++ b/library/Rules/FloatVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Graph.php
+++ b/library/Rules/Graph.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/GreaterThan.php
+++ b/library/Rules/GreaterThan.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/GreaterThanOrEqual.php
+++ b/library/Rules/GreaterThanOrEqual.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Hetu.php
+++ b/library/Rules/Hetu.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/HexRgbColor.php
+++ b/library/Rules/HexRgbColor.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Iban.php
+++ b/library/Rules/Iban.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Identical.php
+++ b/library/Rules/Identical.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Image.php
+++ b/library/Rules/Image.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Imei.php
+++ b/library/Rules/Imei.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/In.php
+++ b/library/Rules/In.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Infinite.php
+++ b/library/Rules/Infinite.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Instance.php
+++ b/library/Rules/Instance.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/IntType.php
+++ b/library/Rules/IntType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/IntVal.php
+++ b/library/Rules/IntVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Ip.php
+++ b/library/Rules/Ip.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Isbn.php
+++ b/library/Rules/Isbn.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/IterableType.php
+++ b/library/Rules/IterableType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/IterableVal.php
+++ b/library/Rules/IterableVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Json.php
+++ b/library/Rules/Json.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Key.php
+++ b/library/Rules/Key.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/KeyExists.php
+++ b/library/Rules/KeyExists.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/KeyOptional.php
+++ b/library/Rules/KeyOptional.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/KeySet.php
+++ b/library/Rules/KeySet.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/LanguageCode.php
+++ b/library/Rules/LanguageCode.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Lazy.php
+++ b/library/Rules/Lazy.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/LeapDate.php
+++ b/library/Rules/LeapDate.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/LeapYear.php
+++ b/library/Rules/LeapYear.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Length.php
+++ b/library/Rules/Length.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/LessThan.php
+++ b/library/Rules/LessThan.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/LessThanOrEqual.php
+++ b/library/Rules/LessThanOrEqual.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Lowercase.php
+++ b/library/Rules/Lowercase.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Luhn.php
+++ b/library/Rules/Luhn.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/MacAddress.php
+++ b/library/Rules/MacAddress.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Max.php
+++ b/library/Rules/Max.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Mimetype.php
+++ b/library/Rules/Mimetype.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Min.php
+++ b/library/Rules/Min.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Multiple.php
+++ b/library/Rules/Multiple.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Named.php
+++ b/library/Rules/Named.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Negative.php
+++ b/library/Rules/Negative.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/NfeAccessKey.php
+++ b/library/Rules/NfeAccessKey.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Nif.php
+++ b/library/Rules/Nif.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Nip.php
+++ b/library/Rules/Nip.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/No.php
+++ b/library/Rules/No.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/NoneOf.php
+++ b/library/Rules/NoneOf.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Not.php
+++ b/library/Rules/Not.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/NullOr.php
+++ b/library/Rules/NullOr.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/NullType.php
+++ b/library/Rules/NullType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Number.php
+++ b/library/Rules/Number.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/NumericVal.php
+++ b/library/Rules/NumericVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/ObjectType.php
+++ b/library/Rules/ObjectType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Odd.php
+++ b/library/Rules/Odd.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/OneOf.php
+++ b/library/Rules/OneOf.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PerfectSquare.php
+++ b/library/Rules/PerfectSquare.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Pesel.php
+++ b/library/Rules/Pesel.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Phone.php
+++ b/library/Rules/Phone.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PhpLabel.php
+++ b/library/Rules/PhpLabel.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Pis.php
+++ b/library/Rules/Pis.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PolishIdCard.php
+++ b/library/Rules/PolishIdCard.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PortugueseNif.php
+++ b/library/Rules/PortugueseNif.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Positive.php
+++ b/library/Rules/Positive.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PostalCode.php
+++ b/library/Rules/PostalCode.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PrimeNumber.php
+++ b/library/Rules/PrimeNumber.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Printable.php
+++ b/library/Rules/Printable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Property.php
+++ b/library/Rules/Property.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PropertyExists.php
+++ b/library/Rules/PropertyExists.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PropertyOptional.php
+++ b/library/Rules/PropertyOptional.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/PublicDomainSuffix.php
+++ b/library/Rules/PublicDomainSuffix.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Punct.php
+++ b/library/Rules/Punct.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Readable.php
+++ b/library/Rules/Readable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Regex.php
+++ b/library/Rules/Regex.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/ResourceType.php
+++ b/library/Rules/ResourceType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Roman.php
+++ b/library/Rules/Roman.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/ScalarVal.php
+++ b/library/Rules/ScalarVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Size.php
+++ b/library/Rules/Size.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Slug.php
+++ b/library/Rules/Slug.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Sorted.php
+++ b/library/Rules/Sorted.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Space.php
+++ b/library/Rules/Space.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Spaced.php
+++ b/library/Rules/Spaced.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/StartsWith.php
+++ b/library/Rules/StartsWith.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/StringType.php
+++ b/library/Rules/StringType.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/StringVal.php
+++ b/library/Rules/StringVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/SubdivisionCode.php
+++ b/library/Rules/SubdivisionCode.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Subset.php
+++ b/library/Rules/Subset.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/SymbolicLink.php
+++ b/library/Rules/SymbolicLink.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Templated.php
+++ b/library/Rules/Templated.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Time.php
+++ b/library/Rules/Time.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Tld.php
+++ b/library/Rules/Tld.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/TrueVal.php
+++ b/library/Rules/TrueVal.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Undef.php
+++ b/library/Rules/Undef.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/UndefOr.php
+++ b/library/Rules/UndefOr.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Unique.php
+++ b/library/Rules/Unique.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Uploaded.php
+++ b/library/Rules/Uploaded.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Uppercase.php
+++ b/library/Rules/Uppercase.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Url.php
+++ b/library/Rules/Url.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Uuid.php
+++ b/library/Rules/Uuid.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Version.php
+++ b/library/Rules/Version.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/VideoUrl.php
+++ b/library/Rules/VideoUrl.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Vowel.php
+++ b/library/Rules/Vowel.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/When.php
+++ b/library/Rules/When.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Writable.php
+++ b/library/Rules/Writable.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Xdigit.php
+++ b/library/Rules/Xdigit.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Rules/Yes.php
+++ b/library/Rules/Yes.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/library/Transformers/Prefix.php
+++ b/library/Transformers/Prefix.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Transformers;

--- a/library/Transformers/RuleSpec.php
+++ b/library/Transformers/RuleSpec.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Transformers;

--- a/library/Transformers/Transformer.php
+++ b/library/Transformers/Transformer.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Transformers;

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/library/ValidatorFactory.php
+++ b/library/ValidatorFactory.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Exceptions\ValidationException;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/tests/feature/AssertWithKeysTest.php
+++ b/tests/feature/AssertWithKeysTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(

--- a/tests/feature/AssertWithPropertiesTest.php
+++ b/tests/feature/AssertWithPropertiesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(

--- a/tests/feature/AssertWithTemplatesTest.php
+++ b/tests/feature/AssertWithTemplatesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Template as a string in the chain', catchAll(

--- a/tests/feature/DoNotRelyOnNestedValidationExceptionInterfaceForCheckTest.php
+++ b/tests/feature/DoNotRelyOnNestedValidationExceptionInterfaceForCheckTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Validator;

--- a/tests/feature/GetFullMessageShouldIncludeAllValidationMessagesInAChainTest.php
+++ b/tests/feature/GetFullMessageShouldIncludeAllValidationMessagesInAChainTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Validator;

--- a/tests/feature/GetMessagesShouldIncludeAllValidationMessagesInAChainTest.php
+++ b/tests/feature/GetMessagesShouldIncludeAllValidationMessagesInAChainTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/tests/feature/GetMessagesTest.php
+++ b/tests/feature/GetMessagesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessages(

--- a/tests/feature/GetMessagesWithReplacementsTest.php
+++ b/tests/feature/GetMessagesWithReplacementsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessages(

--- a/tests/feature/HandlingNamesTest.php
+++ b/tests/feature/HandlingNamesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 $input = ['email' => 'not an email'];

--- a/tests/feature/Issues/Issue1033Test.php
+++ b/tests/feature/Issues/Issue1033Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1033', catchAll(

--- a/tests/feature/Issues/Issue1244Test.php
+++ b/tests/feature/Issues/Issue1244Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1244', catchAll(

--- a/tests/feature/Issues/Issue1289Test.php
+++ b/tests/feature/Issues/Issue1289Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Rules\ArrayType;

--- a/tests/feature/Issues/Issue1333Test.php
+++ b/tests/feature/Issues/Issue1333Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1333', catchAll(

--- a/tests/feature/Issues/Issue1334Test.php
+++ b/tests/feature/Issues/Issue1334Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1334', catchAll(

--- a/tests/feature/Issues/Issue1376Test.php
+++ b/tests/feature/Issues/Issue1376Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1376', catchAll(

--- a/tests/feature/Issues/Issue1469Test.php
+++ b/tests/feature/Issues/Issue1469Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1469', catchAll(

--- a/tests/feature/Issues/Issue1477Test.php
+++ b/tests/feature/Issues/Issue1477Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Rules\Core\Simple;

--- a/tests/feature/Issues/Issue179Test.php
+++ b/tests/feature/Issues/Issue179Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/179', catchAll(

--- a/tests/feature/Issues/Issue425Test.php
+++ b/tests/feature/Issues/Issue425Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/425', catchAll(

--- a/tests/feature/Issues/Issue446Test.php
+++ b/tests/feature/Issues/Issue446Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 $arr = [

--- a/tests/feature/Issues/Issue619Test.php
+++ b/tests/feature/Issues/Issue619Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/619', catchAll(

--- a/tests/feature/Issues/Issue739Test.php
+++ b/tests/feature/Issues/Issue739Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/739', catchAll(

--- a/tests/feature/Issues/Issue796Test.php
+++ b/tests/feature/Issues/Issue796Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/796', catchAll(

--- a/tests/feature/Issues/Issue799Test.php
+++ b/tests/feature/Issues/Issue799Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Test\Stubs\CountableStub;

--- a/tests/feature/Issues/Issue805Test.php
+++ b/tests/feature/Issues/Issue805Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/805', catchAll(

--- a/tests/feature/KeysAsValidatorNamesTest.php
+++ b/tests/feature/KeysAsValidatorNamesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/tests/feature/Message/StandardStringifierTest.php
+++ b/tests/feature/Message/StandardStringifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Message\ValidationStringifier;

--- a/tests/feature/NotShouldWorkWithBuilderTestTest.php
+++ b/tests/feature/NotShouldWorkWithBuilderTestTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test(

--- a/tests/feature/NotWithRecursionTest.php
+++ b/tests/feature/NotWithRecursionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/NotWithoutRecursionTest.php
+++ b/tests/feature/NotWithoutRecursionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Validator;

--- a/tests/feature/Readme/CustomMessagesTest.php
+++ b/tests/feature/Readme/CustomMessagesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessages(

--- a/tests/feature/Readme/ExampleTest.php
+++ b/tests/feature/Readme/ExampleTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(

--- a/tests/feature/Readme/GettingMessagesAsAnArrayTest.php
+++ b/tests/feature/Readme/GettingMessagesAsAnArrayTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessages(

--- a/tests/feature/Rules/AllOfTest.php
+++ b/tests/feature/Rules/AllOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default: fail, fail', catchAll(

--- a/tests/feature/Rules/AlnumTest.php
+++ b/tests/feature/Rules/AlnumTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/AlphaTest.php
+++ b/tests/feature/Rules/AlphaTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/AlwaysInvalidTest.php
+++ b/tests/feature/Rules/AlwaysInvalidTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/AlwaysValidTest.php
+++ b/tests/feature/Rules/AlwaysValidTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/AnyOfTest.php
+++ b/tests/feature/Rules/AnyOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default: fail, fail', catchAll(

--- a/tests/feature/Rules/ArrayTypeTest.php
+++ b/tests/feature/Rules/ArrayTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ArrayValTest.php
+++ b/tests/feature/Rules/ArrayValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/AttributesTest.php
+++ b/tests/feature/Rules/AttributesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Test\Stubs\WithAttributes;

--- a/tests/feature/Rules/Base64Test.php
+++ b/tests/feature/Rules/Base64Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/BaseTest.php
+++ b/tests/feature/Rules/BaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/BeetwenTest.php
+++ b/tests/feature/Rules/BeetwenTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/BetweenExclusiveTest.php
+++ b/tests/feature/Rules/BetweenExclusiveTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/BlankTest.php
+++ b/tests/feature/Rules/BlankTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('default template', catchAll(

--- a/tests/feature/Rules/BoolTypeTest.php
+++ b/tests/feature/Rules/BoolTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/BoolValTest.php
+++ b/tests/feature/Rules/BoolValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/BsnTest.php
+++ b/tests/feature/Rules/BsnTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CallTest.php
+++ b/tests/feature/Rules/CallTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CallableTypeTest.php
+++ b/tests/feature/Rules/CallableTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CallbackTest.php
+++ b/tests/feature/Rules/CallbackTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CharsetTest.php
+++ b/tests/feature/Rules/CharsetTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CircuitTest.php
+++ b/tests/feature/Rules/CircuitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/CnhTest.php
+++ b/tests/feature/Rules/CnhTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CnpjTest.php
+++ b/tests/feature/Rules/CnpjTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 require_once 'vendor/autoload.php';

--- a/tests/feature/Rules/CntrlTest.php
+++ b/tests/feature/Rules/CntrlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 require_once 'vendor/autoload.php';

--- a/tests/feature/Rules/ConsonantTest.php
+++ b/tests/feature/Rules/ConsonantTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ContainsAnyTest.php
+++ b/tests/feature/Rules/ContainsAnyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ContainsTest.php
+++ b/tests/feature/Rules/ContainsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CountableTest.php
+++ b/tests/feature/Rules/CountableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CountryCodeTest.php
+++ b/tests/feature/Rules/CountryCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CpfTest.php
+++ b/tests/feature/Rules/CpfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CreditCardTest.php
+++ b/tests/feature/Rules/CreditCardTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/CurrencyCodeTest.php
+++ b/tests/feature/Rules/CurrencyCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/DateTest.php
+++ b/tests/feature/Rules/DateTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/tests/feature/Rules/DateTimeDiffTest.php
+++ b/tests/feature/Rules/DateTimeDiffTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('With $type = "years"', catchAll(

--- a/tests/feature/Rules/DateTimeTest.php
+++ b/tests/feature/Rules/DateTimeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/tests/feature/Rules/DecimalTest.php
+++ b/tests/feature/Rules/DecimalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/DigitTest.php
+++ b/tests/feature/Rules/DigitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/DirectoryTest.php
+++ b/tests/feature/Rules/DirectoryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/DomainTest.php
+++ b/tests/feature/Rules/DomainTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/EachTest.php
+++ b/tests/feature/Rules/EachTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Non-iterable', catchAll(

--- a/tests/feature/Rules/EmailTest.php
+++ b/tests/feature/Rules/EmailTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/EmojiTest.php
+++ b/tests/feature/Rules/EmojiTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('default template', catchAll(

--- a/tests/feature/Rules/EndsWithTest.php
+++ b/tests/feature/Rules/EndsWithTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/EqualsTest.php
+++ b/tests/feature/Rules/EqualsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/EquivalentTest.php
+++ b/tests/feature/Rules/EquivalentTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/EvenTest.php
+++ b/tests/feature/Rules/EvenTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ExecutableTest.php
+++ b/tests/feature/Rules/ExecutableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ExistsTest.php
+++ b/tests/feature/Rules/ExistsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ExtensionTest.php
+++ b/tests/feature/Rules/ExtensionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FactorTest.php
+++ b/tests/feature/Rules/FactorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FalseValTest.php
+++ b/tests/feature/Rules/FalseValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FalsyTest.php
+++ b/tests/feature/Rules/FalsyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('default template', catchAll(

--- a/tests/feature/Rules/FibonacciTest.php
+++ b/tests/feature/Rules/FibonacciTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FileTest.php
+++ b/tests/feature/Rules/FileTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FilterVarTest.php
+++ b/tests/feature/Rules/FilterVarTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FiniteTest.php
+++ b/tests/feature/Rules/FiniteTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FloatTypeTest.php
+++ b/tests/feature/Rules/FloatTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/FloatvalTest.php
+++ b/tests/feature/Rules/FloatvalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/GraphTest.php
+++ b/tests/feature/Rules/GraphTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/GreaterThanOrEqualTest.php
+++ b/tests/feature/Rules/GreaterThanOrEqualTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/GreaterThanTest.php
+++ b/tests/feature/Rules/GreaterThanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/HetuTest.php
+++ b/tests/feature/Rules/HetuTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/HexRgbColorTest.php
+++ b/tests/feature/Rules/HexRgbColorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IbanTest.php
+++ b/tests/feature/Rules/IbanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IdenticalTest.php
+++ b/tests/feature/Rules/IdenticalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ImageTest.php
+++ b/tests/feature/Rules/ImageTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ImeiTest.php
+++ b/tests/feature/Rules/ImeiTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/InTest.php
+++ b/tests/feature/Rules/InTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/InfiniteTest.php
+++ b/tests/feature/Rules/InfiniteTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/InstanceTest.php
+++ b/tests/feature/Rules/InstanceTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IntTypeTest.php
+++ b/tests/feature/Rules/IntTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IntValTest.php
+++ b/tests/feature/Rules/IntValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IpTest.php
+++ b/tests/feature/Rules/IpTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IsbnTest.php
+++ b/tests/feature/Rules/IsbnTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/IterableTypeTest.php
+++ b/tests/feature/Rules/IterableTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/IterableValTest.php
+++ b/tests/feature/Rules/IterableValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/JsonTest.php
+++ b/tests/feature/Rules/JsonTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/KeyExistsTest.php
+++ b/tests/feature/Rules/KeyExistsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default mode', catchAll(

--- a/tests/feature/Rules/KeyOptionalTest.php
+++ b/tests/feature/Rules/KeyOptionalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/KeySetTest.php
+++ b/tests/feature/Rules/KeySetTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('one rule / one failed', catchAll(

--- a/tests/feature/Rules/KeyTest.php
+++ b/tests/feature/Rules/KeyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Missing key', catchAll(

--- a/tests/feature/Rules/LanguageCodeTest.php
+++ b/tests/feature/Rules/LanguageCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/LazyTest.php
+++ b/tests/feature/Rules/LazyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/LeapDateTest.php
+++ b/tests/feature/Rules/LeapDateTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/LeapYearTest.php
+++ b/tests/feature/Rules/LeapYearTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/LengthTest.php
+++ b/tests/feature/Rules/LengthTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/LessThanOrEqualTest.php
+++ b/tests/feature/Rules/LessThanOrEqualTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/LessThanTest.php
+++ b/tests/feature/Rules/LessThanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/LowercaseTest.php
+++ b/tests/feature/Rules/LowercaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/LuhnTest.php
+++ b/tests/feature/Rules/LuhnTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/MacAddressTest.php
+++ b/tests/feature/Rules/MacAddressTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/MaxTest.php
+++ b/tests/feature/Rules/MaxTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Non-iterable', catchAll(

--- a/tests/feature/Rules/MimetypeTest.php
+++ b/tests/feature/Rules/MimetypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/MinTest.php
+++ b/tests/feature/Rules/MinTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/MultipleTest.php
+++ b/tests/feature/Rules/MultipleTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NamedTest.php
+++ b/tests/feature/Rules/NamedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/NegativeTest.php
+++ b/tests/feature/Rules/NegativeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NfeAccessKeyTest.php
+++ b/tests/feature/Rules/NfeAccessKeyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NifTest.php
+++ b/tests/feature/Rules/NifTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NipTest.php
+++ b/tests/feature/Rules/NipTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 require_once 'vendor/autoload.php';

--- a/tests/feature/Rules/NoTest.php
+++ b/tests/feature/Rules/NoTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NoneOfTest.php
+++ b/tests/feature/Rules/NoneOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default: fail, fail', catchAll(

--- a/tests/feature/Rules/NullOrTest.php
+++ b/tests/feature/Rules/NullOrTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/NullTypeTest.php
+++ b/tests/feature/Rules/NullTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NumberTest.php
+++ b/tests/feature/Rules/NumberTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/NumericValTest.php
+++ b/tests/feature/Rules/NumericValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ObjectTypeTest.php
+++ b/tests/feature/Rules/ObjectTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/OddTest.php
+++ b/tests/feature/Rules/OddTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/OneOfTest.php
+++ b/tests/feature/Rules/OneOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default: fail, fail', catchAll(

--- a/tests/feature/Rules/PerfectSquareTest.php
+++ b/tests/feature/Rules/PerfectSquareTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PeselTest.php
+++ b/tests/feature/Rules/PeselTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 require_once 'vendor/autoload.php';

--- a/tests/feature/Rules/PhoneTest.php
+++ b/tests/feature/Rules/PhoneTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/PhplabelTest.php
+++ b/tests/feature/Rules/PhplabelTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PisTest.php
+++ b/tests/feature/Rules/PisTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PolishIdCardTest.php
+++ b/tests/feature/Rules/PolishIdCardTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 require_once 'vendor/autoload.php';

--- a/tests/feature/Rules/PositiveTest.php
+++ b/tests/feature/Rules/PositiveTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PostalCodeTest.php
+++ b/tests/feature/Rules/PostalCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PrimeNumberTest.php
+++ b/tests/feature/Rules/PrimeNumberTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PrintableTest.php
+++ b/tests/feature/Rules/PrintableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/PropertyExistsTest.php
+++ b/tests/feature/Rules/PropertyExistsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default mode', catchAll(

--- a/tests/feature/Rules/PropertyOptionalTest.php
+++ b/tests/feature/Rules/PropertyOptionalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/PropertyTest.php
+++ b/tests/feature/Rules/PropertyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Missing property', catchAll(

--- a/tests/feature/Rules/PunctTest.php
+++ b/tests/feature/Rules/PunctTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ReadableTest.php
+++ b/tests/feature/Rules/ReadableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/RegexTest.php
+++ b/tests/feature/Rules/RegexTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ResourceTypeTest.php
+++ b/tests/feature/Rules/ResourceTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/RomanTest.php
+++ b/tests/feature/Rules/RomanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/ScalarValTest.php
+++ b/tests/feature/Rules/ScalarValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/SizeTest.php
+++ b/tests/feature/Rules/SizeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use org\bovigo\vfs\content\LargeFileContent;

--- a/tests/feature/Rules/SlugTest.php
+++ b/tests/feature/Rules/SlugTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/SortedTest.php
+++ b/tests/feature/Rules/SortedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/SpaceTest.php
+++ b/tests/feature/Rules/SpaceTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/SpacedTest.php
+++ b/tests/feature/Rules/SpacedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('default template', catchAll(

--- a/tests/feature/Rules/StartsWithTest.php
+++ b/tests/feature/Rules/StartsWithTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/StringTypeTest.php
+++ b/tests/feature/Rules/StringTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/StringValTest.php
+++ b/tests/feature/Rules/StringValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/SubsetTest.php
+++ b/tests/feature/Rules/SubsetTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/SymbolicLinkTest.php
+++ b/tests/feature/Rules/SymbolicLinkTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/TemplatedTest.php
+++ b/tests/feature/Rules/TemplatedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/TimeTest.php
+++ b/tests/feature/Rules/TimeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/tests/feature/Rules/TldTest.php
+++ b/tests/feature/Rules/TldTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/TrueValTest.php
+++ b/tests/feature/Rules/TrueValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/UndefOrTest.php
+++ b/tests/feature/Rules/UndefOrTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Default', catchAll(

--- a/tests/feature/Rules/UndefTest.php
+++ b/tests/feature/Rules/UndefTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('default template', catchAll(

--- a/tests/feature/Rules/UniqueTest.php
+++ b/tests/feature/Rules/UniqueTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/UploadedTest.php
+++ b/tests/feature/Rules/UploadedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/UppercaseTest.php
+++ b/tests/feature/Rules/UppercaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/UrlTest.php
+++ b/tests/feature/Rules/UrlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/UuidTest.php
+++ b/tests/feature/Rules/UuidTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/VersionTest.php
+++ b/tests/feature/Rules/VersionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/VideoUrlTest.php
+++ b/tests/feature/Rules/VideoUrlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/VowelTest.php
+++ b/tests/feature/Rules/VowelTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/WhenTest.php
+++ b/tests/feature/Rules/WhenTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('When valid use "then"', catchAll(

--- a/tests/feature/Rules/WritableTest.php
+++ b/tests/feature/Rules/WritableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/XdigitTest.php
+++ b/tests/feature/Rules/XdigitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/Rules/YesTest.php
+++ b/tests/feature/Rules/YesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchMessage(

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageHeaderTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageHeaderTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Validator;

--- a/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Validator;

--- a/tests/feature/Transformers/PrefixTest.php
+++ b/tests/feature/Transformers/PrefixTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/tests/feature/TranslatorTest.php
+++ b/tests/feature/TranslatorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\ContainerRegistry;

--- a/tests/feature/ValidationExceptionStackTraceTest.php
+++ b/tests/feature/ValidationExceptionStackTraceTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Exceptions\ValidationException;

--- a/tests/fixtures/data-provider.php
+++ b/tests/fixtures/data-provider.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 use Respect\Validation\Test\Stubs\WithAttributes;

--- a/tests/library/Builders/ResultBuilder.php
+++ b/tests/library/Builders/ResultBuilder.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Builders;

--- a/tests/library/DataProvider.php
+++ b/tests/library/DataProvider.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test;

--- a/tests/library/Message/NullStringifier.php
+++ b/tests/library/Message/NullStringifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Message;

--- a/tests/library/Message/TestingArrayFormatter.php
+++ b/tests/library/Message/TestingArrayFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Message;

--- a/tests/library/Message/TestingMessageRenderer.php
+++ b/tests/library/Message/TestingMessageRenderer.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Message;

--- a/tests/library/Message/TestingModifier.php
+++ b/tests/library/Message/TestingModifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Message;

--- a/tests/library/Message/TestingStringFormatter.php
+++ b/tests/library/Message/TestingStringFormatter.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Message;

--- a/tests/library/Message/TestingStringifier.php
+++ b/tests/library/Message/TestingStringifier.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Message;

--- a/tests/library/RuleTestCase.php
+++ b/tests/library/RuleTestCase.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test;

--- a/tests/library/Rules/Core/ConcreteComparison.php
+++ b/tests/library/Rules/Core/ConcreteComparison.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/Core/ConcreteComposite.php
+++ b/tests/library/Rules/Core/ConcreteComposite.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/Core/ConcreteEnvelope.php
+++ b/tests/library/Rules/Core/ConcreteEnvelope.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/Core/ConcreteFilteredNonEmptyArray.php
+++ b/tests/library/Rules/Core/ConcreteFilteredNonEmptyArray.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/Core/ConcreteFilteredString.php
+++ b/tests/library/Rules/Core/ConcreteFilteredString.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/Core/ConcreteSimple.php
+++ b/tests/library/Rules/Core/ConcreteSimple.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/Core/ConcreteWrapper.php
+++ b/tests/library/Rules/Core/ConcreteWrapper.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules\Core;

--- a/tests/library/Rules/CustomRule.php
+++ b/tests/library/Rules/CustomRule.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules;

--- a/tests/library/Rules/Invalid.php
+++ b/tests/library/Rules/Invalid.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules;

--- a/tests/library/Rules/MyAbstractClass.php
+++ b/tests/library/Rules/MyAbstractClass.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules;

--- a/tests/library/Rules/Stub.php
+++ b/tests/library/Rules/Stub.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules;

--- a/tests/library/Rules/Valid.php
+++ b/tests/library/Rules/Valid.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Rules;

--- a/tests/library/Stubs/CountableStub.php
+++ b/tests/library/Stubs/CountableStub.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/MyValidator.php
+++ b/tests/library/Stubs/MyValidator.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/ParentWithAttributes.php
+++ b/tests/library/Stubs/ParentWithAttributes.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/StreamStub.php
+++ b/tests/library/Stubs/StreamStub.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/ToStringStub.php
+++ b/tests/library/Stubs/ToStringStub.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/UploadedFileStub.php
+++ b/tests/library/Stubs/UploadedFileStub.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/WithAttributes.php
+++ b/tests/library/Stubs/WithAttributes.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/WithMethods.php
+++ b/tests/library/Stubs/WithMethods.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/WithProperties.php
+++ b/tests/library/Stubs/WithProperties.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/WithStaticProperties.php
+++ b/tests/library/Stubs/WithStaticProperties.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/Stubs/WithUninitialized.php
+++ b/tests/library/Stubs/WithUninitialized.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Stubs;

--- a/tests/library/TestCase.php
+++ b/tests/library/TestCase.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test;

--- a/tests/library/Transformers/StubTransformer.php
+++ b/tests/library/Transformers/StubTransformer.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Test\Transformers;

--- a/tests/unit/CloneValidatorFactoryTest.php
+++ b/tests/unit/CloneValidatorFactoryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/tests/unit/ContainerRegistryTest.php
+++ b/tests/unit/ContainerRegistryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/tests/unit/Exceptions/InvalidRuleConstructorExceptionTest.php
+++ b/tests/unit/Exceptions/InvalidRuleConstructorExceptionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/tests/unit/Exceptions/MissingComposerDependencyExceptionTest.php
+++ b/tests/unit/Exceptions/MissingComposerDependencyExceptionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Exceptions;

--- a/tests/unit/Helpers/CanValidateDateTimeTest.php
+++ b/tests/unit/Helpers/CanValidateDateTimeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/tests/unit/Helpers/CanValidateUndefinedTest.php
+++ b/tests/unit/Helpers/CanValidateUndefinedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;

--- a/tests/unit/Message/Formatter/FirstResultStringFormatterTest.php
+++ b/tests/unit/Message/Formatter/FirstResultStringFormatterTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/tests/unit/Message/Formatter/NestedArrayFormatterTest.php
+++ b/tests/unit/Message/Formatter/NestedArrayFormatterTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/tests/unit/Message/Formatter/NestedListStringFormatterTest.php
+++ b/tests/unit/Message/Formatter/NestedListStringFormatterTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/tests/unit/Message/Formatter/OnlyFailedChildrenResultFilterTest.php
+++ b/tests/unit/Message/Formatter/OnlyFailedChildrenResultFilterTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/tests/unit/Message/Formatter/TemplateResolverTest.php
+++ b/tests/unit/Message/Formatter/TemplateResolverTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Formatter;

--- a/tests/unit/Message/InterpolationRendererTest.php
+++ b/tests/unit/Message/InterpolationRendererTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message;

--- a/tests/unit/Message/Modifier/ListAndModifierTest.php
+++ b/tests/unit/Message/Modifier/ListAndModifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/tests/unit/Message/Modifier/ListOrModifierTest.php
+++ b/tests/unit/Message/Modifier/ListOrModifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/tests/unit/Message/Modifier/QuoteModifierTest.php
+++ b/tests/unit/Message/Modifier/QuoteModifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/tests/unit/Message/Modifier/RawModifierTest.php
+++ b/tests/unit/Message/Modifier/RawModifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/tests/unit/Message/Modifier/StringifyModifierTest.php
+++ b/tests/unit/Message/Modifier/StringifyModifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/tests/unit/Message/Modifier/TransModifierTest.php
+++ b/tests/unit/Message/Modifier/TransModifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Modifier;

--- a/tests/unit/Message/StandardFormatter/ResultCreator.php
+++ b/tests/unit/Message/StandardFormatter/ResultCreator.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\StandardFormatter;

--- a/tests/unit/Message/Stringifier/ListedStringifierTest.php
+++ b/tests/unit/Message/Stringifier/ListedStringifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Stringifier;

--- a/tests/unit/Message/Stringifier/QuotedStringifierTest.php
+++ b/tests/unit/Message/Stringifier/QuotedStringifierTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Stringifier;

--- a/tests/unit/Message/Translator/ArrayTranslatorTest.php
+++ b/tests/unit/Message/Translator/ArrayTranslatorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Message\Translator;

--- a/tests/unit/NamespacedRuleFactoryTest.php
+++ b/tests/unit/NamespacedRuleFactoryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/tests/unit/ResultQueryTest.php
+++ b/tests/unit/ResultQueryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;

--- a/tests/unit/Rules/AllOfTest.php
+++ b/tests/unit/Rules/AllOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/AlnumTest.php
+++ b/tests/unit/Rules/AlnumTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/AlphaTest.php
+++ b/tests/unit/Rules/AlphaTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/AlwaysInvalidTest.php
+++ b/tests/unit/Rules/AlwaysInvalidTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/AlwaysValidTest.php
+++ b/tests/unit/Rules/AlwaysValidTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/AnyOfTest.php
+++ b/tests/unit/Rules/AnyOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ArrayTypeTest.php
+++ b/tests/unit/Rules/ArrayTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ArrayValTest.php
+++ b/tests/unit/Rules/ArrayValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/AttributesTest.php
+++ b/tests/unit/Rules/AttributesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/Base64Test.php
+++ b/tests/unit/Rules/Base64Test.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BaseTest.php
+++ b/tests/unit/Rules/BaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BetweenExclusiveTest.php
+++ b/tests/unit/Rules/BetweenExclusiveTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BetweenTest.php
+++ b/tests/unit/Rules/BetweenTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BlankTest.php
+++ b/tests/unit/Rules/BlankTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BoolTypeTest.php
+++ b/tests/unit/Rules/BoolTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BoolValTest.php
+++ b/tests/unit/Rules/BoolValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/BsnTest.php
+++ b/tests/unit/Rules/BsnTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CallTest.php
+++ b/tests/unit/Rules/CallTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CallableTypeTest.php
+++ b/tests/unit/Rules/CallableTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CallbackTest.php
+++ b/tests/unit/Rules/CallbackTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CharsetTest.php
+++ b/tests/unit/Rules/CharsetTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CircuitTest.php
+++ b/tests/unit/Rules/CircuitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CnhTest.php
+++ b/tests/unit/Rules/CnhTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CnpjTest.php
+++ b/tests/unit/Rules/CnpjTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ConsonantTest.php
+++ b/tests/unit/Rules/ConsonantTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ContainsAnyTest.php
+++ b/tests/unit/Rules/ContainsAnyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ContainsTest.php
+++ b/tests/unit/Rules/ContainsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ControlTest.php
+++ b/tests/unit/Rules/ControlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/Core/ComparisonTest.php
+++ b/tests/unit/Rules/Core/ComparisonTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/CompositeTest.php
+++ b/tests/unit/Rules/Core/CompositeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/EnvelopeTest.php
+++ b/tests/unit/Rules/Core/EnvelopeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/FilteredNonEmptyArrayTest.php
+++ b/tests/unit/Rules/Core/FilteredNonEmptyArrayTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/FilteredStringTest.php
+++ b/tests/unit/Rules/Core/FilteredStringTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/ReducerTest.php
+++ b/tests/unit/Rules/Core/ReducerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/SimpleTest.php
+++ b/tests/unit/Rules/Core/SimpleTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/Core/WrapperTest.php
+++ b/tests/unit/Rules/Core/WrapperTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules\Core;

--- a/tests/unit/Rules/CountableTest.php
+++ b/tests/unit/Rules/CountableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CountryCodeTest.php
+++ b/tests/unit/Rules/CountryCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CpfTest.php
+++ b/tests/unit/Rules/CpfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CreditCardTest.php
+++ b/tests/unit/Rules/CreditCardTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/CurrencyCodeTest.php
+++ b/tests/unit/Rules/CurrencyCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DateTest.php
+++ b/tests/unit/Rules/DateTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DateTimeDiffTest.php
+++ b/tests/unit/Rules/DateTimeDiffTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DateTimeTest.php
+++ b/tests/unit/Rules/DateTimeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DecimalTest.php
+++ b/tests/unit/Rules/DecimalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DigitTest.php
+++ b/tests/unit/Rules/DigitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DirectoryTest.php
+++ b/tests/unit/Rules/DirectoryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/DomainTest.php
+++ b/tests/unit/Rules/DomainTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EachTest.php
+++ b/tests/unit/Rules/EachTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EmailTest.php
+++ b/tests/unit/Rules/EmailTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EmojiTest.php
+++ b/tests/unit/Rules/EmojiTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EndsWithTest.php
+++ b/tests/unit/Rules/EndsWithTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EqualsTest.php
+++ b/tests/unit/Rules/EqualsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EquivalentTest.php
+++ b/tests/unit/Rules/EquivalentTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/EvenTest.php
+++ b/tests/unit/Rules/EvenTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ExecutableTest.php
+++ b/tests/unit/Rules/ExecutableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ExistsTest.php
+++ b/tests/unit/Rules/ExistsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ExtensionTest.php
+++ b/tests/unit/Rules/ExtensionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FactorTest.php
+++ b/tests/unit/Rules/FactorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FalseValTest.php
+++ b/tests/unit/Rules/FalseValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FalsyTest.php
+++ b/tests/unit/Rules/FalsyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FibonacciTest.php
+++ b/tests/unit/Rules/FibonacciTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FileTest.php
+++ b/tests/unit/Rules/FileTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FilterVarTest.php
+++ b/tests/unit/Rules/FilterVarTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FiniteTest.php
+++ b/tests/unit/Rules/FiniteTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FloatTypeTest.php
+++ b/tests/unit/Rules/FloatTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/FloatValTest.php
+++ b/tests/unit/Rules/FloatValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/GraphTest.php
+++ b/tests/unit/Rules/GraphTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/GreaterThanOrEqualTest.php
+++ b/tests/unit/Rules/GreaterThanOrEqualTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/GreaterThanTest.php
+++ b/tests/unit/Rules/GreaterThanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/HetuTest.php
+++ b/tests/unit/Rules/HetuTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/HexRgbColorTest.php
+++ b/tests/unit/Rules/HexRgbColorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IbanTest.php
+++ b/tests/unit/Rules/IbanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IdenticalTest.php
+++ b/tests/unit/Rules/IdenticalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ImageTest.php
+++ b/tests/unit/Rules/ImageTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ImeiTest.php
+++ b/tests/unit/Rules/ImeiTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/InTest.php
+++ b/tests/unit/Rules/InTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/InfiniteTest.php
+++ b/tests/unit/Rules/InfiniteTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/InstanceTest.php
+++ b/tests/unit/Rules/InstanceTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IntTypeTest.php
+++ b/tests/unit/Rules/IntTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IntValTest.php
+++ b/tests/unit/Rules/IntValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IpTest.php
+++ b/tests/unit/Rules/IpTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IsbnTest.php
+++ b/tests/unit/Rules/IsbnTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IterableTypeTest.php
+++ b/tests/unit/Rules/IterableTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/IterableValTest.php
+++ b/tests/unit/Rules/IterableValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/JsonTest.php
+++ b/tests/unit/Rules/JsonTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/KeyExistsTest.php
+++ b/tests/unit/Rules/KeyExistsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/KeyOptionalTest.php
+++ b/tests/unit/Rules/KeyOptionalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/KeySetTest.php
+++ b/tests/unit/Rules/KeySetTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/KeyTest.php
+++ b/tests/unit/Rules/KeyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LanguageCodeTest.php
+++ b/tests/unit/Rules/LanguageCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LazyTest.php
+++ b/tests/unit/Rules/LazyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LeapDateTest.php
+++ b/tests/unit/Rules/LeapDateTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LeapYearTest.php
+++ b/tests/unit/Rules/LeapYearTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LengthTest.php
+++ b/tests/unit/Rules/LengthTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LessThanOrEqualTest.php
+++ b/tests/unit/Rules/LessThanOrEqualTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LessThanTest.php
+++ b/tests/unit/Rules/LessThanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LowercaseTest.php
+++ b/tests/unit/Rules/LowercaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/LuhnTest.php
+++ b/tests/unit/Rules/LuhnTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/MacAddressTest.php
+++ b/tests/unit/Rules/MacAddressTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/MaxTest.php
+++ b/tests/unit/Rules/MaxTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/MimetypeTest.php
+++ b/tests/unit/Rules/MimetypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/MinTest.php
+++ b/tests/unit/Rules/MinTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/MultipleTest.php
+++ b/tests/unit/Rules/MultipleTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NegativeTest.php
+++ b/tests/unit/Rules/NegativeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NfeAccessKeyTest.php
+++ b/tests/unit/Rules/NfeAccessKeyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NifTest.php
+++ b/tests/unit/Rules/NifTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NipTest.php
+++ b/tests/unit/Rules/NipTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NoTest.php
+++ b/tests/unit/Rules/NoTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NoneOfTest.php
+++ b/tests/unit/Rules/NoneOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NotTest.php
+++ b/tests/unit/Rules/NotTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NullOrTest.php
+++ b/tests/unit/Rules/NullOrTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NullTypeTest.php
+++ b/tests/unit/Rules/NullTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NumberTest.php
+++ b/tests/unit/Rules/NumberTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/NumericValTest.php
+++ b/tests/unit/Rules/NumericValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ObjectTypeTest.php
+++ b/tests/unit/Rules/ObjectTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/OddTest.php
+++ b/tests/unit/Rules/OddTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/OneOfTest.php
+++ b/tests/unit/Rules/OneOfTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PerfectSquareTest.php
+++ b/tests/unit/Rules/PerfectSquareTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PeselTest.php
+++ b/tests/unit/Rules/PeselTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PhoneTest.php
+++ b/tests/unit/Rules/PhoneTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PhpLabelTest.php
+++ b/tests/unit/Rules/PhpLabelTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PisTest.php
+++ b/tests/unit/Rules/PisTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PolishIdCardTest.php
+++ b/tests/unit/Rules/PolishIdCardTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PortugueseNifTest.php
+++ b/tests/unit/Rules/PortugueseNifTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PositiveTest.php
+++ b/tests/unit/Rules/PositiveTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PostalCodeTest.php
+++ b/tests/unit/Rules/PostalCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PrimeNumberTest.php
+++ b/tests/unit/Rules/PrimeNumberTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PrintableTest.php
+++ b/tests/unit/Rules/PrintableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PropertyExistsTest.php
+++ b/tests/unit/Rules/PropertyExistsTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PropertyOptionalTest.php
+++ b/tests/unit/Rules/PropertyOptionalTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PropertyTest.php
+++ b/tests/unit/Rules/PropertyTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PublicDomainSuffixTest.php
+++ b/tests/unit/Rules/PublicDomainSuffixTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/PunctTest.php
+++ b/tests/unit/Rules/PunctTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ReadableTest.php
+++ b/tests/unit/Rules/ReadableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/RegexTest.php
+++ b/tests/unit/Rules/RegexTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ResourceTypeTest.php
+++ b/tests/unit/Rules/ResourceTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/RomanTest.php
+++ b/tests/unit/Rules/RomanTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/ScalarValTest.php
+++ b/tests/unit/Rules/ScalarValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SizeTest.php
+++ b/tests/unit/Rules/SizeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SlugTest.php
+++ b/tests/unit/Rules/SlugTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SortedTest.php
+++ b/tests/unit/Rules/SortedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SpaceTest.php
+++ b/tests/unit/Rules/SpaceTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SpacedTest.php
+++ b/tests/unit/Rules/SpacedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/StartsWithTest.php
+++ b/tests/unit/Rules/StartsWithTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/StringTypeTest.php
+++ b/tests/unit/Rules/StringTypeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/StringValTest.php
+++ b/tests/unit/Rules/StringValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SubdivisionCodeTest.php
+++ b/tests/unit/Rules/SubdivisionCodeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SubsetTest.php
+++ b/tests/unit/Rules/SubsetTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/SymbolicLinkTest.php
+++ b/tests/unit/Rules/SymbolicLinkTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/TimeTest.php
+++ b/tests/unit/Rules/TimeTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/TldTest.php
+++ b/tests/unit/Rules/TldTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/TrueValTest.php
+++ b/tests/unit/Rules/TrueValTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UndefOrTest.php
+++ b/tests/unit/Rules/UndefOrTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UndefTest.php
+++ b/tests/unit/Rules/UndefTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UniqueTest.php
+++ b/tests/unit/Rules/UniqueTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UploadedTest.php
+++ b/tests/unit/Rules/UploadedTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UppercaseTest.php
+++ b/tests/unit/Rules/UppercaseTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UrlTest.php
+++ b/tests/unit/Rules/UrlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/UuidTest.php
+++ b/tests/unit/Rules/UuidTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/VersionTest.php
+++ b/tests/unit/Rules/VersionTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/VideoUrlTest.php
+++ b/tests/unit/Rules/VideoUrlTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/VowelTest.php
+++ b/tests/unit/Rules/VowelTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/WhenTest.php
+++ b/tests/unit/Rules/WhenTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/WritableTest.php
+++ b/tests/unit/Rules/WritableTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/XdigitTest.php
+++ b/tests/unit/Rules/XdigitTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Rules/YesTest.php
+++ b/tests/unit/Rules/YesTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Rules;

--- a/tests/unit/Transformers/PrefixTest.php
+++ b/tests/unit/Transformers/PrefixTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation\Transformers;

--- a/tests/unit/ValidatorTest.php
+++ b/tests/unit/ValidatorTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/*
- * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
- * SPDX-License-Identifier: MIT
- */
-
 declare(strict_types=1);
 
 namespace Respect\Validation;


### PR DESCRIPTION
I don't see much value on having those headers in the files, and I've seen that some packages (like Doctrine) are moving away from it.