### PR TITLE
Lint Changelog format in validator docs

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -24,6 +24,7 @@ use Respect\Dev\Markdown\Linters\ValidatorHeaderLinter;
 use Respect\Dev\Markdown\Linters\ValidatorIndexLinter;
 use Respect\Dev\Markdown\Linters\ValidatorRelatedLinter;
 use Respect\Dev\Markdown\Linters\ValidatorTemplatesLinter;
+use Respect\Dev\Markdown\Linters\ValidatorChangelogLinter;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use Symfony\Component\Console\Application;
@@ -39,6 +40,7 @@ return (static function () {
         new ValidatorIndexLinter(),
         new ValidatorRelatedLinter(),
         new ValidatorTemplatesLinter(),
+        new ValidatorChangelogLinter(),
     )));
     $application->addCommand(new UpdateDomainSuffixesCommand());
     $application->addCommand(new UpdateDomainToplevelCommand());

--- a/docs/comparing-empty-values.md
+++ b/docs/comparing-empty-values.md
@@ -134,9 +134,7 @@ Choose the validator based on what you consider "empty":
 
 3. **Use `Blank`** when whitespace-only strings, nested empty arrays, and empty objects should also be considered empty.
 
----
-
-See also:
+## See Also
 
 - [Undef](validators/Undef.md)
 - [Blank](validators/Blank.md)

--- a/docs/validators/All.md
+++ b/docs/validators/All.md
@@ -27,9 +27,9 @@ This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] inter
 
 ### `All::TEMPLATE_STANDARD`
 
-| Mode       | Template      |
-| ---------- | ------------- |
-| `default`  | Every item in |
+|       Mode | Template      |
+| ---------: | :------------ |
+|  `default` | Every item in |
 | `inverted` | Every item in |
 
 ## Template as prefix
@@ -52,12 +52,10 @@ v::not(v::all(v::intType()))->assert([1, 2, -3]);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Each](Each.md)
 - [Length](Length.md)

--- a/docs/validators/AllOf.md
+++ b/docs/validators/AllOf.md
@@ -21,18 +21,18 @@ v::allOf(v::intVal(), v::positive())->assert(15);
 
 Used when some validators must be failed.
 
-| Mode       | Template                        |
-| ---------- | ------------------------------- |
-| `default`  | {{subject}} must pass the rules |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must pass the rules |
 | `inverted` | {{subject}} must pass the rules |
 
 ### `AllOf::TEMPLATE_ALL`
 
 Used when all validators have failed.
 
-| Mode       | Template                            |
-| ---------- | ----------------------------------- |
-| `default`  | {{subject}} must pass all the rules |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must pass all the rules |
 | `inverted` | {{subject}} must pass all the rules |
 
 ## Template placeholders
@@ -49,13 +49,11 @@ Used when all validators have failed.
 ## Changelog
 
 | Version | Description                                  |
-| ------: | -------------------------------------------- |
+| ------: | :------------------------------------------- |
 |   3.0.0 | Require at least two validators to be passed |
 |   0.3.9 | Created                                      |
 
----
-
-See also:
+## See Also
 
 - [AnyOf](AnyOf.md)
 - [Circuit](Circuit.md)

--- a/docs/validators/Alnum.md
+++ b/docs/validators/Alnum.md
@@ -45,16 +45,16 @@ of extra chars passed as the parameter.
 
 ### `Alnum::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                     |
-| ---------- | ------------------------------------------------------------ |
-| `default`  | {{subject}} must contain only letters (a-z) and digits (0-9) |
+|       Mode | Template                                                     |
+| ---------: | :----------------------------------------------------------- |
+|  `default` | {{subject}} must contain only letters (a-z) and digits (0-9) |
 | `inverted` | {{subject}} must not contain letters (a-z) or digits (0-9)   |
 
 ### `Alnum::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                           |
-| ---------- | ---------------------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain only letters (a-z), digits (0-9), and {{additionalChars}} |
+|       Mode | Template                                                                           |
+| ---------: | :--------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must contain only letters (a-z), digits (0-9), and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}   |
 
 ## Template placeholders
@@ -71,13 +71,11 @@ of extra chars passed as the parameter.
 ## Changelog
 
 | Version | Description                               |
-| ------: | ----------------------------------------- |
+| ------: | :---------------------------------------- |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.3.9 | Created                                   |
 
----
-
-See also:
+## See Also
 
 - [Alpha](Alpha.md)
 - [Charset](Charset.md)

--- a/docs/validators/Alpha.md
+++ b/docs/validators/Alpha.md
@@ -40,16 +40,16 @@ v::alpha()->uppercase()->assert('example');
 
 ### `Alpha::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must contain only letters (a-z) |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must contain only letters (a-z) |
 | `inverted` | {{subject}} must not contain letters (a-z)  |
 
 ### `Alpha::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                            |
-| ---------- | ------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain only letters (a-z) and {{additionalChars}} |
+|       Mode | Template                                                            |
+| ---------: | :------------------------------------------------------------------ |
+|  `default` | {{subject}} must contain only letters (a-z) and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain letters (a-z) or {{additionalChars}}   |
 
 ## Template placeholders
@@ -66,13 +66,11 @@ v::alpha()->uppercase()->assert('example');
 ## Changelog
 
 | Version | Description                               |
-| ------: | ----------------------------------------- |
+| ------: | :---------------------------------------- |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.3.9 | Created                                   |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Charset](Charset.md)

--- a/docs/validators/AlwaysInvalid.md
+++ b/docs/validators/AlwaysInvalid.md
@@ -18,16 +18,16 @@ v::alwaysInvalid()->assert('whatever');
 
 ### `AlwaysInvalid::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-| ---------- | --------------------------- |
-| `default`  | {{subject}} must be valid   |
+|       Mode | Template                    |
+| ---------: | :-------------------------- |
+|  `default` | {{subject}} must be valid   |
 | `inverted` | {{subject}} must be invalid |
 
 ### `AlwaysInvalid::TEMPLATE_SIMPLE`
 
-| Mode       | Template               |
-| ---------- | ---------------------- |
-| `default`  | {{subject}} is invalid |
+|       Mode | Template               |
+| ---------: | :--------------------- |
+|  `default` | {{subject}} is invalid |
 | `inverted` | {{subject}} is valid   |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::alwaysInvalid()->assert('whatever');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [AlwaysValid](AlwaysValid.md)
 - [When](When.md)

--- a/docs/validators/AlwaysValid.md
+++ b/docs/validators/AlwaysValid.md
@@ -18,9 +18,9 @@ v::alwaysValid()->assert('whatever');
 
 ### `AlwaysValid::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-| ---------- | --------------------------- |
-| `default`  | {{subject}} must be valid   |
+|       Mode | Template                    |
+| ---------: | :-------------------------- |
+|  `default` | {{subject}} must be valid   |
 | `inverted` | {{subject}} must be invalid |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::alwaysValid()->assert('whatever');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [AlwaysInvalid](AlwaysInvalid.md)
 - [KeyExists](KeyExists.md)

--- a/docs/validators/AnyOf.md
+++ b/docs/validators/AnyOf.md
@@ -24,9 +24,9 @@ so `AnyOf()` returns true.
 
 ### `AnyOf::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-| ---------- | ----------------------------------------------- |
-| `default`  | {{subject}} must pass at least one of the rules |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must pass at least one of the rules |
 | `inverted` | {{subject}} must pass at least one of the rules |
 
 ## Template placeholders
@@ -43,13 +43,11 @@ so `AnyOf()` returns true.
 ## Changelog
 
 | Version | Description                                   |
-| ------: | --------------------------------------------- |
+| ------: | :-------------------------------------------- |
 |   3.0.0 | Require at least two validators to be defined |
 |   2.0.0 | Created                                       |
 
----
-
-See also:
+## See Also
 
 - [AllOf](AllOf.md)
 - [Circuit](Circuit.md)

--- a/docs/validators/ArrayType.md
+++ b/docs/validators/ArrayType.md
@@ -24,9 +24,9 @@ v::arrayType()->assert(new ArrayObject());
 
 ### `ArrayType::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-| ---------- | -------------------------------- |
