### PR TITLE
Streamline validators.md index

### DIFF
--- a/docs/validators.md
+++ b/docs/validators.md
@@ -7,467 +7,374 @@ SPDX-License-Identifier: MIT
 
 In this page you will find a list of validators by their category.
 
-## Arrays
+**Arrays**: [ArrayType][] - [ArrayVal][] - [Contains][] - [ContainsAny][] - [ContainsCount][] - [Each][] - [EndsWith][] - [In][] - [Key][] - [KeyExists][] - [KeyOptional][] - [KeySet][] - [Sorted][] - [StartsWith][] - [Subset][] - [Unique][]
 
-- [ArrayType](validators/ArrayType.md)
-- [ArrayVal](validators/ArrayVal.md)
-- [Contains](validators/Contains.md)
-- [ContainsAny](validators/ContainsAny.md)
-- [ContainsCount](validators/ContainsCount.md)
-- [Each](validators/Each.md)
-- [EndsWith](validators/EndsWith.md)
-- [In](validators/In.md)
-- [Key](validators/Key.md)
-- [KeyExists](validators/KeyExists.md)
-- [KeyOptional](validators/KeyOptional.md)
-- [KeySet](validators/KeySet.md)
-- [Sorted](validators/Sorted.md)
-- [StartsWith](validators/StartsWith.md)
-- [Subset](validators/Subset.md)
-- [Unique](validators/Unique.md)
+**Banking**: [CreditCard][] - [Iban][]
 
-## Banking
+**Booleans**: [AlwaysInvalid][] - [AlwaysValid][] - [BoolType][] - [BoolVal][] - [FalseVal][] - [TrueVal][]
 
-- [CreditCard](validators/CreditCard.md)
-- [Iban](validators/Iban.md)
+**Callables**: [Call][] - [CallableType][] - [Callback][] - [Lazy][]
 
-## Booleans
+**Comparisons**: [All][] - [Between][] - [BetweenExclusive][] - [Equals][] - [Equivalent][] - [GreaterThan][] - [GreaterThanOrEqual][] - [Identical][] - [In][] - [Length][] - [LessThan][] - [LessThanOrEqual][] - [Max][] - [Min][]
 
-- [AlwaysInvalid](validators/AlwaysInvalid.md)
-- [AlwaysValid](validators/AlwaysValid.md)
-- [BoolType](validators/BoolType.md)
-- [BoolVal](validators/BoolVal.md)
-- [FalseVal](validators/FalseVal.md)
-- [TrueVal](validators/TrueVal.md)
+**Composite**: [AllOf][] - [AnyOf][] - [Circuit][] - [NoneOf][] - [OneOf][]
 
-## Callables
+**Conditions**: [Circuit][] - [Not][] - [When][]
 
-- [Call](validators/Call.md)
-- [CallableType](validators/CallableType.md)
-- [Callback](validators/Callback.md)
-- [Lazy](validators/Lazy.md)
+**Core**: [Named][] - [Not][] - [Templated][]
 
-## Comparisons
+**Date and Time**: [Date][] - [DateTime][] - [DateTimeDiff][] - [LeapDate][] - [LeapYear][] - [Time][]
 
-- [All](validators/All.md)
-- [Between](validators/Between.md)
-- [BetweenExclusive](validators/BetweenExclusive.md)
-- [Equals](validators/Equals.md)
-- [Equivalent](validators/Equivalent.md)
-- [GreaterThan](validators/GreaterThan.md)
-- [GreaterThanOrEqual](validators/GreaterThanOrEqual.md)
-- [Identical](validators/Identical.md)
-- [In](validators/In.md)
-- [Length](validators/Length.md)
-- [LessThan](validators/LessThan.md)
-- [LessThanOrEqual](validators/LessThanOrEqual.md)
-- [Max](validators/Max.md)
-- [Min](validators/Min.md)
+**File system**: [Directory][] - [Executable][] - [Exists][] - [Extension][] - [File][] - [Image][] - [Mimetype][] - [Readable][] - [Size][] - [SymbolicLink][] - [Uploaded][] - [Writable][]
 
-## Composite
+**ISO codes**: [CountryCode][] - [CurrencyCode][] - [LanguageCode][] - [SubdivisionCode][]
 
-- [AllOf](validators/AllOf.md)
-- [AnyOf](validators/AnyOf.md)
-- [Circuit](validators/Circuit.md)
-- [NoneOf](validators/NoneOf.md)
-- [OneOf](validators/OneOf.md)
+**Identifications**: [Bsn][] - [Cnh][] - [Cnpj][] - [Cpf][] - [Hetu][] - [Imei][] - [Isbn][] - [Luhn][] - [MacAddress][] - [NfeAccessKey][] - [Nif][] - [Nip][] - [Pesel][] - [Pis][] - [PolishIdCard][] - [PortugueseNif][]
 
-## Conditions
+**Internet**: [Domain][] - [Email][] - [Ip][] - [PublicDomainSuffix][] - [Tld][] - [Url][] - [VideoUrl][]
 
-- [Circuit](validators/Circuit.md)
-- [Not](validators/Not.md)
-- [When](validators/When.md)
+**Localization**: [CountryCode][] - [CurrencyCode][] - [LanguageCode][] - [PostalCode][] - [SubdivisionCode][]
 
-## Core
+**Math**: [Factor][] - [Fibonacci][] - [Finite][] - [Infinite][] - [Multiple][] - [Negative][] - [PerfectSquare][] - [Positive][] - [PrimeNumber][]
 
-- [Named](validators/Named.md)
-- [Not](validators/Not.md)
-- [Templated](validators/Templated.md)
+**Miscellaneous**: [Blank][] - [Falsy][] - [FilterVar][] - [Named][] - [Templated][] - [Undef][]
 
-## Date and Time
+**Nesting**: [AllOf][] - [AnyOf][] - [Call][] - [Circuit][] - [Each][] - [Key][] - [KeySet][] - [Lazy][] - [NoneOf][] - [Not][] - [NullOr][] - [OneOf][] - [Property][] - [PropertyOptional][] - [UndefOr][] - [When][]
 
-- [Date](validators/Date.md)
-- [DateTime](validators/DateTime.md)
-- [DateTimeDiff](validators/DateTimeDiff.md)
-- [LeapDate](validators/LeapDate.md)
-- [LeapYear](validators/LeapYear.md)
-- [Time](validators/Time.md)
+**Numbers**: [Base][] - [Decimal][] - [Digit][] - [Even][] - [Factor][] - [Fibonacci][] - [Finite][] - [FloatType][] - [FloatVal][] - [Infinite][] - [IntType][] - [IntVal][] - [Multiple][] - [Negative][] - [Number][] - [NumericVal][] - [Odd][] - [PerfectSquare][] - [Positive][] - [PrimeNumber][] - [Roman][]
 
-## File system
+**Objects**: [Attributes][] - [Instance][] - [ObjectType][] - [Property][] - [PropertyExists][] - [PropertyOptional][]
 
-- [Directory](validators/Directory.md)
-- [Executable](validators/Executable.md)
-- [Exists](validators/Exists.md)
-- [Extension](validators/Extension.md)
-- [File](validators/File.md)
-- [Image](validators/Image.md)
-- [Mimetype](validators/Mimetype.md)
-- [Readable](validators/Readable.md)
-- [Size](validators/Size.md)
-- [SymbolicLink](validators/SymbolicLink.md)
-- [Uploaded](validators/Uploaded.md)
-- [Writable](validators/Writable.md)
+**Strings**: [Alnum][] - [Alpha][] - [Base64][] - [Charset][] - [Consonant][] - [Contains][] - [ContainsAny][] - [ContainsCount][] - [Control][] - [Digit][] - [Emoji][] - [EndsWith][] - [Graph][] - [HexRgbColor][] - [In][] - [Json][] - [Lowercase][] - [Phone][] - [PhpLabel][] - [PostalCode][] - [Printable][] - [Punct][] - [Regex][] - [Slug][] - [Sorted][] - [Space][] - [Spaced][] - [StartsWith][] - [StringType][] - [StringVal][] - [Uppercase][] - [Uuid][] - [Version][] - [Vowel][] - [Xdigit][]
 
-## ISO codes
+**Structures**: [Attributes][] - [Key][] - [KeyExists][] - [KeyOptional][] - [KeySet][] - [Named][] - [Property][] - [PropertyExists][] - [PropertyOptional][] - [Templated][]
 
