### PR TITLE
Change order of arguments in `Named` rule

### DIFF
--- a/docs/02-feature-guide.md
+++ b/docs/02-feature-guide.md
@@ -112,8 +112,6 @@ $validator->assert('alexandre gaigalas');
 Template messages include the placeholder `{{subject}}`, which defaults to the input. Use `setName()` to replace it with a more descriptive label.
 
 ```php
-v::named(
-        v::dateTime('Y-m-d')->between('1980-02-02', 'now'),
-        'Age'
-    )->assert($input);
+v::named('Age', v::dateTime('Y-m-d')->between('1980-02-02', 'now'))
+    ->assert($input);
 ```

--- a/docs/rules/KeyExists.md
+++ b/docs/rules/KeyExists.md
@@ -45,14 +45,14 @@ When no custom name is set, the path is displayed as `{{name}}`. When a custom n
 v::keyExists('foo')->assert([]);
 // Message: `.foo` must be present
 
-v::named(v::keyExists('foo'), 'Custom name')->assert([]);
+v::named('Custom name', v::keyExists('foo'))->assert([]);
 // Message: `.foo` (<- Custom name) must be present
 ```
 
 If you want to display only a custom name while checking if a key exists, use [Key](Key.md) with [AlwaysValid](AlwaysValid.md):
 
 ```php
