### PR TITLE
Fix BC break when using RFC3339 constants with Zulu timezone

### DIFF
--- a/library/Helpers/CanValidateDateTime.php
+++ b/library/Helpers/CanValidateDateTime.php
@@ -16,6 +16,9 @@ use function checkdate;
 use function date_default_timezone_get;
 use function date_parse_from_format;
 use function preg_match;
+use function strlen;
+use function strrpos;
+use function substr;
 
 /**
  * Helper to handle date/time.
@@ -43,6 +46,10 @@ trait CanValidateDateTime
         }
 
         if ($this->isDateFormat($format)) {
+            if ($this->needsZuluTimezoneReplacement($format, $value)) {
+                $value = substr($value, 0, -1) . '+00:00';
+            }
+
             $formattedDate = DateTime::createFromFormat(
                 '!' . $format,
                 $value,
@@ -57,6 +64,12 @@ trait CanValidateDateTime
         }
 
         return true;
+    }
+
+    private function needsZuluTimezoneReplacement(string $format, string $value): bool
+    {
+        return ($format === DateTime::RFC3339_EXTENDED || $format === DateTime::RFC3339)
+            && strrpos($value, 'Z') === strlen($value) - 1;
     }
 
     /**

--- a/tests/unit/Helpers/CanValidateDateTimeTest.php
+++ b/tests/unit/Helpers/CanValidateDateTimeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Helpers;
 
+use DateTime;
 use Respect\Validation\Test\TestCase;
 
 /**
@@ -57,6 +58,8 @@ final class CanValidateDateTimeTest extends TestCase
             ['Y-m-d\TH:i:sP', '2018-01-30T19:04:35+00:00'],
             ['r', 'Tue, 30 Jan 2018 19:06:01 +0000'],
             ['D, d M Y H:i:s O', 'Tue, 30 Jan 2018 19:06:01 +0000'],
+            [DateTime::RFC3339_EXTENDED, '2014-04-12T23:20:50.052Z'],
+            [DateTime::RFC3339, '2005-08-15T15:52:01Z'],
         ];
     }
 


### PR DESCRIPTION
Addresses BC break in 2.x series reported in #1442 (maybe too late, but better than never fixed!)

I'm not sure we should do this in 3.x. Doing it in 2.x just to ensure BC with 2.2. While the PHP constant says "RFC3339", the RFC itself has several formats and PHP does not provide a full breadth of constants for all of the specified formats, so it's really not our fault. There should be a `\DateTime::RFC3339_Z` or something. I'll provide a 3.x follow up in the next few days.