### PR TITLE
Containerize sokil databases

### DIFF
--- a/src/Validators/Phone.php
+++ b/src/Validators/Phone.php
@@ -21,6 +21,8 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
+use Psr\Container\NotFoundExceptionInterface;
+use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
@@ -64,7 +66,9 @@ final class Phone implements Validator
             return;
         }
 
-        if (!class_exists(Countries::class)) {
+        try {
+            $countries ??= ContainerRegistry::getContainer()->get(Countries::class);
+        } catch (NotFoundExceptionInterface) {
             throw new MissingComposerDependencyException(
                 'Phone rule with country code requires PHP ISO Codes',
                 'sokil/php-isocodes',
@@ -72,7 +76,6 @@ final class Phone implements Validator
             );
         }
 
-        $countries ??= new Countries();
         $this->country = $countries->getByAlpha2($countryCode);
         if ($this->country === null) {
             throw new InvalidValidatorException('Invalid country code %s', $countryCode);

--- a/tests/benchmark/IsoCodesBench.php
+++ b/tests/benchmark/IsoCodesBench.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Benchmarks;
+
+use PhpBench\Attributes as Bench;
+use Respect\Validation\Test\SmokeTestProvider;
+use Respect\Validation\ValidatorBuilder;
+
+class IsoCodesBench
+{
+    use SmokeTestProvider;
+
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(5)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function subdivisionCode(): void
+    {
+        ValidatorBuilder::subdivisionCode('US')->evaluate('CA');
+    }
+
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(5)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function countryCode(): void
+    {
+        ValidatorBuilder::countryCode()->evaluate('US');
+    }
+
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(5)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function currencyCode(): void
+    {
+        ValidatorBuilder::currencyCode()->evaluate('USD');
+    }
+
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(5)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function languageCode(): void
+    {
+        ValidatorBuilder::languageCode()->evaluate('en');
+    }
+
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(5)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function phone(): void
+    {
+        ValidatorBuilder::phone('US')->evaluate('+1 202-555-0125');
+    }
+}

--- a/tests/unit/Validators/CountryCodeTest.php
+++ b/tests/unit/Validators/CountryCodeTest.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
+use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
+use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -34,6 +37,24 @@ final class CountryCodeTest extends RuleTestCase
 
         // @phpstan-ignore-next-line
         new CountryCode('whatever');
+    }
+
+    #[Test]
+    public function shouldThrowWhenMissingComponent(): void
+    {
+        $mainContainer = ContainerRegistry::getContainer();
+        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        try {
+            new CountryCode('alpha-3');
+            $this->fail('Expected MissingComposerDependencyException was not thrown.');
+        } catch (MissingComposerDependencyException $e) {
+            $this->assertStringContainsString(
+                'CountryCode rule requires PHP ISO Codes',
+                $e->getMessage(),
+            );
+        } finally {
+            ContainerRegistry::setContainer($mainContainer);
+        }
     }
 
     /** @return iterable<array{CountryCode, mixed}> */

--- a/tests/unit/Validators/CurrencyCodeTest.php
+++ b/tests/unit/Validators/CurrencyCodeTest.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
+use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
+use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -34,6 +37,24 @@ final class CurrencyCodeTest extends RuleTestCase
 
         // @phpstan-ignore-next-line
         new CurrencyCode('whatever');
+    }
+
+    #[Test]
+    public function shouldThrowWhenMissingComponent(): void
+    {
+        $mainContainer = ContainerRegistry::getContainer();
+        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        try {
+            new CurrencyCode('alpha-3');
+            $this->fail('Expected MissingComposerDependencyException was not thrown.');
+        } catch (MissingComposerDependencyException $e) {
+            $this->assertStringContainsString(
+                'CurrencyCode rule requires PHP ISO Codes',
+                $e->getMessage(),
+            );
+        } finally {
+            ContainerRegistry::setContainer($mainContainer);
+        }
     }
 
     /** @return iterable<array{CurrencyCode, mixed}> */

--- a/tests/unit/Validators/LanguageCodeTest.php
+++ b/tests/unit/Validators/LanguageCodeTest.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
+use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
+use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -33,6 +36,24 @@ final class LanguageCodeTest extends RuleTestCase
 
         // @phpstan-ignore-next-line
         new LanguageCode('whatever');
+    }
+
+    #[Test]
+    public function shouldThrowWhenMissingComponent(): void
+    {
+        $mainContainer = ContainerRegistry::getContainer();
+        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        try {
+            new LanguageCode('alpha-3');
+            $this->fail('Expected MissingComposerDependencyException was not thrown.');
+        } catch (MissingComposerDependencyException $e) {
+            $this->assertStringContainsString(
+                'LanguageCode rule requires PHP ISO Codes',
+                $e->getMessage(),
+            );
+        } finally {
+            ContainerRegistry::setContainer($mainContainer);
+        }
     }
 
     /** @return iterable<array{LanguageCode, mixed}> */

--- a/tests/unit/Validators/SubdivisionCodeTest.php
+++ b/tests/unit/Validators/SubdivisionCodeTest.php
@@ -12,10 +12,13 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
+use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
+use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Test\RuleTestCase;
 
 #[Group('validator')]
@@ -29,6 +32,24 @@ final class SubdivisionCodeTest extends RuleTestCase
         $this->expectExceptionMessage('"whatever" is not a supported country code');
 
         new SubdivisionCode('whatever');
+    }
+
+    #[Test]
+    public function shouldThrowWhenMissingComponent(): void
+    {
+        $mainContainer = ContainerRegistry::getContainer();
+        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        try {
+            new SubdivisionCode('US');
+            $this->fail('Expected MissingComposerDependencyException was not thrown.');
+        } catch (MissingComposerDependencyException $e) {
+            $this->assertStringContainsString(
+                'SubdivisionCode rule requires PHP ISO Codes',
+                $e->getMessage(),
+            );
+        } finally {
+            ContainerRegistry::setContainer($mainContainer);
+        }
     }
 
     /** @return iterable<array{SubdivisionCode, mixed}> */


### PR DESCRIPTION
The main focus of this change is to make those optional dependencies more testable.

Unfortunately, some phpstan-ignores had to be included, since ::set is not a PsrContainer method. We're only using it on tests though, so it's fine. It targets our php-di container for testing purposes only. The real implementation only relies on ::get.

This change also has the side effect of improving the performance of those validators by not instantiating their databases each time a iso validator is built, achieving massive improvements in those scenarios. A small benchmark with no assertions was added to track that improvement.

---

This brings the total coverage to almost 99%, addressing one of the key uncoverable paths that existed before.