### PR TITLE
Improve Url validator to be more strict

### DIFF
--- a/docs/migrating-from-v2-to-v3.md
+++ b/docs/migrating-from-v2-to-v3.md
@@ -331,6 +331,14 @@ _strict typing_.
 
 For more information, refer to [case-sensitiveness.md](case-sensitiveness.md)
 
+##### `Url` now validates domains, IP addresses and domains when appropriate.
+
+ - `news` scheme is now unsupported. Consult the validator documentation for
+   the list of supported schemes.
+ - `mailto` URLs now are also validated with the `Email` validator.
+ - Supported schemes now validate using `Ip` and `Domain` when appropriate.
+
+
 ##### New package dependencies
 
 Some validators now require additional packages:

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -361,7 +361,7 @@ In this page you will find a list of validators by their category.
 [UndefOr]: validators/UndefOr.md "Validates the input using a defined validator when the input is not `null` or an empty string (`''`)."
 [Unique]: validators/Unique.md "Validates whether the input array contains only unique values."
 [Uppercase]: validators/Uppercase.md "Validates whether the characters in the input are uppercase."
-[Url]: validators/Url.md "Validates whether the input is a URL."
+[Url]: validators/Url.md "Validates whether the input is a valid URL in a popular internet format."
 [Uuid]: validators/Uuid.md "Validates whether the input is a valid UUID. It also supports validation of"
 [Version]: validators/Version.md "Validates version numbers using Semantic Versioning."
 [Vowel]: validators/Vowel.md "Validates whether the input contains only vowels."

--- a/docs/validators/Url.md
+++ b/docs/validators/Url.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 
 - `Url()`
 
-Validates whether the input is a URL.
+Validates whether the input is a valid URL in a popular internet format.
 
 ```php
 v::url()->assert('http://example.com');
@@ -22,18 +22,32 @@ v::url()->assert('ldap://[::1]');
 v::url()->assert('mailto:john.doe@example.com');
 // Validation passes successfully
 
-v::url()->assert('news:new.example.com');
+v::url()->assert('http://example.this_top_level_domain_does_not_exist');
+// → "http://example.this_top_level_domain_does_not_exist" must be a valid URL
+```
+
+This validator uses [Ip][Ip.md], [Domain][Domain.md] and [Email][Email.md] internally,
+activating them depending on the input scheme.
+
+If you want to restrict URLs to a specific scheme, you can use [StartsWith][StartsWith.md]
+or any other verifier:
+
+```php
+v::startsWith('http')->url()->assert('http://example.com');
 // Validation passes successfully
+
+v::startsWith('http')->url()->assert('ftp://example.com');
+// → "ftp://example.com" must start with "http"
 ```
 
 ## Templates
 
 ### `Url::TEMPLATE_STANDARD`
 
-|       Mode | Template                      |
-| ---------: | :---------------------------- |
-|  `default` | {{subject}} must be a URL     |
-| `inverted` | {{subject}} must not be a URL |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a valid URL     |
+| `inverted` | {{subject}} must not be a valid URL |
 
 ## Template placeholders
 
@@ -47,13 +61,15 @@ v::url()->assert('news:new.example.com');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.8.0 | Created     |
+| Version | Description                                                                 |
+| ------: | :-------------------------------------------------------------------------- |
+|   3.0.0 | Stricter use of `Ip`, `Domain` and `Email` internally. Select schemes only. |
+|   0.8.0 | Created                                                                     |
 
 ## See Also
 
 - [Domain](Domain.md)
 - [Email](Email.md)
+- [Ip](Ip.md)
 - [Phone](Phone.md)
 - [Slug](Slug.md)

--- a/src/Validators/Call.php
+++ b/src/Validators/Call.php
@@ -20,8 +20,6 @@ use Attribute;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
 
-use function call_user_func;
-
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 final class Call implements Validator
 {
@@ -37,6 +35,6 @@ final class Call implements Validator
 
     public function evaluate(mixed $input): Result
     {
-        return $this->validator->evaluate(call_user_func($this->callable, $input));
+        return $this->validator->evaluate(($this->callable)($input));
     }
 }

--- a/tests/feature/Transformers/PrefixTest.php
+++ b/tests/feature/Transformers/PrefixTest.php
@@ -78,7 +78,7 @@ test('Property', catchAll(
 test('UndefOr', catchAll(
     fn() => v::undefOrUrl()->assert('string'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"string" must be a URL or must be undefined')
-        ->and($fullMessage)->toBe('- "string" must be a URL or must be undefined')
-        ->and($messages)->toBe(['undefOrUrl' => '"string" must be a URL or must be undefined']),
+        ->and($message)->toBe('"string" must be a valid URL or must be undefined')
+        ->and($fullMessage)->toBe('- "string" must be a valid URL or must be undefined')
+        ->and($messages)->toBe(['undefOrUrl' => '"string" must be a valid URL or must be undefined']),
 ));

--- a/tests/feature/Validators/UrlTest.php
+++ b/tests/feature/Validators/UrlTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::url()->assert('example.com'),
-    fn(string $message) => expect($message)->toBe('"example.com" must be a URL'),
+    fn(string $message) => expect($message)->toBe('"example.com" must be a valid URL'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::url())->assert('http://example.com'),
-    fn(string $message) => expect($message)->toBe('"http://example.com" must not be a URL'),
+    fn(string $message) => expect($message)->toBe('"http://example.com" must not be a valid URL'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::url()->assert('example.com'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a URL'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a valid URL'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::url())->assert('http://example.com'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "http://example.com" must not be a URL'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "http://example.com" must not be a valid URL'),
 ));

--- a/tests/unit/Validators/UrlTest.php
+++ b/tests/unit/Validators/UrlTest.php
@@ -34,8 +34,6 @@ final class UrlTest extends RuleTestCase
             [$validator, 'ldap://[2001:db8::7]/c=GB?objectClass?one'],
             [$validator, 'mailto:John.Doe@example.com'],
             [$validator, 'mailto:mduerst@ifi.unizh.example.gov'],
-            [$validator, 'news:comp.infosystems.www.servers.unix'],
-            [$validator, 'news:comp.infosystems.www.servers.unix'],
             [$validator, 'telnet://192.0.2.16:80/'],
             [$validator, 'telnet://melvyl.ucop.example.edu/'],
         ];
@@ -48,6 +46,10 @@ final class UrlTest extends RuleTestCase
 
         return [
             [$validator, 'example.com'],
+            [$validator, 'news:comp.infosystems.www.servers.unix'],
+            [$validator, 'news:comp.infosystems.www.servers.unix'],
+            [$validator, 'mailto:not_an_actual_email'],
+            [$validator, 'https://example.this_tld_is_invalid'],
             [$validator, 'http:/example.com/'],
             [$validator, 'tel:+1-816-555-1212'],
             [$validator, 'urn:oasis:names:specification:docbook:dtd:xml:4.1.2'],


### PR DESCRIPTION
Previously, the URL validator accepted all kinds of URLs.

Combining it with other validators like `Domain` and `Ip` manually is clumbersome, since the rules are extensive and require small tweaks such as understanding bracketed IP addresses.

This change makes that composition built-in. The validator still uses the FILTER_VALIDATE_URL from PHP, but now it also goes deeper and validate portions of the URL that other validators support.

Changes to `Call` were made so that it can be serialized under certain circumstances (when invoking a static method call), making it more flexible.

A static internal method helper for trimming the IP was added to the Url validator class and marked as internal, as it cannot be both private, serializable and accessible to the `Call` instance all at the same time. The `@internal` annotation should advise users that it's not a public API according to phpdoc conventions.