### PR TITLE
Rename InvalidRuleConstructorException to InvalidValidatorException

### DIFF
--- a/library/Exceptions/InvalidValidatorException.php
+++ b/library/Exceptions/InvalidValidatorException.php
@@ -17,7 +17,7 @@ use function implode;
 use function is_scalar;
 use function sprintf;
 
-final class InvalidRuleConstructorException extends ComponentException implements Exception
+final class InvalidValidatorException extends ComponentException implements Exception
 {
     /** @param string|array<string> ...$arguments */
     public function __construct(string $message, string|array ...$arguments)

--- a/library/Validators/Base.php
+++ b/library/Validators/Base.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -32,7 +32,7 @@ final readonly class Base implements Validator
     ) {
         $max = mb_strlen($this->chars);
         if ($base > $max) {
-            throw new InvalidRuleConstructorException('a base between 1 and %s is required', (string) $max);
+            throw new InvalidValidatorException('a base between 1 and %s is required', (string) $max);
         }
     }
 

--- a/library/Validators/Between.php
+++ b/library/Validators/Between.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanCompareValues;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
@@ -27,7 +27,7 @@ final class Between extends Envelope
     public function __construct(mixed $minValue, mixed $maxValue)
     {
         if ($this->toComparable($minValue) >= $this->toComparable($maxValue)) {
-            throw new InvalidRuleConstructorException('Minimum cannot be less than or equals to maximum');
+            throw new InvalidValidatorException('Minimum cannot be less than or equals to maximum');
         }
 
         parent::__construct(

--- a/library/Validators/BetweenExclusive.php
+++ b/library/Validators/BetweenExclusive.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanCompareValues;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
@@ -27,7 +27,7 @@ final class BetweenExclusive extends Envelope
     public function __construct(mixed $minimum, mixed $maximum)
     {
         if ($this->toComparable($minimum) >= $this->toComparable($maximum)) {
-            throw new InvalidRuleConstructorException('Minimum cannot be less than or equals to maximum');
+            throw new InvalidValidatorException('Minimum cannot be less than or equals to maximum');
         }
 
         parent::__construct(

--- a/library/Validators/Charset.php
+++ b/library/Validators/Charset.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -39,7 +39,7 @@ final readonly class Charset implements Validator
         $charsets = array_merge([$charset], $charsets);
         $diff = array_diff($charsets, $available);
         if (count($diff) > 0) {
-            throw new InvalidRuleConstructorException('Invalid charset provided: %s', array_values($diff));
+            throw new InvalidValidatorException('Invalid charset provided: %s', array_values($diff));
         }
 
         $this->charset = $charsets;

--- a/library/Validators/ContainsAny.php
+++ b/library/Validators/ContainsAny.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
 
@@ -28,7 +28,7 @@ final class ContainsAny extends Envelope
     public function __construct(array $needles, bool $identical = false)
     {
         if (empty($needles)) {
-            throw new InvalidRuleConstructorException('At least one value must be provided');
+            throw new InvalidValidatorException('At least one value must be provided');
         }
 
         $validators = $this->getValidators($needles, $identical);

--- a/library/Validators/CountryCode.php
+++ b/library/Validators/CountryCode.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -45,7 +45,7 @@ final readonly class CountryCode implements Validator
 
         $availableOptions = ['alpha-2', 'alpha-3', 'numeric'];
         if (!in_array($set, $availableOptions, true)) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 '"%s" is not a valid set for ISO 3166-1 (Available: %s)',
                 $set,
                 $availableOptions,

--- a/library/Validators/CreditCard.php
+++ b/library/Validators/CreditCard.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -58,7 +58,7 @@ final readonly class CreditCard implements Validator
         private string $brand = self::ANY,
     ) {
         if (!isset(self::BRAND_REGEX_LIST[$brand])) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 '"%s" is not a valid credit card brand (Available: %s)',
                 $brand,
                 array_keys(self::BRAND_REGEX_LIST),

--- a/library/Validators/CurrencyCode.php
+++ b/library/Validators/CurrencyCode.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -44,7 +44,7 @@ final readonly class CurrencyCode implements Validator
 
         $availableSets = ['alpha-3', 'numeric'];
         if (!in_array($set, $availableSets, true)) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 '"%s" is not a valid set for ISO 4217 (Available: %s)',
                 $set,
                 $availableSets,

--- a/library/Validators/Date.php
+++ b/library/Validators/Date.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -34,7 +34,7 @@ final readonly class Date implements Validator
         private string $format = 'Y-m-d',
     ) {
         if (!preg_match('/^[djSFmMnYy\W]+$/', $format)) {
-            throw new InvalidRuleConstructorException('"%s" is not a valid date format', $format);
+            throw new InvalidValidatorException('"%s" is not a valid date format', $format);
         }
     }
 

--- a/library/Validators/DateTimeDiff.php
+++ b/library/Validators/DateTimeDiff.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -59,7 +59,7 @@ final readonly class DateTimeDiff implements Validator
     ) {
         $availableTypes = ['years', 'months', 'days', 'hours', 'minutes', 'seconds', 'microseconds'];
         if (!in_array($this->type, $availableTypes, true)) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 '"%s" is not a valid type of age (Available: %s)',
                 $this->type,
                 $availableTypes,

--- a/library/Validators/FilterVar.php
+++ b/library/Validators/FilterVar.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
 
@@ -49,7 +49,7 @@ final class FilterVar extends Envelope
     public function __construct(int $filter, mixed $options = null)
     {
         if (!array_key_exists($filter, self::ALLOWED_FILTERS)) {
-            throw new InvalidRuleConstructorException('Cannot accept the given filter');
+            throw new InvalidValidatorException('Cannot accept the given filter');
         }
 
         $arguments = [$filter];

--- a/library/Validators/Ip.php
+++ b/library/Validators/Ip.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -107,11 +107,11 @@ final class Ip implements Validator
             [$this->startAddress, $this->endAddress] = explode('-', $input);
 
             if (is_string($this->startAddress) && !$this->verifyAddress($this->startAddress)) {
-                throw new InvalidRuleConstructorException('Invalid network range');
+                throw new InvalidValidatorException('Invalid network range');
             }
 
             if (is_string($this->endAddress) && !$this->verifyAddress($this->endAddress)) {
-                throw new InvalidRuleConstructorException('Invalid network range');
+                throw new InvalidValidatorException('Invalid network range');
             }
 
             return;
@@ -129,7 +129,7 @@ final class Ip implements Validator
             return;
         }
 
-        throw new InvalidRuleConstructorException('Invalid network range');
+        throw new InvalidValidatorException('Invalid network range');
     }
 
     private function fillAddress(string $address, string $fill = '*'): string
@@ -159,7 +159,7 @@ final class Ip implements Validator
         }
 
         if ($isAddressMask || $parts[1] < 8 || $parts[1] > 30) {
-            throw new InvalidRuleConstructorException('Invalid network mask');
+            throw new InvalidValidatorException('Invalid network mask');
         }
 
         $this->mask = sprintf('%032b', ip2long(long2ip(~(2 ** (32 - (int) $parts[1]) - 1))));

--- a/library/Validators/KeySet.php
+++ b/library/Validators/KeySet.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -106,7 +106,7 @@ final readonly class KeySet implements Validator
             }
 
             if (!$validator instanceof ValidatorBuilder) {
-                throw new InvalidRuleConstructorException('You must provide only key-related rules');
+                throw new InvalidValidatorException('You must provide only key-related rules');
             }
 
             $keyRelatedValidators = array_merge(

--- a/library/Validators/LanguageCode.php
+++ b/library/Validators/LanguageCode.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -46,7 +46,7 @@ final readonly class LanguageCode implements Validator
 
         $availableSets = ['alpha-2', 'alpha-3'];
         if (!in_array($set, $availableSets, true)) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 '"%s" is not a valid set for ISO 639-3 (Available: %s)',
                 $set,
                 $availableSets,

--- a/library/Validators/Phone.php
+++ b/library/Validators/Phone.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -66,7 +66,7 @@ final class Phone implements Validator
         $countries ??= new Countries();
         $this->country = $countries->getByAlpha2($countryCode);
         if ($this->country === null) {
-            throw new InvalidRuleConstructorException('Invalid country code %s', $countryCode);
+            throw new InvalidValidatorException('Invalid country code %s', $countryCode);
         }
     }
 

--- a/library/Validators/PostalCode.php
+++ b/library/Validators/PostalCode.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
 
@@ -42,7 +42,7 @@ final class PostalCode extends Envelope
     {
         $countryCodeRule = new CountryCode();
         if (!$countryCodeRule->evaluate($countryCode)->hasPassed) {
-            throw new InvalidRuleConstructorException('Cannot validate postal code from "%s" country', $countryCode);
+            throw new InvalidValidatorException('Cannot validate postal code from "%s" country', $countryCode);
         }
 
         parent::__construct(

--- a/library/Validators/Size.php
+++ b/library/Validators/Size.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -55,7 +55,7 @@ final class Size extends Wrapper
         Validator $validator,
     ) {
         if (!isset(self::DATA_STORAGE_UNITS[$unit])) {
-            throw new InvalidRuleConstructorException('"%s" is not a recognized data storage unit.', $unit);
+            throw new InvalidValidatorException('"%s" is not a recognized data storage unit.', $unit);
         }
 
         parent::__construct($validator);

--- a/library/Validators/Sorted.php
+++ b/library/Validators/Sorted.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -44,7 +44,7 @@ final readonly class Sorted implements Validator
         private string $direction,
     ) {
         if ($direction !== self::ASCENDING && $direction !== self::DESCENDING) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 'Direction should be either "%s" or "%s"',
                 self::ASCENDING,
                 self::DESCENDING,

--- a/library/Validators/SubdivisionCode.php
+++ b/library/Validators/SubdivisionCode.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Helpers\CanValidateUndefined;
 use Respect\Validation\Message\Template;
@@ -50,7 +50,7 @@ final readonly class SubdivisionCode implements Validator
         $countries ??= new Countries();
         $country = $countries->getByAlpha2($countryCode);
         if ($country === null) {
-            throw new InvalidRuleConstructorException('"%s" is not a supported country code', $countryCode);
+            throw new InvalidValidatorException('"%s" is not a supported country code', $countryCode);
         }
 
         $this->country = $country;

--- a/library/Validators/Time.php
+++ b/library/Validators/Time.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -34,7 +34,7 @@ final readonly class Time implements Validator
         private string $format = 'H:i:s',
     ) {
         if (!preg_match('/^[gGhHisuvaA\W]+$/', $format)) {
-            throw new InvalidRuleConstructorException('"%s" is not a valid date format', $format);
+            throw new InvalidValidatorException('"%s" is not a valid date format', $format);
         }
     }
 

--- a/library/Validators/Uuid.php
+++ b/library/Validators/Uuid.php
@@ -13,7 +13,7 @@ use Attribute;
 use Ramsey\Uuid\Rfc4122\FieldsInterface;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 use Ramsey\Uuid\UuidInterface;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -46,7 +46,7 @@ final class Uuid implements Validator
         }
 
         if ($version !== null && !$this->isSupportedVersion($version)) {
-            throw new InvalidRuleConstructorException(
+            throw new InvalidValidatorException(
                 'Only versions 1 to 8 are supported: %d given',
                 (string) $version,
             );

--- a/library/Validators/VideoUrl.php
+++ b/library/Validators/VideoUrl.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -47,7 +47,7 @@ final class VideoUrl implements Validator
         private readonly string|null $service = null,
     ) {
         if ($service !== null && !$this->isSupportedService($service)) {
-            throw new InvalidRuleConstructorException('"%s" is not a recognized video service.', $service);
+            throw new InvalidValidatorException('"%s" is not a recognized video service.', $service);
         }
     }
 

--- a/tests/unit/Exceptions/InvalidValidatorExceptionTest.php
+++ b/tests/unit/Exceptions/InvalidValidatorExceptionTest.php
@@ -14,15 +14,15 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\TestCase;
 
-#[CoversClass(InvalidRuleConstructorException::class)]
-final class InvalidRuleConstructorExceptionTest extends TestCase
+#[CoversClass(InvalidValidatorException::class)]
+final class InvalidValidatorExceptionTest extends TestCase
 {
     /** @param array<string|array<string>> $arguments */
     #[Test]
     #[DataProvider('providerForMessages')]
     public function itShouldCreateMessageForWithString(string $expect, string $format, array $arguments): void
     {
-        $exception = new InvalidRuleConstructorException($format, ...$arguments);
+        $exception = new InvalidValidatorException($format, ...$arguments);
 
         self::assertEquals($expect, $exception->getMessage());
     }

--- a/tests/unit/Validators/BaseTest.php
+++ b/tests/unit/Validators/BaseTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class BaseTest extends RuleTestCase
     #[Test]
     public function itShouldThrowsExceptionWhenBaseIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('a base between 1 and 62 is required');
 
         new Base(63);

--- a/tests/unit/Validators/BetweenExclusiveTest.php
+++ b/tests/unit/Validators/BetweenExclusiveTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\Stubs\CountableStub;
 use Respect\Validation\Test\TestCase;
 
@@ -26,7 +26,7 @@ final class BetweenExclusiveTest extends TestCase
     public function minimumValueShouldNotBeGreaterThanMaximumValue(): void
     {
         $this->expectExceptionObject(
-            new InvalidRuleConstructorException('Minimum cannot be less than or equals to maximum'),
+            new InvalidValidatorException('Minimum cannot be less than or equals to maximum'),
         );
 
         new BetweenExclusive(10, 5);
@@ -36,7 +36,7 @@ final class BetweenExclusiveTest extends TestCase
     public function minimumValueShouldNotBeEqualsToMaximumValue(): void
     {
         $this->expectExceptionObject(
-            new InvalidRuleConstructorException('Minimum cannot be less than or equals to maximum'),
+            new InvalidValidatorException('Minimum cannot be less than or equals to maximum'),
         );
 
         new BetweenExclusive(5, 5);

--- a/tests/unit/Validators/BetweenTest.php
+++ b/tests/unit/Validators/BetweenTest.php
@@ -13,7 +13,7 @@ use DateTime;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Stubs\CountableStub;
 
@@ -24,7 +24,7 @@ final class BetweenTest extends RuleTestCase
     #[Test]
     public function minimumValueShouldNotBeGreaterThanMaximumValue(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Minimum cannot be less than or equals to maximum');
 
         new Between(10, 5);
@@ -33,7 +33,7 @@ final class BetweenTest extends RuleTestCase
     #[Test]
     public function minimumValueShouldNotBeEqualsToMaximumValue(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Minimum cannot be less than or equals to maximum');
 
         new Between(5, 5);

--- a/tests/unit/Validators/CharsetTest.php
+++ b/tests/unit/Validators/CharsetTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 use function mb_convert_encoding;
@@ -24,7 +24,7 @@ final class CharsetTest extends RuleTestCase
     #[Test]
     public function itShouldThrowsExceptionWhenCharsetIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Invalid charset provided: "UTF-9"');
 
         new Charset('UTF-8', 'UTF-9');

--- a/tests/unit/Validators/ContainsAnyTest.php
+++ b/tests/unit/Validators/ContainsAnyTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class ContainsAnyTest extends RuleTestCase
     #[Test]
     public function itShouldThrowAnExceptionWhenThereAreNoNeedles(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('At least one value must be provided');
 
         // @phpstan-ignore-next-line

--- a/tests/unit/Validators/CountryCodeTest.php
+++ b/tests/unit/Validators/CountryCodeTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class CountryCodeTest extends RuleTestCase
     #[Test]
     public function itShouldThrowsExceptionWhenInvalidFormat(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage(
             '"whatever" is not a valid set for ISO 3166-1 (Available: "alpha-2", "alpha-3", and "numeric")',
         );

--- a/tests/unit/Validators/CreditCardTest.php
+++ b/tests/unit/Validators/CreditCardTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class CreditCardTest extends RuleTestCase
     #[Test]
     public function itShouldThrowExceptionWhenCreditCardBrandIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessageMatches('/"RespectCard" is not a valid credit card brand \(Available: .+\)/');
 
         new CreditCard('RespectCard');

--- a/tests/unit/Validators/CurrencyCodeTest.php
+++ b/tests/unit/Validators/CurrencyCodeTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class CurrencyCodeTest extends RuleTestCase
     #[Test]
     public function itShouldThrowsExceptionWhenInvalidFormat(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage(
             '"whatever" is not a valid set for ISO 4217 (Available: "alpha-3" and "numeric")',
         );

--- a/tests/unit/Validators/DateTest.php
+++ b/tests/unit/Validators/DateTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -26,7 +26,7 @@ final class DateTest extends RuleTestCase
     #[DataProvider('validFormatsProvider')]
     public function shouldThrowAnExceptionWhenFormatIsNotValid(string $format): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
 
         new Date($format);
     }

--- a/tests/unit/Validators/DateTimeDiffTest.php
+++ b/tests/unit/Validators/DateTimeDiffTest.php
@@ -13,7 +13,7 @@ use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Validators\Stub;
 
@@ -27,7 +27,7 @@ final class DateTimeDiffTest extends RuleTestCase
     #[Test]
     public function isShouldThrowAnExceptionWhenTypeIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessageMatches('/"invalid" is not a valid type of age \(Available: .+\)/');
 
         // @phpstan-ignore-next-line

--- a/tests/unit/Validators/FilterVarTest.php
+++ b/tests/unit/Validators/FilterVarTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 use const FILTER_FLAG_HOSTNAME;
@@ -32,7 +32,7 @@ final class FilterVarTest extends RuleTestCase
     #[Test]
     public function itShouldThrowsExceptionWhenFilterIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Cannot accept the given filter');
 
         new FilterVar(FILTER_SANITIZE_EMAIL);

--- a/tests/unit/Validators/IpTest.php
+++ b/tests/unit/Validators/IpTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 use function extension_loaded;
@@ -38,7 +38,7 @@ final class IpTest extends RuleTestCase
     #[DataProvider('providerForInvalidRanges')]
     public function invalidRangeShouldRaiseException(string $range): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
 
         new Ip($range);
     }

--- a/tests/unit/Validators/KeySetTest.php
+++ b/tests/unit/Validators/KeySetTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Validators\Stub;
 
@@ -23,7 +23,7 @@ final class KeySetTest extends RuleTestCase
     #[Test]
     public function nonKeyRelatedRuleShouldNotBeAllowed(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('You must provide only key-related rules');
 
         new KeySet(new Equals('foo'));

--- a/tests/unit/Validators/LanguageCodeTest.php
+++ b/tests/unit/Validators/LanguageCodeTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class LanguageCodeTest extends RuleTestCase
     #[Test]
     public function itShouldThrowAnExceptionWhenSetIsInvalid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage(
             '"whatever" is not a valid set for ISO 639-3 (Available: "alpha-2" and "alpha-3")',
         );

--- a/tests/unit/Validators/PhoneTest.php
+++ b/tests/unit/Validators/PhoneTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\TestCase;
 use stdClass;
 
@@ -52,7 +52,7 @@ final class PhoneTest extends TestCase
     #[Test]
     public function itShouldThrowsExceptionWhenCountryCodeIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Invalid country code BRR');
 
         new Phone('BRR');

--- a/tests/unit/Validators/PostalCodeTest.php
+++ b/tests/unit/Validators/PostalCodeTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -38,7 +38,7 @@ final class PostalCodeTest extends RuleTestCase
     #[Test]
     public function shouldThrowsExceptionWhenCountryCodeIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Cannot validate postal code from "Whatever" country');
 
         new PostalCode('Whatever');

--- a/tests/unit/Validators/SizeTest.php
+++ b/tests/unit/Validators/SizeTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\Stubs\StreamStub;
 use Respect\Validation\Test\Stubs\UploadedFileStub;
 use Respect\Validation\Test\TestCase;
@@ -40,7 +40,7 @@ final class SizeTest extends TestCase
     #[Test]
     public function shouldThrowsAnExceptionWhenSizeIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('"whatever" is not a recognized data storage unit');
 
         // @phpstan-ignore-next-line

--- a/tests/unit/Validators/SortedTest.php
+++ b/tests/unit/Validators/SortedTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 use stdClass;
 
@@ -23,7 +23,7 @@ final class SortedTest extends RuleTestCase
     #[Test]
     public function itShouldNotAcceptWrongSortingDirection(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('Direction should be either "ASC" or "DESC"');
 
         new Sorted('something');

--- a/tests/unit/Validators/SubdivisionCodeTest.php
+++ b/tests/unit/Validators/SubdivisionCodeTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class SubdivisionCodeTest extends RuleTestCase
     #[Test]
     public function shouldNotAcceptWrongNamesOnConstructor(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('"whatever" is not a supported country code');
 
         new SubdivisionCode('whatever');

--- a/tests/unit/Validators/TimeTest.php
+++ b/tests/unit/Validators/TimeTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -26,7 +26,7 @@ final class TimeTest extends RuleTestCase
     #[DataProvider('invalidFormatsProvider')]
     public function shouldThrowAnExceptionWhenFormatIsNotValid(string $format): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
 
         new Time($format);
     }

--- a/tests/unit/Validators/UuidTest.php
+++ b/tests/unit/Validators/UuidTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Ramsey\Uuid\Uuid as RamseyUuid;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 use stdClass;
 
@@ -45,7 +45,7 @@ final class UuidTest extends RuleTestCase
     {
         $version = random_int(8, PHP_INT_MAX);
 
-        self::expectException(InvalidRuleConstructorException::class);
+        self::expectException(InvalidValidatorException::class);
         self::expectExceptionMessage('Only versions 1 to 8 are supported: ' . $version . ' given');
 
         new Uuid($version);
@@ -56,7 +56,7 @@ final class UuidTest extends RuleTestCase
     {
         $version = random_int(PHP_INT_MIN, 0);
 
-        self::expectException(InvalidRuleConstructorException::class);
+        self::expectException(InvalidValidatorException::class);
         self::expectExceptionMessage('Only versions 1 to 8 are supported: ' . $version . ' given');
 
         new Uuid($version);

--- a/tests/unit/Validators/VideoUrlTest.php
+++ b/tests/unit/Validators/VideoUrlTest.php
@@ -12,7 +12,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Respect\Validation\Exceptions\InvalidRuleConstructorException;
+use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -22,7 +22,7 @@ final class VideoUrlTest extends RuleTestCase
     #[Test]
     public function itShouldThrowsExceptionWhenVideoUrlIsNotValid(): void
     {
-        $this->expectException(InvalidRuleConstructorException::class);
+        $this->expectException(InvalidValidatorException::class);
         $this->expectExceptionMessage('"tiktok" is not a recognized video service.');
 
         new VideoUrl('tiktok');


### PR DESCRIPTION
After renaming rules to validatores, it doesn't make sense to keep on having that exception. I renamed it to a more cleaner name, not mentioning the constructor because I think that if the constructor is not valid, the validator is not valid, hence the name I chose.