-- [CountryCode](validators/CountryCode.md)
-- [CurrencyCode](validators/CurrencyCode.md)
-- [LanguageCode](validators/LanguageCode.md)
-- [SubdivisionCode](validators/SubdivisionCode.md)
+**Transformations**: [All][] - [Call][] - [Each][] - [Length][] - [Max][] - [Min][] - [Size][]
 
-## Identifications
-
-- [Bsn](validators/Bsn.md)
-- [Cnh](validators/Cnh.md)
-- [Cnpj](validators/Cnpj.md)
-- [Cpf](validators/Cpf.md)
-- [Hetu](validators/Hetu.md)
-- [Imei](validators/Imei.md)
-- [Isbn](validators/Isbn.md)
-- [Luhn](validators/Luhn.md)
-- [MacAddress](validators/MacAddress.md)
-- [NfeAccessKey](validators/NfeAccessKey.md)
-- [Nif](validators/Nif.md)
-- [Nip](validators/Nip.md)
-- [Pesel](validators/Pesel.md)
-- [Pis](validators/Pis.md)
-- [PolishIdCard](validators/PolishIdCard.md)
-- [PortugueseNif](validators/PortugueseNif.md)
-
-## Internet
-
-- [Domain](validators/Domain.md)
-- [Email](validators/Email.md)
-- [Ip](validators/Ip.md)
-- [PublicDomainSuffix](validators/PublicDomainSuffix.md)
-- [Tld](validators/Tld.md)
-- [Url](validators/Url.md)
-- [VideoUrl](validators/VideoUrl.md)
-
-## Localization
-
-- [CountryCode](validators/CountryCode.md)
-- [CurrencyCode](validators/CurrencyCode.md)
-- [LanguageCode](validators/LanguageCode.md)
-- [PostalCode](validators/PostalCode.md)
-- [SubdivisionCode](validators/SubdivisionCode.md)
-
-## Math
-
-- [Factor](validators/Factor.md)
-- [Fibonacci](validators/Fibonacci.md)
-- [Finite](validators/Finite.md)
-- [Infinite](validators/Infinite.md)
-- [Multiple](validators/Multiple.md)
-- [Negative](validators/Negative.md)
-- [PerfectSquare](validators/PerfectSquare.md)
-- [Positive](validators/Positive.md)
-- [PrimeNumber](validators/PrimeNumber.md)
-
-## Miscellaneous
-
-- [Blank](validators/Blank.md)
-- [Falsy](validators/Falsy.md)
-- [FilterVar](validators/FilterVar.md)
-- [Named](validators/Named.md)
-- [Templated](validators/Templated.md)
-- [Undef](validators/Undef.md)
-
-## Nesting
-
-- [AllOf](validators/AllOf.md)
-- [AnyOf](validators/AnyOf.md)
-- [Call](validators/Call.md)
-- [Circuit](validators/Circuit.md)
-- [Each](validators/Each.md)
-- [Key](validators/Key.md)
-- [KeySet](validators/KeySet.md)
-- [Lazy](validators/Lazy.md)
-- [NoneOf](validators/NoneOf.md)
-- [Not](validators/Not.md)
-- [NullOr](validators/NullOr.md)
-- [OneOf](validators/OneOf.md)
-- [Property](validators/Property.md)
-- [PropertyOptional](validators/PropertyOptional.md)
-- [UndefOr](validators/UndefOr.md)
-- [When](validators/When.md)
-
-## Numbers
-
-- [Base](validators/Base.md)
-- [Decimal](validators/Decimal.md)
-- [Digit](validators/Digit.md)
-- [Even](validators/Even.md)
-- [Factor](validators/Factor.md)
-- [Fibonacci](validators/Fibonacci.md)
-- [Finite](validators/Finite.md)
-- [FloatType](validators/FloatType.md)
-- [FloatVal](validators/FloatVal.md)
-- [Infinite](validators/Infinite.md)
-- [IntType](validators/IntType.md)
-- [IntVal](validators/IntVal.md)
-- [Multiple](validators/Multiple.md)
-- [Negative](validators/Negative.md)
-- [Number](validators/Number.md)
-- [NumericVal](validators/NumericVal.md)
-- [Odd](validators/Odd.md)
-- [PerfectSquare](validators/PerfectSquare.md)
-- [Positive](validators/Positive.md)
-- [PrimeNumber](validators/PrimeNumber.md)
-- [Roman](validators/Roman.md)
-
-## Objects
-
-- [Attributes](validators/Attributes.md)
-- [Instance](validators/Instance.md)
-- [ObjectType](validators/ObjectType.md)
-- [Property](validators/Property.md)
-- [PropertyExists](validators/PropertyExists.md)
-- [PropertyOptional](validators/PropertyOptional.md)
-
-## Strings
-
-- [Alnum](validators/Alnum.md)
-- [Alpha](validators/Alpha.md)
-- [Base64](validators/Base64.md)
-- [Charset](validators/Charset.md)
-- [Consonant](validators/Consonant.md)
-- [Contains](validators/Contains.md)
-- [ContainsAny](validators/ContainsAny.md)
-- [ContainsCount](validators/ContainsCount.md)
-- [Control](validators/Control.md)
-- [Digit](validators/Digit.md)
-- [Emoji](validators/Emoji.md)
-- [EndsWith](validators/EndsWith.md)
-- [Graph](validators/Graph.md)
-- [HexRgbColor](validators/HexRgbColor.md)
-- [In](validators/In.md)
-- [Json](validators/Json.md)
-- [Lowercase](validators/Lowercase.md)
-- [Phone](validators/Phone.md)
-- [PhpLabel](validators/PhpLabel.md)
-- [PostalCode](validators/PostalCode.md)
-- [Printable](validators/Printable.md)
-- [Punct](validators/Punct.md)
-- [Regex](validators/Regex.md)
-- [Slug](validators/Slug.md)
-- [Sorted](validators/Sorted.md)
-- [Space](validators/Space.md)
-- [Spaced](validators/Spaced.md)
-- [StartsWith](validators/StartsWith.md)
-- [StringType](validators/StringType.md)
-- [StringVal](validators/StringVal.md)
-- [Uppercase](validators/Uppercase.md)
-- [Uuid](validators/Uuid.md)
-- [Version](validators/Version.md)
-- [Vowel](validators/Vowel.md)
-- [Xdigit](validators/Xdigit.md)
-
-## Structures
-
-- [Attributes](validators/Attributes.md)
-- [Key](validators/Key.md)
-- [KeyExists](validators/KeyExists.md)
-- [KeyOptional](validators/KeyOptional.md)
-- [KeySet](validators/KeySet.md)
-- [Named](validators/Named.md)
-- [Property](validators/Property.md)
-- [PropertyExists](validators/PropertyExists.md)
-- [PropertyOptional](validators/PropertyOptional.md)
-- [Templated](validators/Templated.md)
-
-## Transformations
-
-- [All](validators/All.md)
-- [Call](validators/Call.md)
-- [Each](validators/Each.md)
-- [Length](validators/Length.md)
-- [Max](validators/Max.md)
-- [Min](validators/Min.md)
-- [Size](validators/Size.md)
-
-## Types
-
-- [ArrayType](validators/ArrayType.md)
-- [ArrayVal](validators/ArrayVal.md)
-- [BoolType](validators/BoolType.md)
-- [BoolVal](validators/BoolVal.md)
-- [CallableType](validators/CallableType.md)
-- [Countable](validators/Countable.md)
-- [FloatType](validators/FloatType.md)
-- [FloatVal](validators/FloatVal.md)
-- [IntType](validators/IntType.md)
-- [IntVal](validators/IntVal.md)
-- [IterableType](validators/IterableType.md)
-- [IterableVal](validators/IterableVal.md)
-- [NullType](validators/NullType.md)
-- [NumericVal](validators/NumericVal.md)
-- [ObjectType](validators/ObjectType.md)
-- [ResourceType](validators/ResourceType.md)
-- [ScalarVal](validators/ScalarVal.md)
-- [StringType](validators/StringType.md)
-- [StringVal](validators/StringVal.md)
+**Types**: [ArrayType][] - [ArrayVal][] - [BoolType][] - [BoolVal][] - [CallableType][] - [Countable][] - [FloatType][] - [FloatVal][] - [IntType][] - [IntVal][] - [IterableType][] - [IterableVal][] - [NullType][] - [NumericVal][] - [ObjectType][] - [ResourceType][] - [ScalarVal][] - [StringType][] - [StringVal][]
 
 ## Alphabetically
 
