### PR TITLE
Allow empty values in iterables for All, Each, Max, Min

### DIFF
--- a/docs/migrating-from-v2-to-v3.md
+++ b/docs/migrating-from-v2-to-v3.md
@@ -279,12 +279,11 @@ The `size()` validator no longer accepts string sizes like `'5MB'`. Use the new 
 
 ##### `Each` validator stricter
 
-The `Each` validator now rejects `stdClass`, non-iterable values, and empty iterables:
+The `Each` validator now rejects `stdClass` and other non-iterable values:
 
 ```php
 // These now fail in 3.0
 v::each(v::alwaysValid())->isValid(new stdClass()); // false
-v::each(v::alwaysValid())->isValid([]);             // false (empty)
 ```
 
 ##### Composite validators require two or more validators
@@ -372,7 +371,13 @@ composer require ramsey/uuid
 + v::undefOr(v::email())->assert($email);
 ```
 
-Note: In 3.0, `Min` and `Max` validators exist but have different semantics — they extract the minimum/maximum value from a collection and validate it (see [Result composition](#result-composition)).
+In 3.0, `Min` and `Max` validators exist but have different semantics. They extract the minimum/maximum value from a collection and validate it (see [Result composition](#result-composition)).
+
+
+| Validator  | 2.x             | 3.x                                           |
+| ---------- | --------------- | --------------------------------------------- |
+| `Min`      | Single value >= | Pick minimum value from iterable and validate |
+| `Max`      | Single value <= | Pick minimum value from iterable and validate |
 
 ##### `NotBlank` logic inverted
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -57,7 +57,7 @@ In this page you will find a list of validators by their category.
 
 ## Alphabetically
 
-- [All][] - `v::all(v::intType())->assert([1, 2, 3]);`
+- [All][] - `v::all(v::dateTime())->assert($releaseDates);`
 - [AllOf][] - `v::allOf(v::intVal(), v::positive())->assert(15);`
 - [Alnum][] - `v::alnum(' ')->assert('foo 123');`
 - [Alpha][] - `v::alpha(' ')->assert('some name');`

--- a/docs/validators/All.md
+++ b/docs/validators/All.md
@@ -10,18 +10,37 @@ SPDX-License-Identifier: MIT
 Validates all items of the input against a given validator.
 
 ```php
-v::all(v::intType())->assert([1, 2, 3]);
-// Validation passes successfully
+$releaseDates = [
+    'validation' => '2010-01-01',
+    'template'   => '2011-01-01',
+    'relational' => '2011-02-05',
+];
 
-v::all(v::intType())->assert([1, 2, '3']);
-// → Every item in `[1, 2, "3"]` must be an integer
+v::all(v::dateTime())->assert($releaseDates);
+// Validation passes successfully
 ```
 
-This validator is similar to [Each](Each.md), but as opposed to the former, it displays a single message when asserting an input.
+This validator is similar to [Each](Each.md), but while `Each` displays a message for each of the failed entries, `All` will display a single message generic to all 
+failed entries instead.
 
+```php
+v::all(v::startsWith('2010'))->assert($releaseDates);
+// → Every item in `["validation": "2010-01-01", "template": "2011-01-01", "relational": "2011-02-05"]` must start with "2010"
+
+v::named('Release Dates', v::all(v::startsWith('2010')))->assert($releaseDates);
+// → Every item in Release Dates must start with "2010"
+```
 ## Note
 
-This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail.
+This validator will pass if the input is empty. Use [Length](Length.md) with [GreaterThan][GreaterThan.md] to perform a stricter check:
+
+```php
+v::all(v::equals(10))->assert([]);
+// Validation passes successfully
+
+v::length(v::greaterThan(0))->all(v::equals(10))->assert([]);
+// → The length of `[]` must be greater than 0
+```
 
 ## Templates
 

--- a/docs/validators/Each.md
+++ b/docs/validators/Each.md
@@ -20,6 +20,22 @@ v::each(v::dateTime())->assert($releaseDates);
 // Validation passes successfully
 ```
 
