### PR TITLE
Add Support for Alphanumeric CNPJ

### DIFF
--- a/docs/validators.md
+++ b/docs/validators.md
@@ -241,7 +241,7 @@ In this page you will find a list of validators by their category.
 [Charset]: validators/Charset.md "Validates if a string is in a specific charset."
 [Circuit]: validators/Circuit.md "Validates the input against a series of validators until the first fails."
 [Cnh]: validators/Cnh.md "Validates a Brazilian driver's license."
-[Cnpj]: validators/Cnpj.md "Validates if the input is a Brazilian National Registry of Legal Entities (CNPJ) number."
+[Cnpj]: validators/Cnpj.md "Validates the structure and mathematical integrity of Brazilian CNPJ identifiers."
 [Consonant]: validators/Consonant.md "Validates if the input contains only consonants."
 [Contains]: validators/Contains.md "Validates if the input contains some value."
 [ContainsAny]: validators/ContainsAny.md "Validates if the input contains at least one of defined values"

--- a/docs/validators/Cnpj.md
+++ b/docs/validators/Cnpj.md
@@ -7,11 +7,14 @@ SPDX-License-Identifier: MIT
 
 - `Cnpj()`
 
-Validates if the input is a Brazilian National Registry of Legal Entities (CNPJ) number.
+Validates the structure and mathematical integrity of Brazilian [CNPJ](https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jur%C3%ADdica) identifiers.
 Ignores non-digit chars, so use `->digit()` if needed.
 
 ```php
 v::cnpj()->assert('00394460005887');
+// Validation passes successfully
+
+v::cnpj()->assert('12ABC34501DE35');
 // Validation passes successfully
 ```
 

--- a/tests/unit/Validators/CnpjTest.php
+++ b/tests/unit/Validators/CnpjTest.php
@@ -39,11 +39,14 @@ final class CnpjTest extends RuleTestCase
             [$validator, '24.760.428/0001-09'],
             [$validator, '27.355.204/0001-00'],
             [$validator, '36.310.327/0001-07'],
+            [$validator, '12.ABC.345/01DE-35'],
+            [$validator, '12.ABC.345/01DE_35'],
             [$validator, '38175021000110'],
             [$validator, '37550610000179'],
             [$validator, '12774546000189'],
             [$validator, '77456211000168'],
             [$validator, '02023077000102'],
+            [$validator, '12ABC34501DE35'],
         ];
     }
 
@@ -75,6 +78,8 @@ final class CnpjTest extends RuleTestCase
             [$validator, '992999999999929384'],
             [$validator, '99-010-0.'],
             [$validator, null],
+            [$validator, '12ABC34501DE00'],
+            [$validator, '12ABC34501DEFG'],
         ];
     }
 }


### PR DESCRIPTION
Adds validation and tests for new CNPJ registrations, which will accept alphanumeric characters starting from July 2026.

The change was instituted through "[Instrução Normativa RFB nº 2.119/2022](https://normasinternet2.receita.fazenda.gov.br/#/consulta/externa/141102)".