-- [All](validators/All.md)
-- [AllOf](validators/AllOf.md)
-- [Alnum](validators/Alnum.md)
-- [Alpha](validators/Alpha.md)
-- [AlwaysInvalid](validators/AlwaysInvalid.md)
-- [AlwaysValid](validators/AlwaysValid.md)
-- [AnyOf](validators/AnyOf.md)
-- [ArrayType](validators/ArrayType.md)
-- [ArrayVal](validators/ArrayVal.md)
-- [Attributes](validators/Attributes.md)
-- [Base](validators/Base.md)
-- [Base64](validators/Base64.md)
-- [Between](validators/Between.md)
-- [BetweenExclusive](validators/BetweenExclusive.md)
-- [Blank](validators/Blank.md)
-- [BoolType](validators/BoolType.md)
-- [BoolVal](validators/BoolVal.md)
-- [Bsn](validators/Bsn.md)
-- [Call](validators/Call.md)
-- [CallableType](validators/CallableType.md)
-- [Callback](validators/Callback.md)
-- [Charset](validators/Charset.md)
-- [Circuit](validators/Circuit.md)
-- [Cnh](validators/Cnh.md)
-- [Cnpj](validators/Cnpj.md)
-- [Consonant](validators/Consonant.md)
-- [Contains](validators/Contains.md)
-- [ContainsAny](validators/ContainsAny.md)
-- [ContainsCount](validators/ContainsCount.md)
-- [Control](validators/Control.md)
-- [Countable](validators/Countable.md)
-- [CountryCode](validators/CountryCode.md)
-- [Cpf](validators/Cpf.md)
-- [CreditCard](validators/CreditCard.md)
-- [CurrencyCode](validators/CurrencyCode.md)
-- [Date](validators/Date.md)
-- [DateTime](validators/DateTime.md)
-- [DateTimeDiff](validators/DateTimeDiff.md)
-- [Decimal](validators/Decimal.md)
-- [Digit](validators/Digit.md)
-- [Directory](validators/Directory.md)
-- [Domain](validators/Domain.md)
-- [Each](validators/Each.md)
-- [Email](validators/Email.md)
-- [Emoji](validators/Emoji.md)
-- [EndsWith](validators/EndsWith.md)
-- [Equals](validators/Equals.md)
-- [Equivalent](validators/Equivalent.md)
-- [Even](validators/Even.md)
-- [Executable](validators/Executable.md)
-- [Exists](validators/Exists.md)
-- [Extension](validators/Extension.md)
-- [Factor](validators/Factor.md)
-- [FalseVal](validators/FalseVal.md)
-- [Falsy](validators/Falsy.md)
-- [Fibonacci](validators/Fibonacci.md)
-- [File](validators/File.md)
-- [FilterVar](validators/FilterVar.md)
-- [Finite](validators/Finite.md)
-- [FloatType](validators/FloatType.md)
-- [FloatVal](validators/FloatVal.md)
-- [Graph](validators/Graph.md)
-- [GreaterThan](validators/GreaterThan.md)
-- [GreaterThanOrEqual](validators/GreaterThanOrEqual.md)
-- [Hetu](validators/Hetu.md)
-- [HexRgbColor](validators/HexRgbColor.md)
-- [Iban](validators/Iban.md)
-- [Identical](validators/Identical.md)
-- [Image](validators/Image.md)
-- [Imei](validators/Imei.md)
-- [In](validators/In.md)
-- [Infinite](validators/Infinite.md)
-- [Instance](validators/Instance.md)
-- [IntType](validators/IntType.md)
-- [IntVal](validators/IntVal.md)
-- [Ip](validators/Ip.md)
-- [Isbn](validators/Isbn.md)
-- [IterableType](validators/IterableType.md)
-- [IterableVal](validators/IterableVal.md)
-- [Json](validators/Json.md)
-- [Key](validators/Key.md)
-- [KeyExists](validators/KeyExists.md)
-- [KeyOptional](validators/KeyOptional.md)
-- [KeySet](validators/KeySet.md)
-- [LanguageCode](validators/LanguageCode.md)
-- [Lazy](validators/Lazy.md)
-- [LeapDate](validators/LeapDate.md)
-- [LeapYear](validators/LeapYear.md)
-- [Length](validators/Length.md)
-- [LessThan](validators/LessThan.md)
-- [LessThanOrEqual](validators/LessThanOrEqual.md)
-- [Lowercase](validators/Lowercase.md)
-- [Luhn](validators/Luhn.md)
-- [MacAddress](validators/MacAddress.md)
-- [Max](validators/Max.md)
-- [Mimetype](validators/Mimetype.md)
-- [Min](validators/Min.md)
-- [Multiple](validators/Multiple.md)
-- [Named](validators/Named.md)
-- [Negative](validators/Negative.md)
-- [NfeAccessKey](validators/NfeAccessKey.md)
-- [Nif](validators/Nif.md)
-- [Nip](validators/Nip.md)
-- [NoneOf](validators/NoneOf.md)
-- [Not](validators/Not.md)
-- [NullOr](validators/NullOr.md)
-- [NullType](validators/NullType.md)
-- [Number](validators/Number.md)
-- [NumericVal](validators/NumericVal.md)
-- [ObjectType](validators/ObjectType.md)
-- [Odd](validators/Odd.md)
-- [OneOf](validators/OneOf.md)
-- [PerfectSquare](validators/PerfectSquare.md)
-- [Pesel](validators/Pesel.md)
-- [Phone](validators/Phone.md)
-- [PhpLabel](validators/PhpLabel.md)
-- [Pis](validators/Pis.md)
-- [PolishIdCard](validators/PolishIdCard.md)
-- [PortugueseNif](validators/PortugueseNif.md)
-- [Positive](validators/Positive.md)
-- [PostalCode](validators/PostalCode.md)
-- [PrimeNumber](validators/PrimeNumber.md)
-- [Printable](validators/Printable.md)
-- [Property](validators/Property.md)
-- [PropertyExists](validators/PropertyExists.md)
-- [PropertyOptional](validators/PropertyOptional.md)
-- [PublicDomainSuffix](validators/PublicDomainSuffix.md)
-- [Punct](validators/Punct.md)
-- [Readable](validators/Readable.md)
-- [Regex](validators/Regex.md)
-- [ResourceType](validators/ResourceType.md)
-- [Roman](validators/Roman.md)
-- [ScalarVal](validators/ScalarVal.md)
-- [Size](validators/Size.md)
-- [Slug](validators/Slug.md)
-- [Sorted](validators/Sorted.md)
-- [Space](validators/Space.md)
-- [Spaced](validators/Spaced.md)
-- [StartsWith](validators/StartsWith.md)
-- [StringType](validators/StringType.md)
-- [StringVal](validators/StringVal.md)
-- [SubdivisionCode](validators/SubdivisionCode.md)
-- [Subset](validators/Subset.md)
-- [SymbolicLink](validators/SymbolicLink.md)
-- [Templated](validators/Templated.md)
-- [Time](validators/Time.md)
-- [Tld](validators/Tld.md)
-- [TrueVal](validators/TrueVal.md)
-- [Undef](validators/Undef.md)
-- [UndefOr](validators/UndefOr.md)
-- [Unique](validators/Unique.md)
-- [Uploaded](validators/Uploaded.md)
-- [Uppercase](validators/Uppercase.md)
-- [Url](validators/Url.md)
-- [Uuid](validators/Uuid.md)
-- [Version](validators/Version.md)
-- [VideoUrl](validators/VideoUrl.md)
-- [Vowel](validators/Vowel.md)
-- [When](validators/When.md)
-- [Writable](validators/Writable.md)
-- [Xdigit](validators/Xdigit.md)
+- [All][] - `v::all(v::intType())->assert([1, 2, 3]);`
+- [AllOf][] - `v::allOf(v::intVal(), v::positive())->assert(15);`
+- [Alnum][] - `v::alnum(' ')->assert('foo 123');`
+- [Alpha][] - `v::alpha(' ')->assert('some name');`
+- [AlwaysInvalid][] - `v::not(v::alwaysInvalid())->assert('whatever');`
+- [AlwaysValid][] - `v::alwaysValid()->assert('whatever');`
+- [AnyOf][] - `v::anyOf(v::intVal(), v::floatVal())->assert(15.5);`
+- [ArrayType][] - `v::arrayType()->assert([]);`
+- [ArrayVal][] - `v::arrayVal()->assert([]);`
+- [Attributes][] - `v::attributes()->assert(new Person('John Doe', '2020-06-23', 'john.doe@gmail.com'));`
+- [Base][] - `v::base(2)->assert('011010001');`
+- [Base64][] - `v::base64()->assert('cmVzcGVjdCE=');`
+- [Between][] - `v::intVal()->between(10, 20)->assert(10);`
+- [BetweenExclusive][] - `v::betweenExclusive('a', 'e')->assert('c');`
+- [Blank][] - `v::blank()->assert(' ');`
+- [BoolType][] - `v::boolType()->assert(true);`
+- [BoolVal][] - `v::boolVal()->assert('on');`
+- [Bsn][] - `v::bsn()->assert('612890053');`
+- [Call][] - `v::call(str_split(...), v::arrayType()->lengthEquals(5))->assert('world');`
+- [CallableType][] - `v::callableType()->assert(function () {});`
+- [Callback][] - `v::callback(fn (int $input): bool => $input % 5 === 0,)->assert(10);`
+- [Charset][] - `v::charset('ASCII')->assert('sugar');`
+- [Circuit][] - `v::circuit(v::intVal(), v::floatVal())->assert(15);`
+- [Cnh][] - `v::cnh()->assert('02650306461');`
+- [Cnpj][] - `v::cnpj()->assert('00394460005887');`
+- [Consonant][] - `v::consonant()->assert('xkcd');`
+- [Contains][] - `v::contains('ipsum')->assert('lorem ipsum');`
+- [ContainsAny][] - `v::containsAny(['lorem', 'dolor'])->assert('lorem ipsum');`
+- [ContainsCount][] - `v::containsCount('ipsum', 2)->assert('ipsum lorem ipsum');`
+- [Control][] - `v::control()->assert("\n\r\t");`
+- [Countable][] - `v::countable()->assert([]);`
+- [CountryCode][] - `v::countryCode()->assert('BR');`
+- [Cpf][] - `v::cpf()->assert('95574461102');`
+- [CreditCard][] - `v::creditCard()->assert('5376 7473 9720 8720');`
+- [CurrencyCode][] - `v::currencyCode()->assert('GBP');`
+- [Date][] - `v::date()->assert('2017-12-31');`
+- [DateTime][] - `v::dateTime()->assert('2009-01-01');`
+- [DateTimeDiff][] - `v::dateTimeDiff('years', v::greaterThan(18), 'd/m/Y')->assert('09/12/1990');`
+- [Decimal][] - `v::decimal(2)->assert('27990.50');`
+- [Digit][] - `v::digit(' ')->assert('020 612 1851');`
+- [Directory][] - `v::directory()->assert(__DIR__);`
+- [Domain][] - `v::domain()->assert('google.com');`
+- [Each][] - `v::each(v::dateTime())->assert($releaseDates);`
+- [Email][] - `v::email()->assert('alganet@gmail.com');`
+- [Emoji][] - `v::emoji()->assert('🍕');`
+- [EndsWith][] - `v::endsWith('ipsum')->assert('lorem ipsum');`
+- [Equals][] - `v::equals('alganet')->assert('alganet');`
+- [Equivalent][] - `v::equivalent(1)->assert(true);`
+- [Even][] - `v::intVal()->even()->assert(2);`
+- [Executable][] - `v::executable()->assert('/path/to/executable');`
+- [Exists][] - `v::exists()->assert(__FILE__);`
+- [Extension][] - `v::extension('png')->assert('image.png');`
+- [Factor][] - `v::factor(0)->assert(5);`
+- [FalseVal][] - `v::falseVal()->assert(false);`
+- [Falsy][] - `v::falsy()->assert('');`
+- [Fibonacci][] - `v::fibonacci()->assert(1);`
+- [File][] - `v::file()->assert(__FILE__);`
+- [FilterVar][] - `v::filterVar(FILTER_VALIDATE_EMAIL)->assert('bob@example.com');`
+- [Finite][] - `v::finite()->assert('10');`
+- [FloatType][] - `v::floatType()->assert(1.5);`
+- [FloatVal][] - `v::floatVal()->assert(1.5);`
+- [Graph][] - `v::graph()->assert('LKM@#$%4;');`
+- [GreaterThan][] - `v::greaterThan(10)->assert(11);`
+- [GreaterThanOrEqual][] - `v::intVal()->greaterThanOrEqual(10)->assert(10);`
+- [Hetu][] - `v::hetu()->assert('010106A9012');`
+- [HexRgbColor][] - `v::hexRgbColor()->assert('#FFFAAA');`
+- [Iban][] - `v::iban()->assert('SE35 5000 0000 0549 1000 0003');`
+- [Identical][] - `v::identical(42)->assert(42);`
+- [Image][] - `v::image()->assert('/path/to/image.gif');`
+- [Imei][] - `v::imei()->assert('35-209900-176148-1');`
+- [In][] - `v::in('lorem ipsum')->assert('ipsum');`
+- [Infinite][] - `v::infinite()->assert(INF);`
+- [Instance][] - `v::instance('DateTime')->assert(new DateTime);`
+- [IntType][] - `v::intType()->assert(42);`
+- [IntVal][] - `v::intVal()->assert('10');`
+- [Ip][] - `v::ip()->assert('127.0.0.1');`
+- [Isbn][] - `v::isbn()->assert('ISBN-13: 978-0-596-52068-7');`
+- [IterableType][] - `v::iterableType()->assert([]);`
+- [IterableVal][] - `v::iterableVal()->assert([]);`
+- [Json][] - `v::json()->assert('{"foo":"bar"}');`
+- [Key][] - `v::key('name', v::stringType())->assert(['name' => 'The Respect Panda']);`
+- [KeyExists][] - `v::keyExists('name')->assert(['name' => 'The Respect Panda']);`
+- [KeyOptional][] - `v::keyOptional('name', v::stringType())->assert([]);`
+- [KeySet][] - `v::keySet(v::key('foo', v::intVal()))->assert(['foo' => 42]);`
+- [LanguageCode][] - `v::languageCode()->assert('pt');`
+- [Lazy][] - `v::lazy(static fn($input) => v::boolVal())->assert(true);`
+- [LeapDate][] - `v::leapDate('Y-m-d')->assert('1988-02-29');`
+- [LeapYear][] - `v::leapYear()->assert('1988');`
+- [Length][] - `v::length(v::between(1, 5))->assert('abc');`
+- [LessThan][] - `v::lessThan(10)->assert(9);`
+- [LessThanOrEqual][] - `v::lessThanOrEqual(10)->assert(9);`
+- [Lowercase][] - `v::stringType()->lowercase()->assert('xkcd');`
+- [Luhn][] - `v::luhn()->assert('2222400041240011');`
+- [MacAddress][] - `v::macAddress()->assert('00:11:22:33:44:55');`
+- [Max][] - `v::max(v::equals(30))->assert([10, 20, 30]);`
+- [Mimetype][] - `v::mimetype('image/png')->assert('/path/to/image.png');`
+- [Min][] - `v::min(v::equals(10))->assert([10, 20, 30]);`
+- [Multiple][] - `v::intVal()->multiple(3)->assert(9);`
+- [Named][] - `v::named('Your email', v::email())->assert('foo@example.com');`
+- [Negative][] - `v::numericVal()->negative()->assert(-15);`
+- [NfeAccessKey][] - `v::nfeAccessKey()->assert('52060433009911002506550120000007800267301615');`
+- [Nif][] - `v::nif()->assert('49294492H');`
+- [Nip][] - `v::nip()->assert('1645865777');`
+- [NoneOf][] - `v::noneOf(v::intVal(), v::floatVal())->assert('foo');`
+- [Not][] - `v::not(v::ip())->assert('foo');`
+- [NullOr][] - `v::nullOr(v::email())->assert(null);`
+- [NullType][] - `v::nullType()->assert(null);`
+- [Number][] - `v::number()->assert(42);`
+- [NumericVal][] - `v::numericVal()->assert(-12);`
+- [ObjectType][] - `v::objectType()->assert(new stdClass);`
+- [Odd][] - `v::odd()->assert(3);`
+- [OneOf][] - `v::oneOf(v::digit(), v::alpha())->assert('AB');`
+- [PerfectSquare][] - `v::perfectSquare()->assert(25); // (5*5)`
+- [Pesel][] - `v::pesel()->assert('21120209256');`
+- [Phone][] - `v::phone()->assert('+1 650 253 00 00');`
+- [PhpLabel][] - `v::phpLabel()->assert('person'); //true`
+- [Pis][] - `v::pis()->assert('120.0340.678-8');`
+- [PolishIdCard][] - `v::polishIdCard()->assert('AYW036733');`
+- [PortugueseNif][] - `v::portugueseNif()->assert('124885446');`
+- [Positive][] - `v::positive()->assert(1);`
+- [PostalCode][] - `v::postalCode('BR')->assert('02179000');`
+- [PrimeNumber][] - `v::primeNumber()->assert(7);`
+- [Printable][] - `v::printable()->assert('LMKA0$% _123');`
+- [Property][] - `v::property('name', v::equals('The Respect Panda'))->assert($object);`
+- [PropertyExists][] - `v::propertyExists('name')->assert($object);`
+- [PropertyOptional][] - `v::propertyOptional('name', v::notBlank())->assert($object);`
+- [PublicDomainSuffix][] - `v::publicDomainSuffix()->assert('co.uk');`
+- [Punct][] - `v::punct()->assert('&,.;[]');`
+- [Readable][] - `v::readable()->assert('/path/to/file.txt');`
+- [Regex][] - `v::regex('/[a-z]/')->assert('a');`
+- [ResourceType][] - `v::resourceType()->assert(fopen('/path/to/file.txt', 'r'));`
+- [Roman][] - `v::roman()->assert('IV');`
+- [ScalarVal][] - `v::scalarVal()->assert(135.0);`
+- [Size][] - `v::size('KB', v::greaterThan(1))->assert('/path/to/file');`
+- [Slug][] - `v::slug()->assert('my-wordpress-title');`
+- [Sorted][] - `v::sorted('ASC')->assert([1, 2, 3]);`
+- [Space][] - `v::space()->assert('    ');`
+- [Spaced][] - `v::spaced()->assert('foo bar');`
+- [StartsWith][] - `v::startsWith('lorem')->assert('lorem ipsum');`
+- [StringType][] - `v::stringType()->assert('hi');`
+- [StringVal][] - `v::stringVal()->assert('6');`
+- [SubdivisionCode][] - `v::subdivisionCode('BR')->assert('SP');`
+- [Subset][] - `v::subset([1, 2, 3])->assert([1, 2]);`
+- [SymbolicLink][] - `v::symbolicLink()->assert('/path/to/symbolic-link');`
+- [Templated][] - `v::templated('You must provide a valid email', v::email())->assert('foo@bar.com');`
+- [Time][] - `v::time()->assert('00:00:00');`
+- [Tld][] - `v::tld()->assert('com');`
+- [TrueVal][] - `v::trueVal()->assert(true);`
+- [Undef][] - `v::undef()->assert('');`
+- [UndefOr][] - `v::undefOr(v::alpha())->assert('');`
+- [Unique][] - `v::unique()->assert([]);`
+- [Uploaded][] - ``
+- [Uppercase][] - `v::uppercase()->assert('W3C');`
+- [Url][] - `v::url()->assert('http://example.com');`
+- [Uuid][] - `v::uuid()->assert('eb3115e5-bd16-4939-ab12-2b95745a30f3');`
+- [Version][] - `v::version()->assert('1.0.0');`
+- [VideoUrl][] - `v::videoUrl()->assert('https://player.vimeo.com/video/71787467');`
+- [Vowel][] - `v::vowel()->assert('aei');`
+- [When][] - `v::when(v::intVal(), v::positive(), v::notBlank())->assert(1);`
+- [Writable][] - `v::writable()->assert('/path/to/file');`
+- [Xdigit][] - `v::xdigit()->assert('abc123');`
+
+[All]: validators/All.md "Validates all items of the input against a given validator."
+[AllOf]: validators/AllOf.md "Will validate if all inner validators validates."
+[Alnum]: validators/Alnum.md "Validates whether the input is alphanumeric or not."
+[Alpha]: validators/Alpha.md "Validates whether the input contains only alphabetic characters. This is similar"
+[AlwaysInvalid]: validators/AlwaysInvalid.md "Validates any input as invalid."
+[AlwaysValid]: validators/AlwaysValid.md "Validates any input as valid."
+[AnyOf]: validators/AnyOf.md "This is a group validator that acts as an OR operator."
+[ArrayType]: validators/ArrayType.md "Validates whether the type of an input is array."
+[ArrayVal]: validators/ArrayVal.md "Validates if the input is an array or if the input can be used as an array"
+[Attributes]: validators/Attributes.md "Validates the PHP attributes defined in the properties of the input."
+[Base]: validators/Base.md "Validate numbers in any base, even with non regular bases."
+[Base64]: validators/Base64.md "Validate if a string is Base64-encoded."
+[Between]: validators/Between.md "Validates whether the input is between two other values."
+[BetweenExclusive]: validators/BetweenExclusive.md "Validates whether the input is between two other values, exclusively."
+[Blank]: validators/Blank.md "Validates if the given input is a blank value (`null`, zeros, empty strings or empty arrays, recursively)."
+[BoolType]: validators/BoolType.md "Validates whether the type of the input is boolean."
+[BoolVal]: validators/BoolVal.md "Validates if the input results in a boolean value:"
+[Bsn]: validators/Bsn.md "Validates a Dutch citizen service number (BSN)."
+[Call]: validators/Call.md "Validates the return of a callable for a given input."
+[CallableType]: validators/CallableType.md "Validates whether the pseudo-type of the input is callable."
+[Callback]: validators/Callback.md "Validates the input using the return of a given callable."
+[Charset]: validators/Charset.md "Validates if a string is in a specific charset."
+[Circuit]: validators/Circuit.md "Validates the input against a series of validators until the first fails."
+[Cnh]: validators/Cnh.md "Validates a Brazilian driver's license."
+[Cnpj]: validators/Cnpj.md "Validates if the input is a Brazilian National Registry of Legal Entities (CNPJ) number."
+[Consonant]: validators/Consonant.md "Validates if the input contains only consonants."
+[Contains]: validators/Contains.md "Validates if the input contains some value."
+[ContainsAny]: validators/ContainsAny.md "Validates if the input contains at least one of defined values"
+[ContainsCount]: validators/ContainsCount.md "Validates if the input contains a value a specific number of times."
+[Control]: validators/Control.md "Validates if all of the characters in the provided string, are control"
+[Countable]: validators/Countable.md "Validates if the input is countable, in other words, if you're allowed to use"
+[CountryCode]: validators/CountryCode.md "Validates whether the input is a country code in ISO 3166-1 standard."
+[Cpf]: validators/Cpf.md "Validates a Brazillian CPF number."
+[CreditCard]: validators/CreditCard.md "Validates a credit card number."
+[CurrencyCode]: validators/CurrencyCode.md "Validates an ISO 4217 currency code."
+[Date]: validators/Date.md "Validates if input is a date. The `$format` argument should be in accordance to"
+[DateTime]: validators/DateTime.md "Validates whether an input is a date/time or not."
+[DateTimeDiff]: validators/DateTimeDiff.md "Validates the difference of date/time against a specific validator."
+[Decimal]: validators/Decimal.md "Validates whether the input matches the expected number of decimals."
+[Digit]: validators/Digit.md "Validates whether the input contains only digits."
+[Directory]: validators/Directory.md "Validates if the given path is a directory."
+[Domain]: validators/Domain.md "Validates whether the input is a valid domain name or not."
+[Each]: validators/Each.md "Validates whether each value in the input is valid according to another validator."
+[Email]: validators/Email.md "Validates an email address."
+[Emoji]: validators/Emoji.md "Validates if the input is an emoji or a sequence of emojis."
+[EndsWith]: validators/EndsWith.md "This validator is similar to `Contains()`, but validates"
+[Equals]: validators/Equals.md "Validates if the input is equal to some value."
+[Equivalent]: validators/Equivalent.md "Validates if the input is equivalent to some value."
+[Even]: validators/Even.md "Validates whether the input is an even number or not."
+[Executable]: validators/Executable.md "Validates if a file is an executable."
+[Exists]: validators/Exists.md "Validates files or directories."
+[Extension]: validators/Extension.md "Validates if the file extension matches the expected one:"
+[Factor]: validators/Factor.md "Validates if the input is a factor of the defined dividend."
+[FalseVal]: validators/FalseVal.md "Validates if a value is considered as `false`."
+[Falsy]: validators/Falsy.md "Validates whether the given input is considered empty or falsy, similar to PHP's `empty()` function."
+[Fibonacci]: validators/Fibonacci.md "Validates whether the input follows the Fibonacci integer sequence."
+[File]: validators/File.md "Validates whether file input is as a regular filename."
+[FilterVar]: validators/FilterVar.md "Validates the input with the PHP's filter_var() function."
+[Finite]: validators/Finite.md "Validates if the input is a finite number."
+[FloatType]: validators/FloatType.md "Validates whether the type of the input is float."
+[FloatVal]: validators/FloatVal.md "Validate whether the input value is float."
+[Graph]: validators/Graph.md "Validates if all characters in the input are printable and actually creates"
+[GreaterThan]: validators/GreaterThan.md "Validates whether the input is greater than a value."
+[GreaterThanOrEqual]: validators/GreaterThanOrEqual.md "Validates whether the input is greater than or equal to a value."
+[Hetu]: validators/Hetu.md "Validates a Finnish personal identity code (HETU)."
+[HexRgbColor]: validators/HexRgbColor.md "Validates weather the input is a hex RGB color or not."
+[Iban]: validators/Iban.md "Validates whether the input is a valid IBAN (International Bank Account"
+[Identical]: validators/Identical.md "Validates if the input is identical to some value."
+[Image]: validators/Image.md "Validates if the file is a valid image by checking its MIME type."
+[Imei]: validators/Imei.md "Validates is the input is a valid IMEI."
+[In]: validators/In.md "Validates if the input is contained in a specific haystack."
+[Infinite]: validators/Infinite.md "Validates if the input is an infinite number."
+[Instance]: validators/Instance.md "Validates if the input is an instance of the given class or interface."
+[IntType]: validators/IntType.md "Validates whether the type of the input is integer."
+[IntVal]: validators/IntVal.md "Validates if the input is an integer, allowing leading zeros and other number bases."
+[Ip]: validators/Ip.md "Validates whether the input is a valid IP address."
+[Isbn]: validators/Isbn.md "Validates whether the input is a valid ISBN or not."
+[IterableType]: validators/IterableType.md "Validates whether the input is iterable, meaning that it matches the built-in compile time type alias `iterable`."
+[IterableVal]: validators/IterableVal.md "Validates whether the input is an iterable value, in other words, if you can iterate over it with the foreach language construct."
+[Json]: validators/Json.md "Validates if the given input is a valid JSON."
+[Key]: validators/Key.md "Validates the value of an array against a given validator."
+[KeyExists]: validators/KeyExists.md "Validates if the given key exists in an array."
+[KeyOptional]: validators/KeyOptional.md "Validates the value of an array against a given validator when the key exists."
+[KeySet]: validators/KeySet.md "Validates a keys in a defined structure."
+[LanguageCode]: validators/LanguageCode.md "Validates whether the input is language code based on ISO 639."
+[Lazy]: validators/Lazy.md "Validates the input using a validator that is created from a callback."
+[LeapDate]: validators/LeapDate.md "Validates if a date is leap."
+[LeapYear]: validators/LeapYear.md "Validates if a year is leap."
+[Length]: validators/Length.md "Validates the length of the given input against a given validator."
+[LessThan]: validators/LessThan.md "Validates whether the input is less than a value."
+[LessThanOrEqual]: validators/LessThanOrEqual.md "Validates whether the input is less than or equal to a value."
+[Lowercase]: validators/Lowercase.md "Validates whether the characters in the input are lowercase."
+[Luhn]: validators/Luhn.md "Validate whether a given input is a Luhn number."
+[MacAddress]: validators/MacAddress.md "Validates whether the input is a valid MAC address."
+[Max]: validators/Max.md "Validates the maximum value of the input against a given validator."
+[Mimetype]: validators/Mimetype.md "Validates if the input is a file and if its MIME type matches the expected one."
+[Min]: validators/Min.md "Validates the minimum value of the input against a given validator."
+[Multiple]: validators/Multiple.md "Validates if the input is a multiple of the given parameter"
+[Named]: validators/Named.md "Validates the input with the given validator, and uses the custom name in the error message."
+[Negative]: validators/Negative.md "Validates whether the input is a negative number."
+[NfeAccessKey]: validators/NfeAccessKey.md "Validates the access key of the Brazilian electronic invoice (NFe)."
+[Nif]: validators/Nif.md "Validates Spain's fiscal identification number (NIF)."
+[Nip]: validators/Nip.md "Validates whether the input is a Polish VAT identification number (NIP)."
+[NoneOf]: validators/NoneOf.md "Validates if NONE of the given validators validate:"
+[Not]: validators/Not.md "Negates any validator."
+[NullOr]: validators/NullOr.md "Validates the input using a defined validator when the input is not `null`."
+[NullType]: validators/NullType.md "Validates whether the input is null."
+[Number]: validators/Number.md "Validates if the input is a number."
+[NumericVal]: validators/NumericVal.md "Validates whether the input is numeric."
+[ObjectType]: validators/ObjectType.md "Validates whether the input is an object."
+[Odd]: validators/Odd.md "Validates whether the input is an odd number or not."
+[OneOf]: validators/OneOf.md "Will validate if exactly one inner validator passes."
+[PerfectSquare]: validators/PerfectSquare.md "Validates whether the input is a perfect square."
+[Pesel]: validators/Pesel.md "Validates PESEL (Polish human identification number)."
+[Phone]: validators/Phone.md "Validates whether the input is a valid phone number. This validator requires"
+[PhpLabel]: validators/PhpLabel.md "Validates if a value is considered a valid PHP Label,"
+[Pis]: validators/Pis.md "Validates a Brazilian PIS/NIS number ignoring any non-digit char."
+[PolishIdCard]: validators/PolishIdCard.md "Validates whether the input is a Polish identity card (Dowód Osobisty)."
+[PortugueseNif]: validators/PortugueseNif.md "Validates Portugal's fiscal identification number (NIF)."
+[Positive]: validators/Positive.md "Validates whether the input is a positive number."
+[PostalCode]: validators/PostalCode.md "Validates whether the input is a valid postal code or not."
+[PrimeNumber]: validators/PrimeNumber.md "Validates a prime number"
+[Printable]: validators/Printable.md "Similar to `Graph` but accepts whitespace."
+[Property]: validators/Property.md "Validates an object property against a given validator."
+[PropertyExists]: validators/PropertyExists.md "Validates if an object property exists."
+[PropertyOptional]: validators/PropertyOptional.md "Validates an object property against a given validator only if the property exists."
+[PublicDomainSuffix]: validators/PublicDomainSuffix.md "Validates whether the input is a public ICANN domain suffix."
+[Punct]: validators/Punct.md "Validates whether the input composed by only punctuation characters."
+[Readable]: validators/Readable.md "Validates if the given data is a file exists and is readable."
+[Regex]: validators/Regex.md "Validates whether the input matches a defined regular expression."
+[ResourceType]: validators/ResourceType.md "Validates whether the input is a resource."
+[Roman]: validators/Roman.md "Validates if the input is a Roman numeral."
+[ScalarVal]: validators/ScalarVal.md "Validates whether the input is a scalar value or not."
+[Size]: validators/Size.md "Validates whether the input is a file that is of a certain size or not."
+[Slug]: validators/Slug.md "Validates whether the input is a valid slug."
+[Sorted]: validators/Sorted.md "Validates whether the input is sorted in a certain order or not."
+[Space]: validators/Space.md "Validates whether the input contains only whitespaces characters."
+[Spaced]: validators/Spaced.md "Validates if a string contains at least one whitespace (spaces, tabs, or line breaks);"
+[StartsWith]: validators/StartsWith.md "Validates whether the input starts with a given value."
+[StringType]: validators/StringType.md "Validates whether the type of an input is string or not."
+[StringVal]: validators/StringVal.md "Validates whether the input can be used as a string."
+[SubdivisionCode]: validators/SubdivisionCode.md "Validates subdivision country codes according to ISO 3166-2."
+[Subset]: validators/Subset.md "Validates whether the input is a subset of a given value."
+[SymbolicLink]: validators/SymbolicLink.md "Validates if the given input is a symbolic link."
+[Templated]: validators/Templated.md "Defines a validator with a custom message template."
+[Time]: validators/Time.md "Validates whether an input is a time or not. The `$format` argument should be in"
+[Tld]: validators/Tld.md "Validates whether the input is a top-level domain."
+[TrueVal]: validators/TrueVal.md "Validates if a value is considered as `true`."
+[Undef]: validators/Undef.md "Validates if the given input is undefined. By _undefined_ we consider `null` or an empty string (`''`)."
+[UndefOr]: validators/UndefOr.md "Validates the input using a defined validator when the input is not `null` or an empty string (`''`)."
+[Unique]: validators/Unique.md "Validates whether the input array contains only unique values."
+[Uploaded]: validators/Uploaded.md "Validates if the given data is a file that was uploaded via HTTP POST."
+[Uppercase]: validators/Uppercase.md "Validates whether the characters in the input are uppercase."
+[Url]: validators/Url.md "Validates whether the input is a URL."
+[Uuid]: validators/Uuid.md "Validates whether the input is a valid UUID. It also supports validation of"
+[Version]: validators/Version.md "Validates version numbers using Semantic Versioning."
+[VideoUrl]: validators/VideoUrl.md "Validates if the input is a video URL value."
+[Vowel]: validators/Vowel.md "Validates whether the input contains only vowels."
+[When]: validators/When.md "A ternary validator that accepts three parameters."
+[Writable]: validators/Writable.md "Validates if the given input is writable file."
+[Xdigit]: validators/Xdigit.md "Validates whether the input is an hexadecimal number or not."

