### PR TITLE
Use Respect\Config instead of php-di

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     },
     "require": {
         "php": ">=8.5",
-        "php-di/php-di": "^7.1",
         "psr/container": "^2.0",
+        "respect/config": "dev-master",
         "respect/string-formatter": "^1.0",
         "respect/stringifier": "^3.0",
         "symfony/polyfill-mbstring": "^1.33"

--- a/docs/messages/placeholder-conversion.md
+++ b/docs/messages/placeholder-conversion.md
@@ -38,7 +38,7 @@ See [PlaceholderFormatter][] documentation for more information on creating cust
 
 ## Container configuration
 
-The `ContainerRegistry::createContainer()` method returns a [PHP-DI](https://php-di.org/) container. The definitions array follows the [PHP-DI definitions format](https://php-di.org/doc/php-definitions.html).
+The `ContainerRegistry::createContainer()` returns a PSR-11 compatible container.
 
 If you prefer to use a different container, `ContainerRegistry::setContainer()` accepts any [PSR-11](https://www.php-fig.org/psr/psr-11/) compatible container:
 

--- a/docs/messages/translation.md
+++ b/docs/messages/translation.md
@@ -65,7 +65,7 @@ When using validators that display lists of values, use the `|list:or` or `|list
 
 ## Container configuration
 
-The `ContainerRegistry::createContainer()` method returns a [PHP-DI](https://php-di.org/) container. The definitions array follows the [PHP-DI definitions format](https://php-di.org/doc/php-definitions.html).
+The `ContainerRegistry::createContainer()` returns a PSR-11 compatible container.
 
 If you prefer to use a different container, `ContainerRegistry::setContainer()` accepts any [PSR-11](https://www.php-fig.org/psr/psr-11/) compatible container:
 

--- a/docs/migrating-from-v2-to-v3.md
+++ b/docs/migrating-from-v2-to-v3.md
@@ -493,7 +493,7 @@ The `Factory` class has been replaced by a dependency injection container approa
 + ContainerRegistry::setContainer($container);
 ```
 
-The `ContainerRegistry::createContainer()` returns a [PHP-DI](https://php-di.org/) container. You can also use any PSR-11 compatible container with `ContainerRegistry::setContainer()`.
+The `ContainerRegistry::createContainer()` returns a PSR-11 compatible container.
 
 ### Custom validators
 

--- a/tests/benchmark/ContainerBench.php
+++ b/tests/benchmark/ContainerBench.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Benchmarks;
+
+use PhpBench\Attributes as Bench;
+use Respect\Validation\ContainerRegistry;
+use Respect\Validation\ValidatorBuilder;
+
+class ContainerBench
+{
+    #[Bench\Iterations(10)]
+    #[Bench\RetryThreshold(5)]
+    #[Bench\Revs(50)]
+    #[Bench\Warmup(1)]
+    #[Bench\Subject]
+    public function containerBuild(): void
+    {
+        ContainerRegistry::resetContainer();
+        ContainerRegistry::getContainer()->get(ValidatorBuilder::class);
+    }
+}

--- a/tests/feature/TranslatorTest.php
+++ b/tests/feature/TranslatorTest.php
@@ -35,7 +35,7 @@ $translator->addResource(
     'en',
 );
 $container = ContainerRegistry::createContainer();
-$container->set(TranslatorInterface::class, $translator);
+$container[TranslatorInterface::class] = $translator;
 
 beforeAll(fn() => ContainerRegistry::setContainer($container));
 

--- a/tests/src/Stubs/MyValidator.php
+++ b/tests/src/Stubs/MyValidator.php
@@ -21,10 +21,10 @@ final class MyValidator
         $defaultContainer = ContainerRegistry::getContainer();
 
         $container = ContainerRegistry::createContainer();
-        $container->set('respect.validation.ignored_backtrace_paths', [
+        $container['respect.validation.ignored_backtrace_paths'] = [
             __FILE__,
             ...$defaultContainer->get('respect.validation.ignored_backtrace_paths'),
-        ]);
+        ];
         ContainerRegistry::setContainer($container);
 
         try {

--- a/tests/unit/ContainerRegistryTest.php
+++ b/tests/unit/ContainerRegistryTest.php
@@ -49,4 +49,15 @@ final class ContainerRegistryTest extends TestCase
 
         self::assertSame($newContainer, ContainerRegistry::getContainer());
     }
+
+    #[Test]
+    public function itResetsTheContainerToTheDefaultState(): void
+    {
+        $newContainer = ContainerRegistry::createContainer(['foo' => 'bar']);
+        ContainerRegistry::setContainer($newContainer);
+        ContainerRegistry::resetContainer();
+        $defaultContainer = ContainerRegistry::getContainer();
+        self::assertNotSame($newContainer, $defaultContainer);
+        self::assertFalse($defaultContainer->has('foo'));
+    }
 }

--- a/tests/unit/Validators/CountryCodeTest.php
+++ b/tests/unit/Validators/CountryCodeTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
-use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Config\Container;
 use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
@@ -42,8 +42,7 @@ final class CountryCodeTest extends RuleTestCase
     #[Test]
     public function shouldThrowWhenMissingComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        ContainerRegistry::setContainer(new Container());
         try {
             new CountryCode('alpha-3');
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -53,7 +52,7 @@ final class CountryCodeTest extends RuleTestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 

--- a/tests/unit/Validators/CurrencyCodeTest.php
+++ b/tests/unit/Validators/CurrencyCodeTest.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
-use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Config\Container;
 use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
@@ -42,8 +42,7 @@ final class CurrencyCodeTest extends RuleTestCase
     #[Test]
     public function shouldThrowWhenMissingComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        ContainerRegistry::setContainer(new Container());
         try {
             new CurrencyCode('alpha-3');
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -53,7 +52,7 @@ final class CurrencyCodeTest extends RuleTestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 

--- a/tests/unit/Validators/LanguageCodeTest.php
+++ b/tests/unit/Validators/LanguageCodeTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
-use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Config\Container;
 use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
@@ -41,8 +41,7 @@ final class LanguageCodeTest extends RuleTestCase
     #[Test]
     public function shouldThrowWhenMissingComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        ContainerRegistry::setContainer(new Container());
         try {
             new LanguageCode('alpha-3');
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -52,7 +51,7 @@ final class LanguageCodeTest extends RuleTestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 

--- a/tests/unit/Validators/PhoneTest.php
+++ b/tests/unit/Validators/PhoneTest.php
@@ -17,12 +17,12 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
-use DI;
 use libphonenumber\PhoneNumberUtil;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Config\Container;
 use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
@@ -74,15 +74,9 @@ final class PhoneTest extends TestCase
     #[Test]
     public function shouldThrowWhenMissingIsocodesComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer(
-            (new DI\ContainerBuilder())
-                ->addDefinitions([
-                    PhoneNumberUtil::class => DI\factory(static fn() => PhoneNumberUtil::getInstance()),
-                ])
-                ->useAutowiring(false)
-                ->build(),
-        );
+        $container = new Container();
+        $container[PhoneNumberUtil::class] = static fn() => PhoneNumberUtil::getInstance();
+        ContainerRegistry::setContainer($container);
         try {
             new Phone('US');
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -92,22 +86,16 @@ final class PhoneTest extends TestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 
     #[Test]
     public function shouldThrowWhenMissingPhonesComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer(
-            (new DI\ContainerBuilder())
-                ->addDefinitions([
-                    Countries::class => DI\create(Countries::class),
-                ])
-                ->useAutowiring(false)
-                ->build(),
-        );
+        $container = new Container();
+        $container[Countries::class] = static fn() => new Countries();
+        ContainerRegistry::setContainer($container);
         try {
             new Phone('US');
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -117,7 +105,7 @@ final class PhoneTest extends TestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 

--- a/tests/unit/Validators/SubdivisionCodeTest.php
+++ b/tests/unit/Validators/SubdivisionCodeTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
-use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Config\Container;
 use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
@@ -37,8 +37,7 @@ final class SubdivisionCodeTest extends RuleTestCase
     #[Test]
     public function shouldThrowWhenMissingComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        ContainerRegistry::setContainer(new Container());
         try {
             new SubdivisionCode('US');
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -48,7 +47,7 @@ final class SubdivisionCodeTest extends RuleTestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 

--- a/tests/unit/Validators/UuidTest.php
+++ b/tests/unit/Validators/UuidTest.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
-use DI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Ramsey\Uuid\Uuid as RamseyUuid;
+use Respect\Config\Container;
 use Respect\Validation\ContainerRegistry;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
@@ -73,8 +73,7 @@ final class UuidTest extends RuleTestCase
     #[Test]
     public function shouldThrowWhenMissingComponent(): void
     {
-        $mainContainer = ContainerRegistry::getContainer();
-        ContainerRegistry::setContainer((new DI\ContainerBuilder())->useAutowiring(false)->build());
+        ContainerRegistry::setContainer(new Container());
         try {
             new Uuid();
             $this->fail('Expected MissingComposerDependencyException was not thrown.');
@@ -84,7 +83,7 @@ final class UuidTest extends RuleTestCase
                 $e->getMessage(),
             );
         } finally {
-            ContainerRegistry::setContainer($mainContainer);
+            ContainerRegistry::resetContainer();
         }
     }
 


### PR DESCRIPTION
Replaces the php-di implementation with Respect\Config, keeps PSR-11 compatibility.

Respect\Config is much lighter (20Kb package, php-di is 80kb), and also much faster (80% gain on cold ValidatorBuild::init) than uncompiled php-di.

While compiled php-di containers would be in theory even faster, it is awkward to commit their artifacts.

Users that want ultimate performance can still leverage php-di with compilation by doing it (together with their app DI defs) and doing `setContainer` on our `ContainerRegistry`.

---

⚠️ This change is experimental ⚠️ Respect\Config 3.0 is not launched yet.

**Benchmarks**:

<img width="943" height="243" alt="image" src="https://github.com/user-attachments/assets/77afb649-8539-44d4-8079-510290abbcb1" />