-| `default`  | {{subject}} must be an array     |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be an array     |
 | `inverted` | {{subject}} must not be an array |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::arrayType()->assert(new ArrayObject());
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayVal](ArrayVal.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/ArrayVal.md
+++ b/docs/validators/ArrayVal.md
@@ -25,9 +25,9 @@ v::arrayVal()->assert(new SimpleXMLElement('<xml></xml>'));
 
 ### `ArrayVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-| ---------- | -------------------------------------- |
-| `default`  | {{subject}} must be an array value     |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be an array value     |
 | `inverted` | {{subject}} must not be an array value |
 
 ## Template placeholders
@@ -44,14 +44,12 @@ v::arrayVal()->assert(new SimpleXMLElement('<xml></xml>'));
 ## Changelog
 
 | Version | Description                                                                                  |
-| ------: | -------------------------------------------------------------------------------------------- |
+| ------: | :------------------------------------------------------------------------------------------- |
 |   2.0.0 | `SimpleXMLElement` is also considered as valid                                               |
 |   1.0.0 | Renamed from `Arr` to `ArrayVal` and validate only if the input can be used as an array (#1) |
 |   0.3.9 | Created as `Arr`                                                                             |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [Countable](Countable.md)

--- a/docs/validators/Attributes.md
+++ b/docs/validators/Attributes.md
@@ -82,12 +82,10 @@ v::attributes()->assert(new Person('', 'not a date', 'not an email', 'not a phon
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Named](Named.md)
 - [NullOr](NullOr.md)

--- a/docs/validators/Base.md
+++ b/docs/validators/Base.md
@@ -31,9 +31,9 @@ v::base(2)->assert('0120122001');
 
 ### `Base::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                   |
-| ---------- | ---------------------------------------------------------- |
-| `default`  | {{subject}} must be a number in base {{base&#124;raw}}     |
+|       Mode | Template                                                   |
+| ---------: | :--------------------------------------------------------- |
+|  `default` | {{subject}} must be a number in base {{base&#124;raw}}     |
 | `inverted` | {{subject}} must not be a number in base {{base&#124;raw}} |
 
 ## Template placeholders
@@ -50,12 +50,10 @@ v::base(2)->assert('0120122001');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Base64](Base64.md)
 - [Uuid](Uuid.md)

--- a/docs/validators/Base64.md
+++ b/docs/validators/Base64.md
@@ -21,9 +21,9 @@ v::base64()->assert('respect!');
 
 ### `Base64::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-| ---------- | ----------------------------------------------- |
-| `default`  | {{subject}} must be a base64 encoded string     |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must be a base64 encoded string     |
 | `inverted` | {{subject}} must not be a base64 encoded string |
 
 ## Template placeholders
@@ -39,11 +39,9 @@ v::base64()->assert('respect!');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Base](Base.md)

--- a/docs/validators/Between.md
+++ b/docs/validators/Between.md
@@ -29,9 +29,9 @@ Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
 
 ### `Between::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                      |
-| ---------- | ------------------------------------------------------------- |
-| `default`  | {{subject}} must be between {{minValue}} and {{maxValue}}     |
+|       Mode | Template                                                      |
+| ---------: | :------------------------------------------------------------ |
+|  `default` | {{subject}} must be between {{minValue}} and {{maxValue}}     |
 | `inverted` | {{subject}} must not be between {{minValue}} and {{maxValue}} |
 
 ## Template placeholders
@@ -49,14 +49,12 @@ Message template for this validator includes `{{minValue}}` and `{{maxValue}}`.
 ## Changelog
 
 | Version | Description                 |
-| ------: | --------------------------- |
+| ------: | :-------------------------- |
 |   2.0.0 | Became always inclusive     |
 |   1.0.0 | Became inclusive by default |
 |   0.3.9 | Created                     |
 
----
-
-See also:
+## See Also
 
 - [BetweenExclusive](BetweenExclusive.md)
 - [DateTime](DateTime.md)

--- a/docs/validators/BetweenExclusive.md
+++ b/docs/validators/BetweenExclusive.md
@@ -32,9 +32,9 @@ Validation makes comparison easier, check out our supported [comparable values](
 
 ### `BetweenExclusive::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                                    |
-| ---------- | --------------------------------------------------------------------------- |
-| `default`  | {{subject}} must be greater than {{minValue}} and less than {{maxValue}}    |
+|       Mode | Template                                                                    |
+| ---------: | :-------------------------------------------------------------------------- |
+|  `default` | {{subject}} must be greater than {{minValue}} and less than {{maxValue}}    |
 | `inverted` | {{subject}} must not be greater than {{minValue}} or less than {{maxValue}} |
 
 ## Template placeholders
@@ -52,12 +52,10 @@ Validation makes comparison easier, check out our supported [comparable values](
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Between](Between.md)
 - [DateTime](DateTime.md)

--- a/docs/validators/Blank.md
+++ b/docs/validators/Blank.md
@@ -34,9 +34,9 @@ It's similar to [Falsy](Falsy.md), but way stricter.
 
 ### `Blank::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be blank     |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be blank     |
 | `inverted` | {{subject}} must not be blank |
 
 ## Template placeholders
@@ -52,13 +52,11 @@ It's similar to [Falsy](Falsy.md), but way stricter.
 ## Changelog
 
 | Version | Description                                 |
-| ------: | ------------------------------------------- |
+| ------: | :------------------------------------------ |
 |   3.0.0 | Renamed to `Blank` and changed the behavior |
 |   1.0.0 | Created as `NotBlank`                       |
 
----
-
-See also:
+## See Also
 
 - [Falsy](Falsy.md)
 - [NullType](NullType.md)

--- a/docs/validators/BoolType.md
+++ b/docs/validators/BoolType.md
@@ -21,9 +21,9 @@ v::boolType()->assert(false);
 
 ### `BoolType::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-| ---------- | --------------------------------- |
-| `default`  | {{subject}} must be a boolean     |
+|       Mode | Template                          |
+| ---------: | :-------------------------------- |
+|  `default` | {{subject}} must be a boolean     |
 | `inverted` | {{subject}} must not be a boolean |
 
 ## Template placeholders
@@ -40,13 +40,11 @@ v::boolType()->assert(false);
 ## Changelog
 
 | Version | Description                       |
-| ------: | --------------------------------- |
+| ------: | :-------------------------------- |
 |   1.0.0 | Renamed from `Bool` to `BoolType` |
 |   0.3.9 | Created as `Bool`                 |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [BoolVal](BoolVal.md)

--- a/docs/validators/BoolVal.md
+++ b/docs/validators/BoolVal.md
@@ -33,9 +33,9 @@ v::boolVal()->assert(0);
 
 ### `BoolVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must be a boolean value     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a boolean value     |
 | `inverted` | {{subject}} must not be a boolean value |
 
 ## Template placeholders
@@ -52,12 +52,10 @@ v::boolVal()->assert(0);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [BoolType](BoolType.md)
 - [CallableType](CallableType.md)

--- a/docs/validators/Bsn.md
+++ b/docs/validators/Bsn.md
@@ -18,9 +18,9 @@ v::bsn()->assert('612890053');
 
 ### `Bsn::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-| ---------- | ----------------------------------- |
-| `default`  | {{subject}} must be a valid BSN     |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a valid BSN     |
 | `inverted` | {{subject}} must not be a valid BSN |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::bsn()->assert('612890053');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Cnh](Cnh.md)
 - [Cnpj](Cnpj.md)

--- a/docs/validators/Call.md
+++ b/docs/validators/Call.md
@@ -51,9 +51,9 @@ v::call(
 
 ### `Call::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                   |
-| ---------- | ---------------------------------------------------------- |
-| `default`  | {{input}} must be a suitable argument for {{callable}}     |
+|       Mode | Template                                                   |
+| ---------: | :--------------------------------------------------------- |
+|  `default` | {{input}} must be a suitable argument for {{callable}}     |
 | `inverted` | {{input}} must not be a suitable argument for {{callable}} |
 
 ## Template placeholders
@@ -73,12 +73,10 @@ v::call(
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Callback](Callback.md)
 - [Each](Each.md)

--- a/docs/validators/CallableType.md
+++ b/docs/validators/CallableType.md
@@ -24,9 +24,9 @@ v::callableType()->assert([new DateTime(), 'format']);
 
 ### `CallableType::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} must be a callable     |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be a callable     |
 | `inverted` | {{subject}} must not be a callable |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::callableType()->assert([new DateTime(), 'format']);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/Callback.md
+++ b/docs/validators/Callback.md
@@ -21,9 +21,9 @@ v::callback(
 
 ### `Callback::TEMPLATE_STANDARD`
 
-| Mode       | Template                    |
-| ---------- | --------------------------- |
-| `default`  | {{subject}} must be valid   |
+|       Mode | Template                    |
+| ---------: | :-------------------------- |
+|  `default` | {{subject}} must be valid   |
 | `inverted` | {{subject}} must be invalid |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::callback(
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Call](Call.md)
 - [CallableType](CallableType.md)

--- a/docs/validators/Charset.md
+++ b/docs/validators/Charset.md
@@ -27,9 +27,9 @@ The array format is a logic OR, not AND.
 
 ### `Charset::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                                          |
-| ---------- | --------------------------------------------------------------------------------- |
-| `default`  | {{subject}} must only contain characters from the {{charset&#124;raw}} charset    |
+|       Mode | Template                                                                          |
+| ---------: | :-------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must only contain characters from the {{charset&#124;raw}} charset    |
 | `inverted` | {{subject}} must not contain any characters from the {{charset&#124;raw}} charset |
 
 ## Template placeholders
@@ -46,13 +46,11 @@ The array format is a logic OR, not AND.
 ## Changelog
 
 | Version | Description                                           |
-| ------: | ----------------------------------------------------- |
+| ------: | :---------------------------------------------------- |
 |   2.0.0 | Charset supports multiple charsets on its constructor |
 |   0.5.0 | Created                                               |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/Circuit.md
+++ b/docs/validators/Circuit.md
@@ -51,12 +51,10 @@ This validator does not have any templates, because it will always return the re
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [AllOf](AllOf.md)
 - [AnyOf](AnyOf.md)

--- a/docs/validators/Cnh.md
+++ b/docs/validators/Cnh.md
@@ -18,9 +18,9 @@ v::cnh()->assert('02650306461');
 
 ### `Cnh::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must be a valid CNH number     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be a valid CNH number     |
 | `inverted` | {{subject}} must not be a valid CNH number |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::cnh()->assert('02650306461');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Bsn](Bsn.md)
 - [Cnpj](Cnpj.md)

--- a/docs/validators/Cnpj.md
+++ b/docs/validators/Cnpj.md
@@ -14,9 +14,9 @@ Ignores non-digit chars, so use `->digit()` if needed.
 
 ### `Cnpj::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must be a valid CNPJ number     |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must be a valid CNPJ number     |
 | `inverted` | {{subject}} must not be a valid CNPJ number |
 
 ## Template placeholders
@@ -32,12 +32,10 @@ Ignores non-digit chars, so use `->digit()` if needed.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Bsn](Bsn.md)
 - [Cnh](Cnh.md)

--- a/docs/validators/Consonant.md
+++ b/docs/validators/Consonant.md
@@ -19,16 +19,16 @@ v::consonant()->assert('xkcd');
 
 ### `Consonant::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | {{subject}} must only contain consonants |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must only contain consonants |
 | `inverted` | {{subject}} must not contain consonants  |
 
 ### `Consonant::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                         |
-| ---------- | ---------------------------------------------------------------- |
-| `default`  | {{subject}} must only contain consonants and {{additionalChars}} |
+|       Mode | Template                                                         |
+| ---------: | :--------------------------------------------------------------- |
+|  `default` | {{subject}} must only contain consonants and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain consonants or {{additionalChars}}   |
 
 ## Template placeholders
@@ -45,13 +45,11 @@ v::consonant()->assert('xkcd');
 ## Changelog
 
 | Version | Description                              |
-| ------: | ---------------------------------------- |
+| ------: | :--------------------------------------- |
 |   0.5.0 | Renamed from `Consonants` to `Consonant` |
 |   0.3.9 | Created as `Consonants`                  |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/Contains.md
+++ b/docs/validators/Contains.md
@@ -33,9 +33,9 @@ Message template for this validator includes `{{containsValue}}`.
 
 ### `Contains::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must contain {{containsValue}}     |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must contain {{containsValue}}     |
 | `inverted` | {{subject}} must not contain {{containsValue}} |
 
 ## Template placeholders
@@ -53,12 +53,10 @@ Message template for this validator includes `{{containsValue}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ContainsAny](ContainsAny.md)
 - [ContainsCount](ContainsCount.md)

--- a/docs/validators/ContainsAny.md
+++ b/docs/validators/ContainsAny.md
@@ -33,9 +33,9 @@ Message template for this validator includes `{{needles}}`.
 
 ### `ContainsAny::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                     |
-| ---------- | ------------------------------------------------------------ |
-| `default`  | {{subject}} must contain at least one value from {{needles}} |
+|       Mode | Template                                                     |
+| ---------: | :----------------------------------------------------------- |
+|  `default` | {{subject}} must contain at least one value from {{needles}} |
 | `inverted` | {{subject}} must not contain any value from {{needles}}      |
 
 ## Template placeholders
@@ -53,12 +53,10 @@ Message template for this validator includes `{{needles}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [AnyOf](AnyOf.md)
 - [Contains](Contains.md)

--- a/docs/validators/ContainsCount.md
+++ b/docs/validators/ContainsCount.md
@@ -38,16 +38,16 @@ v::containsCount('1', 1, true)->assert([1, 2, 3]);
 
 ### `ContainsCount::TEMPLATE_TIMES`
 
-| Mode       | Template                                                         |
-| ---------- | ---------------------------------------------------------------- |
-| `default`  | {{subject}} must contain {{containsValue}} {{count}} time(s)     |
+|       Mode | Template                                                         |
+| ---------: | :--------------------------------------------------------------- |
+|  `default` | {{subject}} must contain {{containsValue}} {{count}} time(s)     |
 | `inverted` | {{subject}} must not contain {{containsValue}} {{count}} time(s) |
 
 ### `ContainsCount::TEMPLATE_ONCE`
 
-| Mode       | Template                                                 |
-| ---------- | -------------------------------------------------------- |
-| `default`  | {{subject}} must contain {{containsValue}} only once     |
+|       Mode | Template                                                 |
+| ---------: | :------------------------------------------------------- |
+|  `default` | {{subject}} must contain {{containsValue}} only once     |
 | `inverted` | {{subject}} must not contain {{containsValue}} only once |
 
 ## Template placeholders
@@ -66,12 +66,10 @@ v::containsCount('1', 1, true)->assert([1, 2, 3]);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [ContainsAny](ContainsAny.md)

--- a/docs/validators/Control.md
+++ b/docs/validators/Control.md
@@ -20,16 +20,16 @@ v::control()->assert("\n\r\t");
 
 ### `Control::TEMPLATE_STANDARD`
 
-| Mode       | Template                                         |
-| ---------- | ------------------------------------------------ |
-| `default`  | {{subject}} must only contain control characters |
+|       Mode | Template                                         |
+| ---------: | :----------------------------------------------- |
+|  `default` | {{subject}} must only contain control characters |
 | `inverted` | {{subject}} must not contain control characters  |
 
 ### `Control::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                 |
-| ---------- | ------------------------------------------------------------------------ |
-| `default`  | {{subject}} must only contain control characters and {{additionalChars}} |
+|       Mode | Template                                                                 |
+| ---------: | :----------------------------------------------------------------------- |
+|  `default` | {{subject}} must only contain control characters and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain control characters or {{additionalChars}}   |
 
 ## Template placeholders
@@ -46,13 +46,11 @@ v::control()->assert("\n\r\t");
 ## Changelog
 
 | Version | Description                       |
-| ------: | --------------------------------- |
+| ------: | :-------------------------------- |
 |   2.0.0 | Renamed from `Cntrl` to `Control` |
 |   0.5.0 | Created                           |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Printable](Printable.md)

--- a/docs/validators/Countable.md
+++ b/docs/validators/Countable.md
@@ -25,9 +25,9 @@ v::countable()->assert('string');
 
 ### `Countable::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a countable value     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a countable value     |
 | `inverted` | {{subject}} must not be a countable value |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::countable()->assert('string');
 ## Changelog
 
 | Version | Description             |
-| ------: | ----------------------- |
+| ------: | :---------------------- |
 |   1.0.0 | Created from `ArrayVal` |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/CountryCode.md
+++ b/docs/validators/CountryCode.md
@@ -38,9 +38,9 @@ When no set is defined, the validator uses `'alpha-2'` (`CountryCode::ALPHA2`).
 
 ### `CountryCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                     |
-| ---------- | -------------------------------------------- |
-| `default`  | {{subject}} must be a valid country code     |
+|       Mode | Template                                     |
+| ---------: | :------------------------------------------- |
+|  `default` | {{subject}} must be a valid country code     |
 | `inverted` | {{subject}} must not be a valid country code |
 
 ## Template placeholders
@@ -57,14 +57,12 @@ When no set is defined, the validator uses `'alpha-2'` (`CountryCode::ALPHA2`).
 ## Changelog
 
 | Version | Description                                                       |
-| ------: | ----------------------------------------------------------------- |
+| ------: | :---------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   2.0.0 | Became case-sensitive                                             |
 |   0.5.0 | Created                                                           |
 
----
-
-See also:
+## See Also
 
 - [CurrencyCode](CurrencyCode.md)
 - [LanguageCode](LanguageCode.md)

--- a/docs/validators/Cpf.md
+++ b/docs/validators/Cpf.md
@@ -33,9 +33,9 @@ v::digit()->cpf()->assert('11598647644');
 
 ### `Cpf::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must be a valid CPF number     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be a valid CPF number     |
 | `inverted` | {{subject}} must not be a valid CPF number |
 
 ## Template placeholders
@@ -51,12 +51,10 @@ v::digit()->cpf()->assert('11598647644');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Bsn](Bsn.md)
 - [Cnh](Cnh.md)

--- a/docs/validators/CreditCard.md
+++ b/docs/validators/CreditCard.md
@@ -64,16 +64,16 @@ v::digit()->creditCard()->assert('5376747397208720');
 
 ### `CreditCard::TEMPLATE_STANDARD`
 
-| Mode       | Template                                           |
-| ---------- | -------------------------------------------------- |
-| `default`  | {{subject}} must be a valid credit card number     |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must be a valid credit card number     |
 | `inverted` | {{subject}} must not be a valid credit card number |
 
 ### `CreditCard::TEMPLATE_BRANDED`
 
-| Mode       | Template                                                              |
-| ---------- | --------------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid {{brand&#124;raw}} credit card number     |
+|       Mode | Template                                                              |
+| ---------: | :-------------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid {{brand&#124;raw}} credit card number     |
 | `inverted` | {{subject}} must not be a valid {{brand&#124;raw}} credit card number |
 
 ## Template placeholders
@@ -90,14 +90,12 @@ v::digit()->creditCard()->assert('5376747397208720');
 ## Changelog
 
 | Version | Description                        |
-| ------: | ---------------------------------- |
+| ------: | :--------------------------------- |
 |   2.2.4 | RuPay is now supported as a brand  |
 |   1.1.0 | Allow the define credit card brand |
 |   0.3.9 | Created                            |
 
----
-
-See also:
+## See Also
 
 - [Decimal](Decimal.md)
 - [Digit](Digit.md)

--- a/docs/validators/CurrencyCode.md
+++ b/docs/validators/CurrencyCode.md
@@ -26,9 +26,9 @@ This validator supports the two [ISO 4217][] sets:
 
 ### `CurrencyCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                      |
-| ---------- | --------------------------------------------- |
-| `default`  | {{subject}} must be a valid currency code     |
+|       Mode | Template                                      |
+| ---------: | :-------------------------------------------- |
+|  `default` | {{subject}} must be a valid currency code     |
 | `inverted` | {{subject}} must not be a valid currency code |
 
 ## Template placeholders
@@ -45,14 +45,12 @@ This validator supports the two [ISO 4217][] sets:
 ## Changelog
 
 | Version | Description                                                       |
-| ------: | ----------------------------------------------------------------- |
+| ------: | :---------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   2.0.0 | Became case-sensitive                                             |
 |   1.0.0 | Created                                                           |
 
----
-
-See also:
+## See Also
 
 - [CountryCode](CountryCode.md)
 - [SubdivisionCode](SubdivisionCode.md)

--- a/docs/validators/Date.md
+++ b/docs/validators/Date.md
@@ -49,9 +49,9 @@ v::date('Ydm')->assert(20173112);
 
 ### `Date::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                      |
-| ---------- | ------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid date in the format {{sample}}     |
+|       Mode | Template                                                      |
+| ---------: | :------------------------------------------------------------ |
+|  `default` | {{subject}} must be a valid date in the format {{sample}}     |
 | `inverted` | {{subject}} must not be a valid date in the format {{sample}} |
 
 ## Template placeholders
@@ -68,13 +68,11 @@ v::date('Ydm')->assert(20173112);
 ## Changelog
 
 | Version | Description                    |
-| ------: | ------------------------------ |
+| ------: | :----------------------------- |
 |   2.0.0 | Changed to only validate dates |
 |   0.3.9 | Created as `Date`              |
 
----
-
-See also:
+## See Also
 
 - [DateTime](DateTime.md)
 - [DateTimeDiff](DateTimeDiff.md)

--- a/docs/validators/DateTime.md
+++ b/docs/validators/DateTime.md
@@ -72,16 +72,16 @@ v::dateTime(DateTime::RFC3339_EXTENDED)->assert($input);
 
 ### `DateTime::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a valid date/time     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a valid date/time     |
 | `inverted` | {{subject}} must not be a valid date/time |
 
 ### `DateTime::TEMPLATE_FORMAT`
 
-| Mode       | Template                                                           |
-| ---------- | ------------------------------------------------------------------ |
-| `default`  | {{subject}} must be a valid date/time in the format {{sample}}     |
+|       Mode | Template                                                           |
+| ---------: | :----------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid date/time in the format {{sample}}     |
 | `inverted` | {{subject}} must not be a valid date/time in the format {{sample}} |
 
 ## Template placeholders
@@ -98,14 +98,12 @@ v::dateTime(DateTime::RFC3339_EXTENDED)->assert($input);
 ## Changelog
 
 | Version | Description                                |
-| ------: | ------------------------------------------ |
+| ------: | :----------------------------------------- |
 |   2.3.0 | Validation became a lot stricter           |
 |   2.2.4 | `v::dateTime('z')` is no longer supported. |
 |   2.0.0 | Created                                    |
 
----
-
-See also:
+## See Also
 
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)

--- a/docs/validators/DateTimeDiff.md
+++ b/docs/validators/DateTimeDiff.md
@@ -47,34 +47,34 @@ The supported types are:
 
 Used when `$format` and `$now` are not defined.
 
-| Mode       | Template                                          |
-| ---------- | ------------------------------------------------- |
-| `default`  | The number of {{type&#124;trans}} between now and |
+|       Mode | Template                                          |
+| ---------: | :------------------------------------------------ |
+|  `default` | The number of {{type&#124;trans}} between now and |
 | `inverted` | The number of {{type&#124;trans}} between now and |
 
 ### `DateTimeDiff::TEMPLATE_CUSTOMIZED`
 
 Used when `$format` or `$now` are defined.
 
-| Mode       | Template                                              |
-| ---------- | ----------------------------------------------------- |
-| `default`  | The number of {{type&#124;trans}} between {{now}} and |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | The number of {{type&#124;trans}} between {{now}} and |
 | `inverted` | The number of {{type&#124;trans}} between {{now}} and |
 
 ### `DateTimeDiff::TEMPLATE_NOT_A_DATE`
 
-| Mode       | Template                                                                       |
-| ---------- | ------------------------------------------------------------------------------ |
-| `default`  | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime     |
+|       Mode | Template                                                                       |
+| ---------: | :----------------------------------------------------------------------------- |
+|  `default` | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime     |
 | `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a valid datetime |
 
 ### `DateTimeDiff::TEMPLATE_WRONG_FORMAT`
 
 Used when the input cannot be parsed with the given format.
 
-| Mode       | Template                                                                                                         |
-| ---------- | ---------------------------------------------------------------------------------------------------------------- |
-| `default`  | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime in the format {{sample&#124;raw}}     |
+|       Mode | Template                                                                                                         |
+| ---------: | :--------------------------------------------------------------------------------------------------------------- |
+|  `default` | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime in the format {{sample&#124;raw}}     |
 | `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a valid datetime in the format {{sample&#124;raw}} |
 
 ## Template as prefix
@@ -116,12 +116,10 @@ v::dateTimeDiff('years', v::equals(2))->assert('1 year ago', [
 ## Changelog
 
 | Version | Description                                |
-| ------: | ------------------------------------------ |
+| ------: | :----------------------------------------- |
 |   3.0.0 | Created from `Age`, `MinAge`, and `MaxAge` |
 
----
-
-See also:
+## See Also
 
 - [Date](Date.md)
 - [DateTime](DateTime.md)

--- a/docs/validators/Decimal.md
+++ b/docs/validators/Decimal.md
@@ -34,9 +34,9 @@ v::decimal(1)->assert(1.50);
 
 ### `Decimal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-| ---------- | ----------------------------------------------- |
-| `default`  | {{subject}} must have {{decimals}} decimals     |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must have {{decimals}} decimals     |
 | `inverted` | {{subject}} must not have {{decimals}} decimals |
 
 ## Template placeholders
@@ -53,13 +53,11 @@ v::decimal(1)->assert(1.50);
 ## Changelog
 
 | Version | Description                                     |
-| ------: | ----------------------------------------------- |
+| ------: | :---------------------------------------------- |
 |   2.2.4 | Float values with trailing zeroes are now valid |
 |   2.0.0 | Created                                         |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/Digit.md
+++ b/docs/validators/Digit.md
@@ -28,16 +28,16 @@ v::digit('.', '-')->assert('172.655.537-21');
 
 ### `Digit::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must contain only digits (0-9) |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must contain only digits (0-9) |
 | `inverted` | {{subject}} must not contain digits (0-9)  |
 
 ### `Digit::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                           |
-| ---------- | ------------------------------------------------------------------ |
-| `default`  | {{subject}} must contain only digits (0-9) and {{additionalChars}} |
+|       Mode | Template                                                           |
+| ---------: | :----------------------------------------------------------------- |
+|  `default` | {{subject}} must contain only digits (0-9) and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain digits (0-9) and {{additionalChars}}  |
 
 ## Template placeholders
@@ -55,14 +55,12 @@ v::digit('.', '-')->assert('172.655.537-21');
 ## Changelog
 
 | Version | Description                               |
-| ------: | ----------------------------------------- |
+| ------: | :---------------------------------------- |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.5.0 | Renamed from `Digits` to `Digit`          |
 |   0.3.9 | Created as `Digits`                       |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/Directory.md
+++ b/docs/validators/Directory.md
@@ -31,9 +31,9 @@ v::directory()->assert(dir('/'));
 
 ### `Directory::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-| ---------- | ----------------------------------- |
-| `default`  | {{subject}} must be a directory     |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a directory     |
 | `inverted` | {{subject}} must not be a directory |
 
 ## Template placeholders
@@ -49,13 +49,11 @@ v::directory()->assert(dir('/'));
 ## Changelog
 
 | Version | Description                       |
-| ------: | --------------------------------- |
+| ------: | :-------------------------------- |
 |   2.0.0 | Validates PHP's `Directory` class |
 |   0.4.4 | Created                           |
 
----
-
-See also:
+## See Also
 
 - [Executable](Executable.md)
 - [Exists](Exists.md)

--- a/docs/validators/Domain.md
+++ b/docs/validators/Domain.md
@@ -40,9 +40,9 @@ Messages for this validator will reflect validators above.
 
 ### `Domain::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-| ---------- | -------------------------------------- |
-| `default`  | {{subject}} must be a valid domain     |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be a valid domain     |
 | `inverted` | {{subject}} must not be a valid domain |
 
 ## Template placeholders
@@ -58,13 +58,11 @@ Messages for this validator will reflect validators above.
 ## Changelog
 
 | Version | Description             |
-| ------: | ----------------------- |
+| ------: | :---------------------- |
 |   0.6.0 | Allow to skip TLD check |
 |   0.3.9 | Created                 |
 
----
-
-See also:
+## See Also
 
 - [Ip](Ip.md)
 - [Json](Json.md)

--- a/docs/validators/Each.md
+++ b/docs/validators/Each.md
@@ -35,9 +35,9 @@ This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] inter
 
 ### `Each::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | Each item in {{subject}} must be valid   |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | Each item in {{subject}} must be valid   |
 | `inverted` | Each item in {{subject}} must be invalid |
 
 ## Template placeholders
@@ -55,14 +55,12 @@ This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] inter
 ## Changelog
 
 | Version | Description                                                 |
-| ------: | ----------------------------------------------------------- |
+| ------: | :---------------------------------------------------------- |
 |   3.0.0 | Rejected `stdClass`, non-iterable. or empty iterable values |
 |   2.0.0 | Remove support for key validation                           |
 |   0.3.9 | Created                                                     |
 
----
-
-See also:
+## See Also
 
 - [All](All.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/Email.md
+++ b/docs/validators/Email.md
@@ -18,9 +18,9 @@ v::email()->assert('alganet@gmail.com');
 
 ### `Email::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a valid email address |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a valid email address |
 | `inverted` | {{subject}} must not be an email address  |
 
 ## Template placeholders
@@ -36,14 +36,12 @@ v::email()->assert('alganet@gmail.com');
 ## Changelog
 
 | Version | Description                                       |
-| ------: | ------------------------------------------------- |
+| ------: | :------------------------------------------------ |
 |   2.3.0 | Use "egulias/emailvalidator" version 4.0          |
 |   0.9.0 | Use "egulias/emailvalidator" for email validation |
 |   0.3.9 | Created                                           |
 
----
-
-See also:
+## See Also
 
 - [Json](Json.md)
 - [Phone](Phone.md)

--- a/docs/validators/Emoji.md
+++ b/docs/validators/Emoji.md
@@ -55,9 +55,9 @@ This validator supports:
 
 ### `Emoji::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-| ---------- | -------------------------------- |
-| `default`  | {{subject}} must be an emoji     |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be an emoji     |
 | `inverted` | {{subject}} must not be an emoji |
 
 ## Template placeholders
@@ -73,13 +73,11 @@ This validator supports:
 ## Changelog
 
 | Version | Description                                                                 |
-| ------: | --------------------------------------------------------------------------- |
+| ------: | :-------------------------------------------------------------------------- |
 |   3.0.0 | Renamed to `Emoji`, changed the behavior, and added support for more emojis |
 |   2.0.0 | Created as `NotEmoji`                                                       |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/EndsWith.md
+++ b/docs/validators/EndsWith.md
@@ -34,9 +34,9 @@ Message template for this validator includes `{{endValue}}`.
 
 ### `EndsWith::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must end with {{endValue}}     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must end with {{endValue}}     |
 | `inverted` | {{subject}} must not end with {{endValue}} |
 
 ## Template placeholders
@@ -54,12 +54,10 @@ Message template for this validator includes `{{endValue}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [In](In.md)

--- a/docs/validators/Equals.md
+++ b/docs/validators/Equals.md
@@ -20,9 +20,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `Equals::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must be equal to {{compareTo}}     |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must be equal to {{compareTo}}     |
 | `inverted` | {{subject}} must not be equal to {{compareTo}} |
 
 ## Template placeholders
@@ -39,13 +39,11 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description                                                |
-| ------: | ---------------------------------------------------------- |
+| ------: | :--------------------------------------------------------- |
 |   1.0.0 | Removed identical checking (see [Identical](Identical.md)) |
 |   0.3.9 | Created                                                    |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [Equivalent](Equivalent.md)

--- a/docs/validators/Equivalent.md
+++ b/docs/validators/Equivalent.md
@@ -29,9 +29,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `Equivalent::TEMPLATE_STANDARD`
 
-| Mode       | Template                                            |
-| ---------- | --------------------------------------------------- |
-| `default`  | {{subject}} must be equivalent to {{compareTo}}     |
+|       Mode | Template                                            |
+| ---------: | :-------------------------------------------------- |
+|  `default` | {{subject}} must be equivalent to {{compareTo}}     |
 | `inverted` | {{subject}} must not be equivalent to {{compareTo}} |
 
 ## Template placeholders
@@ -48,12 +48,10 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [ContainsAny](ContainsAny.md)

--- a/docs/validators/Even.md
+++ b/docs/validators/Even.md
@@ -20,9 +20,9 @@ Using `int()` before `even()` is a best practice.
 
 ### `Even::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} must be an even number |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be an even number |
 | `inverted` | {{subject}} must be an odd number  |
 
 ## Template placeholders
@@ -38,12 +38,10 @@ Using `int()` before `even()` is a best practice.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Multiple](Multiple.md)
 - [Odd](Odd.md)

--- a/docs/validators/Executable.md
+++ b/docs/validators/Executable.md
@@ -21,9 +21,9 @@ v::executable()->assert('/path/to/executable');
 
 ### `Executable::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must be an executable file     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be an executable file     |
 | `inverted` | {{subject}} must not be an executable file |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::executable()->assert('/path/to/executable');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.7.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Exists](Exists.md)

--- a/docs/validators/Exists.md
+++ b/docs/validators/Exists.md
@@ -28,9 +28,9 @@ v::exists()->assert(new SplFileInfo('/path/to/file.txt'));
 
 ### `Exists::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | {{subject}} must be an existing file     |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be an existing file     |
 | `inverted` | {{subject}} must not be an existing file |
 
 ## Template placeholders
@@ -46,12 +46,10 @@ v::exists()->assert(new SplFileInfo('/path/to/file.txt'));
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Extension.md
+++ b/docs/validators/Extension.md
@@ -20,9 +20,9 @@ This validator is case-sensitive.
 
 ### `Extension::TEMPLATE_STANDARD`
 
-| Mode       | Template                                          |
-| ---------- | ------------------------------------------------- |
-| `default`  | {{subject}} must have {{extension}} extension     |
+|       Mode | Template                                          |
+| ---------: | :------------------------------------------------ |
+|  `default` | {{subject}} must have {{extension}} extension     |
 | `inverted` | {{subject}} must not have {{extension}} extension |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ This validator is case-sensitive.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Factor.md
+++ b/docs/validators/Factor.md
@@ -24,9 +24,9 @@ v::factor(4)->assert(3);
 
 ### `Factor::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                  |
-| ---------- | --------------------------------------------------------- |
-| `default`  | {{subject}} must be a factor of {{dividend&#124;raw}}     |
+|       Mode | Template                                                  |
+| ---------: | :-------------------------------------------------------- |
+|  `default` | {{subject}} must be a factor of {{dividend&#124;raw}}     |
 | `inverted` | {{subject}} must not be a factor of {{dividend&#124;raw}} |
 
 ## Template placeholders
@@ -44,12 +44,10 @@ v::factor(4)->assert(3);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Decimal](Decimal.md)
 - [Digit](Digit.md)

--- a/docs/validators/FalseVal.md
+++ b/docs/validators/FalseVal.md
@@ -39,9 +39,9 @@ v::falseVal()->assert('2');
 
 ### `FalseVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | {{subject}} must evaluate to `false`     |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must evaluate to `false`     |
 | `inverted` | {{subject}} must not evaluate to `false` |
 
 ## Template placeholders
@@ -57,12 +57,10 @@ v::falseVal()->assert('2');
 ## Changelog
 
 | Version | Description                        |
-| ------: | ---------------------------------- |
+| ------: | :--------------------------------- |
 |   1.0.0 | Renamed from `False` to `FalseVal` |
 |   0.8.0 | Created as `False`                 |
 
----
-
-See also:
+## See Also
 
 - [TrueVal](TrueVal.md)

--- a/docs/validators/Falsy.md
+++ b/docs/validators/Falsy.md
@@ -41,9 +41,9 @@ v::falsy()->assert([]);
 
 ### `Falsy::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be falsy     |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be falsy     |
 | `inverted` | {{subject}} must not be falsy |
 
 ## Template placeholders
@@ -59,13 +59,11 @@ v::falsy()->assert([]);
 ## Changelog
 
 | Version | Description                                 |
-| ------: | ------------------------------------------- |
+| ------: | :------------------------------------------ |
 |   3.0.0 | Renamed to `Falsy` and changed the behavior |
 |   0.3.9 | Created as `NotEmpty`                       |
 
----
-
-See also:
+## See Also
 
 - [Blank](Blank.md)
 - [Each](Each.md)

--- a/docs/validators/Fibonacci.md
+++ b/docs/validators/Fibonacci.md
@@ -24,9 +24,9 @@ v::fibonacci()->assert(6);
 
 ### `Fibonacci::TEMPLATE_STANDARD`
 
-| Mode       | Template                                         |
-| ---------- | ------------------------------------------------ |
-| `default`  | {{subject}} must be a valid Fibonacci number     |
+|       Mode | Template                                         |
+| ---------: | :----------------------------------------------- |
+|  `default` | {{subject}} must be a valid Fibonacci number     |
 | `inverted` | {{subject}} must not be a valid Fibonacci number |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::fibonacci()->assert(6);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.1.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [PerfectSquare](PerfectSquare.md)
 - [PrimeNumber](PrimeNumber.md)

--- a/docs/validators/File.md
+++ b/docs/validators/File.md
@@ -28,9 +28,9 @@ v::file()->assert(new SplFileInfo('/path/to/file.txt'));
 
 ### `File::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-| ---------- | ----------------------------------- |
-| `default`  | {{subject}} must be a valid file    |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a valid file    |
 | `inverted` | {{subject}} must be an invalid file |
 
 ## Template placeholders
@@ -46,12 +46,10 @@ v::file()->assert(new SplFileInfo('/path/to/file.txt'));
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/FilterVar.md
+++ b/docs/validators/FilterVar.md
@@ -34,9 +34,9 @@ v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->assert('@local');
 
 ### `FilterVar::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be valid     |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be valid     |
 | `inverted` | {{subject}} must not be valid |
 
 ## Template placeholders
@@ -52,14 +52,12 @@ v::filterVar(FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)->assert('@local');
 ## Changelog
 
 | Version | Description                                                        |
-| ------: | ------------------------------------------------------------------ |
+| ------: | :----------------------------------------------------------------- |
 |   2.3.0 | `v::filterVar(FILTER_VALIDATE_INT)->isValid(0)` is no longer false |
 |  2.0.15 | Allow validating domains                                           |
 |   0.8.0 | Created                                                            |
 
----
-
-See also:
+## See Also
 
 - [Callback](Callback.md)
 - [Json](Json.md)

--- a/docs/validators/Finite.md
+++ b/docs/validators/Finite.md
@@ -21,9 +21,9 @@ v::finite()->assert(10);
 
 ### `Finite::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must be a finite number     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a finite number     |
 | `inverted` | {{subject}} must not be a finite number |
 
 ## Template placeholders
@@ -40,12 +40,10 @@ v::finite()->assert(10);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Decimal](Decimal.md)
 - [Digit](Digit.md)

--- a/docs/validators/FloatType.md
+++ b/docs/validators/FloatType.md
@@ -24,9 +24,9 @@ v::floatType()->assert(0e5);
 
 ### `FloatType::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be float     |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be float     |
 | `inverted` | {{subject}} must not be float |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::floatType()->assert(0e5);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/FloatVal.md
+++ b/docs/validators/FloatVal.md
@@ -21,9 +21,9 @@ v::floatVal()->assert('1e5');
 
 ### `FloatVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-| ---------- | ------------------------------------- |
-| `default`  | {{subject}} must be a float value     |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a float value     |
 | `inverted` | {{subject}} must not be a float value |
 
 ## Template placeholders
@@ -40,12 +40,10 @@ v::floatVal()->assert('1e5');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [BoolType](BoolType.md)
 - [BoolVal](BoolVal.md)

--- a/docs/validators/Graph.md
+++ b/docs/validators/Graph.md
@@ -20,16 +20,16 @@ v::graph()->assert('LKM@#$%4;');
 
 ### `Graph::TEMPLATE_STANDARD`
 
-| Mode       | Template                                           |
-| ---------- | -------------------------------------------------- |
-| `default`  | {{subject}} must contain only graphical characters |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must contain only graphical characters |
 | `inverted` | {{subject}} must not contain graphical characters  |
 
 ### `Graph::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                   |
-| ---------- | -------------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain only graphical characters and {{additionalChars}} |
+|       Mode | Template                                                                   |
+| ---------: | :------------------------------------------------------------------------- |
+|  `default` | {{subject}} must contain only graphical characters and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain graphical characters or {{additionalChars}}   |
 
 ## Template placeholders
@@ -46,12 +46,10 @@ v::graph()->assert('LKM@#$%4;');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Printable](Printable.md)
 - [Punct](Punct.md)

--- a/docs/validators/GreaterThan.md
+++ b/docs/validators/GreaterThan.md
@@ -26,9 +26,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `GreaterThan::TEMPLATE_STANDARD`
 
-| Mode       | Template                                           |
-| ---------- | -------------------------------------------------- |
-| `default`  | {{subject}} must be greater than {{compareTo}}     |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must be greater than {{compareTo}}     |
 | `inverted` | {{subject}} must not be greater than {{compareTo}} |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)

--- a/docs/validators/GreaterThanOrEqual.md
+++ b/docs/validators/GreaterThanOrEqual.md
@@ -29,9 +29,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `GreaterThanOrEqual::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                   |
-| ---------- | ---------------------------------------------------------- |
-| `default`  | {{subject}} must be greater than or equal to {{compareTo}} |
+|       Mode | Template                                                   |
+| ---------: | :--------------------------------------------------------- |
+|  `default` | {{subject}} must be greater than or equal to {{compareTo}} |
 | `inverted` | {{subject}} must be less than {{compareTo}}                |
 
 ## Template placeholders
@@ -48,15 +48,13 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description                                |
-| ------: | ------------------------------------------ |
+| ------: | :----------------------------------------- |
 |   3.0.0 | Renamed from "Min" to "GreaterThanOrEqual" |
 |   2.0.0 | Became always inclusive                    |
 |   1.0.0 | Became inclusive by default                |
 |   0.3.9 | Created                                    |
 
----
-
-See also:
+## See Also
 
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)

--- a/docs/validators/Hetu.md
+++ b/docs/validators/Hetu.md
@@ -29,9 +29,9 @@ The validation is case-sensitive.
 
 ### `Hetu::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                       |
-| ---------- | -------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid Finnish personal identity code     |
+|       Mode | Template                                                       |
+| ---------: | :------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid Finnish personal identity code     |
 | `inverted` | {{subject}} must not be a valid Finnish personal identity code |
 
 ## Template placeholders
@@ -47,12 +47,10 @@ The validation is case-sensitive.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Cnh](Cnh.md)
 - [Cnpj](Cnpj.md)

--- a/docs/validators/HexRgbColor.md
+++ b/docs/validators/HexRgbColor.md
@@ -27,9 +27,9 @@ v::hexRgbColor()->assert('FCD');
 
 ### `HexRgbColor::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must be a hex RGB color     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a hex RGB color     |
 | `inverted` | {{subject}} must not be a hex RGB color |
 
 ## Template placeholders
@@ -45,13 +45,11 @@ v::hexRgbColor()->assert('FCD');
 ## Changelog
 
 | Version | Description                                 |
-| ------: | ------------------------------------------- |
+| ------: | :------------------------------------------ |
 |   2.1.0 | Allow hex RGB colors to be case-insensitive |
 |   2.0.0 | Allow hex RGB colors with 3 integers        |
 |   0.7.0 | Created                                     |
 
----
-
-See also:
+## See Also
 
 - [Xdigit](Xdigit.md)

--- a/docs/validators/Iban.md
+++ b/docs/validators/Iban.md
@@ -31,9 +31,9 @@ v::iban()->assert('');
 
 ### `Iban::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-| ---------- | ------------------------------------ |
-| `default`  | {{subject}} must be a valid IBAN     |
+|       Mode | Template                             |
+| ---------: | :----------------------------------- |
+|  `default` | {{subject}} must be a valid IBAN     |
 | `inverted` | {{subject}} must not be a valid IBAN |
 
 ## Template placeholders
@@ -49,12 +49,10 @@ v::iban()->assert('');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [CreditCard](CreditCard.md)
 - [MacAddress](MacAddress.md)

--- a/docs/validators/Identical.md
+++ b/docs/validators/Identical.md
@@ -23,9 +23,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `Identical::TEMPLATE_STANDARD`
 
-| Mode       | Template                                           |
-| ---------- | -------------------------------------------------- |
-| `default`  | {{subject}} must be identical to {{compareTo}}     |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must be identical to {{compareTo}}     |
 | `inverted` | {{subject}} must not be identical to {{compareTo}} |
 
 ## Template placeholders
@@ -42,12 +42,10 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [Equals](Equals.md)

--- a/docs/validators/Image.md
+++ b/docs/validators/Image.md
@@ -29,9 +29,9 @@ This validator relies on [fileinfo](http://php.net/fileinfo) PHP extension.
 
 ### `Image::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must be a valid image file     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be a valid image file     |
 | `inverted` | {{subject}} must not be a valid image file |
 
 ## Template placeholders
@@ -47,12 +47,10 @@ This validator relies on [fileinfo](http://php.net/fileinfo) PHP extension.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.1.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Imei.md
+++ b/docs/validators/Imei.md
@@ -21,9 +21,9 @@ v::imei()->assert('490154203237518');
 
 ### `Imei::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must be a valid IMEI number     |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must be a valid IMEI number     |
 | `inverted` | {{subject}} must not be a valid IMEI number |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::imei()->assert('490154203237518');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Bsn](Bsn.md)
 - [Cnh](Cnh.md)

--- a/docs/validators/In.md
+++ b/docs/validators/In.md
@@ -33,9 +33,9 @@ Message template for this validator includes `{{haystack}}`.
 
 ### `In::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must be in {{haystack}}     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be in {{haystack}}     |
 | `inverted` | {{subject}} must not be in {{haystack}} |
 
 ## Template placeholders
@@ -54,12 +54,10 @@ Message template for this validator includes `{{haystack}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [ContainsAny](ContainsAny.md)

--- a/docs/validators/Infinite.md
+++ b/docs/validators/Infinite.md
@@ -18,9 +18,9 @@ v::infinite()->assert(INF);
 
 ### `Infinite::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must be an infinite number     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be an infinite number     |
 | `inverted` | {{subject}} must not be an infinite number |
 
 ## Template placeholders
@@ -37,12 +37,10 @@ v::infinite()->assert(INF);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Decimal](Decimal.md)
 - [Digit](Digit.md)

--- a/docs/validators/Instance.md
+++ b/docs/validators/Instance.md
@@ -23,9 +23,9 @@ Message template for this validator includes `{{instanceName}}`.
 
 ### `Instance::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                    |
-| ---------- | ----------------------------------------------------------- |
-| `default`  | {{subject}} must be an instance of {{class&#124;quote}}     |
+|       Mode | Template                                                    |
+| ---------: | :---------------------------------------------------------- |
+|  `default` | {{subject}} must be an instance of {{class&#124;quote}}     |
 | `inverted` | {{subject}} must not be an instance of {{class&#124;quote}} |
 
 ## Template placeholders
@@ -42,12 +42,10 @@ Message template for this validator includes `{{instanceName}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Countable](Countable.md)
 - [IterableType](IterableType.md)

--- a/docs/validators/IntType.md
+++ b/docs/validators/IntType.md
@@ -21,9 +21,9 @@ v::intType()->assert('10');
 
 ### `IntType::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} must be an integer     |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be an integer     |
 | `inverted` | {{subject}} must not be an integer |
 
 ## Template placeholders
@@ -40,12 +40,10 @@ v::intType()->assert('10');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/IntVal.md
+++ b/docs/validators/IntVal.md
@@ -45,9 +45,9 @@ consider them as valid.
 
 ### `IntVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | {{subject}} must be an integer value     |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be an integer value     |
 | `inverted` | {{subject}} must not be an integer value |
 
 ## Template placeholders
@@ -64,15 +64,13 @@ consider them as valid.
 ## Changelog
 
 | Version | Description                                               |
-| ------: | --------------------------------------------------------- |
+| ------: | :-------------------------------------------------------- |
 |   2.2.4 | Improved support for negative values with trailing zeroes |
 |  2.0.14 | Allow leading zeros                                       |
 |   1.0.0 | Renamed from `Int` to `IntVal`                            |
 |   0.3.9 | Created as `Int`                                          |
 
----
-
-See also:
+## See Also
 
 - [Decimal](Decimal.md)
 - [Digit](Digit.md)

--- a/docs/validators/Ip.md
+++ b/docs/validators/Ip.md
@@ -52,16 +52,16 @@ v::ip('*', FILTER_FLAG_IPV6)->assert('2001:0db8:85a3:08d3:1319:8a2e:0370:7334');
 
 ### `Ip::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-| ---------- | ------------------------------------- |
-| `default`  | {{subject}} must be an IP address     |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be an IP address     |
 | `inverted` | {{subject}} must not be an IP address |
 
 ### `Ip::TEMPLATE_NETWORK_RANGE`
 
-| Mode       | Template                                                              |
-| ---------- | --------------------------------------------------------------------- |
-| `default`  | {{subject}} must be an IP address in the {{range&#124;raw}} range     |
+|       Mode | Template                                                              |
+| ---------: | :-------------------------------------------------------------------- |
+|  `default` | {{subject}} must be an IP address in the {{range&#124;raw}} range     |
 | `inverted` | {{subject}} must not be an IP address in the {{range&#124;raw}} range |
 
 ## Template placeholders
@@ -78,14 +78,12 @@ v::ip('*', FILTER_FLAG_IPV6)->assert('2001:0db8:85a3:08d3:1319:8a2e:0370:7334');
 ## Changelog
 
 | Version | Description                                            |
-| ------: | ------------------------------------------------------ |
+| ------: | :----------------------------------------------------- |
 |   2.0.0 | Allow to define range and options to the same instance |
 |   0.5.0 | Implemented IP range validation                        |
 |   0.3.9 | Created                                                |
 
----
-
-See also:
+## See Also
 
 - [Domain](Domain.md)
 - [MacAddress](MacAddress.md)

--- a/docs/validators/Isbn.md
+++ b/docs/validators/Isbn.md
@@ -27,9 +27,9 @@ v::isbn()->assert('978 10 596 52068 7');
 
 ### `Isbn::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-| ---------- | ------------------------------------ |
-| `default`  | {{subject}} must be a valid ISBN     |
+|       Mode | Template                             |
+| ---------: | :----------------------------------- |
+|  `default` | {{subject}} must be a valid ISBN     |
 | `inverted` | {{subject}} must not be a valid ISBN |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::isbn()->assert('978 10 596 52068 7');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Imei](Imei.md)
 - [Luhn](Luhn.md)

--- a/docs/validators/IterableType.md
+++ b/docs/validators/IterableType.md
@@ -27,9 +27,9 @@ v::iterableType()->assert('string');
 
 ### `IterableType::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be iterable  |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be iterable  |
 | `inverted` | {{subject}} must not iterable |
 
 ## Template placeholders
@@ -45,14 +45,12 @@ v::iterableType()->assert('string');
 ## Changelog
 
 | Version | Description                               |
-| ------: | ----------------------------------------- |
+| ------: | :---------------------------------------- |
 |   3.0.0 | Rejected `stdClass` as iterable           |
 |   1.0.8 | Renamed from `Iterable` to `IterableType` |
 |   1.0.0 | Created as `Iterable`                     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/IterableVal.md
+++ b/docs/validators/IterableVal.md
@@ -31,9 +31,9 @@ This validator doesn't behave as PHP's [is_iterable()][] function because it con
 
 ### `IterableVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be an iterable value     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be an iterable value     |
 | `inverted` | {{subject}} must not be an iterable value |
 
 ## Template placeholders
@@ -49,14 +49,12 @@ This validator doesn't behave as PHP's [is_iterable()][] function because it con
 ## Changelog
 
 | Version | Description                                  |
-| ------: | -------------------------------------------- |
+| ------: | :------------------------------------------- |
 |   3.0.0 | Renamed from `IterableType` to `IterableVal` |
 |   1.0.8 | Renamed from `Iterable` to `IterableType`    |
 |   1.0.0 | Created as `Iterable`                        |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/Json.md
+++ b/docs/validators/Json.md
@@ -18,9 +18,9 @@ v::json()->assert('{"foo":"bar"}');
 
 ### `Json::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must be a valid JSON string     |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must be a valid JSON string     |
 | `inverted` | {{subject}} must not be a valid JSON string |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::json()->assert('{"foo":"bar"}');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Domain](Domain.md)
 - [Email](Email.md)

--- a/docs/validators/Key.md
+++ b/docs/validators/Key.md
@@ -66,13 +66,11 @@ v::key('email', v::email())->assert(['email' => 'not email']);
 ## Changelog
 
 | Version | Description                                                          |
-| ------: | -------------------------------------------------------------------- |
+| ------: | :------------------------------------------------------------------- |
 |   3.0.0 | Split by [KeyExists](KeyExists.md) and [KeyOptional](KeyOptional.md) |
 |   0.3.9 | Created                                                              |
 
----
-
-See also:
+## See Also
 
 - [ArrayVal](ArrayVal.md)
 - [Each](Each.md)

--- a/docs/validators/KeyExists.md
+++ b/docs/validators/KeyExists.md
@@ -38,9 +38,9 @@ v::keyExists(5)->assert(new ArrayObject(['a', 'b', 'c']));
 
 ### `KeyExists::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-| ---------- | ------------------------------- |
-| `default`  | {{subject}} must be present     |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be present     |
 | `inverted` | {{subject}} must not be present |
 
 ## Template placeholders
@@ -78,12 +78,10 @@ v::key('foo', v::named('Custom name', v::alwaysValid()))->assert([]);
 ## Changelog
 
 | Version | Description                |
-| ------: | -------------------------- |
+| ------: | :------------------------- |
 |   3.0.0 | Created from [Key](Key.md) |
 
----
-
-See also:
+## See Also
 
 - [AlwaysValid](AlwaysValid.md)
 - [ArrayType](ArrayType.md)

--- a/docs/validators/KeyOptional.md
+++ b/docs/validators/KeyOptional.md
@@ -64,12 +64,10 @@ Below are some other validators that are tightly related to `KeyOptional`:
 ## Changelog
 
 | Version | Description                |
-| ------: | -------------------------- |
+| ------: | :------------------------- |
 |   3.0.0 | Created from [Key](Key.md) |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/KeySet.md
+++ b/docs/validators/KeySet.md
@@ -83,30 +83,30 @@ The keys' order is not considered in the validation.
 
 ### `KeySet::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} validation failed |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} validation failed |
 | `inverted` | {{subject}} validation passed |
 
 ### `KeySet::TEMPLATE_BOTH`
 
-| Mode       | Template                                         |
-| ---------- | ------------------------------------------------ |
-| `default`  | {{subject}} contains both missing and extra keys |
+|       Mode | Template                                         |
+| ---------: | :----------------------------------------------- |
+|  `default` | {{subject}} contains both missing and extra keys |
 | `inverted` | {{subject}} contains no missing or extra keys.   |
 
 ### `KeySet::TEMPLATE_EXTRA_KEYS`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} contains extra keys    |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} contains extra keys    |
 | `inverted` | {{subject}} contains no extra keys |
 
 ### `KeySet::TEMPLATE_MISSING_KEYS`
 
-| Mode       | Template                             |
-| ---------- | ------------------------------------ |
-| `default`  | {{subject}} contains missing keys    |
+|       Mode | Template                             |
+| ---------: | :----------------------------------- |
+|  `default` | {{subject}} contains missing keys    |
 | `inverted` | {{subject}} contains no missing keys |
 
 ## Template placeholders
@@ -124,14 +124,12 @@ The keys' order is not considered in the validation.
 ## Changelog
 
 | Version | Description                                           |
-| ------: | ----------------------------------------------------- |
+| ------: | :---------------------------------------------------- |
 |   3.0.0 | Requires at least one key-related validator           |
 |   2.3.0 | KeySet is NonNegatable, fixed message with extra keys |
 |   1.0.0 | Created                                               |
 
----
-
-See also:
+## See Also
 
 - [ArrayVal](ArrayVal.md)
 - [Key](Key.md)

--- a/docs/validators/LanguageCode.md
+++ b/docs/validators/LanguageCode.md
@@ -38,9 +38,9 @@ This validator supports the two[ISO 639][] sets:
 
 ### `LanguageCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                      |
-| ---------- | --------------------------------------------- |
-| `default`  | {{subject}} must be a valid language code     |
+|       Mode | Template                                      |
+| ---------: | :-------------------------------------------- |
+|  `default` | {{subject}} must be a valid language code     |
 | `inverted` | {{subject}} must not be a valid language code |
 
 ## Template placeholders
@@ -57,13 +57,11 @@ This validator supports the two[ISO 639][] sets:
 ## Changelog
 
 | Version | Description                                                       |
-| ------: | ----------------------------------------------------------------- |
+| ------: | :---------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   1.1.0 | Created                                                           |
 
----
-
-See also:
+## See Also
 
 - [CountryCode](CountryCode.md)
 

--- a/docs/validators/Lazy.md
+++ b/docs/validators/Lazy.md
@@ -46,12 +46,10 @@ on the input itself (`$_POST`), but it will use any input that’s given to the 
 ## Changelog
 
 | Version | Description             |
-| ------: | ----------------------- |
+| ------: | :---------------------- |
 |   3.0.0 | Created from `KeyValue` |
 
----
-
-See also:
+## See Also
 
 - [Call](Call.md)
 - [CallableType](CallableType.md)

--- a/docs/validators/LeapDate.md
+++ b/docs/validators/LeapDate.md
@@ -21,9 +21,9 @@ parameter is mandatory.
 
 ### `LeapDate::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-| ---------- | ------------------------------------- |
-| `default`  | {{subject}} must be a valid leap date |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a valid leap date |
 | `inverted` | {{subject}} must not be a leap date   |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ parameter is mandatory.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Date](Date.md)
 - [DateTime](DateTime.md)

--- a/docs/validators/LeapYear.md
+++ b/docs/validators/LeapYear.md
@@ -20,9 +20,9 @@ This validator accepts DateTime instances as well.
 
 ### `LeapYear::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-| ---------- | ------------------------------------- |
-| `default`  | {{subject}} must be a valid leap year |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a valid leap year |
 | `inverted` | {{subject}} must not be a leap year   |
 
 ## Template placeholders
@@ -38,12 +38,10 @@ This validator accepts DateTime instances as well.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Date](Date.md)
 - [DateTime](DateTime.md)

--- a/docs/validators/Length.md
+++ b/docs/validators/Length.md
@@ -36,16 +36,16 @@ v::length(v::equals(0))->assert(new SplPriorityQueue());
 
 Used when it's possible to get the length of the input.
 
-| Mode       | Template      |
-| ---------- | ------------- |
-| `default`  | The length of |
+|       Mode | Template      |
+| ---------: | :------------ |
+|  `default` | The length of |
 | `inverted` | The length of |
 
 ### `Length::TEMPLATE_WRONG_TYPE`
 
-| Mode       | Template                                              |
-| ---------- | ----------------------------------------------------- |
-| `default`  | {{subject}} must be a countable value or a string     |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | {{subject}} must be a countable value or a string     |
 | `inverted` | {{subject}} must not be a countable value or a string |
 
 ## Template as prefix
@@ -83,13 +83,11 @@ Used when it's impossible to get the length of the input.
 ## Changelog
 
 | Version | Description             |
-| ------: | ----------------------- |
+| ------: | :---------------------- |
 |   3.0.0 | Became a transformation |
 |   0.3.9 | Created                 |
 
----
-
-See also:
+## See Also
 
 - [All](All.md)
 - [Between](Between.md)

--- a/docs/validators/LessThan.md
+++ b/docs/validators/LessThan.md
@@ -26,9 +26,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `LessThan::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-| ---------- | ----------------------------------------------- |
-| `default`  | {{subject}} must be less than {{compareTo}}     |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must be less than {{compareTo}}     |
 | `inverted` | {{subject}} must not be less than {{compareTo}} |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)

--- a/docs/validators/LessThanOrEqual.md
+++ b/docs/validators/LessThanOrEqual.md
@@ -29,9 +29,9 @@ Message template for this validator includes `{{compareTo}}`.
 
 ### `LessThanOrEqual::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                |
-| ---------- | ------------------------------------------------------- |
-| `default`  | {{subject}} must be less than or equal to {{compareTo}} |
+|       Mode | Template                                                |
+| ---------: | :------------------------------------------------------ |
+|  `default` | {{subject}} must be less than or equal to {{compareTo}} |
 | `inverted` | {{subject}} must be greater than {{compareTo}}          |
 
 ## Template placeholders
@@ -48,15 +48,13 @@ Message template for this validator includes `{{compareTo}}`.
 ## Changelog
 
 | Version | Description                             |
-| ------: | --------------------------------------- |
+| ------: | :-------------------------------------- |
 |   3.0.0 | Renamed from "Max" to "LessThanOrEqual" |
 |   2.0.0 | Became always inclusive                 |
 |   1.0.0 | Became inclusive by default             |
 |   0.3.9 | Created                                 |
 
----
-
-See also:
+## See Also
 
 - [Between](Between.md)
 - [BetweenExclusive](BetweenExclusive.md)

--- a/docs/validators/Lowercase.md
+++ b/docs/validators/Lowercase.md
@@ -18,9 +18,9 @@ v::stringType()->lowercase()->assert('xkcd');
 
 ### `Lowercase::TEMPLATE_STANDARD`
 
-| Mode       | Template                                            |
-| ---------- | --------------------------------------------------- |
-| `default`  | {{subject}} must contain only lowercase letters     |
+|       Mode | Template                                            |
+| ---------: | :-------------------------------------------------- |
+|  `default` | {{subject}} must contain only lowercase letters     |
 | `inverted` | {{subject}} must not contain only lowercase letters |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::stringType()->lowercase()->assert('xkcd');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/Luhn.md
+++ b/docs/validators/Luhn.md
@@ -21,9 +21,9 @@ v::luhn()->assert('respect!');
 
 ### `Luhn::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must be a valid Luhn number     |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must be a valid Luhn number     |
 | `inverted` | {{subject}} must not be a valid Luhn number |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::luhn()->assert('respect!');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [CreditCard](CreditCard.md)
 - [Imei](Imei.md)

--- a/docs/validators/MacAddress.md
+++ b/docs/validators/MacAddress.md
@@ -21,9 +21,9 @@ v::macAddress()->assert('af-AA-22-33-44-55');
 
 ### `MacAddress::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must be a valid MAC address     |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must be a valid MAC address     |
 | `inverted` | {{subject}} must not be a valid MAC address |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::macAddress()->assert('af-AA-22-33-44-55');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Domain](Domain.md)
 - [Iban](Iban.md)

--- a/docs/validators/Max.md
+++ b/docs/validators/Max.md
@@ -32,9 +32,9 @@ This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] inter
 
 ### `Max::TEMPLATE_STANDARD`
 
-| Mode       | Template       |
-| ---------- | -------------- |
-| `default`  | The maximum of |
+|       Mode | Template       |
+| ---------: | :------------- |
+|  `default` | The maximum of |
 | `inverted` | The maximum of |
 
 ## Template as prefix
@@ -55,15 +55,13 @@ The template serves as a prefix to the template of the inner validator.
 ## Changelog
 
 | Version | Description                 |
-| ------: | --------------------------- |
+| ------: | :-------------------------- |
 |   3.0.0 | Became a transformation     |
 |   2.0.0 | Became always inclusive     |
 |   1.0.0 | Became inclusive by default |
 |   0.3.9 | Created                     |
 
----
-
-See also:
+## See Also
 
 - [All](All.md)
 - [Between](Between.md)

--- a/docs/validators/Mimetype.md
+++ b/docs/validators/Mimetype.md
@@ -23,9 +23,9 @@ This validator is case-sensitive and requires [fileinfo](http://php.net/fileinfo
 
 ### `Mimetype::TEMPLATE_STANDARD`
 
-| Mode       | Template                                             |
-| ---------- | ---------------------------------------------------- |
-| `default`  | {{subject}} must have the {{mimetype}} MIME type     |
+|       Mode | Template                                             |
+| ---------: | :--------------------------------------------------- |
+|  `default` | {{subject}} must have the {{mimetype}} MIME type     |
 | `inverted` | {{subject}} must not have the {{mimetype}} MIME type |
 
 ## Template placeholders
@@ -42,12 +42,10 @@ This validator is case-sensitive and requires [fileinfo](http://php.net/fileinfo
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Min.md
+++ b/docs/validators/Min.md
@@ -32,9 +32,9 @@ This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] inter
 
 ### `Min::TEMPLATE_STANDARD`
 
-| Mode       | Template       |
-| ---------- | -------------- |
-| `default`  | The minimum of |
+|       Mode | Template       |
+| ---------: | :------------- |
+|  `default` | The minimum of |
 | `inverted` | The minimum of |
 
 ## Template as prefix
@@ -55,15 +55,13 @@ The template serves as a prefix to the template of the inner validator.
 ## Changelog
 
 | Version | Description                 |
-| ------: | --------------------------- |
+| ------: | :-------------------------- |
 |   3.0.0 | Became a transformation     |
 |   2.0.0 | Became always inclusive     |
 |   1.0.0 | Became inclusive by default |
 |   0.3.9 | Created                     |
 
----
-
-See also:
+## See Also
 
 - [All](All.md)
 - [Between](Between.md)

--- a/docs/validators/Multiple.md
+++ b/docs/validators/Multiple.md
@@ -18,9 +18,9 @@ v::intVal()->multiple(3)->assert(9);
 
 ### `Multiple::TEMPLATE_STANDARD`
 
-| Mode       | Template                                             |
-| ---------- | ---------------------------------------------------- |
-| `default`  | {{subject}} must be a multiple of {{multipleOf}}     |
+|       Mode | Template                                             |
+| ---------: | :--------------------------------------------------- |
+|  `default` | {{subject}} must be a multiple of {{multipleOf}}     |
 | `inverted` | {{subject}} must not be a multiple of {{multipleOf}} |
 
 ## Template placeholders
@@ -38,12 +38,10 @@ v::intVal()->multiple(3)->assert(9);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Even](Even.md)
 - [Odd](Odd.md)

--- a/docs/validators/Named.md
+++ b/docs/validators/Named.md
@@ -42,12 +42,10 @@ This validator does not have any templates, as it will use the template of the g
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Attributes](Attributes.md)
 - [Not](Not.md)

--- a/docs/validators/Negative.md
+++ b/docs/validators/Negative.md
@@ -18,9 +18,9 @@ v::numericVal()->negative()->assert(-15);
 
 ### `Negative::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a negative number     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a negative number     |
 | `inverted` | {{subject}} must not be a negative number |
 
 ## Template placeholders
@@ -37,12 +37,10 @@ v::numericVal()->negative()->assert(-15);
 ## Changelog
 
 | Version | Description                          |
-| ------: | ------------------------------------ |
+| ------: | :----------------------------------- |
 |   2.0.0 | Does not validate non-numeric values |
 |   0.3.9 | Created                              |
 
----
-
-See also:
+## See Also
 
 - [Positive](Positive.md)

--- a/docs/validators/NfeAccessKey.md
+++ b/docs/validators/NfeAccessKey.md
@@ -18,9 +18,9 @@ v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906');
 
 ### `NfeAccessKey::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must be a valid NFe access key     |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must be a valid NFe access key     |
 | `inverted` | {{subject}} must not be a valid NFe access key |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.6.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Cnh](Cnh.md)
 - [Cnpj](Cnpj.md)

--- a/docs/validators/Nif.md
+++ b/docs/validators/Nif.md
@@ -21,9 +21,9 @@ v::nif()->assert('P6437358A');
 
 ### `Nif::TEMPLATE_STANDARD`
 
-| Mode       | Template                            |
-| ---------- | ----------------------------------- |
-| `default`  | {{subject}} must be a valid NIF     |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a valid NIF     |
 | `inverted` | {{subject}} must not be a valid NIF |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::nif()->assert('P6437358A');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.2.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Bsn](Bsn.md)
 - [Cnh](Cnh.md)

--- a/docs/validators/Nip.md
+++ b/docs/validators/Nip.md
@@ -30,9 +30,9 @@ v::nip()->assert('164-58-65-777');
 
 ### `Nip::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                         |
-| ---------- | ---------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid Polish VAT identification number     |
+|       Mode | Template                                                         |
+| ---------: | :--------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid Polish VAT identification number     |
 | `inverted` | {{subject}} must not be a valid Polish VAT identification number |
 
 ## Template placeholders
@@ -48,12 +48,10 @@ v::nip()->assert('164-58-65-777');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Pesel](Pesel.md)
 - [PolishIdCard](PolishIdCard.md)

--- a/docs/validators/NoneOf.md
+++ b/docs/validators/NoneOf.md
@@ -23,18 +23,18 @@ In the sample above, 'foo' isn't a integer nor a float, so noneOf returns true.
 
 Used when some validators have passed.
 
-| Mode       | Template                        |
-| ---------- | ------------------------------- |
-| `default`  | {{subject}} must pass the rules |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must pass the rules |
 | `inverted` | {{subject}} must pass the rules |
 
 ### `NoneOf::TEMPLATE_ALL`
 
 Used when all validators have passed.
 
-| Mode       | Template                            |
-| ---------- | ----------------------------------- |
-| `default`  | {{subject}} must pass all the rules |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must pass all the rules |
 | `inverted` | {{subject}} must pass all the rules |
 
 ## Template placeholders
@@ -51,13 +51,11 @@ Used when all validators have passed.
 ## Changelog
 
 | Version | Description                                   |
-| ------: | --------------------------------------------- |
+| ------: | :-------------------------------------------- |
 |   3.0.0 | Require at least two validators to be defined |
 |   0.3.9 | Created                                       |
 
----
-
-See also:
+## See Also
 
 - [AllOf](AllOf.md)
 - [AnyOf](AnyOf.md)

--- a/docs/validators/Not.md
+++ b/docs/validators/Not.md
@@ -42,12 +42,10 @@ Each other validation has custom messages for negated validators.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Named](Named.md)
 - [NoneOf](NoneOf.md)

--- a/docs/validators/NullOr.md
+++ b/docs/validators/NullOr.md
@@ -41,9 +41,9 @@ v::nullOrBetween(1, 3)->assert(null);
 
 ### `NullOr::TEMPLATE_STANDARD`
 
-| Mode       | Template             |
-| ---------- | -------------------- |
-| `default`  | or must be null      |
+|       Mode | Template             |
+| ---------: | :------------------- |
+|  `default` | or must be null      |
 | `inverted` | and must not be null |
 
 ## Template as suffix
@@ -71,13 +71,11 @@ v::not(v::nullOr(v::alpha()))->assert("alpha");
 ## Changelog
 
 | Version | Description           |
-| ------: | --------------------- |
+| ------: | :-------------------- |
 |   3.0.0 | Renamed to `NullOr`   |
 |   2.0.0 | Created as `Nullable` |
 
----
-
-See also:
+## See Also
 
 - [Attributes](Attributes.md)
 - [NullType](NullType.md)

--- a/docs/validators/NullType.md
+++ b/docs/validators/NullType.md
@@ -18,9 +18,9 @@ v::nullType()->assert(null);
 
 ### `NullType::TEMPLATE_STANDARD`
 
-| Mode       | Template                     |
-| ---------- | ---------------------------- |
-| `default`  | {{subject}} must be null     |
+|       Mode | Template                     |
+| ---------: | :--------------------------- |
+|  `default` | {{subject}} must be null     |
 | `inverted` | {{subject}} must not be null |
 
 ## Template placeholders
@@ -36,13 +36,11 @@ v::nullType()->assert(null);
 ## Changelog
 
 | Version | Description                            |
-| ------: | -------------------------------------- |
+| ------: | :------------------------------------- |
 |   1.0.0 | Renamed from `NullValue` to `NullType` |
 |   0.3.9 | Created as `NullValue`                 |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [Blank](Blank.md)

--- a/docs/validators/Number.md
+++ b/docs/validators/Number.md
@@ -25,9 +25,9 @@ v::number()->assert(acos(8));
 
 ### `Number::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} must be a valid number |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be a valid number |
 | `inverted` | {{subject}} must not be a number   |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::number()->assert(acos(8));
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Blank](Blank.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/NumericVal.md
+++ b/docs/validators/NumericVal.md
@@ -24,9 +24,9 @@ purpose use the [Number](Number.md) validator.
 
 ### `NumericVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must be a numeric value     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a numeric value     |
 | `inverted` | {{subject}} must not be a numeric value |
 
 ## Template placeholders
@@ -43,13 +43,11 @@ purpose use the [Number](Number.md) validator.
 ## Changelog
 
 | Version | Description                            |
-| ------: | -------------------------------------- |
+| ------: | :------------------------------------- |
 |   2.0.0 | Renamed from `Numeric` to `NumericVal` |
 |   0.3.9 | Created as `Numeric`                   |
 
----
-
-See also:
+## See Also
 
 - [Decimal](Decimal.md)
 - [Digit](Digit.md)

--- a/docs/validators/ObjectType.md
+++ b/docs/validators/ObjectType.md
@@ -18,9 +18,9 @@ v::objectType()->assert(new stdClass);
 
 ### `ObjectType::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-| ---------- | --------------------------------- |
-| `default`  | {{subject}} must be an object     |
+|       Mode | Template                          |
+| ---------: | :-------------------------------- |
+|  `default` | {{subject}} must be an object     |
 | `inverted` | {{subject}} must not be an object |
 
 ## Template placeholders
@@ -37,13 +37,11 @@ v::objectType()->assert(new stdClass);
 ## Changelog
 
 | Version | Description                           |
-| ------: | ------------------------------------- |
+| ------: | :------------------------------------ |
 |   1.0.0 | Renamed from `Object` to `ObjectType` |
 |   0.3.9 | Created as `Object`                   |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [Attributes](Attributes.md)

--- a/docs/validators/Odd.md
+++ b/docs/validators/Odd.md
@@ -23,9 +23,9 @@ Using `intVal()` before `odd()` is a best practice.
 
 ### `Odd::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} must be an odd number  |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be an odd number  |
 | `inverted` | {{subject}} must be an even number |
 
 ## Template placeholders
@@ -41,13 +41,11 @@ Using `intVal()` before `odd()` is a best practice.
 ## Changelog
 
 | Version | Description             |
-| ------: | ----------------------- |
+| ------: | :---------------------- |
 |   2.0.0 | Only validates integers |
 |   0.3.9 | Created                 |
 
----
-
-See also:
+## See Also
 
 - [Even](Even.md)
 - [Multiple](Multiple.md)

--- a/docs/validators/OneOf.md
+++ b/docs/validators/OneOf.md
@@ -37,18 +37,18 @@ character, one or the other, but not neither nor both.
 
 Used when none of the validators have passed.
 
-| Mode       | Template                               |
-| ---------- | -------------------------------------- |
-| `default`  | {{subject}} must pass one of the rules |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must pass one of the rules |
 | `inverted` | {{subject}} must pass one of the rules |
 
 ### `OneOf::TEMPLATE_MORE_THAN_ONE`
 
 Used when more than one validator has passed.
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must pass only one of the rules |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must pass only one of the rules |
 | `inverted` | {{subject}} must pass only one of the rules |
 
 ## Template placeholders
@@ -65,13 +65,11 @@ Used when more than one validator has passed.
 ## Changelog
 
 | Version | Description                                  |
-| ------: | -------------------------------------------- |
+| ------: | :------------------------------------------- |
 |   3.0.0 | Require at least two validators to be passed |
 |   0.3.9 | Created                                      |
 
----
-
-See also:
+## See Also
 
 - [AllOf](AllOf.md)
 - [AnyOf](AnyOf.md)

--- a/docs/validators/PerfectSquare.md
+++ b/docs/validators/PerfectSquare.md
@@ -21,9 +21,9 @@ v::perfectSquare()->assert(9); // (3*3)
 
 ### `PerfectSquare::TEMPLATE_STANDARD`
 
-| Mode       | Template                                        |
-| ---------- | ----------------------------------------------- |
-| `default`  | {{subject}} must be a perfect square number     |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must be a perfect square number     |
 | `inverted` | {{subject}} must not be a perfect square number |
 
 ## Template placeholders
@@ -40,12 +40,10 @@ v::perfectSquare()->assert(9); // (3*3)
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Factor](Factor.md)
 - [Fibonacci](Fibonacci.md)

--- a/docs/validators/Pesel.md
+++ b/docs/validators/Pesel.md
@@ -27,9 +27,9 @@ v::pesel()->assert('PESEL123456');
 
 ### `Pesel::TEMPLATE_STANDARD`
 
-| Mode       | Template                              |
-| ---------- | ------------------------------------- |
-| `default`  | {{subject}} must be a valid PESEL     |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a valid PESEL     |
 | `inverted` | {{subject}} must not be a valid PESEL |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::pesel()->assert('PESEL123456');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.1.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Nip](Nip.md)
 - [PolishIdCard](PolishIdCard.md)

--- a/docs/validators/Phone.md
+++ b/docs/validators/Phone.md
@@ -26,16 +26,16 @@ v::phone('BR')->assert('11 91111 1111');
 
 ### `Phone::TEMPLATE_INTERNATIONAL`
 
-| Mode       | Template                                         |
-| ---------- | ------------------------------------------------ |
-| `default`  | {{subject}} must be a valid telephone number     |
+|       Mode | Template                                         |
+| ---------: | :----------------------------------------------- |
+|  `default` | {{subject}} must be a valid telephone number     |
 | `inverted` | {{subject}} must not be a valid telephone number |
 
 ### `Phone::TEMPLATE_FOR_COUNTRY`
 
-| Mode       | Template                                                                                |
-| ---------- | --------------------------------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid telephone number for country {{countryName&#124;trans}}     |
+|       Mode | Template                                                                                |
+| ---------: | :-------------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid telephone number for country {{countryName&#124;trans}}     |
 | `inverted` | {{subject}} must not be a valid telephone number for country {{countryName&#124;trans}} |
 
 ## Template placeholders
@@ -52,13 +52,11 @@ v::phone('BR')->assert('11 91111 1111');
 ## Changelog
 
 | Version | Description                       |
-| ------: | --------------------------------- |
+| ------: | :-------------------------------- |
 |   2.3.0 | Updated to use external validator |
 |   0.5.0 | Created                           |
 
----
-
-See also:
+## See Also
 
 - [Email](Email.md)
 - [Json](Json.md)

--- a/docs/validators/PhpLabel.md
+++ b/docs/validators/PhpLabel.md
@@ -28,9 +28,9 @@ v::phpLabel()->assert('4ccess'); //false
 
 ### `PhpLabel::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a valid PHP label     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a valid PHP label     |
 | `inverted` | {{subject}} must not be a valid PHP label |
 
 ## Template placeholders
@@ -46,12 +46,10 @@ v::phpLabel()->assert('4ccess'); //false
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.1.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Charset](Charset.md)
 - [Regex](Regex.md)

--- a/docs/validators/Pis.md
+++ b/docs/validators/Pis.md
@@ -30,9 +30,9 @@ v::pis()->assert('12003406788');
 
 ### `Pis::TEMPLATE_STANDARD`
 
-| Mode       | Template                                   |
-| ---------- | ------------------------------------------ |
-| `default`  | {{subject}} must be a valid PIS number     |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be a valid PIS number     |
 | `inverted` | {{subject}} must not be a valid PIS number |
 
 ## Template placeholders
@@ -48,12 +48,10 @@ v::pis()->assert('12003406788');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Cnh](Cnh.md)
 - [Cnpj](Cnpj.md)

--- a/docs/validators/PolishIdCard.md
+++ b/docs/validators/PolishIdCard.md
@@ -27,9 +27,9 @@ v::polishIdCard()->assert('AYW036731');
 
 ### `PolishIdCard::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                    |
-| ---------- | ----------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid Polish Identity Card number     |
+|       Mode | Template                                                    |
+| ---------: | :---------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid Polish Identity Card number     |
 | `inverted` | {{subject}} must not be a valid Polish Identity Card number |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::polishIdCard()->assert('AYW036731');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Nip](Nip.md)
 - [Pesel](Pesel.md)

--- a/docs/validators/PortugueseNif.md
+++ b/docs/validators/PortugueseNif.md
@@ -21,9 +21,9 @@ v::portugueseNif()->assert('220005245');
 
 ### `PortugueseNif::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | {{subject}} must be a Portuguese NIF     |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be a Portuguese NIF     |
 | `inverted` | {{subject}} must not be a Portuguese NIF |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::portugueseNif()->assert('220005245');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.2.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Bsn](Bsn.md)
 - [Cnh](Cnh.md)

--- a/docs/validators/Positive.md
+++ b/docs/validators/Positive.md
@@ -24,9 +24,9 @@ v::positive()->assert(-15);
 
 ### `Positive::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a positive number     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a positive number     |
 | `inverted` | {{subject}} must not be a positive number |
 
 ## Template placeholders
@@ -43,12 +43,10 @@ v::positive()->assert(-15);
 ## Changelog
 
 | Version | Description                          |
-| ------: | ------------------------------------ |
+| ------: | :----------------------------------- |
 |   2.0.0 | Does not validate non-numeric values |
 |   0.3.9 | Created                              |
 
----
-
-See also:
+## See Also
 
 - [Negative](Negative.md)

--- a/docs/validators/PostalCode.md
+++ b/docs/validators/PostalCode.md
@@ -45,9 +45,9 @@ Extracted from [GeoNames](http://www.geonames.org/).
 
 ### `PostalCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                       |
-| ---------- | -------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid postal code on {{countryCode}}     |
+|       Mode | Template                                                       |
+| ---------: | :------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid postal code on {{countryCode}}     |
 | `inverted` | {{subject}} must not be a valid postal code on {{countryCode}} |
 
 ## Template placeholders
@@ -65,14 +65,12 @@ Extracted from [GeoNames](http://www.geonames.org/).
 ## Changelog
 
 | Version | Description                                       |
-| ------: | ------------------------------------------------- |
+| ------: | :------------------------------------------------ |
 |   2.3.0 | Add option to validate formatting                 |
 |   2.2.4 | Cambodian postal codes now support 5 and 6 digits |
 |   0.7.0 | Created                                           |
 
----
-
-See also:
+## See Also
 
 - [CountryCode](CountryCode.md)
 - [Iban](Iban.md)

--- a/docs/validators/PrimeNumber.md
+++ b/docs/validators/PrimeNumber.md
@@ -18,9 +18,9 @@ v::primeNumber()->assert(7);
 
 ### `PrimeNumber::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-| ---------- | -------------------------------------- |
-| `default`  | {{subject}} must be a prime number     |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be a prime number     |
 | `inverted` | {{subject}} must not be a prime number |
 
 ## Template placeholders
@@ -37,12 +37,10 @@ v::primeNumber()->assert(7);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Factor](Factor.md)
 - [Fibonacci](Fibonacci.md)

--- a/docs/validators/Printable.md
+++ b/docs/validators/Printable.md
@@ -19,16 +19,16 @@ v::printable()->assert('LMKA0$% _123');
 
 ### `Printable::TEMPLATE_STANDARD`
 
-| Mode       | Template                                           |
-| ---------- | -------------------------------------------------- |
-| `default`  | {{subject}} must contain only printable characters |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must contain only printable characters |
 | `inverted` | {{subject}} must not contain printable characters  |
 
 ### `Printable::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                   |
-| ---------- | -------------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain only printable characters and {{additionalChars}} |
+|       Mode | Template                                                                   |
+| ---------: | :------------------------------------------------------------------------- |
+|  `default` | {{subject}} must contain only printable characters and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain printable characters or {{additionalChars}}   |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::printable()->assert('LMKA0$% _123');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Control](Control.md)
 - [Graph](Graph.md)

--- a/docs/validators/Property.md
+++ b/docs/validators/Property.md
@@ -62,13 +62,11 @@ This validator will validate public, private, protected, uninitialised, and stat
 ## Changelog
 
 | Version | Description                                                                                                                          |
-| ------: | ------------------------------------------------------------------------------------------------------------------------------------ |
+| ------: | :----------------------------------------------------------------------------------------------------------------------------------- |
 |   3.0.0 | Renamed from `Attribute` to `Property`, and split by [PropertyExists](PropertyExists.md) and [PropertyOptional](PropertyOptional.md) |
 |   0.3.9 | Created                                                                                                                              |
 
----
-
-See also:
+## See Also
 
 - [Attributes](Attributes.md)
 - [Key](Key.md)

--- a/docs/validators/PropertyExists.md
+++ b/docs/validators/PropertyExists.md
@@ -35,9 +35,9 @@ This validator will validate public, private, protected, uninitialised, and stat
 
 ### `PropertyExists::TEMPLATE_STANDARD`
 
-| Mode       | Template                        |
-| ---------- | ------------------------------- |
-| `default`  | {{subject}} must be present     |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be present     |
 | `inverted` | {{subject}} must not be present |
 
 ## Template placeholders
@@ -75,12 +75,10 @@ v::property('foo', v::named('Custom name', v::alwaysValid()))->assert([]);
 ## Changelog
 
 | Version | Description                          |
-| ------: | ------------------------------------ |
+| ------: | :----------------------------------- |
 |   3.0.0 | Created from [Property](Property.md) |
 
----
-
-See also:
+## See Also
 
 - [AlwaysValid](AlwaysValid.md)
 - [Attributes](Attributes.md)

--- a/docs/validators/PropertyOptional.md
+++ b/docs/validators/PropertyOptional.md
@@ -71,12 +71,10 @@ v::objectType()->propertyOptional('name', v::notBlank())->assert('Not an object'
 ## Changelog
 
 | Version | Description                          |
-| ------: | ------------------------------------ |
+| ------: | :----------------------------------- |
 |   3.0.0 | Created from [Property](Property.md) |
 
----
-
-See also:
+## See Also
 
 - [Attributes](Attributes.md)
 - [Key](Key.md)

--- a/docs/validators/PublicDomainSuffix.md
+++ b/docs/validators/PublicDomainSuffix.md
@@ -35,9 +35,9 @@ v::oneOf(v::tld(), v::publicDomainSuffix())->assert('tk');
 
 ### `PublicDomainSuffix::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must be a public domain suffix     |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must be a public domain suffix     |
 | `inverted` | {{subject}} must not be a public domain suffix |
 
 ## Template placeholders
@@ -53,12 +53,10 @@ v::oneOf(v::tld(), v::publicDomainSuffix())->assert('tk');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.3.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [CountryCode](CountryCode.md)
 - [Domain](Domain.md)

--- a/docs/validators/Punct.md
+++ b/docs/validators/Punct.md
@@ -19,16 +19,16 @@ v::punct()->assert('&,.;[]');
 
 ### `Punct::TEMPLATE_STANDARD`
 
-| Mode       | Template                                             |
-| ---------- | ---------------------------------------------------- |
-| `default`  | {{subject}} must contain only punctuation characters |
+|       Mode | Template                                             |
+| ---------: | :--------------------------------------------------- |
+|  `default` | {{subject}} must contain only punctuation characters |
 | `inverted` | {{subject}} must not contain punctuation characters  |
 
 ### `Punct::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                                     |
-| ---------- | ---------------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain only punctuation characters and {{additionalChars}} |
+|       Mode | Template                                                                     |
+| ---------: | :--------------------------------------------------------------------------- |
+|  `default` | {{subject}} must contain only punctuation characters and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain punctuation characters or {{additionalChars}}   |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::punct()->assert('&,.;[]');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Control](Control.md)
 - [Graph](Graph.md)

--- a/docs/validators/Readable.md
+++ b/docs/validators/Readable.md
@@ -18,9 +18,9 @@ v::readable()->assert('/path/to/file.txt');
 
 ### `Readable::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-| ---------- | -------------------------------- |
-| `default`  | {{subject}} must be readable     |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be readable     |
 | `inverted` | {{subject}} must not be readable |
 
 ## Template placeholders
@@ -36,13 +36,11 @@ v::readable()->assert('/path/to/file.txt');
 ## Changelog
 
 | Version | Description       |
-| ------: | ----------------- |
+| ------: | :---------------- |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Regex.md
+++ b/docs/validators/Regex.md
@@ -20,9 +20,9 @@ Message template for this validator includes `{{regex}}`.
 
 ### `Regex::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                    |
-| ---------- | ----------------------------------------------------------- |
-| `default`  | {{subject}} must match the pattern {{regex&#124;quote}}     |
+|       Mode | Template                                                    |
+| ---------: | :---------------------------------------------------------- |
+|  `default` | {{subject}} must match the pattern {{regex&#124;quote}}     |
 | `inverted` | {{subject}} must not match the pattern {{regex&#124;quote}} |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ Message template for this validator includes `{{regex}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/ResourceType.md
+++ b/docs/validators/ResourceType.md
@@ -18,9 +18,9 @@ v::resourceType()->assert(fopen('/path/to/file.txt', 'r'));
 
 ### `ResourceType::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | {{subject}} must be a resource     |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be a resource     |
 | `inverted` | {{subject}} must not be a resource |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::resourceType()->assert(fopen('/path/to/file.txt', 'r'));
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/Roman.md
+++ b/docs/validators/Roman.md
@@ -18,9 +18,9 @@ v::roman()->assert('IV');
 
 ### `Roman::TEMPLATE_STANDARD`
 
-| Mode       | Template                                      |
-| ---------- | --------------------------------------------- |
-| `default`  | {{subject}} must be a valid Roman numeral     |
+|       Mode | Template                                      |
+| ---------: | :-------------------------------------------- |
+|  `default` | {{subject}} must be a valid Roman numeral     |
 | `inverted` | {{subject}} must not be a valid Roman numeral |
 
 ## Template placeholders
@@ -36,14 +36,12 @@ v::roman()->assert('IV');
 ## Changelog
 
 | Version | Description                                                       |
-| ------: | ----------------------------------------------------------------- |
+| ------: | :---------------------------------------------------------------- |
 |   2.0.0 | Exception message refers to Roman "numerals" instead of "numbers" |
 |   2.0.0 | Do not consider empty strings as valid                            |
 |   0.3.9 | Created                                                           |
 
----
-
-See also:
+## See Also
 
 - [In](In.md)
 - [Regex](Regex.md)

--- a/docs/validators/ScalarVal.md
+++ b/docs/validators/ScalarVal.md
@@ -21,9 +21,9 @@ v::scalarVal()->assert(135.0);
 
 ### `ScalarVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-| ---------- | -------------------------------------- |
-| `default`  | {{subject}} must be a scalar value     |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be a scalar value     |
 | `inverted` | {{subject}} must not be a scalar value |
 
 ## Template placeholders
@@ -39,12 +39,10 @@ v::scalarVal()->assert(135.0);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayVal](ArrayVal.md)
 - [NumericVal](NumericVal.md)

--- a/docs/validators/Size.md
+++ b/docs/validators/Size.md
@@ -33,18 +33,18 @@ This validator will accept:
 
 ### `Size::TEMPLATE_STANDARD`
 
-| Mode       | Template                           |
-| ---------- | ---------------------------------- |
-| `default`  | The size in {{unit&#124;trans}} of |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | The size in {{unit&#124;trans}} of |
 | `inverted` | The size in {{unit&#124;trans}} of |
 
 ### `Size::TEMPLATE_WRONG_TYPE`
 
 Used when the input is not a valid file path, a `SplFileInfo` object, or a PSR-7 interface.
 
-| Mode       | Template                                                                              |
-| ---------- | ------------------------------------------------------------------------------------- |
-| `default`  | {{subject}} must be a filename or an instance of SplFileInfo or a PSR-7 interface     |
+|       Mode | Template                                                                              |
+| ---------: | :------------------------------------------------------------------------------------ |
+|  `default` | {{subject}} must be a filename or an instance of SplFileInfo or a PSR-7 interface     |
 | `inverted` | {{subject}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface |
 
 ## Template as prefix
@@ -74,14 +74,12 @@ v::size('KB', v::not(v::equals(56)))->assert('/path/to/file');
 ## Changelog
 
 | Version | Description             |
-| ------: | ----------------------- |
+| ------: | :---------------------- |
 |   3.0.0 | Became a transformation |
 |   2.1.0 | Add [PSR-7][] support   |
 |   1.0.0 | Created                 |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Slug.md
+++ b/docs/validators/Slug.md
@@ -24,9 +24,9 @@ v::slug()->assert('my-wordpress-title-');
 
 ### `Slug::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-| ---------- | ------------------------------------ |
-| `default`  | {{subject}} must be a valid slug     |
+|       Mode | Template                             |
+| ---------: | :----------------------------------- |
+|  `default` | {{subject}} must be a valid slug     |
 | `inverted` | {{subject}} must not be a valid slug |
 
 ## Template placeholders
@@ -42,12 +42,10 @@ v::slug()->assert('my-wordpress-title-');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [PhpLabel](PhpLabel.md)
 - [Url](Url.md)

--- a/docs/validators/Sorted.md
+++ b/docs/validators/Sorted.md
@@ -50,16 +50,16 @@ v::call('iterator_to_array', v::sorted('ASC'))->assert(new ArrayIterator([1, 7, 
 
 ### `Sorted::TEMPLATE_ASCENDING`
 
-| Mode       | Template                                          |
-| ---------- | ------------------------------------------------- |
-| `default`  | {{subject}} must be sorted in ascending order     |
+|       Mode | Template                                          |
+| ---------: | :------------------------------------------------ |
+|  `default` | {{subject}} must be sorted in ascending order     |
 | `inverted` | {{subject}} must not be sorted in ascending order |
 
 ### `Sorted::TEMPLATE_DESCENDING`
 
-| Mode       | Template                                           |
-| ---------- | -------------------------------------------------- |
-| `default`  | {{subject}} must be sorted in descending order     |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must be sorted in descending order     |
 | `inverted` | {{subject}} must not be sorted in descending order |
 
 ## Template placeholders
@@ -76,16 +76,14 @@ v::call('iterator_to_array', v::sorted('ASC'))->assert(new ArrayIterator([1, 7, 
 ## Changelog
 
 | Version | Description                                    |
-| ------: | ---------------------------------------------- |
+| ------: | :--------------------------------------------- |
 |   2.0.0 | Add support for strings                        |
 |   2.0.0 | Do not use array keys to sort                  |
 |   2.0.0 | Use sorting direction instead of boolean value |
 |   2.0.0 | Do not accept callback in the constructor      |
 |   1.1.1 | Created                                        |
 
----
-
-See also:
+## See Also
 
 - [ArrayVal](ArrayVal.md)
 - [Call](Call.md)

--- a/docs/validators/Space.md
+++ b/docs/validators/Space.md
@@ -19,16 +19,16 @@ v::space()->assert('    ');
 
 ### `Space::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must contain only space characters |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must contain only space characters |
 | `inverted` | {{subject}} must not contain space characters  |
 
 ### `Space::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                               |
-| ---------- | ---------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain only space characters and {{additionalChars}} |
+|       Mode | Template                                                               |
+| ---------: | :--------------------------------------------------------------------- |
+|  `default` | {{subject}} must contain only space characters and {{additionalChars}} |
 | `inverted` | {{subject}} must not contain space characters or {{additionalChars}}   |
 
 ## Template placeholders
@@ -45,11 +45,9 @@ v::space()->assert('    ');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Control](Control.md)

--- a/docs/validators/Spaced.md
+++ b/docs/validators/Spaced.md
@@ -33,9 +33,9 @@ v::notSpaced()->alnum()->assert('user name');
 
 ### `Spaced::TEMPLATE_STANDARD`
 
-| Mode       | Template                                         |
-| ---------- | ------------------------------------------------ |
-| `default`  | {{subject}} must contain at least one whitespace |
+|       Mode | Template                                         |
+| ---------: | :----------------------------------------------- |
+|  `default` | {{subject}} must contain at least one whitespace |
 | `inverted` | {{subject}} must not contain whitespaces         |
 
 ## Template placeholders
@@ -51,13 +51,11 @@ v::notSpaced()->alnum()->assert('user name');
 ## Changelog
 
 | Version | Description                                  |
-| ------: | -------------------------------------------- |
+| ------: | :------------------------------------------- |
 |   3.0.0 | Renamed to `Spaced` and changed the behavior |
 |   0.3.9 | Created as `NoWhitespace`                    |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/StartsWith.md
+++ b/docs/validators/StartsWith.md
@@ -36,9 +36,9 @@ Message template for this validator includes `{{startValue}}`.
 
 ### `StartsWith::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must start with {{startValue}}     |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must start with {{startValue}}     |
 | `inverted` | {{subject}} must not start with {{startValue}} |
 
 ## Template placeholders
@@ -56,12 +56,10 @@ Message template for this validator includes `{{startValue}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Contains](Contains.md)
 - [EndsWith](EndsWith.md)

--- a/docs/validators/StringType.md
+++ b/docs/validators/StringType.md
@@ -18,9 +18,9 @@ v::stringType()->assert('hi');
 
 ### `StringType::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-| ---------- | -------------------------------- |
-| `default`  | {{subject}} must be a string     |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be a string     |
 | `inverted` | {{subject}} must not be a string |
 
 ## Template placeholders
@@ -37,13 +37,11 @@ v::stringType()->assert('hi');
 ## Changelog
 
 | Version | Description                           |
-| ------: | ------------------------------------- |
+| ------: | :------------------------------------ |
 |   1.0.0 | Renamed from `String` to `StringType` |
 |   0.3.9 | Created as `String`                   |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [ArrayType](ArrayType.md)

--- a/docs/validators/StringVal.md
+++ b/docs/validators/StringVal.md
@@ -36,9 +36,9 @@ v::stringVal()->assert(new ClassWithToString());
 
 ### `StringVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                               |
-| ---------- | -------------------------------------- |
-| `default`  | {{subject}} must be a string value     |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be a string value     |
 | `inverted` | {{subject}} must not be a string value |
 
 ## Template placeholders
@@ -55,12 +55,10 @@ v::stringVal()->assert(new ClassWithToString());
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [BoolType](BoolType.md)

--- a/docs/validators/SubdivisionCode.md
+++ b/docs/validators/SubdivisionCode.md
@@ -25,9 +25,9 @@ v::subdivisionCode('US')->assert('CA');
 
 ### `SubdivisionCode::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                                 |
-| ---------- | ------------------------------------------------------------------------ |
-| `default`  | {{subject}} must be a subdivision code of {{countryName&#124;trans}}     |
+|       Mode | Template                                                                 |
+| ---------: | :----------------------------------------------------------------------- |
+|  `default` | {{subject}} must be a subdivision code of {{countryName&#124;trans}}     |
 | `inverted` | {{subject}} must not be a subdivision code of {{countryName&#124;trans}} |
 
 ## Template placeholders
@@ -45,13 +45,11 @@ v::subdivisionCode('US')->assert('CA');
 ## Changelog
 
 | Version | Description                                                       |
-| ------: | ----------------------------------------------------------------- |
+| ------: | :---------------------------------------------------------------- |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   1.0.0 | Created                                                           |
 
----
-
-See also:
+## See Also
 
 - [Circuit](Circuit.md)
 - [CountryCode](CountryCode.md)

--- a/docs/validators/Subset.md
+++ b/docs/validators/Subset.md
@@ -21,9 +21,9 @@ v::subset([1, 2])->assert([1, 2, 3]);
 
 ### `Subset::TEMPLATE_STANDARD`
 
-| Mode       | Template                                       |
-| ---------- | ---------------------------------------------- |
-| `default`  | {{subject}} must be subset of {{superset}}     |
+|       Mode | Template                                       |
+| ---------: | :--------------------------------------------- |
+|  `default` | {{subject}} must be subset of {{superset}}     |
 | `inverted` | {{subject}} must not be subset of {{superset}} |
 
 ## Template placeholders
@@ -40,12 +40,10 @@ v::subset([1, 2])->assert([1, 2, 3]);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/SymbolicLink.md
+++ b/docs/validators/SymbolicLink.md
@@ -24,9 +24,9 @@ v::symbolicLink()->assert(new SplFileObject('/path/to/file'));
 
 ### `SymbolicLink::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must be a symbolic link     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a symbolic link     |
 | `inverted` | {{subject}} must not be a symbolic link |
 
 ## Template placeholders
@@ -42,12 +42,10 @@ v::symbolicLink()->assert(new SplFileObject('/path/to/file'));
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Templated.md
+++ b/docs/validators/Templated.md
@@ -43,12 +43,10 @@ This validator does not have any templates, as you must define the templates you
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   3.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Attributes](Attributes.md)
 - [Named](Named.md)

--- a/docs/validators/Time.md
+++ b/docs/validators/Time.md
@@ -57,9 +57,9 @@ v::time()->assert(new DateTimeImmutable());
 
 ### `Time::TEMPLATE_STANDARD`
 
-| Mode       | Template                                                      |
-| ---------- | ------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid time in the format {{sample}}     |
+|       Mode | Template                                                      |
+| ---------: | :------------------------------------------------------------ |
+|  `default` | {{subject}} must be a valid time in the format {{sample}}     |
 | `inverted` | {{subject}} must not be a valid time in the format {{sample}} |
 
 ## Template placeholders
@@ -76,12 +76,10 @@ v::time()->assert(new DateTimeImmutable());
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Date](Date.md)
 - [DateTime](DateTime.md)

--- a/docs/validators/Tld.md
+++ b/docs/validators/Tld.md
@@ -27,9 +27,9 @@ v::tld()->assert('COM');
 
 ### `Tld::TEMPLATE_STANDARD`
 
-| Mode       | Template                                              |
-| ---------- | ----------------------------------------------------- |
-| `default`  | {{subject}} must be a valid top-level domain name     |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | {{subject}} must be a valid top-level domain name     |
 | `inverted` | {{subject}} must not be a valid top-level domain name |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::tld()->assert('COM');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [CountryCode](CountryCode.md)
 - [Domain](Domain.md)

--- a/docs/validators/TrueVal.md
+++ b/docs/validators/TrueVal.md
@@ -39,9 +39,9 @@ v::trueVal()->assert('2');
 
 ### `TrueVal::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must evaluate to `true`     |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must evaluate to `true`     |
 | `inverted` | {{subject}} must not evaluate to `true` |
 
 ## Template placeholders
@@ -57,13 +57,11 @@ v::trueVal()->assert('2');
 ## Changelog
 
 | Version | Description                      |
-| ------: | -------------------------------- |
+| ------: | :------------------------------- |
 |   1.0.0 | Renamed from `True` to `TrueVal` |
 |   0.8.0 | Created as `True`                |
 
----
-
-See also:
+## See Also
 
 - [BoolType](BoolType.md)
 - [BoolVal](BoolVal.md)

--- a/docs/validators/Undef.md
+++ b/docs/validators/Undef.md
@@ -66,9 +66,9 @@ v::undef()->assert(new stdClass());
 
 ### `Undef::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be undefined |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be undefined |
 | `inverted` | {{subject}} must be defined   |
 
 ## Template placeholders
@@ -84,13 +84,11 @@ v::undef()->assert(new stdClass());
 ## Changelog
 
 | Version | Description                                 |
-| ------: | ------------------------------------------- |
+| ------: | :------------------------------------------ |
 |   3.0.0 | Renamed to `Undef` and changed the behavior |
 |   1.0.0 | Created as `NotOptional`                    |
 
----
-
-See also:
+## See Also
 
 - [Blank](Blank.md)
 - [Falsy](Falsy.md)

--- a/docs/validators/UndefOr.md
+++ b/docs/validators/UndefOr.md
@@ -43,9 +43,9 @@ v::undefOrBetween(1, 3)->assert(2);
 
 ### `UndefOr::TEMPLATE_STANDARD`
 
-| Mode       | Template                  |
-| ---------- | ------------------------- |
-| `default`  | or must be undefined      |
+|       Mode | Template                  |
+| ---------: | :------------------------ |
+|  `default` | or must be undefined      |
 | `inverted` | and must not be undefined |
 
 ## Template as suffix
@@ -73,13 +73,11 @@ v::not(v::undefOr(v::alpha()))->assert("alpha");
 ## Changelog
 
 | Version | Description           |
-| ------: | --------------------- |
+| ------: | :-------------------- |
 |   3.0.0 | Renamed to `UndefOr`  |
 |   1.0.0 | Created as `Optional` |
 
----
-
-See also:
+## See Also
 
 - [Blank](Blank.md)
 - [Falsy](Falsy.md)

--- a/docs/validators/Unique.md
+++ b/docs/validators/Unique.md
@@ -27,9 +27,9 @@ v::unique()->assert([1, 2, 3, 1]);
 
 ### `Unique::TEMPLATE_STANDARD`
 
-| Mode       | Template                                |
-| ---------- | --------------------------------------- |
-| `default`  | {{subject}} must not contain duplicates |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must not contain duplicates |
 | `inverted` | {{subject}} must contain duplicates     |
 
 ## Template placeholders
@@ -45,12 +45,10 @@ v::unique()->assert([1, 2, 3, 1]);
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   2.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [ArrayType](ArrayType.md)
 - [ArrayVal](ArrayVal.md)

--- a/docs/validators/Uploaded.md
+++ b/docs/validators/Uploaded.md
@@ -18,9 +18,9 @@ v::uploaded()->assert('/path/of/an/uploaded/file');
 
 ### `Uploaded::TEMPLATE_STANDARD`
 
-| Mode       | Template                                 |
-| ---------- | ---------------------------------------- |
-| `default`  | {{subject}} must be an uploaded file     |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be an uploaded file     |
 | `inverted` | {{subject}} must not be an uploaded file |
 
 ## Template placeholders
@@ -36,13 +36,11 @@ v::uploaded()->assert('/path/of/an/uploaded/file');
 ## Changelog
 
 | Version | Description       |
-| ------: | ----------------- |
+| ------: | :---------------- |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Uppercase.md
+++ b/docs/validators/Uppercase.md
@@ -33,9 +33,9 @@ v::not(v::numericVal())->alnum()->uppercase()->assert('W3C');
 
 ### `Uppercase::TEMPLATE_STANDARD`
 
-| Mode       | Template                                            |
-| ---------- | --------------------------------------------------- |
-| `default`  | {{subject}} must contain only uppercase letters     |
+|       Mode | Template                                            |
+| ---------: | :-------------------------------------------------- |
+|  `default` | {{subject}} must contain only uppercase letters     |
 | `inverted` | {{subject}} must not contain only uppercase letters |
 
 ## Template placeholders
@@ -51,12 +51,10 @@ v::not(v::numericVal())->alnum()->uppercase()->assert('W3C');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/Url.md
+++ b/docs/validators/Url.md
@@ -30,9 +30,9 @@ v::url()->assert('news:new.example.com');
 
 ### `Url::TEMPLATE_STANDARD`
 
-| Mode       | Template                      |
-| ---------- | ----------------------------- |
-| `default`  | {{subject}} must be a URL     |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be a URL     |
 | `inverted` | {{subject}} must not be a URL |
 
 ## Template placeholders
@@ -48,12 +48,10 @@ v::url()->assert('news:new.example.com');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.8.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Domain](Domain.md)
 - [Email](Email.md)

--- a/docs/validators/Uuid.md
+++ b/docs/validators/Uuid.md
@@ -38,16 +38,16 @@ v::uuid(4)->assert(\Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2b9574
 
 ### `Uuid::TEMPLATE_STANDARD`
 
-| Mode       | Template                             |
-| ---------- | ------------------------------------ |
-| `default`  | {{subject}} must be a valid UUID     |
+|       Mode | Template                             |
+| ---------: | :----------------------------------- |
+|  `default` | {{subject}} must be a valid UUID     |
 | `inverted` | {{subject}} must not be a valid UUID |
 
 ### `Uuid::TEMPLATE_VERSION`
 
-| Mode       | Template                                                          |
-| ---------- | ----------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid UUID version {{version&#124;raw}}     |
+|       Mode | Template                                                          |
+| ---------: | :---------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid UUID version {{version&#124;raw}}     |
 | `inverted` | {{subject}} must not be a valid UUID version {{version&#124;raw}} |
 
 ## Template placeholders
@@ -64,13 +64,11 @@ v::uuid(4)->assert(\Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2b9574
 ## Changelog
 
 | Version | Description            |
-| ------: | ---------------------- |
+| ------: | :--------------------- |
 |   3.0.0 | Requires `ramsey/uuid` |
 |   2.0.0 | Created                |
 
----
-
-See also:
+## See Also
 
 - [Base](Base.md)
 - [Decimal](Decimal.md)

--- a/docs/validators/Version.md
+++ b/docs/validators/Version.md
@@ -18,9 +18,9 @@ v::version()->assert('1.0.0');
 
 ### `Version::TEMPLATE_STANDARD`
 
-| Mode       | Template                          |
-| ---------- | --------------------------------- |
-| `default`  | {{subject}} must be a version     |
+|       Mode | Template                          |
+| ---------: | :-------------------------------- |
+|  `default` | {{subject}} must be a version     |
 | `inverted` | {{subject}} must not be a version |
 
 ## Template placeholders
@@ -36,12 +36,10 @@ v::version()->assert('1.0.0');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.3.9 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Equals](Equals.md)
 - [Regex](Regex.md)

--- a/docs/validators/VideoUrl.md
+++ b/docs/validators/VideoUrl.md
@@ -71,16 +71,16 @@ Message template for this validator includes `{{service}}`.
 
 ### `VideoUrl::TEMPLATE_STANDARD`
 
-| Mode       | Template                                  |
-| ---------- | ----------------------------------------- |
-| `default`  | {{subject}} must be a valid video URL     |
+|       Mode | Template                                  |
+| ---------: | :---------------------------------------- |
+|  `default` | {{subject}} must be a valid video URL     |
 | `inverted` | {{subject}} must not be a valid video URL |
 
 ### `VideoUrl::TEMPLATE_SERVICE`
 
-| Mode       | Template                                                       |
-| ---------- | -------------------------------------------------------------- |
-| `default`  | {{subject}} must be a valid {{service&#124;raw}} video URL     |
+|       Mode | Template                                                       |
+| ---------: | :------------------------------------------------------------- |
+|  `default` | {{subject}} must be a valid {{service&#124;raw}} video URL     |
 | `inverted` | {{subject}} must not be a valid {{service&#124;raw}} video URL |
 
 ## Template placeholders
@@ -97,12 +97,10 @@ Message template for this validator includes `{{service}}`.
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   1.0.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Email](Email.md)
 - [Json](Json.md)

--- a/docs/validators/Vowel.md
+++ b/docs/validators/Vowel.md
@@ -19,16 +19,16 @@ v::vowel()->assert('aei');
 
 ### `Vowel::TEMPLATE_STANDARD`
 
-| Mode       | Template                                    |
-| ---------- | ------------------------------------------- |
-| `default`  | {{subject}} must consist of vowels only     |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must consist of vowels only     |
 | `inverted` | {{subject}} must not consist of vowels only |
 
 ### `Vowel::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                      |
-| ---------- | ------------------------------------------------------------- |
-| `default`  | {{subject}} must consist of vowels and {{additionalChars}}    |
+|       Mode | Template                                                      |
+| ---------: | :------------------------------------------------------------ |
+|  `default` | {{subject}} must consist of vowels and {{additionalChars}}    |
 | `inverted` | {{subject}} must not consist of vowels or {{additionalChars}} |
 
 ## Template placeholders
@@ -45,14 +45,12 @@ v::vowel()->assert('aei');
 ## Changelog
 
 | Version | Description                          |
-| ------: | ------------------------------------ |
+| ------: | :----------------------------------- |
 |   2.0.0 | Do not consider whitespaces as valid |
 |   0.5.0 | Renamed from `Vowels` to `Vowel`     |
 |   0.3.9 | Created as `Vowels`                  |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Alpha](Alpha.md)

--- a/docs/validators/When.md
+++ b/docs/validators/When.md
@@ -47,13 +47,11 @@ When `$else` is not defined use [AlwaysInvalid](AlwaysInvalid.md)
 ## Changelog
 
 | Version | Description                         |
-| ------: | ----------------------------------- |
+| ------: | :---------------------------------- |
 |   0.8.0 | Allow to use validator without else |
 |   0.3.9 | Created                             |
 
----
-
-See also:
+## See Also
 
 - [AllOf](AllOf.md)
 - [AlwaysInvalid](AlwaysInvalid.md)

--- a/docs/validators/Writable.md
+++ b/docs/validators/Writable.md
@@ -21,9 +21,9 @@ v::writable()->assert('/path/to/non-writable');
 
 ### `Writable::TEMPLATE_STANDARD`
 
-| Mode       | Template                         |
-| ---------- | -------------------------------- |
-| `default`  | {{subject}} must be writable     |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be writable     |
 | `inverted` | {{subject}} must not be writable |
 
 ## Template placeholders
@@ -39,13 +39,11 @@ v::writable()->assert('/path/to/non-writable');
 ## Changelog
 
 | Version | Description       |
-| ------: | ----------------- |
+| ------: | :---------------- |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 
----
-
-See also:
+## See Also
 
 - [Directory](Directory.md)
 - [Executable](Executable.md)

--- a/docs/validators/Xdigit.md
+++ b/docs/validators/Xdigit.md
@@ -26,16 +26,16 @@ v::xdigit()->assert('0x1f');
 
 ### `Xdigit::TEMPLATE_STANDARD`
 
-| Mode       | Template                                             |
-| ---------- | ---------------------------------------------------- |
-| `default`  | {{subject}} must only contain hexadecimal digits     |
+|       Mode | Template                                             |
+| ---------: | :--------------------------------------------------- |
+|  `default` | {{subject}} must only contain hexadecimal digits     |
 | `inverted` | {{subject}} must not only contain hexadecimal digits |
 
 ### `Xdigit::TEMPLATE_EXTRA`
 
-| Mode       | Template                                                               |
-| ---------- | ---------------------------------------------------------------------- |
-| `default`  | {{subject}} must contain hexadecimal digits and {{additionalChars}}    |
+|       Mode | Template                                                               |
+| ---------: | :--------------------------------------------------------------------- |
+|  `default` | {{subject}} must contain hexadecimal digits and {{additionalChars}}    |
 | `inverted` | {{subject}} must not contain hexadecimal digits or {{additionalChars}} |
 
 ## Template placeholders
@@ -52,12 +52,10 @@ v::xdigit()->assert('0x1f');
 ## Changelog
 
 | Version | Description |
-| ------: | ----------- |
+| ------: | :---------- |
 |   0.5.0 | Created     |
 
----
-
-See also:
+## See Also
 
 - [Alnum](Alnum.md)
 - [Decimal](Decimal.md)

--- a/src-dev/Markdown/Linters/ValidatorChangelogLinter.php
+++ b/src-dev/Markdown/Linters/ValidatorChangelogLinter.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Dev\Markdown\Linters;
+
+use Respect\Dev\Markdown\Content;
+use Respect\Dev\Markdown\File;
+use Respect\Dev\Markdown\Linter;
+use UnexpectedValueException;
+
+use function count;
+use function explode;
+use function is_numeric;
+use function str_contains;
+use function str_replace;
+use function trim;
+
+final readonly class ValidatorChangelogLinter implements Linter
+{
+    public function lint(File $file): File
+    {
+        if (!str_contains($file->filename, '/validators/')) {
+            return $file;
+        }
+
+        $changeLogItems = $this->getChangelogItems($file);
+
+        $content = new Content();
+        $content->h2('Changelog');
+        $content->table(['Version', 'Description'], $changeLogItems, alignment: [1, -1]);
+
+        return $file->withContent($file->content->withSection($content));
+    }
+
+    /** @return array<int, array<int, string>> */
+    private function getChangelogItems(File $validator): array
+    {
+        try {
+            $changeLog = $validator->content->getSection('## Changelog');
+        } catch (UnexpectedValueException) {
+            return [];
+        }
+
+        $changeLogEntries = [];
+        foreach ($changeLog->toArray() as $line) {
+            $lineParts = explode('|', $line);
+            if (count($lineParts) < 3) {
+                continue;
+            }
+
+            if (!is_numeric(str_replace('.', '', trim($lineParts[1])))) {
+                continue;
+            }
+
+            $changeLogEntries[] = [trim($lineParts[1]), trim($lineParts[2])];
+        }
+
+        return $changeLogEntries;
+    }
+}

--- a/src-dev/Markdown/Linters/ValidatorTemplatesLinter.php
+++ b/src-dev/Markdown/Linters/ValidatorTemplatesLinter.php
@@ -69,10 +69,14 @@ final readonly class ValidatorTemplatesLinter implements Linter
                 $content->emptyLine();
             }
 
-            $content->table(['Mode', 'Template'], [
-                ['`default`', $template->default],
-                ['`inverted`', $template->inverted],
-            ]);
+            $content->table(
+                ['Mode', 'Template'],
+                [
+                    ['`default`', $template->default],
+                    ['`inverted`', $template->inverted],
+                ],
+                alignment: [1, -1],
+            );
         }
 
         return $file->withContent($file->content->withSection($content));


### PR DESCRIPTION
Introduces a Markdown linter for checking the Changelog format.

"See Also" was transformed into a section to make it easier to handle it with the `Content` class. The "Related" linter was simplified to reflect that change too.

An additional "alignment" parameter was added to markdown table generators, allowing the padding and headers to be explicitly marked with a specific left (-1), middle (0) or right(1) alignment.

Existing files were fixed using the `fix` option after the changes.