### PR TITLE
Make ValidatorBuilder::isValid fail fast implicitly

### DIFF
--- a/src/IsValid.php
+++ b/src/IsValid.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation;
+
+interface IsValid extends Validator
+{
+    public function isValid(mixed $input): bool;
+}

--- a/src/Validators/AllOf.php
+++ b/src/Validators/AllOf.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Validation\IsValid;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -36,7 +37,7 @@ use function count;
     '{{subject}} must pass all the rules',
     self::TEMPLATE_ALL,
 )]
-final class AllOf extends Composite
+final class AllOf extends Composite implements IsValid
 {
     public const string TEMPLATE_ALL = '__all__';
     public const string TEMPLATE_SOME = '__some__';
@@ -52,5 +53,20 @@ final class AllOf extends Composite
         }
 
         return Result::of($valid, $input, $this, [], $template)->withChildren(...$children);
+    }
+
+    public function isValid(mixed $input): bool
+    {
+        foreach ($this->validators as $validator) {
+            if ($validator instanceof IsValid) {
+                return $validator->isValid($input);
+            }
+
+            if (!$validator->evaluate($input)->hasPassed) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Validators/AnyOf.php
+++ b/src/Validators/AnyOf.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Validation\IsValid;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -28,7 +29,7 @@ use function array_reduce;
     '{{subject}} must pass at least one of the rules',
     '{{subject}} must pass at least one of the rules',
 )]