--- a/docs/validators/Alnum.md
+++ b/docs/validators/Alnum.md
@@ -14,11 +14,11 @@ Alphanumeric is a combination of alphabetic (a-z and A-Z) and numeric (0-9)
 characters.
 
 ```php
-v::alnum()->assert('foo 123');
-// → "foo 123" must contain only letters (a-z) and digits (0-9)
-
 v::alnum(' ')->assert('foo 123');
 // Validation passes successfully
+
+v::alnum()->assert('foo 123');
+// → "foo 123" must contain only letters (a-z) and digits (0-9)
 
 v::alnum()->assert('100%');
 // → "100%" must contain only letters (a-z) and digits (0-9)

--- a/docs/validators/Alpha.md
+++ b/docs/validators/Alpha.md
@@ -12,11 +12,11 @@ Validates whether the input contains only alphabetic characters. This is similar
 to [Alnum](Alnum.md), but it does not allow numbers.
 
 ```php
-v::alpha()->assert('some name');
-// → "some name" must contain only letters (a-z)
-
 v::alpha(' ')->assert('some name');
 // Validation passes successfully
+
+v::alpha()->assert('some name');
+// → "some name" must contain only letters (a-z)
 
 v::alpha()->assert('Cedric-Fabian');
 // → "Cedric-Fabian" must contain only letters (a-z)

