### PR TITLE
Fix misplaced Outer/Inner names when using named() on Each

### DIFF
--- a/src/Message/Formatter/NestedArrayFormatter.php
+++ b/src/Message/Formatter/NestedArrayFormatter.php
@@ -45,6 +45,8 @@ final readonly class NestedArrayFormatter implements ArrayFormatter
                 $renderer,
                 $templates,
                 $hasString,
+                $result,
+                isParentVisible: count($children) > 1,
             ),
             [],
         );
@@ -91,12 +93,14 @@ final readonly class NestedArrayFormatter implements ArrayFormatter
         Renderer $renderer,
         array $templates,
         bool $hasString,
+        Result $parent,
+        bool $isParentVisible,
     ): array {
         if ($hasString && is_numeric($key)) {
             $key = $child->id->value;
         }
 
-        $message = $this->renderChild($child, $renderer, $templates);
+        $message = $this->renderChild($child, $renderer, $templates, $parent, $isParentVisible);
 
         if (!$hasString) {
             $messages[] = $message;
@@ -124,10 +128,15 @@ final readonly class NestedArrayFormatter implements ArrayFormatter
      *
      * @return array<string>|string
      */
-    private function renderChild(Result $child, Renderer $renderer, array $templates): array|string
-    {
+    private function renderChild(
+        Result $child,
+        Renderer $renderer,
+        array $templates,
+        Result $parent,
+        bool $isParentVisible,
+    ): array|string {
         $formatted = $this->format(
-            $child->withoutName(),
+            $isParentVisible && $child->name === $parent->name ? $child->withoutName() : $child,
             $renderer,
             $templates,
         );

--- a/src/Validators/Core/FilteredNonEmptyArray.php
+++ b/src/Validators/Core/FilteredNonEmptyArray.php
@@ -28,7 +28,7 @@ abstract class FilteredNonEmptyArray extends Wrapper
     {
         $iterableResult = (new IterableType())->evaluate($input);
         if (!$iterableResult->hasPassed) {
-            return $iterableResult->withIdFrom($this)->withNameFrom($this->validator);
+            return $iterableResult->withIdFrom($this);
         }
 
         $array = $this->toArray($input);
@@ -38,7 +38,7 @@ abstract class FilteredNonEmptyArray extends Wrapper
         );
         $result = $validator->evaluate($array);
         if (!$result->hasPassed) {
-            return $result->withIdFrom($this)->withNameFrom($this->validator);
+            return $result->withIdFrom($this);
         }
 
         // @phpstan-ignore-next-line

--- a/src/Validators/Each.php
+++ b/src/Validators/Each.php
@@ -37,7 +37,7 @@ final class Each extends FilteredNonEmptyArray
     {
         $children = [];
         foreach ($input as $key => $value) {
-            $children[] = $this->validator->evaluate($value)->withPath(new Path($key));
+            $children[] = $this->validator->evaluate($value)->withPath(new Path($key))->withPrecedentName(false);
         }
 
         $hasPassed = array_reduce(
@@ -46,6 +46,6 @@ final class Each extends FilteredNonEmptyArray
             true,
         );
 
-        return Result::of($hasPassed, $input, $this)->withChildren(...$children)->withNameFrom($this->validator);
+        return Result::of($hasPassed, $input, $this)->withChildren(...$children);
     }
 }

--- a/src/Validators/Key.php
+++ b/src/Validators/Key.php
@@ -44,6 +44,7 @@ final class Key extends Wrapper implements KeyRelated
             return $keyExistsResult->withNameFrom($this->validator);
         }
 
-        return $this->validator->evaluate($input[$this->key])->withPath($keyExistsResult->path ?? new Path($this->key));
+        return $this->validator->evaluate($input[$this->key])
+            ->withPath($keyExistsResult->path ?? new Path($this->key));
     }
 }