-final class AnyOf extends Composite
+final class AnyOf extends Composite implements IsValid
 {
     public function evaluate(mixed $input): Result
     {
@@ -40,5 +41,24 @@ final class AnyOf extends Composite
         );
 
         return Result::of($valid, $input, $this)->withChildren(...$children);
+    }
+
+    public function isValid(mixed $input): bool
+    {
+        foreach ($this->validators as $validator) {
+            if ($validator instanceof IsValid) {
+                if ($validator->isValid($input)) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if ($validator->evaluate($input)->hasPassed) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/benchmark/CompositeValidatorsBench.php
+++ b/tests/benchmark/CompositeValidatorsBench.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Benchmarks;
+
+use Generator;
+use PhpBench\Attributes as Bench;
+use Respect\Validation\Validator;
+use Respect\Validation\ValidatorBuilder;
+use Respect\Validation\Validators\Alnum;
+use Respect\Validation\Validators\Alpha;
+use Respect\Validation\Validators\BoolType;
+use Respect\Validation\Validators\Digit;
+use Respect\Validation\Validators\Even;
+use Respect\Validation\Validators\FloatType;
+use Respect\Validation\Validators\IntType;
+use Respect\Validation\Validators\Negative;
+use Respect\Validation\Validators\Positive;
+use Respect\Validation\Validators\StringType;
+
+final class CompositeValidatorsBench
+{
+    /** @param array{string, array<Validator>} $params */
+    #[Bench\ParamProviders(['provideValidatorBuilder'])]
+    #[Bench\Iterations(5)]
+    #[Bench\Revs(50)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function isValid(array $params): void
+    {
+        ValidatorBuilder::__callStatic(...$params)->isValid(42);
+    }
+
+    public function provideValidatorBuilder(): Generator
+    {
+        yield 'allOf(10)' => ['allOf', $this->buildValidators(10)];
+        yield 'oneOf(10)' => ['oneOf', $this->buildValidators(10)];
+        yield 'anyOf(10)' => ['anyOf', $this->buildValidators(10)];
+        yield 'noneOf(10)' => ['noneOf', $this->buildValidators(10)];
+        yield 'allOf(100)' => ['allOf', $this->buildValidators(100)];
+        yield 'oneOf(100)' => ['oneOf', $this->buildValidators(100)];
+        yield 'anyOf(100)' => ['anyOf', $this->buildValidators(100)];
+        yield 'noneOf(100)' => ['noneOf', $this->buildValidators(100)];
+    }
+
+    /** @return array<Validator> */
+    private function buildValidators(int $count): array
+    {
+        $validators = [];
+        for ($i = 0; $i < $count; $i++) {
+            $validators[] = $this->makeValidator($i);
+        }
+
+        return $validators;
+    }
+
+    private function makeValidator(int $index): Validator
+    {
+        return match ($index % 10) {
+            0 => new IntType(),
+            1 => new Positive(),
+            2 => new Negative(),
+            3 => new Even(),
+            4 => new FloatType(),
+            5 => new StringType(),
+            6 => new Alpha(),
+            7 => new Alnum(),
+            8 => new Digit(),
+            default => new BoolType(),
+        };
+    }
+}

--- a/tests/unit/ValidatorBuilderTest.php
+++ b/tests/unit/ValidatorBuilderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\Exceptions\ComponentException;
+use Respect\Validation\Test\TestCase;
+use Respect\Validation\Test\Validators\Stub;
+use Respect\Validation\Validators\AllOf;
+
+#[Group('validator')]
+#[CoversClass(ValidatorBuilder::class)]
+final class ValidatorBuilderTest extends TestCase
+{
+    #[Test]
+    public function shouldDelegateToIsValidWhenSingleValidatorInBuilder(): void
+    {
+        $builder = ValidatorBuilder::init(new AllOf(Stub::pass(1), Stub::pass(1)));
+
+        self::assertTrue($builder->isValid([]));
+    }
+
+    #[Test]
+    public function shouldCallIsValidOnCombinedIsValidWhenMultipleValidatorsExist(): void
+    {
+        $builder = ValidatorBuilder::init(
+            Stub::pass(1),
+            Stub::pass(1),
+            Stub::pass(1),
+            Stub::fail(1),
+        );
+
+        self::assertFalse($builder->isValid([]));
+    }
+
+    #[Test]
+    public function shouldThrowComponentExceptionWhenNoValidatorsExist(): void
+    {
+        $this->expectException(ComponentException::class);
+
+        ValidatorBuilder::init()->isValid([]);
+    }
+}

--- a/tests/unit/Validators/AllOfTest.php
+++ b/tests/unit/Validators/AllOfTest.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Validators\Stub;
 
@@ -38,5 +40,33 @@ final class AllOfTest extends RuleTestCase
         yield 'pass, pass, fail' => [new AllOf(Stub::pass(1), Stub::pass(1), Stub::fail(1)), []];
         yield 'pass, fail, pass' => [new AllOf(Stub::pass(1), Stub::fail(1), Stub::pass(1)), []];
         yield 'fail, pass, pass' => [new AllOf(Stub::fail(1), Stub::pass(1), Stub::pass(1)), []];
+    }
+
+    #[Test]
+    #[DataProvider('providerForValidInput')]
+    public function isValid(AllOf $allOf, mixed $input): void
+    {
+        self::assertTrue($allOf->isValid($input));
+    }
+
+    #[Test]
+    #[DataProvider('providerForInvalidInput')]
+    public function notIsValid(AllOf $allOf, mixed $input): void
+    {
+        self::assertFalse($allOf->isValid($input));
+    }
+
+    #[Test]
+    public function shouldRecursivelyCheckIsValid(): void
+    {
+        $validator = new AllOf(
+            new AllOf(
+                Stub::pass(1),
+                Stub::pass(1),
+            ),
+            Stub::pass(1),
+        );
+
+        self::assertTrue($validator->isValid('any input'));
     }
 }

--- a/tests/unit/Validators/AnyOfTest.php
+++ b/tests/unit/Validators/AnyOfTest.php
@@ -18,7 +18,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Validators\Stub;
 
@@ -41,5 +43,37 @@ final class AnyOfTest extends RuleTestCase
     {
         yield 'fail, fail' => [new AnyOf(Stub::fail(1), Stub::fail(1)), []];
         yield 'fail, fail, fail' => [new AnyOf(Stub::fail(1), Stub::fail(1), Stub::fail(1)), []];
+    }
+
+    #[Test]
+    #[DataProvider('providerForValidInput')]
+    public function isValid(AnyOf $anyOf, mixed $input): void
+    {
+        self::assertTrue($anyOf->isValid($input));
+    }
+
+    #[Test]
+    #[DataProvider('providerForInvalidInput')]
+    public function notIsValid(AnyOf $anyOf, mixed $input): void
+    {
+        self::assertFalse($anyOf->isValid($input));
+    }
+
+    #[Test]
+    public function shouldRecursivelyCheckIsValid(): void
+    {
+        $validator = new AnyOf(
+            new AllOf(
+                Stub::pass(2),
+                Stub::fail(2),
+            ),
+            new AnyOf(
+                Stub::fail(2),
+                Stub::pass(2),
+            ),
+            Stub::fail(1),
+        );
+
+        self::assertTrue($validator->isValid('any value'));
     }
 }

--- a/tests/unit/Validators/NoneOfTest.php
+++ b/tests/unit/Validators/NoneOfTest.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Validators\Stub;
 
