### PR TITLE
Fixes git workspace after checking out benchmarks

### DIFF
--- a/.github/workflows/ci-perf.yml
+++ b/.github/workflows/ci-perf.yml
@@ -77,3 +77,12 @@ jobs:
           git add .phpbench latest.md
           git commit -m "Store benchmark results [skip ci]" || echo "No changes to commit"
           git push origin benchmarks
+
+      - name: Restore workspace
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "Restoring workspace to original commit: ${GITHUB_SHA}"
+          git fetch origin || true
+          git checkout --detach "${GITHUB_SHA}"
+          git reset --hard "${GITHUB_SHA}"


### PR DESCRIPTION
With the introduction of composite actions in the GitHub workflows, the ci-perf.yml workflow broke.

This happens because the setup-action configures a Post Run (a hook to be executed after the workflow).

Since the benchmarks checkout a different orphan branch, when that Post Run executes, it cannot find the action anymore.

To fix it, I introduce a new step that restores the git workspace, making it available for that hook.

---

Example failure:

https://github.com/Respect/Validation/actions/runs/21448771339/job/61772437584

<img width="1322" height="646" alt="image" src="https://github.com/user-attachments/assets/157663b7-5f2c-41b9-a272-54c83daabbcb" />