--- a/tests/feature/Validators/EachTest.php
+++ b/tests/feature/Validators/EachTest.php
@@ -65,52 +65,52 @@ test('Inverted', catchAll(
 test('With name, non-iterable', catchAll(
     fn() => v::each(v::named('Wrapped', v::intType()))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapped must be iterable')
-        ->and($fullMessage)->toBe('- Wrapped must be iterable')
-        ->and($messages)->toBe(['each' => 'Wrapped must be iterable']),
+        ->and($message)->toBe('`null` must be iterable')
+        ->and($fullMessage)->toBe('- `null` must be iterable')
+        ->and($messages)->toBe(['each' => '`null` must be iterable']),
 ));
 
 test('With name, empty', catchAll(
     fn() => v::each(v::named('Wrapped', v::intType()))->assert([]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('The length of Wrapped must be greater than 0')
-        ->and($fullMessage)->toBe('- The length of Wrapped must be greater than 0')
-        ->and($messages)->toBe(['each' => 'The length of Wrapped must be greater than 0']),
+        ->and($message)->toBe('The length of `[]` must be greater than 0')
+        ->and($fullMessage)->toBe('- The length of `[]` must be greater than 0')
+        ->and($messages)->toBe(['each' => 'The length of `[]` must be greater than 0']),
 ));
 
 test('With name, default', catchAll(
-    fn() => v::named('Wrapper', v::each(v::named('Wrapped', v::intType())))->assert(['a', 'b', 'c']),
+    fn() => v::named('Outer', v::each(v::named('Inner', v::intType())))->assert(['a', 'b', 'c']),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapped must be an integer')
+        ->and($message)->toBe('`.0` (<- Inner) must be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
-        - Each item in Wrapped must be valid
-          - `.0` must be an integer
-          - `.1` must be an integer
-          - `.2` must be an integer
+        - Each item in Outer must be valid
+          - `.0` (<- Inner) must be an integer
+          - `.1` (<- Inner) must be an integer
+          - `.2` (<- Inner) must be an integer
         FULL_MESSAGE)
         ->and($messages)->toBe([
-            '__root__' => 'Each item in Wrapped must be valid',
-            0 => '`.0` must be an integer',
-            1 => '`.1` must be an integer',
-            2 => '`.2` must be an integer',
+            '__root__' => 'Each item in Outer must be valid',
+            0 => '`.0` (<- Inner) must be an integer',
+            1 => '`.1` (<- Inner) must be an integer',
+            2 => '`.2` (<- Inner) must be an integer',
         ]),
 ));
 
 test('With name, inverted', catchAll(
-    fn() => v::named('Not', v::not(v::named('Wrapper', v::each(v::named('Wrapped', v::intType())))))->assert([1, 2, 3]),
+    fn() => v::named('Not', v::not(v::named('Outer', v::each(v::named('Inner', v::intType())))))->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapped must not be an integer')
+        ->and($message)->toBe('`.0` (<- Inner) must not be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
-        - Each item in Wrapped must be invalid
-          - `.0` must not be an integer
-          - `.1` must not be an integer
-          - `.2` must not be an integer
+        - Each item in Outer must be invalid
+          - `.0` (<- Inner) must not be an integer
+          - `.1` (<- Inner) must not be an integer
+          - `.2` (<- Inner) must not be an integer
         FULL_MESSAGE)
         ->and($messages)->toBe([
-            '__root__' => 'Each item in Wrapped must be invalid',
-            0 => '`.0` must not be an integer',
-            1 => '`.1` must not be an integer',
-            2 => '`.2` must not be an integer',
+            '__root__' => 'Each item in Outer must be invalid',
+            0 => '`.0` (<- Inner) must not be an integer',
+            1 => '`.1` (<- Inner) must not be an integer',
+            2 => '`.2` (<- Inner) must not be an integer',
         ]),
 ));
 


### PR DESCRIPTION
The Each validator was using "Outer" names (the name applied to the parent) in child results and vice-versa.

This commit fixes it, and also streamlines the Result class, introducing helper `mapChildren` and `mapAdjacent` methods and removing unecessary recursive array_maps.

Named children now also display their names, allowing users to create more meaningful messages that do not spam nested `.0`...`.0`...etc numeric keys which could be confusing. If the user does not name them, the previous behavior is kept.

---

This fixes #1639 