+This validator is similar to [All](All.md), but while `All` displays a single message 
+generic to all failed entries, `Each` will display a message for each failed 
+entry instead.
+
+```php
+v::each(v::startsWith('2010'))->assert($releaseDates);
+// → - Each item in `["validation": "2010-01-01", "template": "2011-01-01", "relational": "2011-02-05"]` must be valid
+// →   - `.template` must start with "2010"
+// →   - `.relational` must start with "2010"
+
+v::named('Release Dates', v::each(v::startsWith('2010')))->assert($releaseDates);
+// → - Each item in Release Dates must be valid
+// →   - `.template` must start with "2010"
+// →   - `.relational` must start with "2010"
+```
+
 You can also validate array keys combining this validator with [Call](Call.md):
 
 ```php
@@ -29,7 +45,15 @@ v::call('array_keys', v::each(v::stringType()))->assert($releaseDates);
 
 ## Note
 
-This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail.
+This validator will pass if the input is empty. Use [Length](Length.md) with [GreaterThan][GreaterThan.md] to perform a stricter check:
+
+```php
+v::each(v::equals(10))->assert([]);
+// Validation passes successfully
+
+v::length(v::greaterThan(0))->each(v::equals(10))->assert([]);
+// → The length of `[]` must be greater than 0
+```
 
 ## Templates
 
@@ -54,11 +78,11 @@ This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] inter
 
 ## Changelog
 
-| Version | Description                                                 |
-| ------: | :---------------------------------------------------------- |
-|   3.0.0 | Rejected `stdClass`, non-iterable. or empty iterable values |
-|   2.0.0 | Remove support for key validation                           |
-|   0.3.9 | Created                                                     |
+| Version | Description                        |
+| ------: | :--------------------------------- |
+|   3.0.0 | Rejected `stdClass`, non-iterables |
+|   2.0.0 | Remove support for key validation  |
+|   0.3.9 | Created                            |
 
 ## See Also
 

--- a/docs/validators/Max.md
+++ b/docs/validators/Max.md
@@ -26,7 +26,15 @@ v::max(v::greaterThan(15))->assert([4, 8, 12]);
 
 ## Note
 
-This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail.
+This validator will pass if the input is empty. Use [Length](Length.md) with [GreaterThan][GreaterThan.md] to perform a stricter check:
+
+```php
+v::max(v::equals(10))->assert([]);
+// Validation passes successfully
+
+v::length(v::greaterThan(0))->max(v::equals(10))->assert([]);
+// → The length of `[]` must be greater than 0
+```
 
 ## Templates
 

--- a/docs/validators/Min.md
+++ b/docs/validators/Min.md
@@ -26,7 +26,15 @@ v::min(v::lessThan(3))->assert([4, 8, 12]);
 
 ## Note
 
-This validator uses [Length](Length.md) with [GreaterThan][GreaterThan.md] internally. If an input has no items, the validation will fail.
+This validator will pass if the input is empty. Use [Length](Length.md) with [GreaterThan][GreaterThan.md] to perform a stricter check:
+
+```php
+v::min(v::equals(10))->assert([]);
+// Validation passes successfully
+
+v::length(v::greaterThan(0))->min(v::equals(10))->assert([]);
+// → The length of `[]` must be greater than 0
+```
 
 ## Templates
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -33,6 +33,7 @@ final readonly class Result
         public string $template = Validator::TEMPLATE_STANDARD,
         public bool $hasInvertedMode = false,
         public bool $hasPrecedentName = true,
+        public bool $isIndeterminate = false,
         public Name|null $name = null,
         public Result|null $adjacent = null,
         public Path|null $path = null,
@@ -238,6 +239,11 @@ final readonly class Result
         );
 
         return count($childrenThatAllowAdjacent) === 1;
+    }
+
+    public function asIndeterminate(): self
+    {
+        return clone($this, ['isIndeterminate' => true]);
     }
 
     /** @return array<Result> */

--- a/src/Validators/All.php
+++ b/src/Validators/All.php
@@ -17,14 +17,14 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\FilteredNonEmptyArray;
+use Respect\Validation\Validators\Core\FilteredArray;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template('Every item in', 'Every item in')]
-final class All extends FilteredNonEmptyArray
+final class All extends FilteredArray
 {
     /** @param non-empty-array<mixed> $input */
-    protected function evaluateNonEmptyArray(array $input): Result
+    protected function evaluateArray(array $input): Result
     {
         $result = null;
         $hasPassed = true;

--- a/src/Validators/Core/FilteredArray.php
+++ b/src/Validators/Core/FilteredArray.php
@@ -12,17 +12,12 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators\Core;
 
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Circuit;
-use Respect\Validation\Validators\GreaterThan;
 use Respect\Validation\Validators\IterableType;
-use Respect\Validation\Validators\Length;
-use Respect\Validation\Validators\Not;
-use Respect\Validation\Validators\Undef;
 
 use function is_array;
 use function iterator_to_array;
 
-abstract class FilteredNonEmptyArray extends Wrapper
+abstract class FilteredArray extends Wrapper
 {
     public function evaluate(mixed $input): Result
     {
@@ -32,21 +27,16 @@ abstract class FilteredNonEmptyArray extends Wrapper
         }
 
         $array = $this->toArray($input);
-        $validator = new Circuit(
-            new Not(new Undef()),
-            new Length(new GreaterThan(0)),
-        );
-        $result = $validator->evaluate($array);
-        if (!$result->hasPassed) {
-            return $result->withIdFrom($this);
+
+        if ($array === []) {
+            return Result::passed($input, $this)->asIndeterminate();
         }
 
-        // @phpstan-ignore-next-line
-        return $this->evaluateNonEmptyArray($array);
+        return $this->evaluateArray($array);
     }
 
-    /** @param non-empty-array<mixed> $input */
-    abstract protected function evaluateNonEmptyArray(array $input): Result;
+    /** @param array<mixed> $input */
+    abstract protected function evaluateArray(array $input): Result;
 
     /**
      * @param iterable<mixed> $input

--- a/src/Validators/Each.php
+++ b/src/Validators/Each.php
@@ -21,7 +21,7 @@ use Attribute;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Path;
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\FilteredNonEmptyArray;
+use Respect\Validation\Validators\Core\FilteredArray;
 
 use function array_reduce;
 
@@ -30,10 +30,10 @@ use function array_reduce;
     'Each item in {{subject}} must be valid',
     'Each item in {{subject}} must be invalid',
 )]
-final class Each extends FilteredNonEmptyArray
+final class Each extends FilteredArray
 {
-    /** @param non-empty-array<mixed> $input */
-    protected function evaluateNonEmptyArray(array $input): Result
+    /** @param array<mixed> $input */
+    protected function evaluateArray(array $input): Result
     {
         $children = [];
         foreach ($input as $key => $value) {

--- a/src/Validators/Max.php
+++ b/src/Validators/Max.php
@@ -17,16 +17,16 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\FilteredNonEmptyArray;
+use Respect\Validation\Validators\Core\FilteredArray;
 
 use function max;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template('The maximum of', 'The maximum of')]
-final class Max extends FilteredNonEmptyArray
+final class Max extends FilteredArray
 {
     /** @param non-empty-array<mixed> $input */
-    protected function evaluateNonEmptyArray(array $input): Result
+    protected function evaluateArray(array $input): Result
     {
         $result = $this->validator->evaluate(max($input));
 

--- a/src/Validators/Min.php
+++ b/src/Validators/Min.php
@@ -17,16 +17,16 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\FilteredNonEmptyArray;
+use Respect\Validation\Validators\Core\FilteredArray;
 
 use function min;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template('The minimum of', 'The minimum of')]
-final class Min extends FilteredNonEmptyArray
+final class Min extends FilteredArray
 {
     /** @param non-empty-array<mixed> $input */
-    protected function evaluateNonEmptyArray(array $input): Result
+    protected function evaluateArray(array $input): Result
     {
         $result = $this->validator->evaluate(min($input));
 

--- a/src/Validators/Not.php
+++ b/src/Validators/Not.php
@@ -28,6 +28,10 @@ final class Not extends Wrapper
     {
         $result = $this->validator->evaluate($input);
 
+        if ($result->isIndeterminate) {
+            return $result;
+        }
+
         return $result
             ->withToggledModeAndValidation()
             ->withId($result->id->withPrefix('not'));

--- a/tests/feature/Validators/EachTest.php
+++ b/tests/feature/Validators/EachTest.php
@@ -18,14 +18,6 @@ test('Non-iterable', catchAll(
         ->and($messages)->toBe(['each' => '`null` must be iterable']),
 ));
 
-test('Empty', catchAll(
-    fn() => v::each(v::intType())->assert([]),
-    fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('The length of `[]` must be greater than 0')
-        ->and($fullMessage)->toBe('- The length of `[]` must be greater than 0')
-        ->and($messages)->toBe(['each' => 'The length of `[]` must be greater than 0']),
-));
-
 test('Default', catchAll(
     fn() => v::each(v::intType())->assert(['a', 'b', 'c']),
     fn(string $message, string $fullMessage, array $messages) => expect()
@@ -68,14 +60,6 @@ test('With name, non-iterable', catchAll(
         ->and($message)->toBe('`null` must be iterable')
         ->and($fullMessage)->toBe('- `null` must be iterable')
         ->and($messages)->toBe(['each' => '`null` must be iterable']),
-));
-
-test('With name, empty', catchAll(
-    fn() => v::each(v::named('Wrapped', v::intType()))->assert([]),
-    fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('The length of `[]` must be greater than 0')
-        ->and($fullMessage)->toBe('- The length of `[]` must be greater than 0')
-        ->and($messages)->toBe(['each' => 'The length of `[]` must be greater than 0']),
 ));
 
 test('With name, default', catchAll(
@@ -174,15 +158,6 @@ test('With template, non-iterable', catchAll(
         ->and($message)->toBe('You should have passed an iterable')
         ->and($fullMessage)->toBe('- You should have passed an iterable')
         ->and($messages)->toBe(['each' => 'You should have passed an iterable']),
-));
-
-test('With template, empty', catchAll(
-    fn() => v::templated('You should have passed an non-empty', v::each(v::intType()))
-        ->assert([]),
-    fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('You should have passed an non-empty')
-        ->and($fullMessage)->toBe('- You should have passed an non-empty')
-        ->and($messages)->toBe(['each' => 'You should have passed an non-empty']),
 ));
 
 test('With template, default', catchAll(

--- a/tests/feature/Validators/MaxTest.php
+++ b/tests/feature/Validators/MaxTest.php
@@ -17,14 +17,6 @@ test('Non-iterable', catchAll(
         ->and($messages)->toBe(['max' => '`null` must be iterable']),
 ));
 
-test('Empty', catchAll(
-    fn() => v::max(v::negative())->assert([]),
-    fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('The length of `[]` must be greater than 0')
-        ->and($fullMessage)->toBe('- The length of `[]` must be greater than 0')
-        ->and($messages)->toBe(['max' => 'The length of `[]` must be greater than 0']),
-));
-
 test('Default', catchAll(
     fn() => v::max(v::negative())->assert([1, 2, 3]),
     fn(string $message, string $fullMessage, array $messages) => expect()

--- a/tests/src/Builders/ResultBuilder.php
+++ b/tests/src/Builders/ResultBuilder.php
@@ -28,6 +28,8 @@ final class ResultBuilder
 
     private bool $hasPrecedentName = true;
 
+    private bool $isIndeterminate = false;
+
     private string $template = Validator::TEMPLATE_STANDARD;
 
     /** @var array<string, mixed> */
@@ -63,6 +65,7 @@ final class ResultBuilder
             $this->template,
             $this->hasInvertedMode,
             $this->hasPrecedentName,
+            $this->isIndeterminate,
             $this->name,
             $this->adjacent,
             $this->path,
@@ -144,6 +147,13 @@ final class ResultBuilder
     public function hasInvertedMode(): self
     {
         $this->hasInvertedMode = true;
+
+        return $this;
+    }
+
+    public function isIndeterminate(): self
+    {
+        $this->isIndeterminate = true;
 
         return $this;
     }

--- a/tests/src/Validators/Core/ConcreteFilteredArray.php
+++ b/tests/src/Validators/Core/ConcreteFilteredArray.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 namespace Respect\Validation\Test\Validators\Core;
 
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\FilteredNonEmptyArray;
+use Respect\Validation\Validators\Core\FilteredArray;
 
-final class ConcreteFilteredNonEmptyArray extends FilteredNonEmptyArray
+final class ConcreteFilteredArray extends FilteredArray
 {
     /** @param non-empty-array<mixed> $input */
-    protected function evaluateNonEmptyArray(array $input): Result
+    protected function evaluateArray(array $input): Result
     {
         return $this->validator->evaluate($input);
     }

--- a/tests/unit/ResultTest.php
+++ b/tests/unit/ResultTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\Builders\ResultBuilder;
 use Respect\Validation\Test\TestCase;
+use Respect\Validation\Test\Validators\Stub;
 
 #[Group('core')]
 #[CoversClass(Result::class)]
@@ -303,5 +304,13 @@ final class ResultTest extends TestCase
         self::assertSame($newInput, $updatedResult->input);
         self::assertSame($originalInput, $updatedResult->children[0]->input);
         self::assertSame($originalInput, $updatedResult->children[0]->children[0]->input);
+    }
+
+    #[Test]
+    public function shouldCreateIndeterminateResult(): void
+    {
+        $result = Result::passed('input', Stub::pass(1))->asIndeterminate();
+
+        self::assertTrue($result->isIndeterminate);
     }
 }

--- a/tests/unit/Validators/AllTest.php
+++ b/tests/unit/Validators/AllTest.php
@@ -29,6 +29,7 @@ final class AllTest extends TestCase
         yield 'all pass with ArrayObject' => [Stub::pass(3), new ArrayObject([1, 2, 3])];
         yield 'single element that passes' => [Stub::pass(1), ['value']];
         yield 'all pass with array of strings' => [Stub::pass(5), ['a', 'b', 'c', 'd', 'e']];
+        yield 'empty array' => [Stub::daze(), []];
     }
 
     /** @return iterable<string, array{Stub, mixed}> */
@@ -44,7 +45,6 @@ final class AllTest extends TestCase
         yield 'null input' => [Stub::daze(), null];
         yield 'boolean input' => [Stub::daze(), true];
         yield 'object input' => [Stub::daze(), (object) ['foo' => 'bar']];
-        yield 'empty array' => [Stub::daze(), []];
     }
 
     #[Test]

--- a/tests/unit/Validators/Core/FilteredArrayTest.php
+++ b/tests/unit/Validators/Core/FilteredArrayTest.php
@@ -15,18 +15,18 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\TestCase;
-use Respect\Validation\Test\Validators\Core\ConcreteFilteredNonEmptyArray;
+use Respect\Validation\Test\Validators\Core\ConcreteFilteredArray;
 use Respect\Validation\Test\Validators\Stub;
 
 #[Group('core')]
-#[CoversClass(FilteredNonEmptyArray::class)]
-final class FilteredNonEmptyArrayTest extends TestCase
+#[CoversClass(FilteredArray::class)]
+final class FilteredArrayTest extends TestCase
 {
     #[Test]
     #[DataProvider('providerForNonIterableTypes')]
     public function itShouldInvalidateNonIterableValues(mixed $input): void
     {
-        $sut = new ConcreteFilteredNonEmptyArray(Stub::daze());
+        $sut = new ConcreteFilteredArray(Stub::daze());
 
         self::assertInvalidInput($sut, $input);
     }
@@ -34,11 +34,11 @@ final class FilteredNonEmptyArrayTest extends TestCase
     /** @param iterable<mixed> $input */
     #[Test]
     #[DataProvider('providerForEmptyIterableValues')]
-    public function itShouldInvalidateEmptyIterableValues(iterable $input): void
+    public function itShouldValidateEmptyIterableValuesAndNoteTheIndeterminate(iterable $input): void
     {
-        $sut = new ConcreteFilteredNonEmptyArray(Stub::daze());
+        $sut = new ConcreteFilteredArray(Stub::daze());
 
-        self::assertInvalidInput($sut, $input);
+        $this->assertTrue($sut->evaluate($input)->isIndeterminate);
     }
 
     #[Test]
@@ -48,7 +48,7 @@ final class FilteredNonEmptyArrayTest extends TestCase
 
         $input = [1, 2, 3];
 
-        $sut = new ConcreteFilteredNonEmptyArray($validator);
+        $sut = new ConcreteFilteredArray($validator);
         $sut->evaluate($input);
 
         self::assertSame([$input], $validator->inputs);
@@ -57,18 +57,18 @@ final class FilteredNonEmptyArrayTest extends TestCase
     #[Test]
     public function itShouldKeepRuleIdWhenInvalidatingNonIterableValues(): void
     {
-        $sut = new ConcreteFilteredNonEmptyArray(Stub::daze());
+        $sut = new ConcreteFilteredArray(Stub::daze());
         $result = $sut->evaluate(null);
 
-        self::assertEquals('concreteFilteredNonEmptyArray', $result->id->value);
+        self::assertEquals('concreteFilteredArray', $result->id->value);
     }
 
     #[Test]
-    public function itShouldKeepRuleIdWhenInvalidatingEmptyIterableValues(): void
+    public function itShouldKeepRuleIdWhenValidatingEmptyIterableValues(): void
     {
-        $sut = new ConcreteFilteredNonEmptyArray(Stub::daze());
+        $sut = new ConcreteFilteredArray(Stub::daze());
         $result = $sut->evaluate([]);
 
-        self::assertEquals('concreteFilteredNonEmptyArray', $result->id->value);
+        self::assertEquals('concreteFilteredArray', $result->id->value);
     }
 }

--- a/tests/unit/Validators/EachTest.php
+++ b/tests/unit/Validators/EachTest.php
@@ -26,10 +26,12 @@ use stdClass;
 #[CoversClass(Each::class)]
 final class EachTest extends RuleTestCase
 {
-    /** @return iterable<array{Each, mixed}> */
+    /** @return iterable<array{Each|Not, mixed}> */
     public static function providerForValidInput(): iterable
     {
         return [
+            [new Each(Stub::daze()), []],
+            [new Not(new Each(Stub::daze())), []],
             [new Each(Stub::pass(5)), [1, 2, 3, 4, 5]],
             [new Each(Stub::pass(5)), new ArrayObject([1, 2, 3, 4, 5])],
         ];
@@ -39,7 +41,6 @@ final class EachTest extends RuleTestCase
     public static function providerForInvalidInput(): iterable
     {
         return [
-            [new Each(Stub::daze()), []],
             [new Each(Stub::daze()), new stdClass()],
             [new Each(Stub::daze()), 123],
             [new Each(Stub::daze()), ''],

--- a/tests/unit/Validators/MaxTest.php
+++ b/tests/unit/Validators/MaxTest.php
@@ -38,11 +38,11 @@ final class MaxTest extends TestCase
     /** @param iterable<mixed> $input */
     #[Test]
     #[DataProvider('providerForEmptyIterableValues')]
-    public function itShouldInvalidateEmptyIterableValues(iterable $input): void
+    public function itShouldValidateEmptyIterableValuesAndNoteTheIndeterminate(iterable $input): void
     {
         $validator = new Max(Stub::daze());
 
-        self::assertInvalidInput($validator, $input);
+        $this->assertTrue($validator->evaluate($input)->isIndeterminate);
     }
 
     /** @param iterable<mixed> $input */

--- a/tests/unit/Validators/MinTest.php
+++ b/tests/unit/Validators/MinTest.php
@@ -38,11 +38,11 @@ final class MinTest extends TestCase
     /** @param iterable<mixed> $input */
     #[Test]
     #[DataProvider('providerForEmptyIterableValues')]
-    public function itShouldInvalidateEmptyIterableValues(iterable $input): void
+    public function itShouldValidateEmptyIterableValuesAndNoteTheIndeterminate(iterable $input): void
     {
         $validator = new Min(Stub::daze());
 
-        self::assertInvalidInput($validator, $input);
+        $this->assertTrue($validator->evaluate($input)->isIndeterminate);
     }
 
     /** @param iterable<mixed> $input */

--- a/tests/unit/Validators/NotTest.php
+++ b/tests/unit/Validators/NotTest.php
@@ -39,6 +39,14 @@ final class NotTest extends RuleTestCase
         );
     }
 
+    #[Test]
+    public function shouldPassOnIndeterminateResults(): void
+    {
+        $validator = new Not(new All(new IntVal()));
+        $validator->evaluate([]);
+        self::assertTrue($validator->evaluate([])->hasPassed);
+    }
+
     /** @return iterable<string, array{Not, mixed}> */
     public static function providerForValidInput(): iterable
     {


### PR DESCRIPTION
Now empty values are again allowed in FilteredArray-style validators.

To solve the issue with negation, a Result attribute was added to signal indeciseveness (when a result cannot be reliably inverted). On such cases, we consider that result to be valid.

For example, `v::not(v::min(v::equals(10)))` says "The lowest value of the iterable input should not be equal 10".

If the input is empty, we cannot decide whether its minimum is equal to 10 or not, so the validator essentially becomes a null-op.

Users that want to ensure these validators have a valid decidable target must use it in combination with `Length` or other similar validators to achieve the same result.