--- a/docs/validators/AlwaysInvalid.md
+++ b/docs/validators/AlwaysInvalid.md
@@ -10,6 +10,9 @@ SPDX-License-Identifier: MIT
 Validates any input as invalid.
 
 ```php
+v::not(v::alwaysInvalid())->assert('whatever');
+// Validation passes successfully
+
 v::alwaysInvalid()->assert('whatever');
 // → "whatever" must be valid
 ```

--- a/docs/validators/BetweenExclusive.md
+++ b/docs/validators/BetweenExclusive.md
@@ -10,11 +10,11 @@ SPDX-License-Identifier: MIT
 Validates whether the input is between two other values, exclusively.
 
 ```php
-v::betweenExclusive(10, 20)->assert(10);
-// → 10 must be greater than 10 and less than 20
-
 v::betweenExclusive('a', 'e')->assert('c');
 // Validation passes successfully
+
+v::betweenExclusive(10, 20)->assert(10);
+// → 10 must be greater than 10 and less than 20
 
 v::betweenExclusive(new DateTime('yesterday'), new DateTime('tomorrow'))->assert(new DateTime('today'));
 // Validation passes successfully

--- a/docs/validators/Call.md
+++ b/docs/validators/Call.md
@@ -9,6 +9,11 @@ SPDX-License-Identifier: MIT
 
 Validates the return of a [callable][] for a given input.
 
+```php
+v::call(str_split(...), v::arrayType()->lengthEquals(5))->assert('world');
+// Validation passes successfully
+```
+
 Consider the following variable:
 
 ```php

