### PR TITLE
Prevent validators from generating `validatorBuilder` Ids

### DIFF
--- a/src/Id.php
+++ b/src/Id.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Respect\Validation;
 
+use function count;
 use function lcfirst;
 use function strrchr;
 use function substr;
@@ -24,6 +25,10 @@ final readonly class Id
 
     public static function fromValidator(Validator $validator): self
     {
+        if ($validator instanceof ValidatorBuilder && count($validator->getValidators()) === 1) {
+            return self::fromValidator($validator->getValidators()[0]);
+        }
+
         return new self(lcfirst(substr((string) strrchr($validator::class, '\\'), 1)));
     }
 

--- a/tests/unit/IdTest.php
+++ b/tests/unit/IdTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\Test\TestCase;
+use Respect\Validation\Validators\AlwaysInvalid;
+
+#[CoversClass(Id::class)]
+final class IdTest extends TestCase
+{
+    #[Test]
+    public function shouldCreateInstanceWithValue(): void
+    {
+        $id = new Id('test');
+
+        self::assertSame('test', $id->value);
+    }
+
+    #[Test]
+    public function shouldCreateIdFromSimpleValidator(): void
+    {
+        $validator = new AlwaysInvalid();
+        $id = Id::fromValidator($validator);
+
+        self::assertSame('alwaysInvalid', $id->value);
+    }
+
+    #[Test]
+    public function shouldCreateIdFromNestedValidatorBuilder(): void
+    {
+        $validator = ValidatorBuilder::stringType();
+
+        $id = Id::fromValidator($validator);
+
+        self::assertSame('stringType', $id->value);
+    }
+
+    #[Test]
+    public function shouldCreateIdFromMultipleValidatorsInBuilder(): void
+    {
+        $validator = ValidatorBuilder::stringType()->intType();
+
+        $id = Id::fromValidator($validator);
+
+        self::assertSame('validatorBuilder', $id->value);
+    }
+
+    #[Test]
+    public function shouldAddPrefixToValue(): void
+    {
+        $id = new Id('test');
+        $prefixed = $id->withPrefix('my');
+
+        self::assertSame('myTest', $prefixed->value);
+        self::assertNotSame($id, $prefixed);
+    }
+
+    #[Test]
+    public function shouldHandleEmptyValueWithPrefix(): void
+    {
+        $id = new Id('');
+        $prefixed = $id->withPrefix('prefix');
+
+        self::assertSame('prefix', $prefixed->value);
+    }
+
+    #[Test]
+    public function shouldHandleMultipleRecursionInFromValidator(): void
+    {
+        $validator = ValidatorBuilder::init(ValidatorBuilder::stringType());
+
+        $id = Id::fromValidator($validator);
+
+        self::assertSame('stringType', $id->value);
+    }
+}


### PR DESCRIPTION
When calling `v::validatorName()`, a `ValidatorBuilder` is instantiated to manage the validation chain. However, users generally expect the ID to reflect the specific validator invoked rather than the internal builder class.

This commit updates `Id::fromValidator()` to resolve the ID from the underlying validator when it is the sole member of the `ValidatorBuilder`, ensuring more intuitive identification.