### PR TITLE
Fix factory when validator has no constructor

### DIFF
--- a/tests/library/Validators/NoConstructor.php
+++ b/tests/library/Validators/NoConstructor.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Validators;
+
+use Respect\Validation\Message\Template;
+use Respect\Validation\Validators\Core\Simple;
+
+#[Template(
+    '{{subject}} must be a no-constructor validator',
+    '{{subject}} must not be a no-constructor validator',
+)]
+final class NoConstructor extends Simple
+{
+    public function isValid(mixed $input): bool
+    {
+        // Accept everything for test purposes
+        return true;
+    }
+}

--- a/tests/unit/NamespacedRuleFactoryTest.php
+++ b/tests/unit/NamespacedRuleFactoryTest.php
@@ -60,6 +60,19 @@ final class NamespacedRuleFactoryTest extends TestCase
     }
 
     #[Test]
+    public function shouldThrowsAnExceptionOnConstructorReflectionFailure(): void
+    {
+        $constructorArguments = ['a', 'b'];
+
+        $factory = new NamespacedValidatorFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);
+
+        $this->expectException(InvalidClassException::class);
+        $this->expectExceptionMessage('"noConstructor" could not be instantiated with arguments `["a", "b"]`');
+
+        $factory->create('noConstructor', $constructorArguments);
+    }
+
+    #[Test]
     public function shouldThrowsAnExceptionWhenRuleIsInvalid(): void
     {
         $factory = new NamespacedValidatorFactory(new StubTransformer(), [self::TEST_RULES_NAMESPACE]);


### PR DESCRIPTION
This was affecting both v::version and v::attributes, making them impossible to use except for the concrete interface.

This change allows these validators to be built using the chain.