--- a/docs/validators/Callback.md
+++ b/docs/validators/Callback.md
@@ -11,9 +11,7 @@ SPDX-License-Identifier: MIT
 Validates the input using the return of a given callable.
 
 ```php
-v::callback(
-    fn (int $input): bool => $input + ($input / 2) == 15,
-)->assert(10);
+v::callback(fn (int $input): bool => $input % 5 === 0,)->assert(10);
 // Validation passes successfully
 ```
 

--- a/docs/validators/Charset.md
+++ b/docs/validators/Charset.md
@@ -11,11 +11,11 @@ SPDX-License-Identifier: MIT
 Validates if a string is in a specific charset.
 
 ```php
-v::charset('ASCII')->assert('açúcar');
-// → "açúcar" must only contain characters from the `["ASCII"]` charset
-
 v::charset('ASCII')->assert('sugar');
 // Validation passes successfully
+
+v::charset('ASCII')->assert('açúcar');
+// → "açúcar" must only contain characters from the `["ASCII"]` charset
 
 v::charset('ISO-8859-1', 'EUC-JP')->assert('日本国');
 // Validation passes successfully

--- a/docs/validators/Circuit.md
+++ b/docs/validators/Circuit.md
@@ -10,6 +10,11 @@ SPDX-License-Identifier: MIT
 
 Validates the input against a series of validators until the first fails.
 
+```php
+v::circuit(v::intVal(), v::floatVal())->assert(15);
+// Validation passes successfully
+```
+
 This validator can be handy for getting the least error messages possible from a chain.
 
 This validator can be helpful in combinations with [Lazy](Lazy.md). An excellent example is when you want to validate a

--- a/docs/validators/Cnpj.md
+++ b/docs/validators/Cnpj.md
@@ -10,6 +10,11 @@ SPDX-License-Identifier: MIT
 Validates if the input is a Brazilian National Registry of Legal Entities (CNPJ) number.
 Ignores non-digit chars, so use `->digit()` if needed.
 
+```php
+v::cnpj()->assert('00394460005887');
+// Validation passes successfully
+```
+
 ## Templates
 
 ### `Cnpj::TEMPLATE_STANDARD`

--- a/docs/validators/Cpf.md
+++ b/docs/validators/Cpf.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 Validates a Brazillian CPF number.
 
 ```php
