### PR TITLE
Change order of arguments in `Templated` rule

### DIFF
--- a/docs/rules/Templated.md
+++ b/docs/rules/Templated.md
@@ -1,17 +1,17 @@
 # Templated
 
-- `Templated(Rule $rule, string $template)`
-- `Templated(Rule $rule, string $template, array<string, mixed> $parameters)`
+- `Templated(string $template, Rule $rule)`
+- `Templated(string $template, Rule $rule, array<string, mixed> $parameters)`
 
 Defines a rule with a custom message template.
 
 ```php
-v::templated(v::email(), 'You must provide a valid email to signup')->assert('not an email');
+v::templated('You must provide a valid email to signup', v::email())->assert('not an email');
 // Message: You must provide a valid email to signup
 
 v::templated(
-    v::notBlank(),
     'The author of the page {{title}} is empty, please fill it up.',
+    v::notBlank(),
     ['title' => 'Feature Guide']
 )->assert('');
 // Message: The author of the page "Feature Guide" is empty, please fill it up.

--- a/library/Mixins/Builder.php
+++ b/library/Mixins/Builder.php
@@ -330,7 +330,7 @@ interface Builder extends
     public static function symbolicLink(): Chain;
 
     /** @param array<string, mixed> $parameters */
-    public static function templated(Rule $rule, string $template, array $parameters = []): Chain;
+    public static function templated(string $template, Rule $rule, array $parameters = []): Chain;
 
     public static function time(string $format = 'H:i:s'): Chain;
 

--- a/library/Mixins/Chain.php
+++ b/library/Mixins/Chain.php
@@ -333,7 +333,7 @@ interface Chain extends
     public function symbolicLink(): Chain;
 
     /** @param array<string, mixed> $parameters */
-    public function templated(Rule $rule, string $template, array $parameters = []): Chain;
+    public function templated(string $template, Rule $rule, array $parameters = []): Chain;
 
     public function time(string $format = 'H:i:s'): Chain;
 

--- a/library/Rules/Templated.php
+++ b/library/Rules/Templated.php
@@ -19,8 +19,8 @@ final class Templated extends Wrapper
 {
     /** @param array<string, mixed> $parameters */
     public function __construct(
-        Rule $rule,
         private readonly string $template,
+        Rule $rule,
         private readonly array $parameters = [],
     ) {
         parent::__construct($rule);

--- a/library/Rules/When.php
+++ b/library/Rules/When.php
@@ -19,7 +19,7 @@ final readonly class When implements Rule
     public function __construct(
         private Rule $when,
         private Rule $then,
-        private Rule $else = new Templated(new AlwaysInvalid(), AlwaysInvalid::TEMPLATE_SIMPLE),
+        private Rule $else = new Templated(AlwaysInvalid::TEMPLATE_SIMPLE, new AlwaysInvalid()),
     ) {
     }
 

--- a/tests/feature/AssertWithTemplatesTest.php
+++ b/tests/feature/AssertWithTemplatesTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Template as a string in the chain', catchAll(
-    fn() => v::templated(v::alwaysInvalid(), 'My string template in the chain')->assert(1),
+    fn() => v::templated('My string template in the chain', v::alwaysInvalid())->assert(1),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('My string template in the chain')
         ->and($fullMessage)->toBe('- My string template in the chain')

--- a/tests/feature/Issues/Issue1477Test.php
+++ b/tests/feature/Issues/Issue1477Test.php
@@ -13,13 +13,13 @@ test('https://github.com/Respect/Validation/issues/1477', catchAll(
     fn() => v::key(
         'Address',
         v::templated(
+            '{{subject}} is not good!',
             new class extends Simple {
                 public function isValid(mixed $input): bool
                 {
                     return false;
                 }
             },
-            '{{subject}} is not good!',
         ),
     )->assert(['Address' => 'cvejvn']),
     fn(string $message, string $fullMessage, array $messages) => expect()

--- a/tests/feature/Issues/Issue619Test.php
+++ b/tests/feature/Issues/Issue619Test.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/619', catchAll(
-    fn() => v::templated(v::instance(stdClass::class), 'invalid object')->assert('test'),
+    fn() => v::templated('invalid object', v::instance(stdClass::class))->assert('test'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('invalid object')
         ->and($fullMessage)->toBe('- invalid object')

--- a/tests/feature/Issues/Issue805Test.php
+++ b/tests/feature/Issues/Issue805Test.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('https://github.com/Respect/Validation/issues/805', catchAll(
-    fn() => v::key('email', v::templated(v::email(), 'WRONG EMAIL!!!!!!'))->assert(['email' => 'qwe']),
+    fn() => v::key('email', v::templated('WRONG EMAIL!!!!!!', v::email()))->assert(['email' => 'qwe']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('WRONG EMAIL!!!!!!')
         ->and($fullMessage)->toBe('- WRONG EMAIL!!!!!!')

--- a/tests/feature/Rules/BetweenExclusiveTest.php
+++ b/tests/feature/Rules/BetweenExclusiveTest.php
@@ -24,7 +24,7 @@ test('Inverted', catchAll(
 ));
 
 test('With template', catchAll(
-    fn() => v::templated(v::betweenExclusive(1, 10), 'Bewildered bees buzzed between blooming begonias')->assert(12),
+    fn() => v::templated('Bewildered bees buzzed between blooming begonias', v::betweenExclusive(1, 10))->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Bewildered bees buzzed between blooming begonias')
         ->and($fullMessage)->toBe('- Bewildered bees buzzed between blooming begonias')

--- a/tests/feature/Rules/CircuitTest.php
+++ b/tests/feature/Rules/CircuitTest.php
@@ -72,7 +72,7 @@ test('With the name set in the "circuit" that has an inverted failing rule', cat
 ));
 
 test('With template', catchAll(
-    fn() => v::templated(v::circuit(v::alwaysValid(), v::trueVal()), 'Circuit cool cats cunningly continuous cookies')
+    fn() => v::templated('Circuit cool cats cunningly continuous cookies', v::circuit(v::alwaysValid(), v::trueVal()))
         ->assert(false),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Circuit cool cats cunningly continuous cookies')

--- a/tests/feature/Rules/DateTimeDiffTest.php
+++ b/tests/feature/Rules/DateTimeDiffTest.php
@@ -85,7 +85,7 @@ test('With custom $now', catchAll(
 ));
 
 test('With custom template', catchAll(
-    fn() => v::dateTimeDiff('years', v::templated(v::equals(2), 'Custom template'))->assert('1 year ago'),
+    fn() => v::dateTimeDiff('years', v::templated('Custom template', v::equals(2)))->assert('1 year ago'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Custom template')
         ->and($fullMessage)->toBe('- Custom template')
@@ -109,7 +109,7 @@ test('Wrapping "not"', catchAll(
 ));
 
 test('Wrapped with custom template', catchAll(
-    fn() => v::dateTimeDiff('years', v::templated(v::equals(2), 'Wrapped with custom template'))->assert('1 year ago'),
+    fn() => v::dateTimeDiff('years', v::templated('Wrapped with custom template', v::equals(2)))->assert('1 year ago'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapped with custom template')
         ->and($fullMessage)->toBe('- Wrapped with custom template')
@@ -117,7 +117,7 @@ test('Wrapped with custom template', catchAll(
 ));
 
 test('Wrapper with custom template', catchAll(
-    fn() => v::templated(v::dateTimeDiff('years', v::equals(2)), 'Wrapper with custom template')->assert('1 year ago'),
+    fn() => v::templated('Wrapper with custom template', v::dateTimeDiff('years', v::equals(2)))->assert('1 year ago'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Wrapper with custom template')
         ->and($fullMessage)->toBe('- Wrapper with custom template')

--- a/tests/feature/Rules/EachTest.php
+++ b/tests/feature/Rules/EachTest.php
@@ -166,7 +166,7 @@ test('With Not name, inverted', catchAll(
 ));
 
 test('With template, non-iterable', catchAll(
-    fn() => v::templated(v::each(v::intType()), 'You should have passed an iterable')->assert(null),
+    fn() => v::templated('You should have passed an iterable', v::each(v::intType()))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('You should have passed an iterable')
         ->and($fullMessage)->toBe('- You should have passed an iterable')
@@ -174,7 +174,7 @@ test('With template, non-iterable', catchAll(
 ));
 
 test('With template, empty', catchAll(
-    fn() => v::templated(v::each(v::intType()), 'You should have passed an non-empty')
+    fn() => v::templated('You should have passed an non-empty', v::each(v::intType()))
         ->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('You should have passed an non-empty')
@@ -183,7 +183,7 @@ test('With template, empty', catchAll(
 ));
 
 test('With template, default', catchAll(
-    fn() => v::templated(v::each(v::intType()), 'All items should have been integers')
+    fn() => v::templated('All items should have been integers', v::each(v::intType()))
         ->assert(['a', 'b', 'c']),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('All items should have been integers')
@@ -202,7 +202,7 @@ test('With template, default', catchAll(
 ));
 
 test('with template, inverted', catchAll(
-    fn() => v::templated(v::not(v::each(v::intType())), 'All items should not have been integers')
+    fn() => v::templated('All items should not have been integers', v::not(v::each(v::intType())))
         ->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('All items should not have been integers')

--- a/tests/feature/Rules/TemplatedTest.php
+++ b/tests/feature/Rules/TemplatedTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Default', catchAll(
-    fn() => v::templated(v::stringType(), 'Template in "Templated"')->assert(12),
+    fn() => v::templated('Template in "Templated"', v::stringType())->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Template in "Templated"')
         ->and($fullMessage)->toBe('- Template in "Templated"')
@@ -16,7 +16,7 @@ test('Default', catchAll(
 ));
 
 test('With parameters', catchAll(
-    fn() => v::templated(v::stringType(), 'Template in {{source}}', ['source' => 'Templated'])->assert(12),
+    fn() => v::templated('Template in {{source}}', v::stringType(), ['source' => 'Templated'])->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Template in "Templated"')
         ->and($fullMessage)->toBe('- Template in "Templated"')
@@ -24,7 +24,7 @@ test('With parameters', catchAll(
 ));
 
 test('Inverted', catchAll(
-    fn() => v::not(v::templated(v::intType(), 'Template in "Templated"'))->assert(12),
+    fn() => v::not(v::templated('Template in "Templated"', v::intType()))->assert(12),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Template in "Templated"')
         ->and($fullMessage)->toBe('- Template in "Templated"')
@@ -32,7 +32,7 @@ test('Inverted', catchAll(
 ));
 
 test('Template passed to Validator::assert()', catchAll(
-    fn() => v::templated(v::stringType(), 'Template in "Templated"')->assert(10, 'Template in "Validator::assert"'),
+    fn() => v::templated('Template in "Templated"', v::stringType())->assert(10, 'Template in "Validator::assert"'),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Template in "Validator::assert"')
         ->and($fullMessage)->toBe('- Template in "Validator::assert"')
@@ -40,7 +40,7 @@ test('Template passed to Validator::assert()', catchAll(
 ));
 
 test('With bound', catchAll(
-    fn() => v::templated(v::attributes(), 'Template in "Templated"')->assert(null),
+    fn() => v::templated('Template in "Templated"', v::attributes())->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
         ->and($message)->toBe('Template in "Templated"')
         ->and($fullMessage)->toBe('- Template in "Templated"')

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageHeaderTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsFullMessageHeaderTest.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 test('Scenario #1', catchFullMessage(
-    fn() => v::templated(v::callback('is_string')->between(1, 2), '{{subject}} is not tasty')->assert('something'),
+    fn() => v::templated('{{subject}} is not tasty', v::callback('is_string')->between(1, 2))->assert('something'),
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - "something" is not tasty
           - "something" must be between 1 and 2

--- a/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithMultipleValidatorsShouldUseTemplateAsMainMessageTest.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 use Respect\Validation\Validator;
 
 test('Scenario #1', catchMessage(function (): void {
-    v::templated(Validator::callback('is_int')->between(1, 2), '{{subject}} is not tasty')->assert('something');
+    v::templated('{{subject}} is not tasty', Validator::callback('is_int')->between(1, 2))->assert('something');
 },
 fn(string $message) => expect($message)->toBe('"something" is not tasty')));

--- a/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
+++ b/tests/feature/SetTemplateWithSingleValidatorShouldUseTemplateAsMainMessageTest.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 use Respect\Validation\Validator;
 
 test('Scenario', catchMessage(
-    fn() => v::templated(Validator::callback('is_int'), '{{subject}} is not tasty')->assert('something'),
+    fn() => v::templated('{{subject}} is not tasty', Validator::callback('is_int'))->assert('something'),
     fn(string $message) => expect($message)->toBe('"something" is not tasty'),
 ));

--- a/tests/feature/TranslatorTest.php
+++ b/tests/feature/TranslatorTest.php
@@ -48,11 +48,11 @@ test('DateTimeDiff', catchMessage(
 ));
 
 test('Using "listOr"', catchMessage(
-    fn() => v::templated(v::in(['Respect', 'Validation']), 'Your name must be {{haystack|listOr}}')->assert(''),
+    fn() => v::templated('Your name must be {{haystack|listOr}}', v::in(['Respect', 'Validation']))->assert(''),
     fn(string $message) => expect($message)->toBe('Seu nome deve ser "Respect" ou "Validation"'),
 ));
 
 test('Using "listAnd"', catchMessage(
-    fn() => v::templated(v::in(['Respect', 'Validation']), '{{haystack|listAnd}} are the only possible names')->assert(''),
+    fn() => v::templated('{{haystack|listAnd}} are the only possible names', v::in(['Respect', 'Validation']))->assert(''),
     fn(string $message) => expect($message)->toBe('"Respect" e "Validation" são os únicos nomes possíveis'),
 ));


### PR DESCRIPTION
Having the template itself as a first argument makes the rule way more intuitive. The third parameter is not as used as the first one, so, even though it's very connected with the template, I thought it was better to keep it as the third argument.