### PR TITLE
Improve performance of Prefix transformer

### DIFF
--- a/tests/benchmark/PrefixBench.php
+++ b/tests/benchmark/PrefixBench.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Benchmarks;
+
+use PhpBench\Attributes as Bench;
+use Respect\Validation\Transformers\Prefix;
+use Respect\Validation\Transformers\ValidatorSpec;
+
+final class PrefixBench
+{
+    /** @param array{0: Prefix, 1: ValidatorSpec} $params */
+    #[Bench\ParamProviders(['provideTransformerSpec'])]
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(100)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function prefixTransformer(array $params): void
+    {
+        $params[0]->transform($params[1]);
+    }
+
+    /** @return array<array{0: Prefix, 1: ValidatorSpec}> */
+    public static function provideTransformerSpec(): array
+    {
+        return [
+            [new Prefix(), new ValidatorSpec('keyName', ['value', 'other'])],
+            [new Prefix(), new ValidatorSpec('propertyTitle', ['value', 'other'])],
+            [new Prefix(), new ValidatorSpec('notSomething', ['value'])],
+            [new Prefix(), new ValidatorSpec('not')],
+            [new Prefix(), new ValidatorSpec('arrayVal')],
+        ];
+    }
+}


### PR DESCRIPTION
The Prefix transformer had many loops that could be avoided. This change replaces them for a compiled PCRE regex, taking advantage of recent PCRE JIT capabilities introduced in PHP.

These changes offer no performance trade-offs, improving lookup for all categories of prefixes (property/key with shift, ignore list and fallback to simple rule).

The most affected is the simple rule (no prefix or no conflict with any kind of prefix rule), yielding the most gains.

---

Gains by scenario:

<img width="892" height="331" alt="image" src="https://github.com/user-attachments/assets/37e564f7-f410-4291-b974-fc77ef7620b8" />