-v::key('foo', v::named(v::alwaysValid(), 'Custom name')->assert([]);
+v::key('foo', v::named('Custom name', v::alwaysValid())->assert([]);
 // Message: Custom name must be present
 ```
 

--- a/docs/rules/Named.md
+++ b/docs/rules/Named.md
@@ -1,11 +1,11 @@
 # Named
 
-- `Named(Rule $rule, string $name)`
+- `Named(string $name, Rule $rule)`
 
 Validates the input with the given rule, and uses the custom name in the error message.
 
 ```php
-v::named(v::email(), 'Your email')->assert('not an email');
+v::named('Your email', v::email())->assert('not an email');
 // Message: Your email must be a valid email address
 ```
 

--- a/docs/rules/PropertyExists.md
+++ b/docs/rules/PropertyExists.md
@@ -46,14 +46,14 @@ When no custom name is set, the path is displayed as `{{name}}`. When a custom n
 v::propertyExists('foo')->assert([]);
 // Message: `.foo` must be present
 
-v::named(v::propertyExists('foo'), 'Custom name')->assert([]);
+v::named('Custom name', v::propertyExists('foo'))->assert([]);
 // Message: `.foo` (<- Custom name) must be present
 ```
 
 If you want to display only a custom name while checking if a property exists, use [Property](Property.md) with [AlwaysValid](AlwaysValid.md):
 
 ```php
-v::property('foo', v::named(v::alwaysValid(), 'Custom name'))->assert([]);
+v::property('foo', v::named('Custom name', v::alwaysValid()))->assert([]);
 // Message: Custom name must be present
 ```
 

--- a/library/Mixins/Builder.php
+++ b/library/Mixins/Builder.php
@@ -233,7 +233,7 @@ interface Builder extends
 
     public static function multiple(int $multipleOf): Chain;
 
-    public static function named(Rule $rule, Name|string $name): Chain;
+    public static function named(Name|string $name, Rule $rule): Chain;
 
     public static function negative(): Chain;
 

--- a/library/Mixins/Chain.php
+++ b/library/Mixins/Chain.php
@@ -236,7 +236,7 @@ interface Chain extends
 
     public function multiple(int $multipleOf): Chain;
 
-    public function named(Rule $rule, Name|string $name): Chain;
+    public function named(Name|string $name, Rule $rule): Chain;
 
     public function negative(): Chain;
 

--- a/library/Rules/Named.php
+++ b/library/Rules/Named.php
@@ -23,7 +23,7 @@ final class Named extends Wrapper implements Nameable
 {
     private readonly Name $name;
 
-    public function __construct(Rule $rule, string|Name $name)
+    public function __construct(string|Name $name, Rule $rule)
     {
         parent::__construct($rule);
 

--- a/tests/feature/AssertWithKeysTest.php
+++ b/tests/feature/AssertWithKeysTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(
-    fn() => v::named(v::init()
+    fn() => v::named('the given data', v::init()
         ->key(
             'mysql',
             v::init()
@@ -24,7 +24,7 @@ test('Scenario #1', catchFullMessage(
                 ->key('user', v::stringType())
                 ->key('password', v::stringType())
                 ->key('schema', v::stringType()),
-        ), 'the given data')
+        ))
         ->assert([
             'mysql' => [
                 'host' => 42,

--- a/tests/feature/AssertWithPropertiesTest.php
+++ b/tests/feature/AssertWithPropertiesTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(
-    fn() => v::named(v::init()
+    fn() => v::named('the given data', v::init()
         ->property(
             'mysql',
             v::init()
@@ -24,7 +24,7 @@ test('Scenario #1', catchFullMessage(
                 ->property('user', v::stringType())
                 ->property('password', v::stringType())
                 ->property('schema', v::stringType()),
-        ), 'the given data')
+        ))
         ->assert(json_decode((string) json_encode([
             'mysql' => [
                 'host' => 42,

--- a/tests/feature/HandlingNamesTest.php
+++ b/tests/feature/HandlingNamesTest.php
@@ -10,32 +10,32 @@ declare(strict_types=1);
 $input = ['email' => 'not an email'];
 
 test('Results with a defined will display the name', catchMessage(
-    fn() => v::named(v::intType(), 'Number')->assert($input),
+    fn() => v::named('Number', v::intType())->assert($input),
     fn(string $message) => expect($message)->toBe('Number must be an integer'),
 ));
 
 test('Results with adjacent results defined will display the name', catchMessage(
-    fn() => v::named(v::length(v::greaterThan(2)), 'Numbers')->assert($input),
+    fn() => v::named('Numbers', v::length(v::greaterThan(2)))->assert($input),
     fn(string $message) => expect($message)->toBe('The length of Numbers must be greater than 2'),
 ));
 
 test('Results with adjacent children results defined will display the name from its children', catchMessage(
-    fn() => v::named(v::positive()->intType()->greaterThan(5), 'Numbers')->assert($input),
+    fn() => v::named('Numbers', v::positive()->intType()->greaterThan(5))->assert($input),
     fn(string $message) => expect($message)->toBe('Numbers must be a positive number'),
 ));
 
 test('Results with a defined name cannot be overwritten by another name', catchMessage(
-    fn() => v::named(v::key('email', v::named(v::email(), 'Email')), 'Foo')->assert($input),
+    fn() => v::named('Foo', v::key('email', v::named('Email', v::email())))->assert($input),
     fn(string $message) => expect($message)->toBe('Email must be a valid email address'),
 ));
 
 test('Defining a name to a result with a path will add the path to the name', catchMessage(
-    fn() => v::named(v::key('email', v::email()), 'Email')->assert($input),
+    fn() => v::named('Email', v::key('email', v::email()))->assert($input),
     fn(string $message) => expect($message)->toBe('`.email` (<- Email) must be a valid email address'),
 ));
 
 test('Results with a defined name will not be affected by a path', catchMessage(
-    fn() => v::key('email', v::named(v::email(), 'Email'))->assert($input),
+    fn() => v::key('email', v::named('Email', v::email()))->assert($input),
     fn(string $message) => expect($message)->toBe('Email must be a valid email address'),
 ));
 

--- a/tests/feature/Issues/Issue1244Test.php
+++ b/tests/feature/Issues/Issue1244Test.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1244', catchAll(
-    fn() => v::key('firstname', v::named(v::notBlank(), 'First Name'))->assert([]),
+    fn() => v::key('firstname', v::named('First Name', v::notBlank()))->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('First Name must be present')
         ->and($fullMessage)->toBe('- First Name must be present')

--- a/tests/feature/Issues/Issue1333Test.php
+++ b/tests/feature/Issues/Issue1333Test.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/1333', catchAll(
-    fn() => v::named(v::notSpaced()->email(), 'User Email')->assert('not email'),
+    fn() => v::named('User Email', v::notSpaced()->email())->assert('not email'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('User Email must not contain whitespaces')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'

--- a/tests/feature/Issues/Issue179Test.php
+++ b/tests/feature/Issues/Issue179Test.php
@@ -16,12 +16,12 @@ test('https://github.com/Respect/Validation/issues/179', catchAll(
         ];
 
         $validator = v::named(
+            'Settings',
             v::arrayType()
                 ->key('host', v::stringType())
                 ->key('user', v::stringType())
                 ->key('password', v::stringType())
                 ->key('schema', v::stringType()),
-            'Settings',
         );
         $validator->assert($config);
     },

--- a/tests/feature/Issues/Issue796Test.php
+++ b/tests/feature/Issues/Issue796Test.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/796', catchAll(
-    fn() => v::named(v::init()
+    fn() => v::named('the given data', v::init()
         ->key(
             'mysql',
             v::init()
@@ -24,7 +24,7 @@ test('https://github.com/Respect/Validation/issues/796', catchAll(
                 ->key('user', v::stringType())
                 ->key('password', v::stringType())
                 ->key('schema', v::stringType()),
-        ), 'the given data')
+        ))
         ->assert([
             'mysql' => [
                 'host' => 42,

--- a/tests/feature/KeysAsValidatorNamesTest.php
+++ b/tests/feature/KeysAsValidatorNamesTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 date_default_timezone_set('UTC');
 
 test('Scenario #1', catchFullMessage(
-    fn() => v::named(v::init()
+    fn() => v::named('User Subscription Form', v::init()
         ->key('username', v::length(v::between(2, 32)))
-        ->key('birthdate', v::dateTime()), 'User Subscription Form')
+        ->key('birthdate', v::dateTime()))
         ->assert(['username' => '0', 'birthdate' => 'Whatever']),
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - User Subscription Form must pass all the rules

--- a/tests/feature/Rules/BetweenExclusiveTest.php
+++ b/tests/feature/Rules/BetweenExclusiveTest.php
@@ -32,7 +32,7 @@ test('With template', catchAll(
 ));
 
 test('With name', catchAll(
-    fn() => v::named(v::betweenExclusive(1, 10), 'Range')->assert(10),
+    fn() => v::named('Range', v::betweenExclusive(1, 10))->assert(10),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Range must be greater than 1 and less than 10')
         ->and($fullMessage)->toBe('- Range must be greater than 1 and less than 10')

--- a/tests/feature/Rules/CircuitTest.php
+++ b/tests/feature/Rules/CircuitTest.php
@@ -32,7 +32,7 @@ test('Default with inverted failing rule', catchAll(
 ));
 
 test('With wrapped name, default', catchAll(
-    fn() => v::named(v::circuit(v::alwaysValid(), v::named(v::trueVal(), 'Wrapped')), 'Wrapper')->assert(false),
+    fn() => v::named('Wrapper', v::circuit(v::alwaysValid(), v::named('Wrapped', v::trueVal())))->assert(false),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must evaluate to `true`')
         ->and($fullMessage)->toBe('- Wrapped must evaluate to `true`')
@@ -40,7 +40,7 @@ test('With wrapped name, default', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::circuit(v::alwaysValid(), v::trueVal()), 'Wrapper')->assert(false),
+    fn() => v::named('Wrapper', v::circuit(v::alwaysValid(), v::trueVal()))->assert(false),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapper must evaluate to `true`')
         ->and($fullMessage)->toBe('- Wrapper must evaluate to `true`')
@@ -48,7 +48,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With the name set in the wrapped rule of an inverted failing rule', catchAll(
-    fn() => v::named(v::circuit(v::alwaysValid(), v::named(v::not(v::named(v::trueVal(), 'Wrapped')), 'Not')), 'Wrapper')->assert(true),
+    fn() => v::named('Wrapper', v::circuit(v::alwaysValid(), v::named('Not', v::not(v::named('Wrapped', v::trueVal())))))->assert(true),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not evaluate to `true`')
         ->and($fullMessage)->toBe('- Wrapped must not evaluate to `true`')
@@ -56,7 +56,7 @@ test('With the name set in the wrapped rule of an inverted failing rule', catchA
 ));
 
 test('With the name set in an inverted failing rule', catchAll(
-    fn() => v::named(v::circuit(v::alwaysValid(), v::named(v::not(v::trueVal()), 'Not')), 'Wrapper')->assert(true),
+    fn() => v::named('Wrapper', v::circuit(v::alwaysValid(), v::named('Not', v::not(v::trueVal()))))->assert(true),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Not must not evaluate to `true`')
         ->and($fullMessage)->toBe('- Not must not evaluate to `true`')
@@ -64,7 +64,7 @@ test('With the name set in an inverted failing rule', catchAll(
 ));
 
 test('With the name set in the "circuit" that has an inverted failing rule', catchAll(
-    fn() => v::named(v::circuit(v::alwaysValid(), v::not(v::trueVal())), 'Wrapper')->assert(true),
+    fn() => v::named('Wrapper', v::circuit(v::alwaysValid(), v::not(v::trueVal())))->assert(true),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapper must not evaluate to `true`')
         ->and($fullMessage)->toBe('- Wrapper must not evaluate to `true`')

--- a/tests/feature/Rules/EachTest.php
+++ b/tests/feature/Rules/EachTest.php
@@ -60,7 +60,7 @@ test('Inverted', catchAll(
 ));
 
 test('With name, non-iterable', catchAll(
-    fn() => v::each(v::named(v::intType(), 'Wrapped'))->assert(null),
+    fn() => v::each(v::named('Wrapped', v::intType()))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be iterable')
         ->and($fullMessage)->toBe('- Wrapped must be iterable')
@@ -68,7 +68,7 @@ test('With name, non-iterable', catchAll(
 ));
 
 test('With name, empty', catchAll(
-    fn() => v::each(v::named(v::intType(), 'Wrapped'))->assert([]),
+    fn() => v::each(v::named('Wrapped', v::intType()))->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The length of Wrapped must be greater than 0')
         ->and($fullMessage)->toBe('- The length of Wrapped must be greater than 0')
@@ -76,7 +76,7 @@ test('With name, empty', catchAll(
 ));
 
 test('With name, default', catchAll(
-    fn() => v::named(v::each(v::named(v::intType(), 'Wrapped')), 'Wrapper')->assert(['a', 'b', 'c']),
+    fn() => v::named('Wrapper', v::each(v::named('Wrapped', v::intType())))->assert(['a', 'b', 'c']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
@@ -94,7 +94,7 @@ test('With name, default', catchAll(
 ));
 
 test('With name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::each(v::named(v::intType(), 'Wrapped')), 'Wrapper')), 'Not')->assert([1, 2, 3]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::each(v::named('Wrapped', v::intType())))))->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
@@ -112,7 +112,7 @@ test('With name, inverted', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::each(v::intType()), 'Wrapper')->assert(['a', 'b', 'c']),
+    fn() => v::named('Wrapper', v::each(v::intType()))->assert(['a', 'b', 'c']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.0` (<- Wrapper) must be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
@@ -130,7 +130,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::each(v::intType()), 'Wrapper')), 'Not')->assert([1, 2, 3]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::each(v::intType()))))->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.0` (<- Wrapper) must not be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
@@ -148,7 +148,7 @@ test('With wrapper name, inverted', catchAll(
 ));
 
 test('With Not name, inverted', catchAll(
-    fn() => v::named(v::not(v::each(v::intType())), 'Not')->assert([1, 2, 3]),
+    fn() => v::named('Not', v::not(v::each(v::intType())))->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.0` (<- Not) must not be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
@@ -245,7 +245,7 @@ test('With array template, default', catchAll(
 ));
 
 test('With array template and name, default', catchAll(
-    fn() => v::named(v::each(v::named(v::intType(), 'Wrapped')), 'Wrapper')
+    fn() => v::named('Wrapper', v::each(v::named('Wrapped', v::intType())))
         ->assert(['a', 'b', 'c'], [
             '__root__' => 'Here a sequence of items that did not pass the validation',
             0 => 'First item should have been an integer',

--- a/tests/feature/Rules/HetuTest.php
+++ b/tests/feature/Rules/HetuTest.php
@@ -32,7 +32,7 @@ test('With template', catchAll(
 ));
 
 test('With name', catchAll(
-    fn() => v::named(v::hetu(), 'Hetu')->assert('010106A901O'),
+    fn() => v::named('Hetu', v::hetu())->assert('010106A901O'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Hetu must be a valid Finnish personal identity code')
         ->and($fullMessage)->toBe('- Hetu must be a valid Finnish personal identity code')

--- a/tests/feature/Rules/IterableTypeTest.php
+++ b/tests/feature/Rules/IterableTypeTest.php
@@ -32,7 +32,7 @@ test('With template', catchAll(
 ));
 
 test('With name', catchAll(
-    fn() => v::named(v::iterableType(), 'Options')->assert(null),
+    fn() => v::named('Options', v::iterableType())->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Options must be iterable')
         ->and($fullMessage)->toBe('- Options must be iterable')

--- a/tests/feature/Rules/KeyExistsTest.php
+++ b/tests/feature/Rules/KeyExistsTest.php
@@ -24,7 +24,7 @@ test('Inverted mode', catchAll(
 ));
 
 test('Custom name', catchAll(
-    fn() => v::named(v::keyExists('foo'), 'Custom name')->assert(['bar' => 'baz']),
+    fn() => v::named('Custom name', v::keyExists('foo'))->assert(['bar' => 'baz']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Custom name) must be present')
         ->and($fullMessage)->toBe('- `.foo` (<- Custom name) must be present')

--- a/tests/feature/Rules/KeyOptionalTest.php
+++ b/tests/feature/Rules/KeyOptionalTest.php
@@ -32,7 +32,7 @@ test('Inverted with missing key', catchAll(
 ));
 
 test('With wrapped name, default', catchAll(
-    fn() => v::named(v::keyOptional('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')->assert(['foo' => 'string']),
+    fn() => v::named('Wrapper', v::keyOptional('foo', v::named('Wrapped', v::intType())))->assert(['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be an integer')
         ->and($fullMessage)->toBe('- Wrapped must be an integer')
@@ -40,7 +40,7 @@ test('With wrapped name, default', catchAll(
 ));
 
 test('With wrapped name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::keyOptional('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')), 'Not')->assert(['foo' => 12]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::keyOptional('foo', v::named('Wrapped', v::intType())))))->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not be an integer')
         ->and($fullMessage)->toBe('- Wrapped must not be an integer')
@@ -48,7 +48,7 @@ test('With wrapped name, inverted', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::keyOptional('foo', v::intType()), 'Wrapper')->assert(['foo' => 'string']),
+    fn() => v::named('Wrapper', v::keyOptional('foo', v::intType()))->assert(['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
@@ -56,7 +56,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::keyOptional('foo', v::intType()), 'Wrapper')), 'Not')->assert(['foo' => 12]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::keyOptional('foo', v::intType()))))->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
@@ -64,7 +64,7 @@ test('With wrapper name, inverted', catchAll(
 ));
 
 test('With "Not" name, inverted', catchAll(
-    fn() => v::named(v::not(v::keyOptional('foo', v::intType())), 'Not')->assert(['foo' => 12]),
+    fn() => v::named('Not', v::not(v::keyOptional('foo', v::intType())))->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')

--- a/tests/feature/Rules/KeyTest.php
+++ b/tests/feature/Rules/KeyTest.php
@@ -40,7 +40,7 @@ test('Double-inverted with missing key', catchAll(
 ));
 
 test('With wrapped name, missing key', catchAll(
-    fn() => v::key('foo', v::named(v::intType(), 'Wrapped'))->assert([]),
+    fn() => v::key('foo', v::named('Wrapped', v::intType()))->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be present')
         ->and($fullMessage)->toBe('- Wrapped must be present')
@@ -48,7 +48,7 @@ test('With wrapped name, missing key', catchAll(
 ));
 
 test('With wrapped name, default', catchAll(
-    fn() => v::named(v::key('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')->assert(['foo' => 'string']),
+    fn() => v::named('Wrapper', v::key('foo', v::named('Wrapped', v::intType())))->assert(['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be an integer')
         ->and($fullMessage)->toBe('- Wrapped must be an integer')
@@ -56,7 +56,7 @@ test('With wrapped name, default', catchAll(
 ));
 
 test('With wrapped name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::key('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')), 'Not')->assert(['foo' => 12]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::key('foo', v::named('Wrapped', v::intType())))))->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not be an integer')
         ->and($fullMessage)->toBe('- Wrapped must not be an integer')
@@ -64,7 +64,7 @@ test('With wrapped name, inverted', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::key('foo', v::intType()), 'Wrapper')->assert(['foo' => 'string']),
+    fn() => v::named('Wrapper', v::key('foo', v::intType()))->assert(['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
@@ -72,7 +72,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With wrapper name, missing key', catchAll(
-    fn() => v::named(v::key('foo', v::intType()), 'Wrapper')->assert([]),
+    fn() => v::named('Wrapper', v::key('foo', v::intType()))->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must be present')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be present')
@@ -80,7 +80,7 @@ test('With wrapper name, missing key', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::key('foo', v::intType()), 'Wrapper')), 'Not')->assert(['foo' => 12]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::key('foo', v::intType()))))->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
@@ -88,7 +88,7 @@ test('With wrapper name, inverted', catchAll(
 ));
 
 test('With "Not" name, inverted', catchAll(
-    fn() => v::named(v::not(v::key('foo', v::intType())), 'Not')->assert(['foo' => 12]),
+    fn() => v::named('Not', v::not(v::key('foo', v::intType())))->assert(['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')

--- a/tests/feature/Rules/LazyTest.php
+++ b/tests/feature/Rules/LazyTest.php
@@ -8,9 +8,7 @@
 declare(strict_types=1);
 
 test('Default', catchAll(
-    fn() => v::lazy(
-        fn() => v::intType(),
-    )->assert(true),
+    fn() => v::lazy(fn() => v::intType())->assert(true),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`true` must be an integer')
         ->and($fullMessage)->toBe('- `true` must be an integer')
@@ -18,9 +16,7 @@ test('Default', catchAll(
 ));
 
 test('Inverted', catchAll(
-    fn() => v::not(v::lazy(
-        fn() => v::intType(),
-    ))->assert(2),
+    fn() => v::not(v::lazy(fn() => v::intType()))->assert(2),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('2 must not be an integer')
         ->and($fullMessage)->toBe('- 2 must not be an integer')
@@ -28,9 +24,7 @@ test('Inverted', catchAll(
 ));
 
 test('With created name, default', catchAll(
-    fn() => v::named(v::lazy(
-        fn() => v::named(v::intType(), 'Created'),
-    ), 'Wrapper')->assert(true),
+    fn() => v::named('Wrapper', v::lazy(fn() => v::named('Created', v::intType())))->assert(true),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Created must be an integer')
         ->and($fullMessage)->toBe('- Created must be an integer')
@@ -38,9 +32,7 @@ test('With created name, default', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::lazy(
-        fn() => v::intType(),
-    ), 'Wrapper')->assert(true),
+    fn() => v::named('Wrapper', v::lazy(fn() => v::intType()))->assert(true),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapper must be an integer')
         ->and($fullMessage)->toBe('- Wrapper must be an integer')
@@ -48,9 +40,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With created name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::lazy(
-        fn() => v::named(v::intType(), 'Created'),
-    ), 'Wrapped')), 'Not')->assert(2),
+    fn() => v::named('Not', v::not(v::named('Wrapped', v::lazy(fn() => v::named('Created', v::intType())))))->assert(2),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Created must not be an integer')
         ->and($fullMessage)->toBe('- Created must not be an integer')
@@ -58,9 +48,7 @@ test('With created name, inverted', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::lazy(
-        fn() => v::intType(),
-    ), 'Wrapped')), 'Not')->assert(2),
+    fn() => v::named('Not', v::not(v::named('Wrapped', v::lazy(fn() => v::intType()))))->assert(2),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not be an integer')
         ->and($fullMessage)->toBe('- Wrapped must not be an integer')
@@ -68,9 +56,7 @@ test('With wrapper name, inverted', catchAll(
 ));
 
 test('With not name, inverted', catchAll(
-    fn() => v::named(v::not(v::lazy(
-        fn() => v::intType(),
-    )), 'Not')->assert(2),
+    fn() => v::named('Not', v::not(v::lazy(fn() => v::intType())))->assert(2),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Not must not be an integer')
         ->and($fullMessage)->toBe('- Not must not be an integer')
@@ -78,9 +64,7 @@ test('With not name, inverted', catchAll(
 ));
 
 test('With template, default', catchAll(
-    fn() => v::lazy(
-        fn() => v::intType(),
-    )->assert(true, 'Lazy lizards lounging like lords in the local lagoon'),
+    fn() => v::lazy(fn() => v::intType())->assert(true, 'Lazy lizards lounging like lords in the local lagoon'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Lazy lizards lounging like lords in the local lagoon')
         ->and($fullMessage)->toBe('- Lazy lizards lounging like lords in the local lagoon')

--- a/tests/feature/Rules/LengthTest.php
+++ b/tests/feature/Rules/LengthTest.php
@@ -40,7 +40,7 @@ test('With template', catchAll(
 ));
 
 test('With wrapper name', catchAll(
-    fn() => v::named(v::length(v::equals(3)), 'Cactus')->assert('peyote'),
+    fn() => v::named('Cactus', v::length(v::equals(3)))->assert('peyote'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The length of Cactus must be equal to 3')
         ->and($fullMessage)->toBe('- The length of Cactus must be equal to 3')

--- a/tests/feature/Rules/MaxTest.php
+++ b/tests/feature/Rules/MaxTest.php
@@ -40,7 +40,7 @@ test('Inverted', catchAll(
 ));
 
 test('With wrapped name, default', catchAll(
-    fn() => v::named(v::max(v::named(v::negative(), 'Wrapped')), 'Wrapper')->assert([1, 2, 3]),
+    fn() => v::named('Wrapper', v::max(v::named('Wrapped', v::negative())))->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The maximum of Wrapped must be a negative number')
         ->and($fullMessage)->toBe('- The maximum of Wrapped must be a negative number')
@@ -48,7 +48,7 @@ test('With wrapped name, default', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::max(v::negative()), 'Wrapper')->assert([1, 2, 3]),
+    fn() => v::named('Wrapper', v::max(v::negative()))->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The maximum of Wrapper must be a negative number')
         ->and($fullMessage)->toBe('- The maximum of Wrapper must be a negative number')
@@ -56,7 +56,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With wrapped name, inverted', catchAll(
-    fn() => v::named(v::not(v::max(v::named(v::negative(), 'Wrapped'))), 'Wrapper')->assert([-3, -2, -1]),
+    fn() => v::named('Wrapper', v::not(v::max(v::named('Wrapped', v::negative()))))->assert([-3, -2, -1]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The maximum of Wrapped must not be a negative number')
         ->and($fullMessage)->toBe('- The maximum of Wrapped must not be a negative number')
@@ -64,7 +64,7 @@ test('With wrapped name, inverted', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::max(v::negative())), 'Wrapper')->assert([-3, -2, -1]),
+    fn() => v::named('Wrapper', v::not(v::max(v::negative())))->assert([-3, -2, -1]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The maximum of Wrapper must not be a negative number')
         ->and($fullMessage)->toBe('- The maximum of Wrapper must not be a negative number')

--- a/tests/feature/Rules/MinTest.php
+++ b/tests/feature/Rules/MinTest.php
@@ -32,7 +32,7 @@ test('With template', catchAll(
 ));
 
 test('With name', catchAll(
-    fn() => v::named(v::min(v::equals(1)), 'Options')->assert([2, 3]),
+    fn() => v::named('Options', v::min(v::equals(1)))->assert([2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The minimum of Options must be equal to 1')
         ->and($fullMessage)->toBe('- The minimum of Options must be equal to 1')

--- a/tests/feature/Rules/NamedTest.php
+++ b/tests/feature/Rules/NamedTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Default', catchAll(
-    fn() => v::named(v::stringType(), 'Potato')->assert(12),
+    fn() => v::named('Potato', v::stringType())->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Potato must be a string')
         ->and($fullMessage)->toBe('- Potato must be a string')
@@ -16,7 +16,7 @@ test('Default', catchAll(
 ));
 
 test('Inverted', catchAll(
-    fn() => v::not(v::named(v::intType(), 'Zucchini'))->assert(12),
+    fn() => v::not(v::named('Zucchini', v::intType()))->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Zucchini must not be an integer')
         ->and($fullMessage)->toBe('- Zucchini must not be an integer')
@@ -24,7 +24,7 @@ test('Inverted', catchAll(
 ));
 
 test('Template in Validator', catchAll(
-    fn() => v::named(v::named(v::stringType(), 'Eggplant'), 'Mushroom')
+    fn() => v::named('Mushroom', v::named('Eggplant', v::stringType()))
         ->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Eggplant must be a string')
@@ -33,7 +33,7 @@ test('Template in Validator', catchAll(
 ));
 
 test('With bound', catchAll(
-    fn() => v::named(v::attributes(), 'Pumpkin')->assert(null),
+    fn() => v::named('Pumpkin', v::attributes())->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Pumpkin must be an object')
         ->and($fullMessage)->toBe('- Pumpkin must be an object')
@@ -41,7 +41,7 @@ test('With bound', catchAll(
 ));
 
 test('With key that does not exist', catchAll(
-    fn() => v::key('vegetable', v::named(v::stringType(), 'Paprika'))->assert([]),
+    fn() => v::key('vegetable', v::named('Paprika', v::stringType()))->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Paprika must be present')
         ->and($fullMessage)->toBe('- Paprika must be present')
@@ -49,7 +49,7 @@ test('With key that does not exist', catchAll(
 ));
 
 test('With property that does not exist', catchAll(
-    fn() => v::key('vegetable', v::named(v::stringType(), 'Broccoli'))->assert((object) []),
+    fn() => v::key('vegetable', v::named('Broccoli', v::stringType()))->assert((object) []),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Broccoli must be present')
         ->and($fullMessage)->toBe('- Broccoli must be present')
@@ -57,7 +57,7 @@ test('With property that does not exist', catchAll(
 ));
 
 test('With key that fails validation', catchAll(
-    fn() => v::key('vegetable', v::named(v::stringType(), 'Artichoke'))->assert(['vegetable' => 12]),
+    fn() => v::key('vegetable', v::named('Artichoke', v::stringType()))->assert(['vegetable' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Artichoke must be a string')
         ->and($fullMessage)->toBe('- Artichoke must be a string')
@@ -68,11 +68,11 @@ test('With nested key that fails validation', catchAll(
     fn() => v::key(
         'vegetables',
         v::named(
+            'Vegetables',
             v::init()
                 ->key('root', v::stringType())
                 ->key('stems', v::stringType())
                 ->keyExists('fruits'),
-            'Vegetables',
         ),
     )->assert(['vegetables' => ['root' => 12, 'stems' => 12]]),
     fn(string $message, string $fullMessage, array $messages) => expect()

--- a/tests/feature/Rules/NullOrTest.php
+++ b/tests/feature/Rules/NullOrTest.php
@@ -40,7 +40,7 @@ test('Inverted nullined', catchAll(
 ));
 
 test('Inverted nullined, wrapped name', catchAll(
-    fn() => v::not(v::nullOr(v::named(v::alpha(), 'Wrapped')))->assert(null),
+    fn() => v::not(v::nullOr(v::named('Wrapped', v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not contain letters (a-z) and must not be null')
         ->and($fullMessage)->toBe('- Wrapped must not contain letters (a-z) and must not be null')
@@ -48,7 +48,7 @@ test('Inverted nullined, wrapped name', catchAll(
 ));
 
 test('Inverted nullined, wrapper name', catchAll(
-    fn() => v::not(v::named(v::nullOr(v::alpha()), 'Wrapper'))->assert(null),
+    fn() => v::not(v::named('Wrapper', v::nullOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapper must not contain letters (a-z) and must not be null')
         ->and($fullMessage)->toBe('- Wrapper must not contain letters (a-z) and must not be null')
@@ -56,7 +56,7 @@ test('Inverted nullined, wrapper name', catchAll(
 ));
 
 test('Inverted nullined, not name', catchAll(
-    fn() => v::named(v::not(v::nullOr(v::alpha())), 'Not')->assert(null),
+    fn() => v::named('Not', v::not(v::nullOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Not must not contain letters (a-z) and must not be null')
         ->and($fullMessage)->toBe('- Not must not contain letters (a-z) and must not be null')

--- a/tests/feature/Rules/PhoneTest.php
+++ b/tests/feature/Rules/PhoneTest.php
@@ -32,7 +32,7 @@ test('Inverted', catchAll(
 ));
 
 test('Default with name', catchAll(
-    fn() => v::named(v::phone(), 'Phone')->assert('123'),
+    fn() => v::named('Phone', v::phone())->assert('123'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Phone must be a valid telephone number')
         ->and($fullMessage)->toBe('- Phone must be a valid telephone number')
@@ -40,7 +40,7 @@ test('Default with name', catchAll(
 ));
 
 test('Country-specific with name', catchAll(
-    fn() => v::named(v::phone('US'), 'Phone')->assert('123'),
+    fn() => v::named('Phone', v::phone('US'))->assert('123'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Phone must be a valid telephone number for country United States')
         ->and($fullMessage)->toBe('- Phone must be a valid telephone number for country United States')

--- a/tests/feature/Rules/PropertyExistsTest.php
+++ b/tests/feature/Rules/PropertyExistsTest.php
@@ -24,7 +24,7 @@ test('Inverted mode', catchAll(
 ));
 
 test('Custom name', catchAll(
-    fn() => v::named(v::propertyExists('foo'), 'Custom name')->assert((object) ['bar' => 'baz']),
+    fn() => v::named('Custom name', v::propertyExists('foo'))->assert((object) ['bar' => 'baz']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Custom name) must be present')
         ->and($fullMessage)->toBe('- `.foo` (<- Custom name) must be present')

--- a/tests/feature/Rules/PropertyOptionalTest.php
+++ b/tests/feature/Rules/PropertyOptionalTest.php
@@ -32,7 +32,7 @@ test('Inverted with missing property', catchAll(
 ));
 
 test('With wrapped name, default', catchAll(
-    fn() => v::named(v::propertyOptional('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')->assert((object) ['foo' => 'string']),
+    fn() => v::named('Wrapper', v::propertyOptional('foo', v::named('Wrapped', v::intType())))->assert((object) ['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be an integer')
         ->and($fullMessage)->toBe('- Wrapped must be an integer')
@@ -40,7 +40,7 @@ test('With wrapped name, default', catchAll(
 ));
 
 test('With wrapped name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::propertyOptional('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')), 'Not')->assert((object) ['foo' => 12]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::propertyOptional('foo', v::named('Wrapped', v::intType())))))->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not be an integer')
         ->and($fullMessage)->toBe('- Wrapped must not be an integer')
@@ -48,7 +48,7 @@ test('With wrapped name, inverted', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::propertyOptional('foo', v::intType()), 'Wrapper')->assert((object) ['foo' => 'string']),
+    fn() => v::named('Wrapper', v::propertyOptional('foo', v::intType()))->assert((object) ['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
@@ -56,7 +56,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::propertyOptional('foo', v::intType()), 'Wrapper')), 'Not')->assert((object) ['foo' => 12]),
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::propertyOptional('foo', v::intType()))))->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must not be an integer')
@@ -64,7 +64,7 @@ test('With wrapper name, inverted', catchAll(
 ));
 
 test('With "Not" name, inverted', catchAll(
-    fn() => v::named(v::not(v::propertyOptional('foo', v::intType())), 'Not')->assert((object) ['foo' => 12]),
+    fn() => v::named('Not', v::not(v::propertyOptional('foo', v::intType())))->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')

--- a/tests/feature/Rules/PropertyTest.php
+++ b/tests/feature/Rules/PropertyTest.php
@@ -40,7 +40,7 @@ test('Double-inverted with missing property', catchAll(
 ));
 
 test('With wrapped name, missing property', catchAll(
-    fn() => v::property('foo', v::named(v::intType(), 'Wrapped'))->assert(new stdClass()),
+    fn() => v::property('foo', v::named('Wrapped', v::intType()))->assert(new stdClass()),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be present')
         ->and($fullMessage)->toBe('- Wrapped must be present')
@@ -48,7 +48,7 @@ test('With wrapped name, missing property', catchAll(
 ));
 
 test('With wrapped name, default', catchAll(
-    fn() => v::named(v::property('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper')->assert((object) ['foo' => 'string']),
+    fn() => v::named('Wrapper', v::property('foo', v::named('Wrapped', v::intType())))->assert((object) ['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must be an integer')
         ->and($fullMessage)->toBe('- Wrapped must be an integer')
@@ -56,9 +56,9 @@ test('With wrapped name, default', catchAll(
 ));
 
 test('With wrapped name, inverted', catchAll(
-    fn() => v::named(v::not(
-        v::named(v::property('foo', v::named(v::intType(), 'Wrapped')), 'Wrapper'),
-    ), 'Not')
+    fn() => v::named('Not', v::not(
+        v::named('Wrapper', v::property('foo', v::named('Wrapped', v::intType()))),
+    ))
             ->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not be an integer')
@@ -67,7 +67,7 @@ test('With wrapped name, inverted', catchAll(
 ));
 
 test('With wrapper name, default', catchAll(
-    fn() => v::named(v::property('foo', v::intType()), 'Wrapper')->assert((object) ['foo' => 'string']),
+    fn() => v::named('Wrapper', v::property('foo', v::intType()))->assert((object) ['foo' => 'string']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be an integer')
@@ -75,7 +75,7 @@ test('With wrapper name, default', catchAll(
 ));
 
 test('With wrapper name, missing property', catchAll(
-    fn() => v::named(v::property('foo', v::intType()), 'Wrapper')->assert(new stdClass()),
+    fn() => v::named('Wrapper', v::property('foo', v::intType()))->assert(new stdClass()),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must be present')
         ->and($fullMessage)->toBe('- `.foo` (<- Wrapper) must be present')
@@ -83,7 +83,7 @@ test('With wrapper name, missing property', catchAll(
 ));
 
 test('With wrapper name, inverted', catchAll(
-    fn() => v::named(v::not(v::named(v::property('foo', v::intType()), 'Wrapper')), 'Not')
+    fn() => v::named('Not', v::not(v::named('Wrapper', v::property('foo', v::intType()))))
             ->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Wrapper) must not be an integer')
@@ -92,7 +92,7 @@ test('With wrapper name, inverted', catchAll(
 ));
 
 test('With "Not" name, inverted', catchAll(
-    fn() => v::named(v::not(v::property('foo', v::intType())), 'Not')->assert((object) ['foo' => 12]),
+    fn() => v::named('Not', v::not(v::property('foo', v::intType())))->assert((object) ['foo' => 12]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('`.foo` (<- Not) must not be an integer')
         ->and($fullMessage)->toBe('- `.foo` (<- Not) must not be an integer')

--- a/tests/feature/Rules/SizeTest.php
+++ b/tests/feature/Rules/SizeTest.php
@@ -47,7 +47,7 @@ test('Inverted', catchAll(
 ));
 
 test('Wrapped with name', catchAll(
-    fn() => v::size('KB', v::named(v::lessThan(2), 'Wrapped'))->assert($this->file2Kb->url()),
+    fn() => v::size('KB', v::named('Wrapped', v::lessThan(2)))->assert($this->file2Kb->url()),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The size in kilobytes of Wrapped must be less than 2')
         ->and($fullMessage)->toBe('- The size in kilobytes of Wrapped must be less than 2')
@@ -55,7 +55,7 @@ test('Wrapped with name', catchAll(
 ));
 
 test('Wrapper with name', catchAll(
-    fn() => v::named(v::size('KB', v::lessThan(2)), 'Wrapper')->assert($this->file2Kb->url()),
+    fn() => v::named('Wrapper', v::size('KB', v::lessThan(2)))->assert($this->file2Kb->url()),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('The size in kilobytes of Wrapper must be less than 2')
         ->and($fullMessage)->toBe('- The size in kilobytes of Wrapper must be less than 2')

--- a/tests/feature/Rules/UndefOrTest.php
+++ b/tests/feature/Rules/UndefOrTest.php
@@ -40,7 +40,7 @@ test('Inverted undefined', catchAll(
 ));
 
 test('Inverted undefined, wrapped name', catchAll(
-    fn() => v::not(v::undefOr(v::named(v::alpha(), 'Wrapped')))->assert(null),
+    fn() => v::not(v::undefOr(v::named('Wrapped', v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped must not contain letters (a-z) and must not be undefined')
         ->and($fullMessage)->toBe('- Wrapped must not contain letters (a-z) and must not be undefined')
@@ -48,7 +48,7 @@ test('Inverted undefined, wrapped name', catchAll(
 ));
 
 test('Inverted undefined, wrapper name', catchAll(
-    fn() => v::not(v::named(v::undefOr(v::alpha()), 'Wrapper'))->assert(null),
+    fn() => v::not(v::named('Wrapper', v::undefOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapper must not contain letters (a-z) and must not be undefined')
         ->and($fullMessage)->toBe('- Wrapper must not contain letters (a-z) and must not be undefined')
@@ -56,7 +56,7 @@ test('Inverted undefined, wrapper name', catchAll(
 ));
 
 test('Inverted undefined, not name', catchAll(
-    fn() => v::named(v::not(v::undefOr(v::alpha())), 'Not')->assert(null),
+    fn() => v::named('Not', v::not(v::undefOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Not must not contain letters (a-z) and must not be undefined')
         ->and($fullMessage)->toBe('- Not must not contain letters (a-z) and must not be undefined')


### PR DESCRIPTION
Having the name as the first argument makes it more intuitive.