@@ -38,5 +40,33 @@ final class NoneOfTest extends RuleTestCase
         yield 'pass, pass, fail' => [new NoneOf(Stub::pass(1), Stub::pass(1), Stub::fail(1)), []];
         yield 'pass, fail, pass' => [new NoneOf(Stub::pass(1), Stub::fail(1), Stub::pass(1)), []];
         yield 'fail, pass, pass' => [new NoneOf(Stub::fail(1), Stub::pass(1), Stub::pass(1)), []];
+    }
+
+    #[Test]
+    #[DataProvider('providerForValidInput')]
+    public function isValid(NoneOf $noneOf, mixed $input): void
+    {
+        self::assertTrue($noneOf->isValid($input));
+    }
+
+    #[Test]
+    #[DataProvider('providerForInvalidInput')]
+    public function notIsValid(NoneOf $noneOf, mixed $input): void
+    {
+        self::assertFalse($noneOf->isValid($input));
+    }
+
+    #[Test]
+    public function shouldRecursivelyCheckIsValid(): void
+    {
+        $validator = new NoneOf(
+            new AllOf(
+                Stub::pass(2),
+                Stub::fail(2),
+            ),
+            Stub::fail(1),
+        );
+
+        self::assertTrue($validator->isValid('any value'));
     }
 }

--- a/tests/unit/Validators/OneOfTest.php
+++ b/tests/unit/Validators/OneOfTest.php
@@ -19,7 +19,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\RuleTestCase;
 use Respect\Validation\Test\Validators\Stub;
 
@@ -43,5 +45,38 @@ final class OneOfTest extends RuleTestCase
         yield 'fail, fail' => [new OneOf(Stub::fail(1), Stub::fail(1)), []];
         yield 'fail, fail, fail' => [new OneOf(Stub::fail(1), Stub::fail(1), Stub::fail(1)), []];
         yield 'fail, pass, pass' => [new OneOf(Stub::fail(1), Stub::pass(1), Stub::pass(1)), []];
+        yield 'pass, pass, fail' => [new OneOf(Stub::pass(1), Stub::pass(1), Stub::fail(1)), []];
+    }
+
+    #[Test]
+    #[DataProvider('providerForValidInput')]
+    public function isValid(OneOf $oneOf, mixed $input): void
+    {
+        self::assertTrue($oneOf->isValid($input));
+    }
+
+    #[Test]
+    #[DataProvider('providerForInvalidInput')]
+    public function notIsValid(OneOf $oneOf, mixed $input): void
+    {
+        self::assertFalse($oneOf->isValid($input));
+    }
+
+    #[Test]
+    public function shouldRecursivelyCheckIsValid(): void
+    {
+        $validator = new OneOf(
+            new AllOf(
+                Stub::pass(2),
+                Stub::fail(2),
+            ),
+            new AnyOf(
+                Stub::fail(2),
+                Stub::pass(2),
+            ),
+            Stub::fail(1),
+        );
+
+        self::assertTrue($validator->isValid('any value'));
     }
 }


### PR DESCRIPTION
The evaluation methods of `ValidatorBuilder`, namely `evaluate` and `isValid`, are very similar.

Each of them performs a full evaluation, only differing in their return.

Whereas `evaluate` returns a full `Result` object, `isValid` only returns a boolean.

As it turns out, if the user is interested only in the boolean, we do not need to gather all `Result` data.

Here we introduce a new interface, `IsValid`, that defines a method to skip all kinds of message generation for such cases.

Fail-fast scenarios such as `isValid` can leverage early failed results to stop the chain when only a boolean is needed.

This results in 70% performance improvement for chains with 10 nodes, and the gains increase with chain size. The more nodes,
the faster this change makes. Chains with 100 nodes can gain up to 90% performance compared to the previous implementation.

A benchmark was added to ensure these gains remain in future library iterations.

Furthermore, this change is only internal and backwards-compatible, making no public interface changes that would affect how users interact with the library.

TL;DR makes ValidatorBuilder::isValid super fast.

---

### Local benchmark results

**BEFORE**
<img width="733" height="318" alt="image" src="https://github.com/user-attachments/assets/63e28d80-e4b9-4645-8ab5-6e30d22d0367" />

**AFTER**
<img width="897" height="350" alt="image" src="https://github.com/user-attachments/assets/d446c3ea-452a-4d24-ac46-7ccfb70edf9d" />
