### PR TITLE
Containerize PhoneNumberUtil instance for Phone rule

### DIFF
--- a/src/ContainerRegistry.php
+++ b/src/ContainerRegistry.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Respect\Validation;
 
 use DI\Container;
+use libphonenumber\PhoneNumberUtil;
 use Psr\Container\ContainerInterface;
 use Respect\StringFormatter\BypassTranslator;
 use Respect\StringFormatter\Modifier;
@@ -52,6 +53,7 @@ final class ContainerRegistry
     public static function createContainer(array $definitions = []): Container
     {
         return new Container($definitions + [
+            PhoneNumberUtil::class => factory(static fn() => PhoneNumberUtil::getInstance()),
             Transformer::class => create(Prefix::class),
             TemplateResolver::class => create(TemplateResolver::class),
             TranslatorInterface::class => autowire(BypassTranslator::class),

--- a/src/Validators/Phone.php
+++ b/src/Validators/Phone.php
@@ -30,7 +30,6 @@ use Respect\Validation\Result;
 use Respect\Validation\Validator;
 use Sokil\IsoCodes\Database\Countries;
 
-use function class_exists;
 use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
@@ -53,9 +52,9 @@ final class Phone implements Validator
 
     public function __construct(string|null $countryCode = null, Countries|null $countries = null)
     {
-        if (!class_exists(PhoneNumberUtil::class)) {
+        if (!ContainerRegistry::getContainer()->has(PhoneNumberUtil::class)) {
             throw new MissingComposerDependencyException(
-                'Phone rule libphonenumber for PHP',
+                'Phone rule requires libphonenumber for PHP',
                 'giggsey/libphonenumber-for-php',
             );
         }
@@ -96,7 +95,7 @@ final class Phone implements Validator
     private function isValidPhone(string $input): bool
     {
         try {
-            $phoneNumberUtil = PhoneNumberUtil::getInstance();
+            $phoneNumberUtil = ContainerRegistry::getContainer()->get(PhoneNumberUtil::class);
             $phoneNumberObject = $phoneNumberUtil->parse($input, $this->country?->getAlpha2());
             if ($this->country === null) {
                 return $phoneNumberUtil->isValidNumber($phoneNumberObject);


### PR DESCRIPTION
Similar to d8e31db (commit that containerized iso code dbs), but this time for PhoneNumberUtil.

This makes the optional dependency testable.

PhoneNumberUtil doesn't have a public constructor, so a factory was declared instead.