-v::cpf()->assert('11598647644');
+v::cpf()->assert('95574461102');
 // Validation passes successfully
 ```
 

--- a/docs/validators/DateTimeDiff.md
+++ b/docs/validators/DateTimeDiff.md
@@ -15,14 +15,14 @@ The `$format` argument should follow PHP's [date()][] function. When the `$forma
 [Supported Date and Time Formats][] by PHP (see [strtotime()][]).
 
 ```php
+v::dateTimeDiff('years', v::greaterThan(18), 'd/m/Y')->assert('09/12/1990');
+// Validation passes successfully
+
 v::dateTimeDiff('years', v::equals(7))->assert('7 years ago');
 // → The number of years between now and "7 years ago" must be equal to 7
 
 v::dateTimeDiff('years', v::equals(7))->assert('7 years ago + 1 minute');
 // → The number of years between now and "7 years ago + 1 minute" must be equal to 7
-
-v::dateTimeDiff('years', v::greaterThan(18), 'd/m/Y')->assert('09/12/1990');
-// Validation passes successfully
 
 v::dateTimeDiff('years', v::greaterThan(18), 'd/m/Y')->assert('09/12/2023');
 // → The number of years between "01/01/2024" and "09/12/2023" must be greater than 18

--- a/docs/validators/Digit.md
+++ b/docs/validators/Digit.md
@@ -11,11 +11,11 @@ SPDX-License-Identifier: MIT
 Validates whether the input contains only digits.
 
 ```php
-v::digit()->assert('020 612 1851');
-// → "020 612 1851" must contain only digits (0-9)
-
 v::digit(' ')->assert('020 612 1851');
 // Validation passes successfully
+
+v::digit()->assert('020 612 1851');
+// → "020 612 1851" must contain only digits (0-9)
 
 v::digit()->assert('172.655.537-21');
 // → "172.655.537-21" must contain only digits (0-9)

--- a/docs/validators/Executable.md
+++ b/docs/validators/Executable.md
@@ -10,11 +10,11 @@ SPDX-License-Identifier: MIT
 Validates if a file is an executable.
 
 ```php
-v::executable()->assert('/path/to/file');
-// → "/path/to/file" must be an executable file
-
 v::executable()->assert('/path/to/executable');
 // Validation passes successfully
+
+v::executable()->assert('/path/to/file');
+// → "/path/to/file" must be an executable file
 ```
 
 ## Templates

--- a/docs/validators/GreaterThanOrEqual.md
+++ b/docs/validators/GreaterThanOrEqual.md
@@ -10,11 +10,11 @@ SPDX-License-Identifier: MIT
 Validates whether the input is greater than or equal to a value.
 
 ```php
-v::intVal()->greaterThanOrEqual(10)->assert(9);
-// → 9 must be greater than or equal to 10
-
 v::intVal()->greaterThanOrEqual(10)->assert(10);
 // Validation passes successfully
+
+v::intVal()->greaterThanOrEqual(10)->assert(9);
+// → 9 must be greater than or equal to 10
 
 v::intVal()->greaterThanOrEqual(10)->assert(11);
 // Validation passes successfully

--- a/docs/validators/KeySet.md
+++ b/docs/validators/KeySet.md
@@ -11,6 +11,9 @@ SPDX-License-Identifier: MIT
 Validates a keys in a defined structure.
 
 ```php
+v::keySet(v::key('foo', v::intVal()))->assert(['foo' => 42]);
+// Validation passes successfully
+
 v::keySet(
     v::keyExists('foo'),
     v::keyExists('bar')
@@ -21,11 +24,6 @@ v::keySet(
 It will validate the keys in the array with the validators passed in the constructor.
 
 ```php
-v::keySet(
-    v::key('foo', v::intVal())
-)->assert(['foo' => 42]);
-// Validation passes successfully
-
 v::keySet(
     v::key('foo', v::intVal())
 )->assert(['foo' => 'string']);

--- a/docs/validators/Lazy.md
+++ b/docs/validators/Lazy.md
@@ -9,6 +9,11 @@ SPDX-License-Identifier: MIT
 
 Validates the input using a validator that is created from a callback.
 
+```php
+v::lazy(static fn($input) => v::boolVal())->assert(true);
+// Validation passes successfully
+```
+
 This validator is particularly useful when creating validators that rely on the input. A good example is validating whether a
 `confirmation` field matches the `password` field when processing data from a form.
 

--- a/docs/validators/Named.md
+++ b/docs/validators/Named.md
@@ -10,6 +10,9 @@ SPDX-License-Identifier: MIT
 Validates the input with the given validator, and uses the custom name in the error message.
 
 ```php
+v::named('Your email', v::email())->assert('foo@example.com');
+// Validation passes successfully
+
 v::named('Your email', v::email())->assert('not an email');
 // → Your email must be a valid email address
 ```

--- a/docs/validators/NfeAccessKey.md
+++ b/docs/validators/NfeAccessKey.md
@@ -10,6 +10,9 @@ SPDX-License-Identifier: MIT
 Validates the access key of the Brazilian electronic invoice (NFe).
 
 ```php
+v::nfeAccessKey()->assert('52060433009911002506550120000007800267301615');
+// Validation passes successfully
+
 v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906');
 // → "31841136830118868211870485416765268625116906" must be a valid NFe access key
 ```

--- a/docs/validators/Odd.md
+++ b/docs/validators/Odd.md
@@ -10,11 +10,11 @@ SPDX-License-Identifier: MIT
 Validates whether the input is an odd number or not.
 
 ```php
-v::odd()->assert(0);
-// → 0 must be an odd number
-
 v::odd()->assert(3);
 // Validation passes successfully
+
+v::odd()->assert(0);
+// → 0 must be an odd number
 ```
 
 Using `intVal()` before `odd()` is a best practice.

--- a/docs/validators/ScalarVal.md
+++ b/docs/validators/ScalarVal.md
@@ -10,11 +10,11 @@ SPDX-License-Identifier: MIT
 Validates whether the input is a scalar value or not.
 
 ```php
-v::scalarVal()->assert([]);
-// → `[]` must be a scalar value
-
 v::scalarVal()->assert(135.0);
 // Validation passes successfully
+
+v::scalarVal()->assert([]);
+// → `[]` must be a scalar value
 ```
 
 ## Templates

--- a/docs/validators/Templated.md
+++ b/docs/validators/Templated.md
@@ -11,8 +11,11 @@ SPDX-License-Identifier: MIT
 Defines a validator with a custom message template.
 
 ```php
-v::templated('You must provide a valid email to signup', v::email())->assert('not an email');
-// → You must provide a valid email to signup
+v::templated('You must provide a valid email', v::email())->assert('foo@bar.com');
+// Validation passes successfully
+
+v::templated('You must provide a valid email', v::email())->assert('not an email');
+// → You must provide a valid email
 
 v::templated(
     'The author of the page {{title}} is empty, please fill it up.',

--- a/docs/validators/Uploaded.md
+++ b/docs/validators/Uploaded.md
@@ -9,11 +9,6 @@ SPDX-License-Identifier: MIT
 
 Validates if the given data is a file that was uploaded via HTTP POST.
 
-```php
-v::uploaded()->assert('/path/of/an/uploaded/file');
-// → "/path/of/an/uploaded/file" must be an uploaded file
-```
-
 ## Templates
 
 ### `Uploaded::TEMPLATE_STANDARD`

--- a/docs/validators/Uuid.md
+++ b/docs/validators/Uuid.md
@@ -12,11 +12,11 @@ Validates whether the input is a valid UUID. It also supports validation of
 specific versions 1 to 8.
 
 ```php
-v::uuid()->assert('Hello World!');
-// → "Hello World!" must be a valid UUID
-
 v::uuid()->assert('eb3115e5-bd16-4939-ab12-2b95745a30f3');
 // Validation passes successfully
+
+v::uuid()->assert('Hello World!');
+// → "Hello World!" must be a valid UUID
 
 v::uuid()->assert('eb3115e5bd164939ab122b95745a30f3');
 // Validation passes successfully

--- a/src-dev/Markdown/Content.php
+++ b/src-dev/Markdown/Content.php
@@ -25,6 +25,7 @@ use function file_get_contents;
 use function implode;
 use function max;
 use function preg_match;
+use function preg_replace;
 use function reset;
 use function rtrim;
 use function sprintf;
@@ -111,6 +112,14 @@ final class Content implements IteratorAggregate
         $this->listItem(sprintf('[%s](%s)', $title, $href));
     }
 
+    public function reference(string $title, string $href, string|null $description = null): void
+    {
+        $this->lines[] = match ($description) {
+            null => sprintf('[%s]: %s', $title, $href),
+            default => sprintf('[%s]: %s "%s"', $title, $href, $description),
+        };
+    }
+
     public function extractSpdx(): self
     {
         $start = 0;
@@ -128,6 +137,11 @@ final class Content implements IteratorAggregate
         }
 
         return new self(array_slice($this->lines, $start, $end + 2));
+    }
+
+    public static function stripRefs(string $text): string
+    {
+        return preg_replace('/\[(.+?)\](?:\[\]|\(.+?\))/', '$1', $text) ?? $text;
     }
 
     public function withSection(Content $content): self


### PR DESCRIPTION
Makes it so the index looks more like a cheatsheet, condensing information instead of making long lists that require lots of
scrolling to explore.

Additionally, the happy path for each validator was also added, providing a quick reference use for comparison.

The direct markdown links were replaced by titled markdown references, offering mouse-over tooltips over links that
display the validator one-line description.

To ensure a proper source of truth for these new index goodies, the AssertionMessageLinter was modified to verify that the first assertion in each doc is a single-line validator that passes (a happy path), further making our documentation conventions more solid.

---

### Cheatsheet-style and tooltips on mouse-over

<img width="1143" height="522" alt="image" src="https://github.com/user-attachments/assets/d9d88534-99cf-4d06-b5b7-44f549a87cc0" />

### Alphabetical list with happy path examples

<img width="1102" height="525" alt="image" src="https://github.com/user-attachments/assets/f006b73a-6f51-4da6-8aee-c3aa740db58b" />

### Plain text

Viewing the document in plain-text gives almost the same feeling as the rendered markdown, respecting the true spirit of the format.

<img width="1106" height="515" alt="image" src="https://github.com/user-attachments/assets/c1b6a968-8438-48f5-a680-c90336756e91" />
