### PR TITLE
Standardize and improve validation message templates

### DIFF
--- a/docs/feature-guide.md
+++ b/docs/feature-guide.md
@@ -149,7 +149,7 @@ Provide unique messages for each validator in a chain:
 
 ```php
 v::alnum()->lowercase()->assert($input, [
-    'alnum' => 'Your username must contain only letters and digits',
+    'alnum' => 'Your username must consist only of letters and digits',
     'lowercase' => 'Your username must be lowercase',
 ]);
 ```

--- a/docs/handling-exceptions.md
+++ b/docs/handling-exceptions.md
@@ -49,7 +49,7 @@ try {
 The code above generates the following output:
 
 ```no-highlight
-"The Panda" must contain only letters (a-z) and digits (0-9)
+"The Panda" must consist only of letters (a-z) and digits (0-9)
 ```
 
 ### Full exception message
@@ -71,8 +71,8 @@ The code above generates the following output:
 
 ```no-highlight
 - "The Panda" must pass all the rules
-  - "The Panda" must contain only letters (a-z) and digits (0-9)
-  - "The Panda" must contain only lowercase letters
+  - "The Panda" must consist only of letters (a-z) and digits (0-9)
+  - "The Panda" must consist only of lowercase letters
 ```
 
 ### Full exception messages as an array
@@ -96,8 +96,8 @@ The code above generates the following output:
 Array
 (
     [__root__] => "The Panda" must pass all the rules
-    [alnum] => "The Panda" must contain only letters (a-z) and digits (0-9)
-    [lowercase] => "The Panda" must contain only lowercase letters
+    [alnum] => "The Panda" must consist only of letters (a-z) and digits (0-9)
+    [lowercase] => "The Panda" must consist only of lowercase letters
 )
 ```
 
@@ -183,7 +183,7 @@ try {
             'The Panda',
             [
                 '__root__' => 'The given input is not valid',
-                'alnum' => 'Your username must contain only letters and digits',
+                'alnum' => 'Your username must consist only of letters and digits',
                 'lowercase' => 'Your username must be lowercase',
             ]
         );
@@ -198,7 +198,7 @@ The code above generates the following output.
 Array
 (
     [__root__] => The given input is not valid
-    [alnum] => Your username must contain only letters and digits
+    [alnum] => Your username must consist only of letters and digits
     [lowercase] => Your username must be lowercase
 )
 ```

--- a/docs/handling-results.md
+++ b/docs/handling-results.md
@@ -54,8 +54,8 @@ $result = v::alnum()->lowercase()->validate('The Panda');
 
 echo $result->getFullMessage();
 // → - "The Panda" must pass all the rules
-// →   - "The Panda" must contain only letters (a-z) and digits (0-9)
-// →   - "The Panda" must contain only lowercase letters
+// →   - "The Panda" must consist only of letters (a-z) and digits (0-9)
+// →   - "The Panda" must consist only of lowercase letters
 ```
 
 ### getMessages()
@@ -69,8 +69,8 @@ print_r($result->getMessages());
 // Array
 // (
 //     [__root__] => "The Panda" must pass all the rules
-//     [alnum] => "The Panda" must contain only letters (a-z) and digits (0-9)
-//     [lowercase] => "The Panda" must contain only lowercase letters
+//     [alnum] => "The Panda" must consist only of letters (a-z) and digits (0-9)
+//     [lowercase] => "The Panda" must consist only of lowercase letters
 // )
 ```
 

--- a/docs/messages/translation.md
+++ b/docs/messages/translation.md
@@ -36,10 +36,10 @@ Use the `|trans` modifier to translate parameter values:
 
 ```php
 // Message template
-'{{subject}} must be a valid telephone number for country {{countryName|trans}}'
+'{{subject}} must be a valid phone number for country {{countryName|trans}}'
 
 // Translations needed
-'{{subject}} must be a valid telephone number for country {{countryName|trans}}' => '{{subject}} deve ser um número de telefone válido para o país {{countryName|trans}}',
+'{{subject}} must be a valid phone number for country {{countryName|trans}}' => '{{subject}} deve ser um número de telefone válido para o país {{countryName|trans}}',
 'Palestine' => 'Palestina',
 ```
 

--- a/docs/validators/All.md
+++ b/docs/validators/All.md
@@ -57,7 +57,7 @@ The template serves as a prefix to the template of the inner validator.
 
 ```php
 v::all(v::floatType())->assert([1.5, 2]);
-// → Every item in `[1.5, 2]` must be float
+// → Every item in `[1.5, 2]` must be a float
 
 v::not(v::all(v::intType()))->assert([1, 2, -3]);
 // → Every item in `[1, 2, -3]` must not be an integer

--- a/docs/validators/Alnum.md
+++ b/docs/validators/Alnum.md
@@ -18,10 +18,10 @@ v::alnum(' ')->assert('foo 123');
 // Validation passes successfully
 
 v::alnum()->assert('foo 123');
-// → "foo 123" must contain only letters (a-z) and digits (0-9)
+// → "foo 123" must consist only of letters (a-z) and digits (0-9)
 
 v::alnum()->assert('100%');
-// → "100%" must contain only letters (a-z) and digits (0-9)
+// → "100%" must consist only of letters (a-z) and digits (0-9)
 
 v::alnum('%')->assert('100%');
 // Validation passes successfully
@@ -35,7 +35,7 @@ You can restrict case using the [Lowercase](Lowercase.md) and
 
 ```php
 v::alnum()->uppercase()->assert('example');
-// → "example" must contain only uppercase letters
+// → "example" must consist only of uppercase letters
 ```
 
 Message template for this validator includes `{{additionalChars}}` as the string
@@ -45,17 +45,17 @@ of extra chars passed as the parameter.
 
 ### `Alnum::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                     |
-| ---------: | :----------------------------------------------------------- |
-|  `default` | {{subject}} must contain only letters (a-z) and digits (0-9) |
-| `inverted` | {{subject}} must not contain letters (a-z) or digits (0-9)   |
+|       Mode | Template                                                           |
+| ---------: | :----------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of letters (a-z) and digits (0-9)    |
+| `inverted` | {{subject}} must not consist only of letters (a-z) or digits (0-9) |
 
 ### `Alnum::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                                           |
-| ---------: | :--------------------------------------------------------------------------------- |
-|  `default` | {{subject}} must contain only letters (a-z), digits (0-9), and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}   |
+|       Mode | Template                                                                                 |
+| ---------: | :--------------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of letters (a-z), digits (0-9), or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of letters (a-z), digits (0-9), or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -72,6 +72,7 @@ of extra chars passed as the parameter.
 
 | Version | Description                               |
 | ------: | :---------------------------------------- |
+|   3.0.0 | Templates changed                         |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.3.9 | Created                                   |
 

--- a/docs/validators/Alpha.md
+++ b/docs/validators/Alpha.md
@@ -16,10 +16,10 @@ v::alpha(' ')->assert('some name');
 // Validation passes successfully
 
 v::alpha()->assert('some name');
-// → "some name" must contain only letters (a-z)
+// → "some name" must consist only of letters (a-z)
 
 v::alpha()->assert('Cedric-Fabian');
-// → "Cedric-Fabian" must contain only letters (a-z)
+// → "Cedric-Fabian" must consist only of letters (a-z)
 
 v::alpha('-')->assert('Cedric-Fabian');
 // Validation passes successfully
@@ -33,24 +33,24 @@ You can restrict case using the [Lowercase](Lowercase.md) and
 
 ```php
 v::alpha()->uppercase()->assert('example');
-// → "example" must contain only uppercase letters
+// → "example" must consist only of uppercase letters
 ```
 
 ## Templates
 
 ### `Alpha::TEMPLATE_STANDARD`
 
-|       Mode | Template                                    |
-| ---------: | :------------------------------------------ |
-|  `default` | {{subject}} must contain only letters (a-z) |
-| `inverted` | {{subject}} must not contain letters (a-z)  |
+|       Mode | Template                                           |
+| ---------: | :------------------------------------------------- |
+|  `default` | {{subject}} must consist only of letters (a-z)     |
+| `inverted` | {{subject}} must not consist only of letters (a-z) |
 
 ### `Alpha::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                            |
-| ---------: | :------------------------------------------------------------------ |
-|  `default` | {{subject}} must contain only letters (a-z) and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain letters (a-z) or {{additionalChars}}   |
+|       Mode | Template                                                                  |
+| ---------: | :------------------------------------------------------------------------ |
+|  `default` | {{subject}} must consist only of letters (a-z) or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of letters (a-z) or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -67,6 +67,7 @@ v::alpha()->uppercase()->assert('example');
 
 | Version | Description                               |
 | ------: | :---------------------------------------- |
+|   3.0.0 | Templates changed                         |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.3.9 | Created                                   |
 

--- a/docs/validators/ArrayVal.md
+++ b/docs/validators/ArrayVal.md
@@ -25,10 +25,10 @@ v::arrayVal()->assert(new SimpleXMLElement('<xml></xml>'));
 
 ### `ArrayVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                               |
-| ---------: | :------------------------------------- |
-|  `default` | {{subject}} must be an array value     |
-| `inverted` | {{subject}} must not be an array value |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be an array     |
+| `inverted` | {{subject}} must not be an array |
 
 ## Template placeholders
 
@@ -45,6 +45,7 @@ v::arrayVal()->assert(new SimpleXMLElement('<xml></xml>'));
 
 | Version | Description                                                                                  |
 | ------: | :------------------------------------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                                            |
 |   2.0.0 | `SimpleXMLElement` is also considered as valid                                               |
 |   1.0.0 | Renamed from `Arr` to `ArrayVal` and validate only if the input can be used as an array (#1) |
 |   0.3.9 | Created as `Arr`                                                                             |

--- a/docs/validators/Attributes.md
+++ b/docs/validators/Attributes.md
@@ -47,13 +47,13 @@ v::attributes()->assert(new Person('', '2020-06-23', 'john.doe@gmail.com', '+120
 // → `.name` must be defined
 
 v::attributes()->assert(new Person('John Doe', 'not a date', 'john.doe@gmail.com', '+12024561111'));
-// → `.birthdate` must be a valid date in the format "2005-12-30"
+// → `.birthdate` must be a date in the "2005-12-30" format
 
 v::attributes()->assert(new Person('John Doe', '2020-06-23', 'not an email', '+12024561111'));
-// → `.email` must be a valid email address or must be null
+// → `.email` must be an email address or must be null
 
 v::attributes()->assert(new Person('John Doe', '2020-06-23', 'john.doe@gmail.com', 'not a phone number'));
-// → `.phone` must be a valid telephone number or must be null
+// → `.phone` must be a phone number or must be null
 
 v::attributes()->assert(new Person('John Doe', '2020-06-23'));
 // → - `Person { +$name="John Doe" +$birthdate="2020-06-23" +$email=null +$phone=null }` must pass at least one of the rules
@@ -63,9 +63,9 @@ v::attributes()->assert(new Person('John Doe', '2020-06-23'));
 v::attributes()->assert(new Person('', 'not a date', 'not an email', 'not a phone number'));
 // → - `Person { +$name="" +$birthdate="not a date" +$email="not an email" +$phone="not a phone number" }` must pass the rules
 // →   - `.name` must be defined
-// →   - `.birthdate` must be a valid date in the format "2005-12-30"
-// →   - `.email` must be a valid email address or must be null
-// →   - `.phone` must be a valid telephone number or must be null
+// →   - `.birthdate` must be a date in the "2005-12-30" format
+// →   - `.email` must be an email address or must be null
+// →   - `.phone` must be a phone number or must be null
 ```
 
 ## Caveats

--- a/docs/validators/Base64.md
+++ b/docs/validators/Base64.md
@@ -14,7 +14,7 @@ v::base64()->assert('cmVzcGVjdCE=');
 // Validation passes successfully
 
 v::base64()->assert('respect!');
-// → "respect!" must be a base64 encoded string
+// → "respect!" must be a base64-encoded string
 ```
 
 ## Templates
@@ -23,8 +23,8 @@ v::base64()->assert('respect!');
 
 |       Mode | Template                                        |
 | ---------: | :---------------------------------------------- |
-|  `default` | {{subject}} must be a base64 encoded string     |
-| `inverted` | {{subject}} must not be a base64 encoded string |
+|  `default` | {{subject}} must be a base64-encoded string     |
+| `inverted` | {{subject}} must not be a base64-encoded string |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::base64()->assert('respect!');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/BoolVal.md
+++ b/docs/validators/BoolVal.md
@@ -33,10 +33,10 @@ v::boolVal()->assert(0);
 
 ### `BoolVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                                |
-| ---------: | :-------------------------------------- |
-|  `default` | {{subject}} must be a boolean value     |
-| `inverted` | {{subject}} must not be a boolean value |
+|       Mode | Template                          |
+| ---------: | :-------------------------------- |
+|  `default` | {{subject}} must be a boolean     |
+| `inverted` | {{subject}} must not be a boolean |
 
 ## Template placeholders
 

--- a/docs/validators/Bsn.md
+++ b/docs/validators/Bsn.md
@@ -18,10 +18,10 @@ v::bsn()->assert('612890053');
 
 ### `Bsn::TEMPLATE_STANDARD`
 
-|       Mode | Template                            |
-| ---------: | :---------------------------------- |
-|  `default` | {{subject}} must be a valid BSN     |
-| `inverted` | {{subject}} must not be a valid BSN |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be a BSN     |
+| `inverted` | {{subject}} must not be a BSN |
 
 ## Template placeholders
 
@@ -35,9 +35,10 @@ v::bsn()->assert('612890053');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/CallableType.md
+++ b/docs/validators/CallableType.md
@@ -24,10 +24,10 @@ v::callableType()->assert([new DateTime(), 'format']);
 
 ### `CallableType::TEMPLATE_STANDARD`
 
-|       Mode | Template                           |
-| ---------: | :--------------------------------- |
-|  `default` | {{subject}} must be a callable     |
-| `inverted` | {{subject}} must not be a callable |
+|       Mode | Template                                    |
+| ---------: | :------------------------------------------ |
+|  `default` | {{subject}} must be a callable function     |
+| `inverted` | {{subject}} must not be a callable function |
 
 ## Template placeholders
 

--- a/docs/validators/Charset.md
+++ b/docs/validators/Charset.md
@@ -15,7 +15,7 @@ v::charset('ASCII')->assert('sugar');
 // Validation passes successfully
 
 v::charset('ASCII')->assert('açúcar');
-// → "açúcar" must only contain characters from the `["ASCII"]` charset
+// → "açúcar" must consist only of characters from the "ASCII" character-set
 
 v::charset('ISO-8859-1', 'EUC-JP')->assert('日本国');
 // Validation passes successfully
@@ -27,10 +27,10 @@ The array format is a logic OR, not AND.
 
 ### `Charset::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                                          |
-| ---------: | :-------------------------------------------------------------------------------- |
-|  `default` | {{subject}} must only contain characters from the {{charset&#124;raw}} charset    |
-| `inverted` | {{subject}} must not contain any characters from the {{charset&#124;raw}} charset |
+|       Mode | Template                                                                                        |
+| ---------: | :---------------------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of characters from the {{charset&#124;list:or}} character-set     |
+| `inverted` | {{subject}} must not consist only of characters from the {{charset&#124;list:or}} character-set |
 
 ## Template placeholders
 
@@ -47,6 +47,7 @@ The array format is a logic OR, not AND.
 
 | Version | Description                                           |
 | ------: | :---------------------------------------------------- |
+|   3.0.0 | Templates changed                                     |
 |   2.0.0 | Charset supports multiple charsets on its constructor |
 |   0.5.0 | Created                                               |
 

--- a/docs/validators/Cnh.md
+++ b/docs/validators/Cnh.md
@@ -18,10 +18,10 @@ v::cnh()->assert('02650306461');
 
 ### `Cnh::TEMPLATE_STANDARD`
 
-|       Mode | Template                                   |
-| ---------: | :----------------------------------------- |
-|  `default` | {{subject}} must be a valid CNH number     |
-| `inverted` | {{subject}} must not be a valid CNH number |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be a CNH     |
+| `inverted` | {{subject}} must not be a CNH |
 
 ## Template placeholders
 
@@ -35,9 +35,10 @@ v::cnh()->assert('02650306461');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Cnpj.md
+++ b/docs/validators/Cnpj.md
@@ -19,10 +19,10 @@ v::cnpj()->assert('00394460005887');
 
 ### `Cnpj::TEMPLATE_STANDARD`
 
-|       Mode | Template                                    |
-| ---------: | :------------------------------------------ |
-|  `default` | {{subject}} must be a valid CNPJ number     |
-| `inverted` | {{subject}} must not be a valid CNPJ number |
+|       Mode | Template                       |
+| ---------: | :----------------------------- |
+|  `default` | {{subject}} must be a CNPJ     |
+| `inverted` | {{subject}} must not be a CNPJ |
 
 ## Template placeholders
 
@@ -36,9 +36,10 @@ v::cnpj()->assert('00394460005887');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Consonant.md
+++ b/docs/validators/Consonant.md
@@ -19,17 +19,17 @@ v::consonant()->assert('xkcd');
 
 ### `Consonant::TEMPLATE_STANDARD`
 
-|       Mode | Template                                 |
-| ---------: | :--------------------------------------- |
-|  `default` | {{subject}} must only contain consonants |
-| `inverted` | {{subject}} must not contain consonants  |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must consist only of consonants     |
+| `inverted` | {{subject}} must not consist only of consonants |
 
 ### `Consonant::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                         |
-| ---------: | :--------------------------------------------------------------- |
-|  `default` | {{subject}} must only contain consonants and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain consonants or {{additionalChars}}   |
+|       Mode | Template                                                               |
+| ---------: | :--------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of consonants or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of consonants or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -46,6 +46,7 @@ v::consonant()->assert('xkcd');
 
 | Version | Description                              |
 | ------: | :--------------------------------------- |
+|   3.0.0 | Templates changed                        |
 |   0.5.0 | Renamed from `Consonants` to `Consonant` |
 |   0.3.9 | Created as `Consonants`                  |
 

--- a/docs/validators/Control.md
+++ b/docs/validators/Control.md
@@ -20,17 +20,17 @@ v::control()->assert("\n\r\t");
 
 ### `Control::TEMPLATE_STANDARD`
 
-|       Mode | Template                                         |
-| ---------: | :----------------------------------------------- |
-|  `default` | {{subject}} must only contain control characters |
-| `inverted` | {{subject}} must not contain control characters  |
+|       Mode | Template                                                |
+| ---------: | :------------------------------------------------------ |
+|  `default` | {{subject}} must consist only of control characters     |
+| `inverted` | {{subject}} must not consist only of control characters |
 
 ### `Control::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                                 |
-| ---------: | :----------------------------------------------------------------------- |
-|  `default` | {{subject}} must only contain control characters and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain control characters or {{additionalChars}}   |
+|       Mode | Template                                                                       |
+| ---------: | :----------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of control characters or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of control characters or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -47,6 +47,7 @@ v::control()->assert("\n\r\t");
 
 | Version | Description                       |
 | ------: | :-------------------------------- |
+|   3.0.0 | Templates changed                 |
 |   2.0.0 | Renamed from `Cntrl` to `Control` |
 |   0.5.0 | Created                           |
 

--- a/docs/validators/Countable.md
+++ b/docs/validators/Countable.md
@@ -18,17 +18,17 @@ v::countable()->assert(new ArrayObject());
 // Validation passes successfully
 
 v::countable()->assert('string');
-// → "string" must be a countable value
+// → "string" must be countable
 ```
 
 ## Templates
 
 ### `Countable::TEMPLATE_STANDARD`
 
-|       Mode | Template                                  |
-| ---------: | :---------------------------------------- |
-|  `default` | {{subject}} must be a countable value     |
-| `inverted` | {{subject}} must not be a countable value |
+|       Mode | Template                          |
+| ---------: | :-------------------------------- |
+|  `default` | {{subject}} must be countable     |
+| `inverted` | {{subject}} must not be countable |
 
 ## Template placeholders
 
@@ -44,6 +44,7 @@ v::countable()->assert('string');
 
 | Version | Description             |
 | ------: | :---------------------- |
+|   3.0.0 | Templates changed       |
 |   1.0.0 | Created from `ArrayVal` |
 
 ## See Also

--- a/docs/validators/CountryCode.md
+++ b/docs/validators/CountryCode.md
@@ -38,10 +38,10 @@ When no set is defined, the validator uses `'alpha-2'` (`CountryCode::ALPHA2`).
 
 ### `CountryCode::TEMPLATE_STANDARD`
 
-|       Mode | Template                                     |
-| ---------: | :------------------------------------------- |
-|  `default` | {{subject}} must be a valid country code     |
-| `inverted` | {{subject}} must not be a valid country code |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be a country code     |
+| `inverted` | {{subject}} must not be a country code |
 
 ## Template placeholders
 
@@ -58,6 +58,7 @@ When no set is defined, the validator uses `'alpha-2'` (`CountryCode::ALPHA2`).
 
 | Version | Description                                                       |
 | ------: | :---------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                 |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   2.0.0 | Became case-sensitive                                             |
 |   0.5.0 | Created                                                           |

--- a/docs/validators/Cpf.md
+++ b/docs/validators/Cpf.md
@@ -33,10 +33,10 @@ v::digit()->cpf()->assert('11598647644');
 
 ### `Cpf::TEMPLATE_STANDARD`
 
-|       Mode | Template                                   |
-| ---------: | :----------------------------------------- |
-|  `default` | {{subject}} must be a valid CPF number     |
-| `inverted` | {{subject}} must not be a valid CPF number |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be a CPF     |
+| `inverted` | {{subject}} must not be a CPF |
 
 ## Template placeholders
 
@@ -50,9 +50,10 @@ v::digit()->cpf()->assert('11598647644');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/CreditCard.md
+++ b/docs/validators/CreditCard.md
@@ -64,17 +64,17 @@ v::digit()->creditCard()->assert('5376747397208720');
 
 ### `CreditCard::TEMPLATE_STANDARD`
 
-|       Mode | Template                                           |
-| ---------: | :------------------------------------------------- |
-|  `default` | {{subject}} must be a valid credit card number     |
-| `inverted` | {{subject}} must not be a valid credit card number |
+|       Mode | Template                                     |
+| ---------: | :------------------------------------------- |
+|  `default` | {{subject}} must be a credit card number     |
+| `inverted` | {{subject}} must not be a credit card number |
 
 ### `CreditCard::TEMPLATE_BRANDED`
 
-|       Mode | Template                                                              |
-| ---------: | :-------------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid {{brand&#124;raw}} credit card number     |
-| `inverted` | {{subject}} must not be a valid {{brand&#124;raw}} credit card number |
+|       Mode | Template                                                        |
+| ---------: | :-------------------------------------------------------------- |
+|  `default` | {{subject}} must be a {{brand&#124;raw}} credit card number     |
+| `inverted` | {{subject}} must not be a {{brand&#124;raw}} credit card number |
 
 ## Template placeholders
 
@@ -91,6 +91,7 @@ v::digit()->creditCard()->assert('5376747397208720');
 
 | Version | Description                        |
 | ------: | :--------------------------------- |
+|   3.0.0 | Templates changed                  |
 |   2.2.4 | RuPay is now supported as a brand  |
 |   1.1.0 | Allow the define credit card brand |
 |   0.3.9 | Created                            |

--- a/docs/validators/CurrencyCode.md
+++ b/docs/validators/CurrencyCode.md
@@ -26,10 +26,10 @@ This validator supports the two [ISO 4217][] sets:
 
 ### `CurrencyCode::TEMPLATE_STANDARD`
 
-|       Mode | Template                                      |
-| ---------: | :-------------------------------------------- |
-|  `default` | {{subject}} must be a valid currency code     |
-| `inverted` | {{subject}} must not be a valid currency code |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a currency code     |
+| `inverted` | {{subject}} must not be a currency code |
 
 ## Template placeholders
 
@@ -46,6 +46,7 @@ This validator supports the two [ISO 4217][] sets:
 
 | Version | Description                                                       |
 | ------: | :---------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                 |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   2.0.0 | Became case-sensitive                                             |
 |   1.0.0 | Created                                                           |

--- a/docs/validators/Date.md
+++ b/docs/validators/Date.md
@@ -33,7 +33,7 @@ v::date()->assert('2020-02-29');
 // Validation passes successfully
 
 v::date()->assert('2019-02-29');
-// → "2019-02-29" must be a valid date in the format "2005-12-30"
+// → "2019-02-29" must be a date in the "2005-12-30" format
 
 v::date('m/d/y')->assert('12/31/17');
 // Validation passes successfully
@@ -49,10 +49,10 @@ v::date('Ydm')->assert(20173112);
 
 ### `Date::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                      |
-| ---------: | :------------------------------------------------------------ |
-|  `default` | {{subject}} must be a valid date in the format {{sample}}     |
-| `inverted` | {{subject}} must not be a valid date in the format {{sample}} |
+|       Mode | Template                                                |
+| ---------: | :------------------------------------------------------ |
+|  `default` | {{subject}} must be a date in the {{sample}} format     |
+| `inverted` | {{subject}} must not be a date in the {{sample}} format |
 
 ## Template placeholders
 
@@ -69,6 +69,7 @@ v::date('Ydm')->assert(20173112);
 
 | Version | Description                    |
 | ------: | :----------------------------- |
+|   3.0.0 | Templates changed              |
 |   2.0.0 | Changed to only validate dates |
 |   0.3.9 | Created as `Date`              |
 

--- a/docs/validators/DateTime.md
+++ b/docs/validators/DateTime.md
@@ -40,7 +40,7 @@ You can pass a format when validating strings:
 
 ```php
 v::dateTime('Y-m-d')->assert('01-01-2009');
-// → "01-01-2009" must be a valid date/time in the format "2005-12-30"
+// → "01-01-2009" must be a date/time in the "2005-12-30" format
 ```
 
 Format has no effect when validating DateTime instances.
@@ -65,24 +65,24 @@ v::satisfies(fn($input) => is_string($input) && DateTime::createFromFormat(DateT
 // Validation passes successfully
 
 v::dateTime(DateTime::RFC3339_EXTENDED)->assert($input);
-// → "2014-04-12T23:20:50.052Z" must be a valid date/time in the format "2005-12-30T01:02:03.000+00:00"
+// → "2014-04-12T23:20:50.052Z" must be a date/time in the "2005-12-30T01:02:03.000+00:00" format
 ```
 
 ## Templates
 
 ### `DateTime::TEMPLATE_STANDARD`
 
-|       Mode | Template                                  |
-| ---------: | :---------------------------------------- |
-|  `default` | {{subject}} must be a valid date/time     |
-| `inverted` | {{subject}} must not be a valid date/time |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a date/time     |
+| `inverted` | {{subject}} must not be a date/time |
 
 ### `DateTime::TEMPLATE_FORMAT`
 
-|       Mode | Template                                                           |
-| ---------: | :----------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid date/time in the format {{sample}}     |
-| `inverted` | {{subject}} must not be a valid date/time in the format {{sample}} |
+|       Mode | Template                                                     |
+| ---------: | :----------------------------------------------------------- |
+|  `default` | {{subject}} must be a date/time in the {{sample}} format     |
+| `inverted` | {{subject}} must not be a date/time in the {{sample}} format |
 
 ## Template placeholders
 
@@ -99,6 +99,7 @@ v::dateTime(DateTime::RFC3339_EXTENDED)->assert($input);
 
 | Version | Description                                |
 | ------: | :----------------------------------------- |
+|   3.0.0 | Templates changed                          |
 |   2.3.0 | Validation became a lot stricter           |
 |   2.2.4 | `v::dateTime('z')` is no longer supported. |
 |   2.0.0 | Created                                    |

--- a/docs/validators/DateTimeDiff.md
+++ b/docs/validators/DateTimeDiff.md
@@ -63,19 +63,19 @@ Used when `$format` or `$now` are defined.
 
 ### `DateTimeDiff::TEMPLATE_NOT_A_DATE`
 
-|       Mode | Template                                                                       |
-| ---------: | :----------------------------------------------------------------------------- |
-|  `default` | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime     |
-| `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a valid datetime |
+|       Mode | Template                                                                 |
+| ---------: | :----------------------------------------------------------------------- |
+|  `default` | For comparison with {{now&#124;raw}}, {{subject}} must be a datetime     |
+| `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a datetime |
 
 ### `DateTimeDiff::TEMPLATE_WRONG_FORMAT`
 
 Used when the input cannot be parsed with the given format.
 
-|       Mode | Template                                                                                                         |
-| ---------: | :--------------------------------------------------------------------------------------------------------------- |
-|  `default` | For comparison with {{now&#124;raw}}, {{subject}} must be a valid datetime in the format {{sample&#124;raw}}     |
-| `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a valid datetime in the format {{sample&#124;raw}} |
+|       Mode | Template                                                                                                   |
+| ---------: | :--------------------------------------------------------------------------------------------------------- |
+|  `default` | For comparison with {{now&#124;raw}}, {{subject}} must be a datetime in the format {{sample&#124;raw}}     |
+| `inverted` | For comparison with {{now&#124;raw}}, {{subject}} must not be a datetime in the format {{sample&#124;raw}} |
 
 ## Template as prefix
 

--- a/docs/validators/Decimal.md
+++ b/docs/validators/Decimal.md
@@ -14,7 +14,7 @@ v::decimal(2)->assert('27990.50');
 // Validation passes successfully
 
 v::decimal(1)->assert('27990.50');
-// → "27990.50" must have 1 decimals
+// → "27990.50" must have 1 decimal places
 
 v::decimal(1)->assert(1.5);
 // Validation passes successfully
@@ -34,10 +34,10 @@ v::decimal(1)->assert(1.50);
 
 ### `Decimal::TEMPLATE_STANDARD`
 
-|       Mode | Template                                        |
-| ---------: | :---------------------------------------------- |
-|  `default` | {{subject}} must have {{decimals}} decimals     |
-| `inverted` | {{subject}} must not have {{decimals}} decimals |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | {{subject}} must have {{decimals}} decimal places     |
+| `inverted` | {{subject}} must not have {{decimals}} decimal places |
 
 ## Template placeholders
 
@@ -54,6 +54,7 @@ v::decimal(1)->assert(1.50);
 
 | Version | Description                                     |
 | ------: | :---------------------------------------------- |
+|   3.0.0 | Templates changed                               |
 |   2.2.4 | Float values with trailing zeroes are now valid |
 |   2.0.0 | Created                                         |
 

--- a/docs/validators/Digit.md
+++ b/docs/validators/Digit.md
@@ -15,10 +15,10 @@ v::digit(' ')->assert('020 612 1851');
 // Validation passes successfully
 
 v::digit()->assert('020 612 1851');
-// → "020 612 1851" must contain only digits (0-9)
+// → "020 612 1851" must consist only of digits (0-9)
 
 v::digit()->assert('172.655.537-21');
-// → "172.655.537-21" must contain only digits (0-9)
+// → "172.655.537-21" must consist only of digits (0-9)
 
 v::digit('.', '-')->assert('172.655.537-21');
 // Validation passes successfully
@@ -28,17 +28,17 @@ v::digit('.', '-')->assert('172.655.537-21');
 
 ### `Digit::TEMPLATE_STANDARD`
 
-|       Mode | Template                                   |
-| ---------: | :----------------------------------------- |
-|  `default` | {{subject}} must contain only digits (0-9) |
-| `inverted` | {{subject}} must not contain digits (0-9)  |
+|       Mode | Template                                          |
+| ---------: | :------------------------------------------------ |
+|  `default` | {{subject}} must consist only of digits (0-9)     |
+| `inverted` | {{subject}} must not consist only of digits (0-9) |
 
 ### `Digit::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                           |
-| ---------: | :----------------------------------------------------------------- |
-|  `default` | {{subject}} must contain only digits (0-9) and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain digits (0-9) and {{additionalChars}}  |
+|       Mode | Template                                                                 |
+| ---------: | :----------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of digits (0-9) or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of digits (0-9) or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -56,6 +56,7 @@ v::digit('.', '-')->assert('172.655.537-21');
 
 | Version | Description                               |
 | ------: | :---------------------------------------- |
+|   3.0.0 | Templates changed                         |
 |   2.0.0 | Removed support to whitespaces by default |
 |   0.5.0 | Renamed from `Digits` to `Digit`          |
 |   0.3.9 | Created as `Digits`                       |

--- a/docs/validators/Directory.md
+++ b/docs/validators/Directory.md
@@ -14,7 +14,7 @@ v::directory()->assert(__DIR__);
 // Validation passes successfully
 
 v::directory()->assert(__FILE__);
-// → "/path/to/file" must be a directory
+// → "/path/to/file" must be an accessible existing directory
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
@@ -31,10 +31,10 @@ v::directory()->assert(dir('/'));
 
 ### `Directory::TEMPLATE_STANDARD`
 
-|       Mode | Template                            |
-| ---------: | :---------------------------------- |
-|  `default` | {{subject}} must be a directory     |
-| `inverted` | {{subject}} must not be a directory |
+|       Mode | Template                                                 |
+| ---------: | :------------------------------------------------------- |
+|  `default` | {{subject}} must be an accessible existing directory     |
+| `inverted` | {{subject}} must not be an accessible existing directory |
 
 ## Template placeholders
 
@@ -50,6 +50,7 @@ v::directory()->assert(dir('/'));
 
 | Version | Description                       |
 | ------: | :-------------------------------- |
+|   3.0.0 | Templates changed                 |
 |   2.0.0 | Validates PHP's `Directory` class |
 |   0.4.4 | Created                           |
 

--- a/docs/validators/Domain.md
+++ b/docs/validators/Domain.md
@@ -40,10 +40,10 @@ Messages for this validator will reflect validators above.
 
 ### `Domain::TEMPLATE_STANDARD`
 
-|       Mode | Template                               |
-| ---------: | :------------------------------------- |
-|  `default` | {{subject}} must be a valid domain     |
-| `inverted` | {{subject}} must not be a valid domain |
+|       Mode | Template                                   |
+| ---------: | :----------------------------------------- |
+|  `default` | {{subject}} must be an internet domain     |
+| `inverted` | {{subject}} must not be an internet domain |
 
 ## Template placeholders
 
@@ -59,6 +59,7 @@ Messages for this validator will reflect validators above.
 
 | Version | Description             |
 | ------: | :---------------------- |
+|   3.0.0 | Templates changed       |
 |   0.6.0 | Allow to skip TLD check |
 |   0.3.9 | Created                 |
 

--- a/docs/validators/Email.md
+++ b/docs/validators/Email.md
@@ -18,10 +18,10 @@ v::email()->assert('alganet@gmail.com');
 
 ### `Email::TEMPLATE_STANDARD`
 
-|       Mode | Template                                  |
-| ---------: | :---------------------------------------- |
-|  `default` | {{subject}} must be a valid email address |
-| `inverted` | {{subject}} must not be an email address  |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be an email address     |
+| `inverted` | {{subject}} must not be an email address |
 
 ## Template placeholders
 
@@ -37,6 +37,7 @@ v::email()->assert('alganet@gmail.com');
 
 | Version | Description                                       |
 | ------: | :------------------------------------------------ |
+|   3.0.0 | Templates changed                                 |
 |   2.3.0 | Use "egulias/emailvalidator" version 4.0          |
 |   0.9.0 | Use "egulias/emailvalidator" for email validation |
 |   0.3.9 | Created                                           |

--- a/docs/validators/Executable.md
+++ b/docs/validators/Executable.md
@@ -14,17 +14,17 @@ v::executable()->assert('/path/to/executable');
 // Validation passes successfully
 
 v::executable()->assert('/path/to/file');
-// → "/path/to/file" must be an executable file
+// → "/path/to/file" must be an accessible existing executable file
 ```
 
 ## Templates
 
 ### `Executable::TEMPLATE_STANDARD`
 
-|       Mode | Template                                   |
-| ---------: | :----------------------------------------- |
-|  `default` | {{subject}} must be an executable file     |
-| `inverted` | {{subject}} must not be an executable file |
+|       Mode | Template                                                       |
+| ---------: | :------------------------------------------------------------- |
+|  `default` | {{subject}} must be an accessible existing executable file     |
+| `inverted` | {{subject}} must not be an accessible existing executable file |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::executable()->assert('/path/to/file');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.7.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.7.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Extension.md
+++ b/docs/validators/Extension.md
@@ -20,10 +20,10 @@ This validator is case-sensitive.
 
 ### `Extension::TEMPLATE_STANDARD`
 
-|       Mode | Template                                          |
-| ---------: | :------------------------------------------------ |
-|  `default` | {{subject}} must have {{extension}} extension     |
-| `inverted` | {{subject}} must not have {{extension}} extension |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | {{subject}} must have the {{extension}} extension     |
+| `inverted` | {{subject}} must not have the {{extension}} extension |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ This validator is case-sensitive.
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/File.md
+++ b/docs/validators/File.md
@@ -14,7 +14,7 @@ v::file()->assert(__FILE__);
 // Validation passes successfully
 
 v::file()->assert(__DIR__);
-// → "/path/to/dir" must be a valid file
+// → "/path/to/dir" must be an accessible existing file
 ```
 
 This validator will consider SplFileInfo instances, so you can do something like:
@@ -28,10 +28,10 @@ v::file()->assert(new SplFileInfo('/path/to/file.txt'));
 
 ### `File::TEMPLATE_STANDARD`
 
-|       Mode | Template                            |
-| ---------: | :---------------------------------- |
-|  `default` | {{subject}} must be a valid file    |
-| `inverted` | {{subject}} must be an invalid file |
+|       Mode | Template                                            |
+| ---------: | :-------------------------------------------------- |
+|  `default` | {{subject}} must be an accessible existing file     |
+| `inverted` | {{subject}} must not be an accessible existing file |
 
 ## Template placeholders
 
@@ -45,9 +45,10 @@ v::file()->assert(new SplFileInfo('/path/to/file.txt'));
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/FloatType.md
+++ b/docs/validators/FloatType.md
@@ -14,7 +14,7 @@ v::floatType()->assert(1.5);
 // Validation passes successfully
 
 v::floatType()->assert('1.5');
-// → "1.5" must be float
+// → "1.5" must be a float
 
 v::floatType()->assert(0e5);
 // Validation passes successfully
@@ -24,10 +24,10 @@ v::floatType()->assert(0e5);
 
 ### `FloatType::TEMPLATE_STANDARD`
 
-|       Mode | Template                      |
-| ---------: | :---------------------------- |
-|  `default` | {{subject}} must be float     |
-| `inverted` | {{subject}} must not be float |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be a float     |
+| `inverted` | {{subject}} must not be a float |
 
 ## Template placeholders
 
@@ -42,9 +42,10 @@ v::floatType()->assert(0e5);
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/FloatVal.md
+++ b/docs/validators/FloatVal.md
@@ -21,10 +21,10 @@ v::floatVal()->assert('1e5');
 
 ### `FloatVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                              |
-| ---------: | :------------------------------------ |
-|  `default` | {{subject}} must be a float value     |
-| `inverted` | {{subject}} must not be a float value |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must be a floating-point number     |
+| `inverted` | {{subject}} must not be a floating-point number |
 
 ## Template placeholders
 
@@ -39,9 +39,10 @@ v::floatVal()->assert('1e5');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Graph.md
+++ b/docs/validators/Graph.md
@@ -20,17 +20,17 @@ v::graph()->assert('LKM@#$%4;');
 
 ### `Graph::TEMPLATE_STANDARD`
 
-|       Mode | Template                                           |
-| ---------: | :------------------------------------------------- |
-|  `default` | {{subject}} must contain only graphical characters |
-| `inverted` | {{subject}} must not contain graphical characters  |
+|       Mode | Template                                                              |
+| ---------: | :-------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of printable non-spacing characters     |
+| `inverted` | {{subject}} must not consist only of printable non-spacing characters |
 
 ### `Graph::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                                   |
-| ---------: | :------------------------------------------------------------------------- |
-|  `default` | {{subject}} must contain only graphical characters and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain graphical characters or {{additionalChars}}   |
+|       Mode | Template                                                                                     |
+| ---------: | :------------------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of printable non-spacing characters or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of printable non-spacing characters or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -45,9 +45,10 @@ v::graph()->assert('LKM@#$%4;');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Hetu.md
+++ b/docs/validators/Hetu.md
@@ -20,7 +20,7 @@ v::hetu()->assert('280291+923X');
 // Validation passes successfully
 
 v::hetu()->assert('010106_9012');
-// → "010106_9012" must be a valid Finnish personal identity code
+// → "010106_9012" must be a Finnish personal identity code
 ```
 
 The validation is case-sensitive.
@@ -29,10 +29,10 @@ The validation is case-sensitive.
 
 ### `Hetu::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                       |
-| ---------: | :------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid Finnish personal identity code     |
-| `inverted` | {{subject}} must not be a valid Finnish personal identity code |
+|       Mode | Template                                                 |
+| ---------: | :------------------------------------------------------- |
+|  `default` | {{subject}} must be a Finnish personal identity code     |
+| `inverted` | {{subject}} must not be a Finnish personal identity code |
 
 ## Template placeholders
 

--- a/docs/validators/Iban.md
+++ b/docs/validators/Iban.md
@@ -15,26 +15,26 @@ v::iban()->assert('SE35 5000 0000 0549 1000 0003');
 // Validation passes successfully
 
 v::iban()->assert('ch9300762011623852957');
-// → "ch9300762011623852957" must be a valid IBAN
+// → "ch9300762011623852957" must be an IBAN
 
 v::iban()->assert('ZZ32 5000 5880 7742');
-// → "ZZ32 5000 5880 7742" must be a valid IBAN
+// → "ZZ32 5000 5880 7742" must be an IBAN
 
 v::iban()->assert(123456789);
-// → 123456789 must be a valid IBAN
+// → 123456789 must be an IBAN
 
 v::iban()->assert('');
-// → "" must be a valid IBAN
+// → "" must be an IBAN
 ```
 
 ## Templates
 
 ### `Iban::TEMPLATE_STANDARD`
 
-|       Mode | Template                             |
-| ---------: | :----------------------------------- |
-|  `default` | {{subject}} must be a valid IBAN     |
-| `inverted` | {{subject}} must not be a valid IBAN |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be an IBAN     |
+| `inverted` | {{subject}} must not be an IBAN |
 
 ## Template placeholders
 
@@ -48,9 +48,10 @@ v::iban()->assert('');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Image.md
+++ b/docs/validators/Image.md
@@ -29,10 +29,10 @@ This validator relies on [fileinfo](http://php.net/fileinfo) PHP extension.
 
 ### `Image::TEMPLATE_STANDARD`
 
-|       Mode | Template                                   |
-| ---------: | :----------------------------------------- |
-|  `default` | {{subject}} must be a valid image file     |
-| `inverted` | {{subject}} must not be a valid image file |
+|       Mode | Template                                                  |
+| ---------: | :-------------------------------------------------------- |
+|  `default` | {{subject}} must be an accessible existing image file     |
+| `inverted` | {{subject}} must not be an accessible existing image file |
 
 ## Template placeholders
 
@@ -46,9 +46,10 @@ This validator relies on [fileinfo](http://php.net/fileinfo) PHP extension.
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.1.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.1.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Imei.md
+++ b/docs/validators/Imei.md
@@ -21,10 +21,10 @@ v::imei()->assert('490154203237518');
 
 ### `Imei::TEMPLATE_STANDARD`
 
-|       Mode | Template                                    |
-| ---------: | :------------------------------------------ |
-|  `default` | {{subject}} must be a valid IMEI number     |
-| `inverted` | {{subject}} must not be a valid IMEI number |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be an IMEI number     |
+| `inverted` | {{subject}} must not be an IMEI number |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::imei()->assert('490154203237518');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/IntVal.md
+++ b/docs/validators/IntVal.md
@@ -32,10 +32,10 @@ value this validator validates, without having surprises.
 
 ```php
 v::intVal()->assert(true);
-// → `true` must be an integer value
+// → `true` must be an integer
 
 v::intVal()->assert('89a');
-// → "89a" must be an integer value
+// → "89a" must be an integer
 ```
 
 Even though PHP can cast the values above as integers, this validator will not
@@ -45,10 +45,10 @@ consider them as valid.
 
 ### `IntVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                                 |
-| ---------: | :--------------------------------------- |
-|  `default` | {{subject}} must be an integer value     |
-| `inverted` | {{subject}} must not be an integer value |
+|       Mode | Template                           |
+| ---------: | :--------------------------------- |
+|  `default` | {{subject}} must be an integer     |
+| `inverted` | {{subject}} must not be an integer |
 
 ## Template placeholders
 
@@ -65,6 +65,7 @@ consider them as valid.
 
 | Version | Description                                               |
 | ------: | :-------------------------------------------------------- |
+|   3.0.0 | Templates changed                                         |
 |   2.2.4 | Improved support for negative values with trailing zeroes |
 |  2.0.14 | Allow leading zeros                                       |
 |   1.0.0 | Renamed from `Int` to `IntVal`                            |

--- a/docs/validators/Ip.md
+++ b/docs/validators/Ip.md
@@ -79,6 +79,7 @@ v::ip('*', FILTER_FLAG_IPV6)->assert('2001:0db8:85a3:08d3:1319:8a2e:0370:7334');
 
 | Version | Description                                            |
 | ------: | :----------------------------------------------------- |
+|   3.0.0 | Templates changed                                      |
 |   2.0.0 | Allow to define range and options to the same instance |
 |   0.5.0 | Implemented IP range validation                        |
 |   0.3.9 | Created                                                |

--- a/docs/validators/Isbn.md
+++ b/docs/validators/Isbn.md
@@ -17,20 +17,20 @@ v::isbn()->assert('978 0 596 52068 7');
 // Validation passes successfully
 
 v::isbn()->assert('ISBN-12: 978-0-596-52068-7');
-// → "ISBN-12: 978-0-596-52068-7" must be a valid ISBN
+// → "ISBN-12: 978-0-596-52068-7" must be an ISBN
 
 v::isbn()->assert('978 10 596 52068 7');
-// → "978 10 596 52068 7" must be a valid ISBN
+// → "978 10 596 52068 7" must be an ISBN
 ```
 
 ## Templates
 
 ### `Isbn::TEMPLATE_STANDARD`
 
-|       Mode | Template                             |
-| ---------: | :----------------------------------- |
-|  `default` | {{subject}} must be a valid ISBN     |
-| `inverted` | {{subject}} must not be a valid ISBN |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be an ISBN     |
+| `inverted` | {{subject}} must not be an ISBN |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::isbn()->assert('978 10 596 52068 7');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/IterableVal.md
+++ b/docs/validators/IterableVal.md
@@ -20,7 +20,7 @@ v::iterableVal()->assert(new stdClass());
 // Validation passes successfully
 
 v::iterableVal()->assert('string');
-// → "string" must be an iterable value
+// → "string" must be iterable
 ```
 
 ## Note
@@ -31,10 +31,10 @@ This validator doesn't behave as PHP's [is_iterable()][] function because it con
 
 ### `IterableVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                                  |
-| ---------: | :---------------------------------------- |
-|  `default` | {{subject}} must be an iterable value     |
-| `inverted` | {{subject}} must not be an iterable value |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be iterable     |
+| `inverted` | {{subject}} must not be iterable |
 
 ## Template placeholders
 
@@ -50,6 +50,7 @@ This validator doesn't behave as PHP's [is_iterable()][] function because it con
 
 | Version | Description                                  |
 | ------: | :------------------------------------------- |
+|   3.0.0 | Templates changed                            |
 |   3.0.0 | Renamed from `IterableType` to `IterableVal` |
 |   1.0.8 | Renamed from `Iterable` to `IterableType`    |
 |   1.0.0 | Created as `Iterable`                        |

--- a/docs/validators/Json.md
+++ b/docs/validators/Json.md
@@ -18,10 +18,10 @@ v::json()->assert('{"foo":"bar"}');
 
 ### `Json::TEMPLATE_STANDARD`
 
-|       Mode | Template                                    |
-| ---------: | :------------------------------------------ |
-|  `default` | {{subject}} must be a valid JSON string     |
-| `inverted` | {{subject}} must not be a valid JSON string |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a JSON string     |
+| `inverted` | {{subject}} must not be a JSON string |
 
 ## Template placeholders
 
@@ -35,9 +35,10 @@ v::json()->assert('{"foo":"bar"}');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Key.md
+++ b/docs/validators/Key.md
@@ -41,7 +41,7 @@ v::key('email', v::email())->assert([]);
 // → `.email` must be present
 
 v::key('email', v::email())->assert(['email' => 'not email']);
-// → `.email` must be a valid email address
+// → `.email` must be an email address
 ```
 
 ## Note
@@ -67,6 +67,7 @@ v::key('email', v::email())->assert(['email' => 'not email']);
 
 | Version | Description                                                          |
 | ------: | :------------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                    |
 |   3.0.0 | Split by [KeyExists](KeyExists.md) and [KeyOptional](KeyOptional.md) |
 |   0.3.9 | Created                                                              |
 

--- a/docs/validators/KeyOptional.md
+++ b/docs/validators/KeyOptional.md
@@ -23,14 +23,14 @@ v::keyOptional('email', v::email())->assert(['email' => 'therespectpanda@gmail.c
 // Validation passes successfully
 
 v::keyOptional('age', v::intVal())->assert(['age' => 'Twenty-Five']);
-// → `.age` must be an integer value
+// → `.age` must be an integer
 ```
 
 The name of this validator is automatically set to the key name.
 
 ```php
 v::keyOptional('age', v::intVal())->assert(['age' => 'Twenty-Five']);
-// → `.age` must be an integer value
+// → `.age` must be an integer
 ```
 
 ## Note

--- a/docs/validators/KeySet.md
+++ b/docs/validators/KeySet.md
@@ -27,7 +27,7 @@ It will validate the keys in the array with the validators passed in the constru
 v::keySet(
     v::key('foo', v::intVal())
 )->assert(['foo' => 'string']);
-// → `.foo` must be an integer value
+// → `.foo` must be an integer
 ```
 
 Extra keys are not allowed:

--- a/docs/validators/LanguageCode.md
+++ b/docs/validators/LanguageCode.md
@@ -38,10 +38,10 @@ This validator supports the two[ISO 639][] sets:
 
 ### `LanguageCode::TEMPLATE_STANDARD`
 
-|       Mode | Template                                      |
-| ---------: | :-------------------------------------------- |
-|  `default` | {{subject}} must be a valid language code     |
-| `inverted` | {{subject}} must not be a valid language code |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a language code     |
+| `inverted` | {{subject}} must not be a language code |
 
 ## Template placeholders
 
@@ -58,6 +58,7 @@ This validator supports the two[ISO 639][] sets:
 
 | Version | Description                                                       |
 | ------: | :---------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                 |
 |   3.0.0 | Require [sokil/php-isocodes][] and [sokil/php-isocodes-db-only][] |
 |   1.1.0 | Created                                                           |
 

--- a/docs/validators/LeapDate.md
+++ b/docs/validators/LeapDate.md
@@ -21,10 +21,10 @@ parameter is mandatory.
 
 ### `LeapDate::TEMPLATE_STANDARD`
 
-|       Mode | Template                              |
-| ---------: | :------------------------------------ |
-|  `default` | {{subject}} must be a valid leap date |
-| `inverted` | {{subject}} must not be a leap date   |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a leap date     |
+| `inverted` | {{subject}} must not be a leap date |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ parameter is mandatory.
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/LeapYear.md
+++ b/docs/validators/LeapYear.md
@@ -20,10 +20,10 @@ This validator accepts DateTime instances as well.
 
 ### `LeapYear::TEMPLATE_STANDARD`
 
-|       Mode | Template                              |
-| ---------: | :------------------------------------ |
-|  `default` | {{subject}} must be a valid leap year |
-| `inverted` | {{subject}} must not be a leap year   |
+|       Mode | Template                            |
+| ---------: | :---------------------------------- |
+|  `default` | {{subject}} must be a leap year     |
+| `inverted` | {{subject}} must not be a leap year |
 
 ## Template placeholders
 
@@ -37,9 +37,10 @@ This validator accepts DateTime instances as well.
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Length.md
+++ b/docs/validators/Length.md
@@ -43,10 +43,10 @@ Used when it's possible to get the length of the input.
 
 ### `Length::TEMPLATE_WRONG_TYPE`
 
-|       Mode | Template                                              |
-| ---------: | :---------------------------------------------------- |
-|  `default` | {{subject}} must be a countable value or a string     |
-| `inverted` | {{subject}} must not be a countable value or a string |
+|       Mode | Template                                      |
+| ---------: | :-------------------------------------------- |
+|  `default` | {{subject}} must be countable or a string     |
+| `inverted` | {{subject}} must not be countable or a string |
 
 ## Template as prefix
 

--- a/docs/validators/Lowercase.md
+++ b/docs/validators/Lowercase.md
@@ -18,10 +18,10 @@ v::stringType()->lowercase()->assert('xkcd');
 
 ### `Lowercase::TEMPLATE_STANDARD`
 
-|       Mode | Template                                            |
-| ---------: | :-------------------------------------------------- |
-|  `default` | {{subject}} must contain only lowercase letters     |
-| `inverted` | {{subject}} must not contain only lowercase letters |
+|       Mode | Template                                               |
+| ---------: | :----------------------------------------------------- |
+|  `default` | {{subject}} must consist only of lowercase letters     |
+| `inverted` | {{subject}} must not consist only of lowercase letters |
 
 ## Template placeholders
 
@@ -35,9 +35,10 @@ v::stringType()->lowercase()->assert('xkcd');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Luhn.md
+++ b/docs/validators/Luhn.md
@@ -14,17 +14,17 @@ v::luhn()->assert('2222400041240011');
 // Validation passes successfully
 
 v::luhn()->assert('respect!');
-// → "respect!" must be a valid Luhn number
+// → "respect!" must be a Luhn number
 ```
 
 ## Templates
 
 ### `Luhn::TEMPLATE_STANDARD`
 
-|       Mode | Template                                    |
-| ---------: | :------------------------------------------ |
-|  `default` | {{subject}} must be a valid Luhn number     |
-| `inverted` | {{subject}} must not be a valid Luhn number |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a Luhn number     |
+| `inverted` | {{subject}} must not be a Luhn number |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::luhn()->assert('respect!');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/MacAddress.md
+++ b/docs/validators/MacAddress.md
@@ -21,10 +21,10 @@ v::macAddress()->assert('af-AA-22-33-44-55');
 
 ### `MacAddress::TEMPLATE_STANDARD`
 
-|       Mode | Template                                    |
-| ---------: | :------------------------------------------ |
-|  `default` | {{subject}} must be a valid MAC address     |
-| `inverted` | {{subject}} must not be a valid MAC address |
+|       Mode | Template                              |
+| ---------: | :------------------------------------ |
+|  `default` | {{subject}} must be a MAC address     |
+| `inverted` | {{subject}} must not be a MAC address |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::macAddress()->assert('af-AA-22-33-44-55');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Masked.md
+++ b/docs/validators/Masked.md
@@ -15,13 +15,13 @@ v::masked('1-@', v::email())->assert('foo@example.com');
 // Validation passes successfully
 
 v::masked('1-@', v::email())->assert('invalid username@domain.com');
-// → "****************@domain.com" must be a valid email address
+// → "****************@domain.com" must be an email address
 
 v::masked('1-', v::lengthGreaterThan(10))->assert('password');
 // → The length of "********" must be greater than 10
 
 v::masked('6-12', v::creditCard(), 'X')->assert('4111111111111211');
-// → "41111XXXXXXX1211" must be a valid credit card number
+// → "41111XXXXXXX1211" must be a credit card number
 ```
 
 This validator is useful for security-sensitive applications where error messages should not expose sensitive data like credit card numbers, passwords, or email addresses.

--- a/docs/validators/Named.md
+++ b/docs/validators/Named.md
@@ -14,14 +14,14 @@ v::named('Your email', v::email())->assert('foo@example.com');
 // Validation passes successfully
 
 v::named('Your email', v::email())->assert('not an email');
-// → Your email must be a valid email address
+// → Your email must be an email address
 ```
 
 Here's an example of a similar code, but without using the `Named` validator:
 
 ```php
 v::email()->assert('not an email');
-// → "not an email" must be a valid email address
+// → "not an email" must be an email address
 ```
 
 The `Named` validator can be also useful when you're using [Attributes](Attributes.md) and want a custom name for a specific property.

--- a/docs/validators/NfeAccessKey.md
+++ b/docs/validators/NfeAccessKey.md
@@ -14,17 +14,17 @@ v::nfeAccessKey()->assert('52060433009911002506550120000007800267301615');
 // Validation passes successfully
 
 v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906');
-// → "31841136830118868211870485416765268625116906" must be a valid NFe access key
+// → "31841136830118868211870485416765268625116906" must be a NFe access key
 ```
 
 ## Templates
 
 ### `NfeAccessKey::TEMPLATE_STANDARD`
 
-|       Mode | Template                                       |
-| ---------: | :--------------------------------------------- |
-|  `default` | {{subject}} must be a valid NFe access key     |
-| `inverted` | {{subject}} must not be a valid NFe access key |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be a NFe access key     |
+| `inverted` | {{subject}} must not be a NFe access key |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.6.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.6.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Nif.md
+++ b/docs/validators/Nif.md
@@ -14,17 +14,17 @@ v::nif()->assert('49294492H');
 // Validation passes successfully
 
 v::nif()->assert('P6437358A');
-// → "P6437358A" must be a valid NIF
+// → "P6437358A" must be a NIF
 ```
 
 ## Templates
 
 ### `Nif::TEMPLATE_STANDARD`
 
-|       Mode | Template                            |
-| ---------: | :---------------------------------- |
-|  `default` | {{subject}} must be a valid NIF     |
-| `inverted` | {{subject}} must not be a valid NIF |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be a NIF     |
+| `inverted` | {{subject}} must not be a NIF |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::nif()->assert('P6437358A');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.2.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.2.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Nip.md
+++ b/docs/validators/Nip.md
@@ -14,26 +14,26 @@ v::nip()->assert('1645865777');
 // Validation passes successfully
 
 v::nip()->assert('1645865778');
-// → "1645865778" must be a valid Polish VAT identification number
+// → "1645865778" must be a Polish VAT identification number
 
 v::nip()->assert('1234567890');
-// → "1234567890" must be a valid Polish VAT identification number
+// → "1234567890" must be a Polish VAT identification number
 
 v::nip()->assert('164-586-57-77');
-// → "164-586-57-77" must be a valid Polish VAT identification number
+// → "164-586-57-77" must be a Polish VAT identification number
 
 v::nip()->assert('164-58-65-777');
-// → "164-58-65-777" must be a valid Polish VAT identification number
+// → "164-58-65-777" must be a Polish VAT identification number
 ```
 
 ## Templates
 
 ### `Nip::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                         |
-| ---------: | :--------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid Polish VAT identification number     |
-| `inverted` | {{subject}} must not be a valid Polish VAT identification number |
+|       Mode | Template                                                   |
+| ---------: | :--------------------------------------------------------- |
+|  `default` | {{subject}} must be a Polish VAT identification number     |
+| `inverted` | {{subject}} must not be a Polish VAT identification number |
 
 ## Template placeholders
 
@@ -47,9 +47,10 @@ v::nip()->assert('164-58-65-777');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/NoneOf.md
+++ b/docs/validators/NoneOf.md
@@ -52,6 +52,7 @@ Used when all validators have passed.
 
 | Version | Description                                   |
 | ------: | :-------------------------------------------- |
+|   3.0.0 | Templates changed                             |
 |   3.0.0 | Require at least two validators to be defined |
 |   0.3.9 | Created                                       |
 

--- a/docs/validators/NullOr.md
+++ b/docs/validators/NullOr.md
@@ -19,7 +19,7 @@ v::nullOr(v::email())->assert('example@example.com');
 // Validation passes successfully
 
 v::nullOr(v::email())->assert('not an email');
-// → "not an email" must be a valid email address or must be null
+// → "not an email" must be an email address or must be null
 ```
 
 ## Prefix
@@ -28,7 +28,7 @@ For convenience, you can use `nullOr` as a prefix to any validator:
 
 ```php
 v::nullOrEmail()->assert('not an email');
-// → "not an email" must be a valid email address or must be null
+// → "not an email" must be an email address or must be null
 
 v::nullOrBetween(1, 3)->assert(2);
 // Validation passes successfully
@@ -52,10 +52,10 @@ The template serves as a suffix to the template of the inner validator.
 
 ```php
 v::nullOr(v::alpha())->assert('has1number');
-// → "has1number" must contain only letters (a-z) or must be null
+// → "has1number" must consist only of letters (a-z) or must be null
 
 v::not(v::nullOr(v::alpha()))->assert("alpha");
-// → "alpha" must not contain letters (a-z) and must not be null
+// → "alpha" must not consist only of letters (a-z) and must not be null
 ```
 
 ## Template placeholders
@@ -72,6 +72,7 @@ v::not(v::nullOr(v::alpha()))->assert("alpha");
 
 | Version | Description           |
 | ------: | :-------------------- |
+|   3.0.0 | Templates changed     |
 |   3.0.0 | Renamed to `NullOr`   |
 |   2.0.0 | Created as `Nullable` |
 

--- a/docs/validators/Number.md
+++ b/docs/validators/Number.md
@@ -14,7 +14,7 @@ v::number()->assert(42);
 // Validation passes successfully
 
 v::number()->assert(acos(8));
-// → `NaN` must be a valid number
+// → `NaN` must be a number
 ```
 
 > "In computing, NaN, standing for not a number, is a numeric data type value
@@ -25,10 +25,10 @@ v::number()->assert(acos(8));
 
 ### `Number::TEMPLATE_STANDARD`
 
-|       Mode | Template                           |
-| ---------: | :--------------------------------- |
-|  `default` | {{subject}} must be a valid number |
-| `inverted` | {{subject}} must not be a number   |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be a number     |
+| `inverted` | {{subject}} must not be a number |
 
 ## Template placeholders
 
@@ -42,9 +42,10 @@ v::number()->assert(acos(8));
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/NumericVal.md
+++ b/docs/validators/NumericVal.md
@@ -24,10 +24,10 @@ purpose use the [Number](Number.md) validator.
 
 ### `NumericVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                                |
-| ---------: | :-------------------------------------- |
-|  `default` | {{subject}} must be a numeric value     |
-| `inverted` | {{subject}} must not be a numeric value |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be numeric     |
+| `inverted` | {{subject}} must not be numeric |
 
 ## Template placeholders
 
@@ -44,6 +44,7 @@ purpose use the [Number](Number.md) validator.
 
 | Version | Description                            |
 | ------: | :------------------------------------- |
+|   3.0.0 | Templates changed                      |
 |   2.0.0 | Renamed from `Numeric` to `NumericVal` |
 |   0.3.9 | Created as `Numeric`                   |
 

--- a/docs/validators/OneOf.md
+++ b/docs/validators/OneOf.md
@@ -19,13 +19,13 @@ v::oneOf(v::digit(), v::alpha())->assert('12');
 
 v::oneOf(v::digit(), v::alpha())->assert('AB12');
 // → - "AB12" must pass one of the rules
-// →   - "AB12" must contain only digits (0-9)
-// →   - "AB12" must contain only letters (a-z)
+// →   - "AB12" must consist only of digits (0-9)
+// →   - "AB12" must consist only of letters (a-z)
 
 v::oneOf(v::digit(), v::alpha())->assert('*');
 // → - "*" must pass one of the rules
-// →   - "*" must contain only digits (0-9)
-// →   - "*" must contain only letters (a-z)
+// →   - "*" must consist only of digits (0-9)
+// →   - "*" must consist only of letters (a-z)
 ```
 
 The chains above validate if the input is either a digit or an alphabetic

--- a/docs/validators/Pesel.md
+++ b/docs/validators/Pesel.md
@@ -17,20 +17,20 @@ v::pesel()->assert('97072704800');
 // Validation passes successfully
 
 v::pesel()->assert('97072704801');
-// → "97072704801" must be a valid PESEL
+// → "97072704801" must be a PESEL
 
 v::pesel()->assert('PESEL123456');
-// → "PESEL123456" must be a valid PESEL
+// → "PESEL123456" must be a PESEL
 ```
 
 ## Templates
 
 ### `Pesel::TEMPLATE_STANDARD`
 
-|       Mode | Template                              |
-| ---------: | :------------------------------------ |
-|  `default` | {{subject}} must be a valid PESEL     |
-| `inverted` | {{subject}} must not be a valid PESEL |
+|       Mode | Template                        |
+| ---------: | :------------------------------ |
+|  `default` | {{subject}} must be a PESEL     |
+| `inverted` | {{subject}} must not be a PESEL |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::pesel()->assert('PESEL123456');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.1.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.1.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Phone.md
+++ b/docs/validators/Phone.md
@@ -26,17 +26,17 @@ v::phone('BR')->assert('11 91111 1111');
 
 ### `Phone::TEMPLATE_INTERNATIONAL`
 
-|       Mode | Template                                         |
-| ---------: | :----------------------------------------------- |
-|  `default` | {{subject}} must be a valid telephone number     |
-| `inverted` | {{subject}} must not be a valid telephone number |
+|       Mode | Template                               |
+| ---------: | :------------------------------------- |
+|  `default` | {{subject}} must be a phone number     |
+| `inverted` | {{subject}} must not be a phone number |
 
 ### `Phone::TEMPLATE_FOR_COUNTRY`
 
-|       Mode | Template                                                                                |
-| ---------: | :-------------------------------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid telephone number for country {{countryName&#124;trans}}     |
-| `inverted` | {{subject}} must not be a valid telephone number for country {{countryName&#124;trans}} |
+|       Mode | Template                                                                      |
+| ---------: | :---------------------------------------------------------------------------- |
+|  `default` | {{subject}} must be a phone number for country {{countryName&#124;trans}}     |
+| `inverted` | {{subject}} must not be a phone number for country {{countryName&#124;trans}} |
 
 ## Template placeholders
 
@@ -53,6 +53,7 @@ v::phone('BR')->assert('11 91111 1111');
 
 | Version | Description                       |
 | ------: | :-------------------------------- |
+|   3.0.0 | Templates changed                 |
 |   2.3.0 | Updated to use external validator |
 |   0.5.0 | Created                           |
 

--- a/docs/validators/Pis.md
+++ b/docs/validators/Pis.md
@@ -30,10 +30,10 @@ v::pis()->assert('12003406788');
 
 ### `Pis::TEMPLATE_STANDARD`
 
-|       Mode | Template                                   |
-| ---------: | :----------------------------------------- |
-|  `default` | {{subject}} must be a valid PIS number     |
-| `inverted` | {{subject}} must not be a valid PIS number |
+|       Mode | Template                             |
+| ---------: | :----------------------------------- |
+|  `default` | {{subject}} must be a PIS number     |
+| `inverted` | {{subject}} must not be a PIS number |
 
 ## Template placeholders
 
@@ -47,9 +47,10 @@ v::pis()->assert('12003406788');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/PolishIdCard.md
+++ b/docs/validators/PolishIdCard.md
@@ -17,20 +17,20 @@ v::polishIdCard()->assert('APH505567');
 // Validation passes successfully
 
 v::polishIdCard()->assert('APH 505567');
-// → "APH 505567" must be a valid Polish Identity Card number
+// → "APH 505567" must be a Polish Identity Card number
 
 v::polishIdCard()->assert('AYW036731');
-// → "AYW036731" must be a valid Polish Identity Card number
+// → "AYW036731" must be a Polish Identity Card number
 ```
 
 ## Templates
 
 ### `PolishIdCard::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                    |
-| ---------: | :---------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid Polish Identity Card number     |
-| `inverted` | {{subject}} must not be a valid Polish Identity Card number |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | {{subject}} must be a Polish Identity Card number     |
+| `inverted` | {{subject}} must not be a Polish Identity Card number |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::polishIdCard()->assert('AYW036731');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/PostalCode.md
+++ b/docs/validators/PostalCode.md
@@ -18,7 +18,7 @@ v::postalCode('BR')->assert('02179-000');
 // Validation passes successfully
 
 v::postalCode('US')->assert('02179-000');
-// → "02179-000" must be a valid postal code on "US"
+// → "02179-000" must be a postal code for "US"
 
 v::postalCode('US')->assert('55372');
 // Validation passes successfully
@@ -31,7 +31,7 @@ By default, `PostalCode` won't validate the format (puncts, spaces), unless you 
 
 ```php
 v::postalCode('BR', true)->assert('02179000');
-// → "02179000" must be a valid postal code on "BR"
+// → "02179000" must be a postal code for "BR"
 
 v::postalCode('BR', true)->assert('02179-000');
 // Validation passes successfully
@@ -45,10 +45,10 @@ Extracted from [GeoNames](http://www.geonames.org/).
 
 ### `PostalCode::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                       |
-| ---------: | :------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid postal code on {{countryCode}}     |
-| `inverted` | {{subject}} must not be a valid postal code on {{countryCode}} |
+|       Mode | Template                                                  |
+| ---------: | :-------------------------------------------------------- |
+|  `default` | {{subject}} must be a postal code for {{countryCode}}     |
+| `inverted` | {{subject}} must not be a postal code for {{countryCode}} |
 
 ## Template placeholders
 
@@ -66,6 +66,7 @@ Extracted from [GeoNames](http://www.geonames.org/).
 
 | Version | Description                                       |
 | ------: | :------------------------------------------------ |
+|   3.0.0 | Templates changed                                 |
 |   2.3.0 | Add option to validate formatting                 |
 |   2.2.4 | Cambodian postal codes now support 5 and 6 digits |
 |   0.7.0 | Created                                           |

--- a/docs/validators/Printable.md
+++ b/docs/validators/Printable.md
@@ -19,17 +19,17 @@ v::printable()->assert('LMKA0$% _123');
 
 ### `Printable::TEMPLATE_STANDARD`
 
-|       Mode | Template                                           |
-| ---------: | :------------------------------------------------- |
-|  `default` | {{subject}} must contain only printable characters |
-| `inverted` | {{subject}} must not contain printable characters  |
+|       Mode | Template                                                  |
+| ---------: | :-------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of printable characters     |
+| `inverted` | {{subject}} must not consist only of printable characters |
 
 ### `Printable::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                                   |
-| ---------: | :------------------------------------------------------------------------- |
-|  `default` | {{subject}} must contain only printable characters and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain printable characters or {{additionalChars}}   |
+|       Mode | Template                                                                         |
+| ---------: | :------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of printable characters or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of printable characters or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::printable()->assert('LMKA0$% _123');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Property.md
+++ b/docs/validators/Property.md
@@ -35,7 +35,7 @@ v::property(
     'address',
     v::property('postalCode', v::postalCode('BR'))
 )->assert($object);
-// → `.address.postalCode` must be a valid postal code on "BR"
+// → `.address.postalCode` must be a postal code for "BR"
 ```
 
 ## Note
@@ -63,6 +63,7 @@ This validator will validate public, private, protected, uninitialised, and stat
 
 | Version | Description                                                                                                                          |
 | ------: | :----------------------------------------------------------------------------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                                                                                    |
 |   3.0.0 | Renamed from `Attribute` to `Property`, and split by [PropertyExists](PropertyExists.md) and [PropertyOptional](PropertyOptional.md) |
 |   0.3.9 | Created                                                                                                                              |
 

--- a/docs/validators/PropertyOptional.md
+++ b/docs/validators/PropertyOptional.md
@@ -27,7 +27,7 @@ v::propertyOptional('website', v::url())->assert($object);
 // Validation passes successfully
 
 v::propertyOptional('name', v::lowercase())->assert($object);
-// → `.name` must contain only lowercase letters
+// → `.name` must consist only of lowercase letters
 ```
 
 The name of this validator is automatically set to the property name.

--- a/docs/validators/PublicDomainSuffix.md
+++ b/docs/validators/PublicDomainSuffix.md
@@ -52,9 +52,10 @@ v::oneOf(v::tld(), v::publicDomainSuffix())->assert('tk');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.3.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.3.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Punct.md
+++ b/docs/validators/Punct.md
@@ -19,17 +19,17 @@ v::punct()->assert('&,.;[]');
 
 ### `Punct::TEMPLATE_STANDARD`
 
-|       Mode | Template                                             |
-| ---------: | :--------------------------------------------------- |
-|  `default` | {{subject}} must contain only punctuation characters |
-| `inverted` | {{subject}} must not contain punctuation characters  |
+|       Mode | Template                                                    |
+| ---------: | :---------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of punctuation characters     |
+| `inverted` | {{subject}} must not consist only of punctuation characters |
 
 ### `Punct::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                                     |
-| ---------: | :--------------------------------------------------------------------------- |
-|  `default` | {{subject}} must contain only punctuation characters and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain punctuation characters or {{additionalChars}}   |
+|       Mode | Template                                                                           |
+| ---------: | :--------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of punctuation characters or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of punctuation characters or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::punct()->assert('&,.;[]');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Regex.md
+++ b/docs/validators/Regex.md
@@ -22,8 +22,8 @@ Message template for this validator includes `{{regex}}`.
 
 |       Mode | Template                                                    |
 | ---------: | :---------------------------------------------------------- |
-|  `default` | {{subject}} must match the pattern {{regex&#124;quote}}     |
-| `inverted` | {{subject}} must not match the pattern {{regex&#124;quote}} |
+|  `default` | {{subject}} must match the {{regex&#124;quote}} pattern     |
+| `inverted` | {{subject}} must not match the {{regex&#124;quote}} pattern |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ Message template for this validator includes `{{regex}}`.
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/ResourceType.md
+++ b/docs/validators/ResourceType.md
@@ -18,10 +18,10 @@ v::resourceType()->assert(fopen('/path/to/file.txt', 'r'));
 
 ### `ResourceType::TEMPLATE_STANDARD`
 
-|       Mode | Template                           |
-| ---------: | :--------------------------------- |
-|  `default` | {{subject}} must be a resource     |
-| `inverted` | {{subject}} must not be a resource |
+|       Mode | Template                                     |
+| ---------: | :------------------------------------------- |
+|  `default` | {{subject}} must be an internal resource     |
+| `inverted` | {{subject}} must not be an internal resource |
 
 ## Template placeholders
 
@@ -35,9 +35,10 @@ v::resourceType()->assert(fopen('/path/to/file.txt', 'r'));
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Roman.md
+++ b/docs/validators/Roman.md
@@ -18,10 +18,10 @@ v::roman()->assert('IV');
 
 ### `Roman::TEMPLATE_STANDARD`
 
-|       Mode | Template                                      |
-| ---------: | :-------------------------------------------- |
-|  `default` | {{subject}} must be a valid Roman numeral     |
-| `inverted` | {{subject}} must not be a valid Roman numeral |
+|       Mode | Template                                |
+| ---------: | :-------------------------------------- |
+|  `default` | {{subject}} must be a Roman numeral     |
+| `inverted` | {{subject}} must not be a Roman numeral |
 
 ## Template placeholders
 
@@ -37,6 +37,7 @@ v::roman()->assert('IV');
 
 | Version | Description                                                       |
 | ------: | :---------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                 |
 |   2.0.0 | Exception message refers to Roman "numerals" instead of "numbers" |
 |   2.0.0 | Do not consider empty strings as valid                            |
 |   0.3.9 | Created                                                           |

--- a/docs/validators/Satisfies.md
+++ b/docs/validators/Satisfies.md
@@ -19,10 +19,10 @@ v::satisfies(fn (int $input): bool => $input % 5 === 0,)->assert(10);
 
 ### `Satisfies::TEMPLATE_STANDARD`
 
-|       Mode | Template                    |
-| ---------: | :-------------------------- |
-|  `default` | {{subject}} must be valid   |
-| `inverted` | {{subject}} must be invalid |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be valid     |
+| `inverted` | {{subject}} must not be valid |
 
 ## Template placeholders
 

--- a/docs/validators/ScalarVal.md
+++ b/docs/validators/ScalarVal.md
@@ -14,17 +14,17 @@ v::scalarVal()->assert(135.0);
 // Validation passes successfully
 
 v::scalarVal()->assert([]);
-// → `[]` must be a scalar value
+// → `[]` must be a scalar
 ```
 
 ## Templates
 
 ### `ScalarVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                               |
-| ---------: | :------------------------------------- |
-|  `default` | {{subject}} must be a scalar value     |
-| `inverted` | {{subject}} must not be a scalar value |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be a scalar     |
+| `inverted` | {{subject}} must not be a scalar |
 
 ## Template placeholders
 
@@ -38,9 +38,10 @@ v::scalarVal()->assert([]);
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   1.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   1.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Size.md
+++ b/docs/validators/Size.md
@@ -42,10 +42,10 @@ This validator will accept:
 
 Used when the input is not a valid file path, a `SplFileInfo` object, or a PSR-7 interface.
 
-|       Mode | Template                                                                              |
-| ---------: | :------------------------------------------------------------------------------------ |
-|  `default` | {{subject}} must be a filename or an instance of SplFileInfo or a PSR-7 interface     |
-| `inverted` | {{subject}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface |
+|       Mode | Template                                                                            |
+| ---------: | :---------------------------------------------------------------------------------- |
+|  `default` | {{subject}} must be a filename, an instance of SplFileInfo or a PSR-7 interface     |
+| `inverted` | {{subject}} must not be a filename, an instance of SplFileInfo or a PSR-7 interface |
 
 ## Template as prefix
 
@@ -75,6 +75,7 @@ v::size('KB', v::not(v::equals(56)))->assert('/path/to/file');
 
 | Version | Description             |
 | ------: | :---------------------- |
+|   3.0.0 | Templates changed       |
 |   3.0.0 | Became a transformation |
 |   2.1.0 | Add [PSR-7][] support   |
 |   1.0.0 | Created                 |

--- a/docs/validators/Slug.md
+++ b/docs/validators/Slug.md
@@ -14,20 +14,20 @@ v::slug()->assert('my-wordpress-title');
 // Validation passes successfully
 
 v::slug()->assert('my-wordpress--title');
-// → "my-wordpress--title" must be a valid slug
+// → "my-wordpress--title" must be a slug
 
 v::slug()->assert('my-wordpress-title-');
-// → "my-wordpress-title-" must be a valid slug
+// → "my-wordpress-title-" must be a slug
 ```
 
 ## Templates
 
 ### `Slug::TEMPLATE_STANDARD`
 
-|       Mode | Template                             |
-| ---------: | :----------------------------------- |
-|  `default` | {{subject}} must be a valid slug     |
-| `inverted` | {{subject}} must not be a valid slug |
+|       Mode | Template                       |
+| ---------: | :----------------------------- |
+|  `default` | {{subject}} must be a slug     |
+| `inverted` | {{subject}} must not be a slug |
 
 ## Template placeholders
 
@@ -41,9 +41,10 @@ v::slug()->assert('my-wordpress-title-');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Space.md
+++ b/docs/validators/Space.md
@@ -19,17 +19,17 @@ v::space()->assert('    ');
 
 ### `Space::TEMPLATE_STANDARD`
 
-|       Mode | Template                                       |
-| ---------: | :--------------------------------------------- |
-|  `default` | {{subject}} must contain only space characters |
-| `inverted` | {{subject}} must not contain space characters  |
+|       Mode | Template                                              |
+| ---------: | :---------------------------------------------------- |
+|  `default` | {{subject}} must consist only of space characters     |
+| `inverted` | {{subject}} must not consist only of space characters |
 
 ### `Space::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                               |
-| ---------: | :--------------------------------------------------------------------- |
-|  `default` | {{subject}} must contain only space characters and {{additionalChars}} |
-| `inverted` | {{subject}} must not contain space characters or {{additionalChars}}   |
+|       Mode | Template                                                                     |
+| ---------: | :--------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of space characters or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of space characters or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::space()->assert('    ');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Spaced.md
+++ b/docs/validators/Spaced.md
@@ -25,8 +25,8 @@ v::notSpaced()->alnum()->assert('username');
 
 v::notSpaced()->alnum()->assert('user name');
 // → - "user name" must pass all the rules
-// →   - "user name" must not contain whitespaces
-// →   - "user name" must contain only letters (a-z) and digits (0-9)
+// →   - "user name" must not contain whitespace
+// →   - "user name" must consist only of letters (a-z) and digits (0-9)
 ```
 
 ## Templates
@@ -36,7 +36,7 @@ v::notSpaced()->alnum()->assert('user name');
 |       Mode | Template                                         |
 | ---------: | :----------------------------------------------- |
 |  `default` | {{subject}} must contain at least one whitespace |
-| `inverted` | {{subject}} must not contain whitespaces         |
+| `inverted` | {{subject}} must not contain whitespace          |
 
 ## Template placeholders
 

--- a/docs/validators/StringVal.md
+++ b/docs/validators/StringVal.md
@@ -36,10 +36,10 @@ v::stringVal()->assert(new ClassWithToString());
 
 ### `StringVal::TEMPLATE_STANDARD`
 
-|       Mode | Template                               |
-| ---------: | :------------------------------------- |
-|  `default` | {{subject}} must be a string value     |
-| `inverted` | {{subject}} must not be a string value |
+|       Mode | Template                         |
+| ---------: | :------------------------------- |
+|  `default` | {{subject}} must be a string     |
+| `inverted` | {{subject}} must not be a string |
 
 ## Template placeholders
 
@@ -54,9 +54,10 @@ v::stringVal()->assert(new ClassWithToString());
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/SymbolicLink.md
+++ b/docs/validators/SymbolicLink.md
@@ -14,20 +14,20 @@ v::symbolicLink()->assert('/path/to/symbolic-link');
 // Validation passes successfully
 
 v::symbolicLink()->assert(new SplFileInfo('/path/to/file'));
-// → `SplFileInfo { __toString() => "/path/to/file" }` must be a symbolic link
+// → `SplFileInfo { __toString() => "/path/to/file" }` must be an accessible existing symbolic link
 
 v::symbolicLink()->assert(new SplFileObject('/path/to/file'));
-// → `SplFileObject { current() => "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec enim vitae ve ... }` must be a symbolic link
+// → `SplFileObject { current() => "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec enim vitae ve ... }` must be an accessible existing symbolic link
 ```
 
 ## Templates
 
 ### `SymbolicLink::TEMPLATE_STANDARD`
 
-|       Mode | Template                                |
-| ---------: | :-------------------------------------- |
-|  `default` | {{subject}} must be a symbolic link     |
-| `inverted` | {{subject}} must not be a symbolic link |
+|       Mode | Template                                                     |
+| ---------: | :----------------------------------------------------------- |
+|  `default` | {{subject}} must be an accessible existing symbolic link     |
+| `inverted` | {{subject}} must not be an accessible existing symbolic link |
 
 ## Template placeholders
 
@@ -41,9 +41,10 @@ v::symbolicLink()->assert(new SplFileObject('/path/to/file'));
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Time.md
+++ b/docs/validators/Time.md
@@ -44,23 +44,23 @@ v::time('His')->assert(232059);
 // Validation passes successfully
 
 v::time()->assert('24:00:00');
-// → "24:00:00" must be a valid time in the format "23:59:59"
+// → "24:00:00" must be a time in the "23:59:59" format
 
 v::time()->assert(new DateTime());
-// → `DateTime { 2024-01-01T12:00:00+00:00 }` must be a valid time in the format "23:59:59"
+// → `DateTime { 2024-01-01T12:00:00+00:00 }` must be a time in the "23:59:59" format
 
 v::time()->assert(new DateTimeImmutable());
-// → `DateTimeImmutable { 2024-01-01T12:00:00+00:00 }` must be a valid time in the format "23:59:59"
+// → `DateTimeImmutable { 2024-01-01T12:00:00+00:00 }` must be a time in the "23:59:59" format
 ```
 
 ## Templates
 
 ### `Time::TEMPLATE_STANDARD`
 
-|       Mode | Template                                                      |
-| ---------: | :------------------------------------------------------------ |
-|  `default` | {{subject}} must be a valid time in the format {{sample}}     |
-| `inverted` | {{subject}} must not be a valid time in the format {{sample}} |
+|       Mode | Template                                                |
+| ---------: | :------------------------------------------------------ |
+|  `default` | {{subject}} must be a time in the {{sample}} format     |
+| `inverted` | {{subject}} must not be a time in the {{sample}} format |
 
 ## Template placeholders
 
@@ -75,9 +75,10 @@ v::time()->assert(new DateTimeImmutable());
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   2.0.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   2.0.0 | Created           |
 
 ## See Also
 

--- a/docs/validators/Tld.md
+++ b/docs/validators/Tld.md
@@ -27,10 +27,10 @@ v::tld()->assert('COM');
 
 ### `Tld::TEMPLATE_STANDARD`
 
-|       Mode | Template                                              |
-| ---------: | :---------------------------------------------------- |
-|  `default` | {{subject}} must be a valid top-level domain name     |
-| `inverted` | {{subject}} must not be a valid top-level domain name |
+|       Mode | Template                                        |
+| ---------: | :---------------------------------------------- |
+|  `default` | {{subject}} must be a top-level domain name     |
+| `inverted` | {{subject}} must not be a top-level domain name |
 
 ## Template placeholders
 
@@ -44,9 +44,10 @@ v::tld()->assert('COM');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/UndefOr.md
+++ b/docs/validators/UndefOr.md
@@ -24,7 +24,7 @@ v::undefOr(v::alpha())->assert('username');
 // Validation passes successfully
 
 v::undefOr(v::alpha())->assert('has1number');
-// → "has1number" must contain only letters (a-z) or must be undefined
+// → "has1number" must consist only of letters (a-z) or must be undefined
 ```
 
 ## Prefix
@@ -33,7 +33,7 @@ For convenience, you can use the `undefOr` as a prefix to any validator:
 
 ```php
 v::undefOrEmail()->assert('not an email');
-// → "not an email" must be a valid email address or must be undefined
+// → "not an email" must be an email address or must be undefined
 
 v::undefOrBetween(1, 3)->assert(2);
 // Validation passes successfully
@@ -54,10 +54,10 @@ The template serves as a suffix to the template of the inner validator.
 
 ```php
 v::undefOr(v::alpha())->assert('has1number');
-// → "has1number" must contain only letters (a-z) or must be undefined
+// → "has1number" must consist only of letters (a-z) or must be undefined
 
 v::not(v::undefOr(v::alpha()))->assert("alpha");
-// → "alpha" must not contain letters (a-z) and must not be undefined
+// → "alpha" must not consist only of letters (a-z) and must not be undefined
 ```
 
 ## Template placeholders
@@ -74,6 +74,7 @@ v::not(v::undefOr(v::alpha()))->assert("alpha");
 
 | Version | Description           |
 | ------: | :-------------------- |
+|   3.0.0 | Templates changed     |
 |   3.0.0 | Renamed to `UndefOr`  |
 |   1.0.0 | Created as `Optional` |
 

--- a/docs/validators/Uppercase.md
+++ b/docs/validators/Uppercase.md
@@ -20,10 +20,10 @@ validation.
 
 ```php
 v::not(v::numericVal())->uppercase()->assert('42');
-// → "42" must not be a numeric value
+// → "42" must not be numeric
 
 v::alnum()->uppercase()->assert('#$%!');
-// → "#$%!" must contain only letters (a-z) and digits (0-9)
+// → "#$%!" must consist only of letters (a-z) and digits (0-9)
 
 v::not(v::numericVal())->alnum()->uppercase()->assert('W3C');
 // Validation passes successfully
@@ -33,10 +33,10 @@ v::not(v::numericVal())->alnum()->uppercase()->assert('W3C');
 
 ### `Uppercase::TEMPLATE_STANDARD`
 
-|       Mode | Template                                            |
-| ---------: | :-------------------------------------------------- |
-|  `default` | {{subject}} must contain only uppercase letters     |
-| `inverted` | {{subject}} must not contain only uppercase letters |
+|       Mode | Template                                               |
+| ---------: | :----------------------------------------------------- |
+|  `default` | {{subject}} must consist only of uppercase letters     |
+| `inverted` | {{subject}} must not consist only of uppercase letters |
 
 ## Template placeholders
 
@@ -50,9 +50,10 @@ v::not(v::numericVal())->alnum()->uppercase()->assert('W3C');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Url.md
+++ b/docs/validators/Url.md
@@ -23,7 +23,7 @@ v::url()->assert('mailto:john.doe@example.com');
 // Validation passes successfully
 
 v::url()->assert('http://example.this_top_level_domain_does_not_exist');
-// → "http://example.this_top_level_domain_does_not_exist" must be a valid URL
+// → "http://example.this_top_level_domain_does_not_exist" must be a URL
 ```
 
 This validator uses [Ip][Ip.md], [Domain][Domain.md] and [Email][Email.md] internally,
@@ -44,10 +44,10 @@ v::startsWith('http')->url()->assert('ftp://example.com');
 
 ### `Url::TEMPLATE_STANDARD`
 
-|       Mode | Template                            |
-| ---------: | :---------------------------------- |
-|  `default` | {{subject}} must be a valid URL     |
-| `inverted` | {{subject}} must not be a valid URL |
+|       Mode | Template                      |
+| ---------: | :---------------------------- |
+|  `default` | {{subject}} must be a URL     |
+| `inverted` | {{subject}} must not be a URL |
 
 ## Template placeholders
 
@@ -63,6 +63,7 @@ v::startsWith('http')->url()->assert('ftp://example.com');
 
 | Version | Description                                                                 |
 | ------: | :-------------------------------------------------------------------------- |
+|   3.0.0 | Templates changed                                                           |
 |   3.0.0 | Stricter use of `Ip`, `Domain` and `Email` internally. Select schemes only. |
 |   0.8.0 | Created                                                                     |
 

--- a/docs/validators/Uuid.md
+++ b/docs/validators/Uuid.md
@@ -16,13 +16,13 @@ v::uuid()->assert('eb3115e5-bd16-4939-ab12-2b95745a30f3');
 // Validation passes successfully
 
 v::uuid()->assert('Hello World!');
-// → "Hello World!" must be a valid UUID
+// → "Hello World!" must be a UUID
 
 v::uuid()->assert('eb3115e5bd164939ab122b95745a30f3');
 // Validation passes successfully
 
 v::uuid(1)->assert('eb3115e5-bd16-4939-ab12-2b95745a30f3');
-// → "eb3115e5-bd16-4939-ab12-2b95745a30f3" must be a valid UUID version 1
+// → "eb3115e5-bd16-4939-ab12-2b95745a30f3" must be a UUID v1
 
 v::uuid(4)->assert('eb3115e5-bd16-4939-ab12-2b95745a30f3');
 // Validation passes successfully
@@ -38,17 +38,17 @@ v::uuid(4)->assert(\Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2b9574
 
 ### `Uuid::TEMPLATE_STANDARD`
 
-|       Mode | Template                             |
-| ---------: | :----------------------------------- |
-|  `default` | {{subject}} must be a valid UUID     |
-| `inverted` | {{subject}} must not be a valid UUID |
+|       Mode | Template                       |
+| ---------: | :----------------------------- |
+|  `default` | {{subject}} must be a UUID     |
+| `inverted` | {{subject}} must not be a UUID |
 
 ### `Uuid::TEMPLATE_VERSION`
 
-|       Mode | Template                                                          |
-| ---------: | :---------------------------------------------------------------- |
-|  `default` | {{subject}} must be a valid UUID version {{version&#124;raw}}     |
-| `inverted` | {{subject}} must not be a valid UUID version {{version&#124;raw}} |
+|       Mode | Template                                             |
+| ---------: | :--------------------------------------------------- |
+|  `default` | {{subject}} must be a UUID v{{version&#124;raw}}     |
+| `inverted` | {{subject}} must not be a UUID v{{version&#124;raw}} |
 
 ## Template placeholders
 
@@ -65,6 +65,7 @@ v::uuid(4)->assert(\Ramsey\Uuid\Uuid::fromString('eb3115e5-bd16-4939-ab12-2b9574
 
 | Version | Description            |
 | ------: | :--------------------- |
+|   3.0.0 | Templates changed      |
 |   3.0.0 | Requires `ramsey/uuid` |
 |   2.0.0 | Created                |
 

--- a/docs/validators/Version.md
+++ b/docs/validators/Version.md
@@ -18,10 +18,10 @@ v::version()->assert('1.0.0');
 
 ### `Version::TEMPLATE_STANDARD`
 
-|       Mode | Template                          |
-| ---------: | :-------------------------------- |
-|  `default` | {{subject}} must be a version     |
-| `inverted` | {{subject}} must not be a version |
+|       Mode | Template                                 |
+| ---------: | :--------------------------------------- |
+|  `default` | {{subject}} must be a version number     |
+| `inverted` | {{subject}} must not be a version number |
 
 ## Template placeholders
 
@@ -35,9 +35,10 @@ v::version()->assert('1.0.0');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.3.9 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.3.9 | Created           |
 
 ## See Also
 

--- a/docs/validators/Vowel.md
+++ b/docs/validators/Vowel.md
@@ -28,7 +28,7 @@ v::vowel()->assert('aei');
 
 |       Mode | Template                                                      |
 | ---------: | :------------------------------------------------------------ |
-|  `default` | {{subject}} must consist of vowels and {{additionalChars}}    |
+|  `default` | {{subject}} must consist of vowels or {{additionalChars}}     |
 | `inverted` | {{subject}} must not consist of vowels or {{additionalChars}} |
 
 ## Template placeholders
@@ -46,6 +46,7 @@ v::vowel()->assert('aei');
 
 | Version | Description                          |
 | ------: | :----------------------------------- |
+|   3.0.0 | Templates changed                    |
 |   2.0.0 | Do not consider whitespaces as valid |
 |   0.5.0 | Renamed from `Vowels` to `Vowel`     |
 |   0.3.9 | Created as `Vowels`                  |

--- a/docs/validators/Writable.md
+++ b/docs/validators/Writable.md
@@ -14,17 +14,17 @@ v::writable()->assert('/path/to/file');
 // Validation passes successfully
 
 v::writable()->assert('/path/to/non-writable');
-// → "/path/to/non-writable" must be writable
+// → "/path/to/non-writable" must be an accessible existing writable filesystem entry
 ```
 
 ## Templates
 
 ### `Writable::TEMPLATE_STANDARD`
 
-|       Mode | Template                         |
-| ---------: | :------------------------------- |
-|  `default` | {{subject}} must be writable     |
-| `inverted` | {{subject}} must not be writable |
+|       Mode | Template                                                                 |
+| ---------: | :----------------------------------------------------------------------- |
+|  `default` | {{subject}} must be an accessible existing writable filesystem entry     |
+| `inverted` | {{subject}} must not be an accessible existing writable filesystem entry |
 
 ## Template placeholders
 
@@ -40,6 +40,7 @@ v::writable()->assert('/path/to/non-writable');
 
 | Version | Description       |
 | ------: | :---------------- |
+|   3.0.0 | Templates changed |
 |   2.1.0 | Add PSR-7 support |
 |   0.5.0 | Created           |
 

--- a/docs/validators/Xdigit.md
+++ b/docs/validators/Xdigit.md
@@ -19,24 +19,24 @@ Notice, however, that it doesn't accept strings starting with 0x:
 
 ```php
 v::xdigit()->assert('0x1f');
-// → "0x1f" must only contain hexadecimal digits
+// → "0x1f" must consist only of hexadecimal digits
 ```
 
 ## Templates
 
 ### `Xdigit::TEMPLATE_STANDARD`
 
-|       Mode | Template                                             |
-| ---------: | :--------------------------------------------------- |
-|  `default` | {{subject}} must only contain hexadecimal digits     |
-| `inverted` | {{subject}} must not only contain hexadecimal digits |
+|       Mode | Template                                                |
+| ---------: | :------------------------------------------------------ |
+|  `default` | {{subject}} must consist only of hexadecimal digits     |
+| `inverted` | {{subject}} must not consist only of hexadecimal digits |
 
 ### `Xdigit::TEMPLATE_EXTRA`
 
-|       Mode | Template                                                               |
-| ---------: | :--------------------------------------------------------------------- |
-|  `default` | {{subject}} must contain hexadecimal digits and {{additionalChars}}    |
-| `inverted` | {{subject}} must not contain hexadecimal digits or {{additionalChars}} |
+|       Mode | Template                                                                       |
+| ---------: | :----------------------------------------------------------------------------- |
+|  `default` | {{subject}} must consist only of hexadecimal digits or {{additionalChars}}     |
+| `inverted` | {{subject}} must not consist only of hexadecimal digits or {{additionalChars}} |
 
 ## Template placeholders
 
@@ -51,9 +51,10 @@ v::xdigit()->assert('0x1f');
 
 ## Changelog
 
-| Version | Description |
-| ------: | :---------- |
-|   0.5.0 | Created     |
+| Version | Description       |
+| ------: | :---------------- |
+|   3.0.0 | Templates changed |
+|   0.5.0 | Created           |
 
 ## See Also
 

--- a/src/Validators/Alnum.php
+++ b/src/Validators/Alnum.php
@@ -22,13 +22,13 @@ use function ctype_alnum;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only letters (a-z) and digits (0-9)',
-    '{{subject}} must not contain letters (a-z) or digits (0-9)',
+    '{{subject}} must consist only of letters (a-z) and digits (0-9)',
+    '{{subject}} must not consist only of letters (a-z) or digits (0-9)',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only letters (a-z), digits (0-9), and {{additionalChars}}',
-    '{{subject}} must not contain letters (a-z), digits (0-9), or {{additionalChars}}',
+    '{{subject}} must consist only of letters (a-z), digits (0-9), or {{additionalChars}}',
+    '{{subject}} must not consist only of letters (a-z), digits (0-9), or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Alnum extends FilteredString

--- a/src/Validators/Alpha.php
+++ b/src/Validators/Alpha.php
@@ -22,13 +22,13 @@ use function ctype_alpha;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only letters (a-z)',
-    '{{subject}} must not contain letters (a-z)',
+    '{{subject}} must consist only of letters (a-z)',
+    '{{subject}} must not consist only of letters (a-z)',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only letters (a-z) and {{additionalChars}}',
-    '{{subject}} must not contain letters (a-z) or {{additionalChars}}',
+    '{{subject}} must consist only of letters (a-z) or {{additionalChars}}',
+    '{{subject}} must not consist only of letters (a-z) or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Alpha extends FilteredString

--- a/src/Validators/ArrayVal.php
+++ b/src/Validators/ArrayVal.php
@@ -26,8 +26,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be an array value',
-    '{{subject}} must not be an array value',
+    '{{subject}} must be an array',
+    '{{subject}} must not be an array',
 )]
 final class ArrayVal extends Simple
 {

--- a/src/Validators/Base64.php
+++ b/src/Validators/Base64.php
@@ -26,8 +26,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a base64 encoded string',
-    '{{subject}} must not be a base64 encoded string',
+    '{{subject}} must be a base64-encoded string',
+    '{{subject}} must not be a base64-encoded string',
 )]
 final class Base64 extends Simple
 {

--- a/src/Validators/BoolVal.php
+++ b/src/Validators/BoolVal.php
@@ -29,8 +29,8 @@ use const FILTER_VALIDATE_BOOLEAN;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a boolean value',
-    '{{subject}} must not be a boolean value',
+    '{{subject}} must be a boolean',
+    '{{subject}} must not be a boolean',
 )]
 final class BoolVal extends Simple
 {

--- a/src/Validators/Bsn.php
+++ b/src/Validators/Bsn.php
@@ -26,8 +26,8 @@ use function strval;
 /** @see https://nl.wikipedia.org/wiki/Burgerservicenummer */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid BSN',
-    '{{subject}} must not be a valid BSN',
+    '{{subject}} must be a BSN',
+    '{{subject}} must not be a BSN',
 )]
 final class Bsn extends Simple
 {

--- a/src/Validators/CallableType.php
+++ b/src/Validators/CallableType.php
@@ -21,8 +21,8 @@ use function is_callable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a callable',
-    '{{subject}} must not be a callable',
+    '{{subject}} must be a callable function',
+    '{{subject}} must not be a callable function',
 )]
 final class CallableType extends Simple
 {

--- a/src/Validators/Charset.php
+++ b/src/Validators/Charset.php
@@ -30,8 +30,8 @@ use function mb_list_encodings;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must only contain characters from the {{charset|raw}} charset',
-    '{{subject}} must not contain any characters from the {{charset|raw}} charset',
+    '{{subject}} must consist only of characters from the {{charset|list:or}} character-set',
+    '{{subject}} must not consist only of characters from the {{charset|list:or}} character-set',
 )]
 final readonly class Charset implements Validator
 {

--- a/src/Validators/Cnh.php
+++ b/src/Validators/Cnh.php
@@ -27,8 +27,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid CNH number',
-    '{{subject}} must not be a valid CNH number',
+    '{{subject}} must be a CNH',
+    '{{subject}} must not be a CNH',
 )]
 final class Cnh extends Simple
 {

--- a/src/Validators/Cnpj.php
+++ b/src/Validators/Cnpj.php
@@ -29,8 +29,8 @@ use function str_split;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid CNPJ number',
-    '{{subject}} must not be a valid CNPJ number',
+    '{{subject}} must be a CNPJ',
+    '{{subject}} must not be a CNPJ',
 )]
 final class Cnpj extends Simple
 {

--- a/src/Validators/Consonant.php
+++ b/src/Validators/Consonant.php
@@ -24,13 +24,13 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must only contain consonants',
-    '{{subject}} must not contain consonants',
+    '{{subject}} must consist only of consonants',
+    '{{subject}} must not consist only of consonants',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must only contain consonants and {{additionalChars}}',
-    '{{subject}} must not contain consonants or {{additionalChars}}',
+    '{{subject}} must consist only of consonants or {{additionalChars}}',
+    '{{subject}} must not consist only of consonants or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Consonant extends FilteredString

--- a/src/Validators/Control.php
+++ b/src/Validators/Control.php
@@ -23,13 +23,13 @@ use function ctype_cntrl;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must only contain control characters',
-    '{{subject}} must not contain control characters',
+    '{{subject}} must consist only of control characters',
+    '{{subject}} must not consist only of control characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must only contain control characters and {{additionalChars}}',
-    '{{subject}} must not contain control characters or {{additionalChars}}',
+    '{{subject}} must consist only of control characters or {{additionalChars}}',
+    '{{subject}} must not consist only of control characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Control extends FilteredString

--- a/src/Validators/Countable.php
+++ b/src/Validators/Countable.php
@@ -27,8 +27,8 @@ use function is_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a countable value',
-    '{{subject}} must not be a countable value',
+    '{{subject}} must be countable',
+    '{{subject}} must not be countable',
 )]
 final class Countable extends Simple
 {

--- a/src/Validators/CountryCode.php
+++ b/src/Validators/CountryCode.php
@@ -32,8 +32,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid country code',
-    '{{subject}} must not be a valid country code',
+    '{{subject}} must be a country code',
+    '{{subject}} must not be a country code',
 )]
 final readonly class CountryCode implements Validator
 {

--- a/src/Validators/Cpf.php
+++ b/src/Validators/Cpf.php
@@ -30,8 +30,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid CPF number',
-    '{{subject}} must not be a valid CPF number',
+    '{{subject}} must be a CPF',
+    '{{subject}} must not be a CPF',
 )]
 final class Cpf extends Simple
 {

--- a/src/Validators/CreditCard.php
+++ b/src/Validators/CreditCard.php
@@ -32,13 +32,13 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid credit card number',
-    '{{subject}} must not be a valid credit card number',
+    '{{subject}} must be a credit card number',
+    '{{subject}} must not be a credit card number',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must be a valid {{brand|raw}} credit card number',
-    '{{subject}} must not be a valid {{brand|raw}} credit card number',
+    '{{subject}} must be a {{brand|raw}} credit card number',
+    '{{subject}} must not be a {{brand|raw}} credit card number',
     self::TEMPLATE_BRANDED,
 )]
 final readonly class CreditCard implements Validator

--- a/src/Validators/CurrencyCode.php
+++ b/src/Validators/CurrencyCode.php
@@ -28,8 +28,8 @@ use function in_array;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid currency code',
-    '{{subject}} must not be a valid currency code',
+    '{{subject}} must be a currency code',
+    '{{subject}} must not be a currency code',
 )]
 final readonly class CurrencyCode implements Validator
 {

--- a/src/Validators/Date.php
+++ b/src/Validators/Date.php
@@ -30,8 +30,8 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid date in the format {{sample}}',
-    '{{subject}} must not be a valid date in the format {{sample}}',
+    '{{subject}} must be a date in the {{sample}} format',
+    '{{subject}} must not be a date in the {{sample}} format',
 )]
 final readonly class Date implements Validator
 {

--- a/src/Validators/DateTime.php
+++ b/src/Validators/DateTime.php
@@ -29,13 +29,13 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid date/time',
-    '{{subject}} must not be a valid date/time',
+    '{{subject}} must be a date/time',
+    '{{subject}} must not be a date/time',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must be a valid date/time in the format {{sample}}',
-    '{{subject}} must not be a valid date/time in the format {{sample}}',
+    '{{subject}} must be a date/time in the {{sample}} format',
+    '{{subject}} must not be a date/time in the {{sample}} format',
     self::TEMPLATE_FORMAT,
 )]
 final class DateTime implements Validator

--- a/src/Validators/DateTimeDiff.php
+++ b/src/Validators/DateTimeDiff.php
@@ -34,13 +34,13 @@ use function in_array;
     self::TEMPLATE_CUSTOMIZED,
 )]
 #[Template(
-    'For comparison with {{now|raw}}, {{subject}} must be a valid datetime',
-    'For comparison with {{now|raw}}, {{subject}} must not be a valid datetime',
+    'For comparison with {{now|raw}}, {{subject}} must be a datetime',
+    'For comparison with {{now|raw}}, {{subject}} must not be a datetime',
     self::TEMPLATE_NOT_A_DATE,
 )]
 #[Template(
-    'For comparison with {{now|raw}}, {{subject}} must be a valid datetime in the format {{sample|raw}}',
-    'For comparison with {{now|raw}}, {{subject}} must not be a valid datetime in the format {{sample|raw}}',
+    'For comparison with {{now|raw}}, {{subject}} must be a datetime in the format {{sample|raw}}',
+    'For comparison with {{now|raw}}, {{subject}} must not be a datetime in the format {{sample|raw}}',
     self::TEMPLATE_WRONG_FORMAT,
 )]
 final readonly class DateTimeDiff implements Validator

--- a/src/Validators/Decimal.php
+++ b/src/Validators/Decimal.php
@@ -25,8 +25,8 @@ use function var_export;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must have {{decimals}} decimals',
-    '{{subject}} must not have {{decimals}} decimals',
+    '{{subject}} must have {{decimals}} decimal places',
+    '{{subject}} must not have {{decimals}} decimal places',
 )]
 final readonly class Decimal implements Validator
 {

--- a/src/Validators/Digit.php
+++ b/src/Validators/Digit.php
@@ -22,13 +22,13 @@ use function ctype_digit;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only digits (0-9)',
-    '{{subject}} must not contain digits (0-9)',
+    '{{subject}} must consist only of digits (0-9)',
+    '{{subject}} must not consist only of digits (0-9)',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only digits (0-9) and {{additionalChars}}',
-    '{{subject}} must not contain digits (0-9) and {{additionalChars}}',
+    '{{subject}} must consist only of digits (0-9) or {{additionalChars}}',
+    '{{subject}} must not consist only of digits (0-9) or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Digit extends FilteredString

--- a/src/Validators/Directory.php
+++ b/src/Validators/Directory.php
@@ -25,8 +25,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a directory',
-    '{{subject}} must not be a directory',
+    '{{subject}} must be an accessible existing directory',
+    '{{subject}} must not be an accessible existing directory',
 )]
 final class Directory extends Simple
 {

--- a/src/Validators/Domain.php
+++ b/src/Validators/Domain.php
@@ -27,8 +27,8 @@ use function explode;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid domain',
-    '{{subject}} must not be a valid domain',
+    '{{subject}} must be an internet domain',
+    '{{subject}} must not be an internet domain',
 )]
 final class Domain implements Validator
 {

--- a/src/Validators/Email.php
+++ b/src/Validators/Email.php
@@ -33,7 +33,7 @@ use const FILTER_VALIDATE_EMAIL;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid email address',
+    '{{subject}} must be an email address',
     '{{subject}} must not be an email address',
 )]
 final class Email extends Simple

--- a/src/Validators/Executable.php
+++ b/src/Validators/Executable.php
@@ -24,8 +24,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be an executable file',
-    '{{subject}} must not be an executable file',
+    '{{subject}} must be an accessible existing executable file',
+    '{{subject}} must not be an accessible existing executable file',
 )]
 final class Executable extends Simple
 {

--- a/src/Validators/Extension.php
+++ b/src/Validators/Extension.php
@@ -25,8 +25,8 @@ use const PATHINFO_EXTENSION;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must have {{extension}} extension',
-    '{{subject}} must not have {{extension}} extension',
+    '{{subject}} must have the {{extension}} extension',
+    '{{subject}} must not have the {{extension}} extension',
 )]
 final readonly class Extension implements Validator
 {

--- a/src/Validators/File.php
+++ b/src/Validators/File.php
@@ -24,8 +24,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid file',
-    '{{subject}} must be an invalid file',
+    '{{subject}} must be an accessible existing file',
+    '{{subject}} must not be an accessible existing file',
 )]
 final class File extends Simple
 {

--- a/src/Validators/FloatType.php
+++ b/src/Validators/FloatType.php
@@ -22,8 +22,8 @@ use function is_float;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be float',
-    '{{subject}} must not be float',
+    '{{subject}} must be a float',
+    '{{subject}} must not be a float',
 )]
 final class FloatType extends Simple
 {

--- a/src/Validators/FloatVal.php
+++ b/src/Validators/FloatVal.php
@@ -26,8 +26,8 @@ use const FILTER_VALIDATE_FLOAT;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a float value',
-    '{{subject}} must not be a float value',
+    '{{subject}} must be a floating-point number',
+    '{{subject}} must not be a floating-point number',
 )]
 final class FloatVal extends Simple
 {

--- a/src/Validators/Graph.php
+++ b/src/Validators/Graph.php
@@ -23,13 +23,13 @@ use function ctype_graph;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only graphical characters',
-    '{{subject}} must not contain graphical characters',
+    '{{subject}} must consist only of printable non-spacing characters',
+    '{{subject}} must not consist only of printable non-spacing characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only graphical characters and {{additionalChars}}',
-    '{{subject}} must not contain graphical characters or {{additionalChars}}',
+    '{{subject}} must consist only of printable non-spacing characters or {{additionalChars}}',
+    '{{subject}} must not consist only of printable non-spacing characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Graph extends FilteredString

--- a/src/Validators/Hetu.php
+++ b/src/Validators/Hetu.php
@@ -23,8 +23,8 @@ use function str_split;
 /** @see https://en.wikipedia.org/wiki/National_identification_number#Finland */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid Finnish personal identity code',
-    '{{subject}} must not be a valid Finnish personal identity code',
+    '{{subject}} must be a Finnish personal identity code',
+    '{{subject}} must not be a Finnish personal identity code',
 )]
 final class Hetu extends Simple
 {

--- a/src/Validators/Iban.php
+++ b/src/Validators/Iban.php
@@ -28,8 +28,8 @@ use function substr;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid IBAN',
-    '{{subject}} must not be a valid IBAN',
+    '{{subject}} must be an IBAN',
+    '{{subject}} must not be an IBAN',
 )]
 final class Iban extends Simple
 {

--- a/src/Validators/Image.php
+++ b/src/Validators/Image.php
@@ -28,8 +28,8 @@ use const FILEINFO_MIME_TYPE;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid image file',
-    '{{subject}} must not be a valid image file',
+    '{{subject}} must be an accessible existing image file',
+    '{{subject}} must not be an accessible existing image file',
 )]
 final readonly class Image implements Validator
 {

--- a/src/Validators/Imei.php
+++ b/src/Validators/Imei.php
@@ -24,8 +24,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid IMEI number',
-    '{{subject}} must not be a valid IMEI number',
+    '{{subject}} must be an IMEI number',
+    '{{subject}} must not be an IMEI number',
 )]
 final class Imei extends Simple
 {

--- a/src/Validators/IntVal.php
+++ b/src/Validators/IntVal.php
@@ -29,8 +29,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be an integer value',
-    '{{subject}} must not be an integer value',
+    '{{subject}} must be an integer',
+    '{{subject}} must not be an integer',
 )]
 final class IntVal extends Simple
 {

--- a/src/Validators/Isbn.php
+++ b/src/Validators/Isbn.php
@@ -23,8 +23,8 @@ use function sprintf;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid ISBN',
-    '{{subject}} must not be a valid ISBN',
+    '{{subject}} must be an ISBN',
+    '{{subject}} must not be an ISBN',
 )]
 final class Isbn extends Simple
 {

--- a/src/Validators/IterableVal.php
+++ b/src/Validators/IterableVal.php
@@ -22,8 +22,8 @@ use Respect\Validation\Validators\Core\Simple;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be an iterable value',
-    '{{subject}} must not be an iterable value',
+    '{{subject}} must be iterable',
+    '{{subject}} must not be iterable',
 )]
 final class IterableVal extends Simple
 {

--- a/src/Validators/Json.php
+++ b/src/Validators/Json.php
@@ -28,8 +28,8 @@ use function json_validate;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid JSON string',
-    '{{subject}} must not be a valid JSON string',
+    '{{subject}} must be a JSON string',
+    '{{subject}} must not be a JSON string',
 )]
 final class Json extends Simple
 {

--- a/src/Validators/LanguageCode.php
+++ b/src/Validators/LanguageCode.php
@@ -29,8 +29,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid language code',
-    '{{subject}} must not be a valid language code',
+    '{{subject}} must be a language code',
+    '{{subject}} must not be a language code',
 )]
 final readonly class LanguageCode implements Validator
 {

--- a/src/Validators/LeapDate.php
+++ b/src/Validators/LeapDate.php
@@ -25,7 +25,7 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid leap date',
+    '{{subject}} must be a leap date',
     '{{subject}} must not be a leap date',
 )]
 final class LeapDate extends Simple

--- a/src/Validators/LeapYear.php
+++ b/src/Validators/LeapYear.php
@@ -28,7 +28,7 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid leap year',
+    '{{subject}} must be a leap year',
     '{{subject}} must not be a leap year',
 )]
 final class LeapYear extends Simple

--- a/src/Validators/Length.php
+++ b/src/Validators/Length.php
@@ -36,8 +36,8 @@ use function mb_strlen;
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must be a countable value or a string',
-    '{{subject}} must not be a countable value or a string',
+    '{{subject}} must be countable or a string',
+    '{{subject}} must not be countable or a string',
     self::TEMPLATE_WRONG_TYPE,
 )]
 final readonly class Length implements Validator

--- a/src/Validators/Lowercase.php
+++ b/src/Validators/Lowercase.php
@@ -24,8 +24,8 @@ use function mb_strtolower;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only lowercase letters',
-    '{{subject}} must not contain only lowercase letters',
+    '{{subject}} must consist only of lowercase letters',
+    '{{subject}} must not consist only of lowercase letters',
 )]
 final class Lowercase extends Simple
 {

--- a/src/Validators/Luhn.php
+++ b/src/Validators/Luhn.php
@@ -25,8 +25,8 @@ use function str_split;
 /** @see https://en.wikipedia.org/wiki/Luhn_algorithm */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid Luhn number',
-    '{{subject}} must not be a valid Luhn number',
+    '{{subject}} must be a Luhn number',
+    '{{subject}} must not be a Luhn number',
 )]
 final class Luhn extends Simple
 {

--- a/src/Validators/MacAddress.php
+++ b/src/Validators/MacAddress.php
@@ -26,8 +26,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid MAC address',
-    '{{subject}} must not be a valid MAC address',
+    '{{subject}} must be a MAC address',
+    '{{subject}} must not be a MAC address',
 )]
 final class MacAddress extends Simple
 {

--- a/src/Validators/NfeAccessKey.php
+++ b/src/Validators/NfeAccessKey.php
@@ -26,8 +26,8 @@ use function str_split;
 /** @see (pt-br) Manual de Integração do Contribuinte v4.0.1 em http://www.nfe.fazenda.gov.br */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid NFe access key',
-    '{{subject}} must not be a valid NFe access key',
+    '{{subject}} must be a NFe access key',
+    '{{subject}} must not be a NFe access key',
 )]
 final class NfeAccessKey extends Simple
 {

--- a/src/Validators/Nif.php
+++ b/src/Validators/Nif.php
@@ -28,8 +28,8 @@ use function str_split;
 /** @see https://es.wikipedia.org/wiki/N%C3%BAmero_de_identificaci%C3%B3n_fiscal */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid NIF',
-    '{{subject}} must not be a valid NIF',
+    '{{subject}} must be a NIF',
+    '{{subject}} must not be a NIF',
 )]
 final class Nif extends Simple
 {

--- a/src/Validators/Nip.php
+++ b/src/Validators/Nip.php
@@ -24,8 +24,8 @@ use function str_split;
 /** @see https://en.wikipedia.org/wiki/VAT_identification_number */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid Polish VAT identification number',
-    '{{subject}} must not be a valid Polish VAT identification number',
+    '{{subject}} must be a Polish VAT identification number',
+    '{{subject}} must not be a Polish VAT identification number',
 )]
 final class Nip extends Simple
 {

--- a/src/Validators/Number.php
+++ b/src/Validators/Number.php
@@ -25,7 +25,7 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid number',
+    '{{subject}} must be a number',
     '{{subject}} must not be a number',
 )]
 final class Number extends Simple

--- a/src/Validators/NumericVal.php
+++ b/src/Validators/NumericVal.php
@@ -22,8 +22,8 @@ use function is_numeric;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a numeric value',
-    '{{subject}} must not be a numeric value',
+    '{{subject}} must be numeric',
+    '{{subject}} must not be numeric',
 )]
 final class NumericVal extends Simple
 {

--- a/src/Validators/Pesel.php
+++ b/src/Validators/Pesel.php
@@ -22,8 +22,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid PESEL',
-    '{{subject}} must not be a valid PESEL',
+    '{{subject}} must be a PESEL',
+    '{{subject}} must not be a PESEL',
 )]
 final class Pesel extends Simple
 {

--- a/src/Validators/Phone.php
+++ b/src/Validators/Phone.php
@@ -34,13 +34,13 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid telephone number',
-    '{{subject}} must not be a valid telephone number',
+    '{{subject}} must be a phone number',
+    '{{subject}} must not be a phone number',
     self::TEMPLATE_INTERNATIONAL,
 )]
 #[Template(
-    '{{subject}} must be a valid telephone number for country {{countryName|trans}}',
-    '{{subject}} must not be a valid telephone number for country {{countryName|trans}}',
+    '{{subject}} must be a phone number for country {{countryName|trans}}',
+    '{{subject}} must not be a phone number for country {{countryName|trans}}',
     self::TEMPLATE_FOR_COUNTRY,
 )]
 final class Phone implements Validator

--- a/src/Validators/Pis.php
+++ b/src/Validators/Pis.php
@@ -24,8 +24,8 @@ use function preg_replace;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid PIS number',
-    '{{subject}} must not be a valid PIS number',
+    '{{subject}} must be a PIS number',
+    '{{subject}} must not be a PIS number',
 )]
 final class Pis extends Simple
 {

--- a/src/Validators/PolishIdCard.php
+++ b/src/Validators/PolishIdCard.php
@@ -22,8 +22,8 @@ use function preg_match;
 /** @see https://en.wikipedia.org/wiki/Polish_identity_card */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid Polish Identity Card number',
-    '{{subject}} must not be a valid Polish Identity Card number',
+    '{{subject}} must be a Polish Identity Card number',
+    '{{subject}} must not be a Polish Identity Card number',
 )]
 final class PolishIdCard extends Simple
 {

--- a/src/Validators/PostalCode.php
+++ b/src/Validators/PostalCode.php
@@ -33,8 +33,8 @@ use Respect\Validation\Validators\Core\Envelope;
 /** @see http://download.geonames.org/export/dump/countryInfo.txt */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid postal code on {{countryCode}}',
-    '{{subject}} must not be a valid postal code on {{countryCode}}',
+    '{{subject}} must be a postal code for {{countryCode}}',
+    '{{subject}} must not be a postal code for {{countryCode}}',
 )]
 final class PostalCode extends Envelope
 {

--- a/src/Validators/Printable.php
+++ b/src/Validators/Printable.php
@@ -23,13 +23,13 @@ use function ctype_print;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only printable characters',
-    '{{subject}} must not contain printable characters',
+    '{{subject}} must consist only of printable characters',
+    '{{subject}} must not consist only of printable characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only printable characters and {{additionalChars}}',
-    '{{subject}} must not contain printable characters or {{additionalChars}}',
+    '{{subject}} must consist only of printable characters or {{additionalChars}}',
+    '{{subject}} must not consist only of printable characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Printable extends FilteredString

--- a/src/Validators/Punct.php
+++ b/src/Validators/Punct.php
@@ -23,13 +23,13 @@ use function ctype_punct;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only punctuation characters',
-    '{{subject}} must not contain punctuation characters',
+    '{{subject}} must consist only of punctuation characters',
+    '{{subject}} must not consist only of punctuation characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only punctuation characters and {{additionalChars}}',
-    '{{subject}} must not contain punctuation characters or {{additionalChars}}',
+    '{{subject}} must consist only of punctuation characters or {{additionalChars}}',
+    '{{subject}} must not consist only of punctuation characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Punct extends FilteredString

--- a/src/Validators/Regex.php
+++ b/src/Validators/Regex.php
@@ -25,8 +25,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must match the pattern {{regex|quote}}',
-    '{{subject}} must not match the pattern {{regex|quote}}',
+    '{{subject}} must match the {{regex|quote}} pattern',
+    '{{subject}} must not match the {{regex|quote}} pattern',
 )]
 final readonly class Regex implements Validator
 {

--- a/src/Validators/ResourceType.php
+++ b/src/Validators/ResourceType.php
@@ -21,8 +21,8 @@ use function is_resource;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a resource',
-    '{{subject}} must not be a resource',
+    '{{subject}} must be an internal resource',
+    '{{subject}} must not be an internal resource',
 )]
 final class ResourceType extends Simple
 {

--- a/src/Validators/Roman.php
+++ b/src/Validators/Roman.php
@@ -23,8 +23,8 @@ use Respect\Validation\Validators\Core\Envelope;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid Roman numeral',
-    '{{subject}} must not be a valid Roman numeral',
+    '{{subject}} must be a Roman numeral',
+    '{{subject}} must not be a Roman numeral',
 )]
 final class Roman extends Envelope
 {

--- a/src/Validators/Satisfies.php
+++ b/src/Validators/Satisfies.php
@@ -25,7 +25,7 @@ use function count;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
     '{{subject}} must be valid',
-    '{{subject}} must be invalid',
+    '{{subject}} must not be valid',
 )]
 final class Satisfies extends Simple
 {

--- a/src/Validators/ScalarVal.php
+++ b/src/Validators/ScalarVal.php
@@ -21,8 +21,8 @@ use function is_scalar;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a scalar value',
-    '{{subject}} must not be a scalar value',
+    '{{subject}} must be a scalar',
+    '{{subject}} must not be a scalar',
 )]
 final class ScalarVal extends Simple
 {

--- a/src/Validators/Size.php
+++ b/src/Validators/Size.php
@@ -32,8 +32,8 @@ use function is_string;
     Size::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must be a filename or an instance of SplFileInfo or a PSR-7 interface',
-    '{{subject}} must not be a filename or an instance of SplFileInfo or a PSR-7 interface',
+    '{{subject}} must be a filename, an instance of SplFileInfo or a PSR-7 interface',
+    '{{subject}} must not be a filename, an instance of SplFileInfo or a PSR-7 interface',
     self::TEMPLATE_WRONG_TYPE,
 )]
 final readonly class Size implements Validator

--- a/src/Validators/Slug.php
+++ b/src/Validators/Slug.php
@@ -28,8 +28,8 @@ use function preg_match;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid slug',
-    '{{subject}} must not be a valid slug',
+    '{{subject}} must be a slug',
+    '{{subject}} must not be a slug',
 )]
 final class Slug extends Simple
 {

--- a/src/Validators/Space.php
+++ b/src/Validators/Space.php
@@ -23,13 +23,13 @@ use function ctype_space;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only space characters',
-    '{{subject}} must not contain space characters',
+    '{{subject}} must consist only of space characters',
+    '{{subject}} must not consist only of space characters',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain only space characters and {{additionalChars}}',
-    '{{subject}} must not contain space characters or {{additionalChars}}',
+    '{{subject}} must consist only of space characters or {{additionalChars}}',
+    '{{subject}} must not consist only of space characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Space extends FilteredString

--- a/src/Validators/Spaced.php
+++ b/src/Validators/Spaced.php
@@ -25,7 +25,7 @@ use function preg_match;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
     '{{subject}} must contain at least one whitespace',
-    '{{subject}} must not contain whitespaces',
+    '{{subject}} must not contain whitespace',
 )]
 final class Spaced extends Simple
 {

--- a/src/Validators/StringVal.php
+++ b/src/Validators/StringVal.php
@@ -26,8 +26,8 @@ use function method_exists;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a string value',
-    '{{subject}} must not be a string value',
+    '{{subject}} must be a string',
+    '{{subject}} must not be a string',
 )]
 final class StringVal extends Simple
 {

--- a/src/Validators/SymbolicLink.php
+++ b/src/Validators/SymbolicLink.php
@@ -24,8 +24,8 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a symbolic link',
-    '{{subject}} must not be a symbolic link',
+    '{{subject}} must be an accessible existing symbolic link',
+    '{{subject}} must not be an accessible existing symbolic link',
 )]
 final class SymbolicLink extends Simple
 {

--- a/src/Validators/Time.php
+++ b/src/Validators/Time.php
@@ -30,8 +30,8 @@ use function strtotime;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid time in the format {{sample}}',
-    '{{subject}} must not be a valid time in the format {{sample}}',
+    '{{subject}} must be a time in the {{sample}} format',
+    '{{subject}} must not be a time in the {{sample}} format',
 )]
 final readonly class Time implements Validator
 {

--- a/src/Validators/Tld.php
+++ b/src/Validators/Tld.php
@@ -16,8 +16,8 @@ use Respect\Validation\Validators\Core\Envelope;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid top-level domain name',
-    '{{subject}} must not be a valid top-level domain name',
+    '{{subject}} must be a top-level domain name',
+    '{{subject}} must not be a top-level domain name',
 )]
 final class Tld extends Envelope
 {

--- a/src/Validators/Uppercase.php
+++ b/src/Validators/Uppercase.php
@@ -24,8 +24,8 @@ use function mb_strtoupper;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must contain only uppercase letters',
-    '{{subject}} must not contain only uppercase letters',
+    '{{subject}} must consist only of uppercase letters',
+    '{{subject}} must not consist only of uppercase letters',
 )]
 final class Uppercase extends Simple
 {

--- a/src/Validators/Url.php
+++ b/src/Validators/Url.php
@@ -23,8 +23,8 @@ use const FILTER_VALIDATE_URL;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid URL',
-    '{{subject}} must not be a valid URL',
+    '{{subject}} must be a URL',
+    '{{subject}} must not be a URL',
 )]
 final class Url implements Validator
 {

--- a/src/Validators/Uuid.php
+++ b/src/Validators/Uuid.php
@@ -34,13 +34,13 @@ use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a valid UUID',
-    '{{subject}} must not be a valid UUID',
+    '{{subject}} must be a UUID',
+    '{{subject}} must not be a UUID',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must be a valid UUID version {{version|raw}}',
-    '{{subject}} must not be a valid UUID version {{version|raw}}',
+    '{{subject}} must be a UUID v{{version|raw}}',
+    '{{subject}} must not be a UUID v{{version|raw}}',
     self::TEMPLATE_VERSION,
 )]
 final class Uuid implements Validator

--- a/src/Validators/Version.php
+++ b/src/Validators/Version.php
@@ -24,8 +24,8 @@ use function preg_match;
 /** @see http://semver.org/ */
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be a version',
-    '{{subject}} must not be a version',
+    '{{subject}} must be a version number',
+    '{{subject}} must not be a version number',
 )]
 final class Version extends Simple
 {

--- a/src/Validators/Vowel.php
+++ b/src/Validators/Vowel.php
@@ -29,7 +29,7 @@ use function preg_match;
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must consist of vowels and {{additionalChars}}',
+    '{{subject}} must consist of vowels or {{additionalChars}}',
     '{{subject}} must not consist of vowels or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]

--- a/src/Validators/Writable.php
+++ b/src/Validators/Writable.php
@@ -26,8 +26,8 @@ use function is_writable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must be writable',
-    '{{subject}} must not be writable',
+    '{{subject}} must be an accessible existing writable filesystem entry',
+    '{{subject}} must not be an accessible existing writable filesystem entry',
 )]
 final class Writable extends Simple
 {

--- a/src/Validators/Xdigit.php
+++ b/src/Validators/Xdigit.php
@@ -22,13 +22,13 @@ use function ctype_xdigit;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
-    '{{subject}} must only contain hexadecimal digits',
-    '{{subject}} must not only contain hexadecimal digits',
+    '{{subject}} must consist only of hexadecimal digits',
+    '{{subject}} must not consist only of hexadecimal digits',
     self::TEMPLATE_STANDARD,
 )]
 #[Template(
-    '{{subject}} must contain hexadecimal digits and {{additionalChars}}',
-    '{{subject}} must not contain hexadecimal digits or {{additionalChars}}',
+    '{{subject}} must consist only of hexadecimal digits or {{additionalChars}}',
+    '{{subject}} must not consist only of hexadecimal digits or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
 final class Xdigit extends FilteredString

--- a/tests/feature/DoNotRelyOnNestedValidationExceptionInterfaceForCheckTest.php
+++ b/tests/feature/DoNotRelyOnNestedValidationExceptionInterfaceForCheckTest.php
@@ -12,5 +12,5 @@ use Respect\Validation\ValidatorBuilder;
 
 test('Scenario #1', catchMessage(
     fn() => ValidatorBuilder::alnum('__')->lengthBetween(1, 15)->notSpaced()->assert('really messed up screen#name'),
-    fn(string $message) => expect($message)->toBe('"really messed up screen#name" must contain only letters (a-z), digits (0-9), and "__"'),
+    fn(string $message) => expect($message)->toBe('"really messed up screen#name" must consist only of letters (a-z), digits (0-9), or "__"'),
 ));

--- a/tests/feature/GetFullMessageShouldIncludeAllValidationMessagesInAChainTest.php
+++ b/tests/feature/GetFullMessageShouldIncludeAllValidationMessagesInAChainTest.php
@@ -15,6 +15,6 @@ test('Scenario #1', catchFullMessage(
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - 0 must pass all the rules
           - 0 must be a string
-          - 0 must be a countable value or a string
+          - 0 must be countable or a string
         FULL_MESSAGE),
 ));

--- a/tests/feature/GetMessagesShouldIncludeAllValidationMessagesInAChainTest.php
+++ b/tests/feature/GetMessagesShouldIncludeAllValidationMessagesInAChainTest.php
@@ -19,7 +19,7 @@ test('Scenario #1', catchMessages(
     fn(array $messages) => expect($messages)->toBe([
         '__root__' => '`["username": "u", "birthdate": "Not a date", "password": ""]` must pass all the rules',
         'username' => 'The length of `.username` must be between 2 and 32',
-        'birthdate' => '`.birthdate` must be a valid date/time',
+        'birthdate' => '`.birthdate` must be a date/time',
         'password' => '`.password` must not be blank',
         'email' => '`.email` must be present',
     ]),

--- a/tests/feature/HandlingNamesTest.php
+++ b/tests/feature/HandlingNamesTest.php
@@ -27,20 +27,20 @@ test('Results with adjacent children results defined will display the name from 
 
 test('Results with a defined name cannot be overwritten by another name', catchMessage(
     fn() => v::named('Foo', v::key('email', v::named('Email', v::email())))->assert($input),
-    fn(string $message) => expect($message)->toBe('Email must be a valid email address'),
+    fn(string $message) => expect($message)->toBe('Email must be an email address'),
 ));
 
 test('Defining a name to a result with a path will add the path to the name', catchMessage(
     fn() => v::named('Email', v::key('email', v::email()))->assert($input),
-    fn(string $message) => expect($message)->toBe('`.email` (<- Email) must be a valid email address'),
+    fn(string $message) => expect($message)->toBe('`.email` (<- Email) must be an email address'),
 ));
 
 test('Results with a defined name will not be affected by a path', catchMessage(
     fn() => v::key('email', v::named('Email', v::email()))->assert($input),
-    fn(string $message) => expect($message)->toBe('Email must be a valid email address'),
+    fn(string $message) => expect($message)->toBe('Email must be an email address'),
 ));
 
 test('Not defining a name to a result with a path will display the path', catchMessage(
     fn() => v::key('email', v::email())->assert($input),
-    fn(string $message) => expect($message)->toBe('`.email` must be a valid email address'),
+    fn(string $message) => expect($message)->toBe('`.email` must be an email address'),
 ));

--- a/tests/feature/Issues/Issue1289Test.php
+++ b/tests/feature/Issues/Issue1289Test.php
@@ -57,7 +57,7 @@ test('https://github.com/Respect/Validation/issues/1289', catchAll(
               - `.0.default` must pass one of the rules
                 - `.0.default` must be a string
                 - `.0.default` must be a boolean
-              - `.0.description` must be a string value
+              - `.0.description` must be a string
             FULL_MESSAGE)
         ->and($messages)->toBe([
             0 => [
@@ -67,7 +67,7 @@ test('https://github.com/Respect/Validation/issues/1289', catchAll(
                     0 => '`.0.default` must be a string',
                     1 => '`.0.default` must be a boolean',
                 ],
-                'description' => '`.0.description` must be a string value',
+                'description' => '`.0.description` must be a string',
             ],
         ]),
 ));

--- a/tests/feature/Issues/Issue1333Test.php
+++ b/tests/feature/Issues/Issue1333Test.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 test('https://github.com/Respect/Validation/issues/1333', catchAll(
     fn() => v::named('User Email', v::notSpaced()->email())->assert('not email'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('User Email must not contain whitespaces')
+        ->and($message)->toBe('User Email must not contain whitespace')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
             - User Email must pass all the rules
-              - "not email" must not contain whitespaces
-              - "not email" must be a valid email address
+              - "not email" must not contain whitespace
+              - "not email" must be an email address
             FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => 'User Email must pass all the rules',
-            'notSpaced' => '"not email" must not contain whitespaces',
-            'email' => '"not email" must be a valid email address',
+            'notSpaced' => '"not email" must not contain whitespace',
+            'email' => '"not email" must be an email address',
         ]),
 ));

--- a/tests/feature/Issues/Issue1469Test.php
+++ b/tests/feature/Issues/Issue1469Test.php
@@ -35,11 +35,11 @@ test('https://github.com/Respect/Validation/issues/1469', catchAll(
             ],
         ]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`.order_items.0.quantity` must be an integer value')
+        ->and($message)->toBe('`.order_items.0.quantity` must be an integer')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
             - Each item in `.order_items` must be valid
               - `.order_items.0` validation failed
-                - `.order_items.0.quantity` must be an integer value
+                - `.order_items.0.quantity` must be an integer
               - `.order_items.1` contains both missing and extra keys
                 - `.order_items.1.product_title` must be present
                 - `.order_items.1.quantity` must be present
@@ -48,7 +48,7 @@ test('https://github.com/Respect/Validation/issues/1469', catchAll(
         ->and($messages)->toBe([
             'keySet' => [
                 '__root__' => 'Each item in `.order_items` must be valid',
-                0 => '`.order_items.0.quantity` must be an integer value',
+                0 => '`.order_items.0.quantity` must be an integer',
                 1 => [
                     '__root__' => '`.order_items.1` contains both missing and extra keys',
                     'product_title' => '`.order_items.1.product_title` must be present',

--- a/tests/feature/Issues/Issue799Test.php
+++ b/tests/feature/Issues/Issue799Test.php
@@ -20,15 +20,15 @@ test('https://github.com/Respect/Validation/issues/799 | #1', catchAll(
         )
         ->assert($input),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('1 must be an array value')
+        ->and($message)->toBe('1 must be an array')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
             - 1 must pass all the rules
-              - 1 must be an array value
+              - 1 must be an array
               - `.scheme` must be present
             FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '1 must pass all the rules',
-            'arrayVal' => '1 must be an array value',
+            'arrayVal' => '1 must be an array',
             'scheme' => '`.scheme` must be present',
         ]),
 ));

--- a/tests/feature/KeysAsValidatorNamesTest.php
+++ b/tests/feature/KeysAsValidatorNamesTest.php
@@ -18,6 +18,6 @@ test('Scenario #1', catchFullMessage(
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - User Subscription Form must pass all the rules
           - The length of `.username` must be between 2 and 32
-          - `.birthdate` must be a valid date/time
+          - `.birthdate` must be a date/time
         FULL_MESSAGE),
 ));

--- a/tests/feature/NotWithRecursionTest.php
+++ b/tests/feature/NotWithRecursionTest.php
@@ -20,7 +20,7 @@ test('Scenario #1', catchMessage(
             ),
         ),
     )->assert(2),
-    fn(string $message) => expect($message)->toBe('2 must not be an integer value'),
+    fn(string $message) => expect($message)->toBe('2 must not be an integer'),
 ));
 
 test('Scenario #2', catchFullMessage(
@@ -37,7 +37,7 @@ test('Scenario #2', catchFullMessage(
     )->assert(2),
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - 2 must pass the rules
-          - 2 must not be an integer value
+          - 2 must not be an integer
           - 2 must not be a positive number
         FULL_MESSAGE),
 ));

--- a/tests/feature/NotWithoutRecursionTest.php
+++ b/tests/feature/NotWithoutRecursionTest.php
@@ -14,4 +14,4 @@ test('Scenario #1', catchMessage(function (): void {
     $validator = ValidatorBuilder::not(ValidatorBuilder::intVal()->positive());
     $validator->assert(2);
 },
-fn(string $message) => expect($message)->toBe('2 must not be an integer value')));
+fn(string $message) => expect($message)->toBe('2 must not be an integer')));

--- a/tests/feature/Readme/ExampleTest.php
+++ b/tests/feature/Readme/ExampleTest.php
@@ -12,8 +12,8 @@ test('Scenario #1', catchFullMessage(
     fn() => v::alnum()->notSpaced()->lengthBetween(1, 15)->assert('really messed up screen#name'),
     fn(string $fullMessage) => expect($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - "really messed up screen#name" must pass all the rules
-          - "really messed up screen#name" must contain only letters (a-z) and digits (0-9)
-          - "really messed up screen#name" must not contain whitespaces
+          - "really messed up screen#name" must consist only of letters (a-z) and digits (0-9)
+          - "really messed up screen#name" must not contain whitespace
           - The length of "really messed up screen#name" must be between 1 and 15
         FULL_MESSAGE),
 ));

--- a/tests/feature/Readme/GettingMessagesAsAnArrayTest.php
+++ b/tests/feature/Readme/GettingMessagesAsAnArrayTest.php
@@ -12,8 +12,8 @@ test('Scenario #1', catchMessages(
     fn() => v::alnum()->notSpaced()->lengthBetween(1, 15)->assert('really messed up screen#name'),
     fn(array $messages) => expect($messages)->toBe([
         '__root__' => '"really messed up screen#name" must pass all the rules',
-        'alnum' => '"really messed up screen#name" must contain only letters (a-z) and digits (0-9)',
-        'notSpaced' => '"really messed up screen#name" must not contain whitespaces',
+        'alnum' => '"really messed up screen#name" must consist only of letters (a-z) and digits (0-9)',
+        'notSpaced' => '"really messed up screen#name" must not contain whitespace',
         'lengthBetween' => 'The length of "really messed up screen#name" must be between 1 and 15',
     ]),
 ));

--- a/tests/feature/ResultQueryTest.php
+++ b/tests/feature/ResultQueryTest.php
@@ -21,7 +21,7 @@ test('findByPath with nested keys', function (): void {
     expect()
         ->and($emailResult)->not->toBeNull()
         ->and($emailResult?->hasFailed())->toBeTrue()
-        ->and($emailResult?->getMessage())->toBe('`.user.email` must be a valid email address');
+        ->and($emailResult?->getMessage())->toBe('`.user.email` must be an email address');
 });
 
 test('findByPath with array index', function (): void {
@@ -45,7 +45,7 @@ test('findByName with named validator', function (): void {
     expect()
         ->and($namedResult)->not->toBeNull()
         ->and($namedResult?->hasFailed())->toBeTrue()
-        ->and($namedResult?->getMessage())->toBe('User Email must be a valid email address');
+        ->and($namedResult?->getMessage())->toBe('User Email must be an email address');
 });
 
 test('findById with validator id', function (): void {

--- a/tests/feature/Transformers/PrefixTest.php
+++ b/tests/feature/Transformers/PrefixTest.php
@@ -78,7 +78,7 @@ test('Property', catchAll(
 test('UndefOr', catchAll(
     fn() => v::undefOrUrl()->assert('string'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"string" must be a valid URL or must be undefined')
-        ->and($fullMessage)->toBe('- "string" must be a valid URL or must be undefined')
-        ->and($messages)->toBe(['undefOrUrl' => '"string" must be a valid URL or must be undefined']),
+        ->and($message)->toBe('"string" must be a URL or must be undefined')
+        ->and($fullMessage)->toBe('- "string" must be a URL or must be undefined')
+        ->and($messages)->toBe(['undefOrUrl' => '"string" must be a URL or must be undefined']),
 ));

--- a/tests/feature/TranslatorTest.php
+++ b/tests/feature/TranslatorTest.php
@@ -22,7 +22,7 @@ $translator->addResource(
         'The length of' => 'O comprimento de',
         '{{subject}} must be a string' => '{{subject}} deve ser uma string',
         '{{subject}} must be between {{minValue}} and {{maxValue}}' => '{{subject}} deve possuir de {{minValue}} a {{maxValue}} caracteres',
-        '{{subject}} must be a valid telephone number for country {{countryName|trans}}' => '{{subject}} deve ser um número de telefone válido para o país {{countryName|trans}}',
+        '{{subject}} must be a phone number for country {{countryName|trans}}' => '{{subject}} deve ser um número de telefone válido para o país {{countryName|trans}}',
         'United States' => 'Estados Unidos',
         'years' => 'anos',
         'The number of {{type|trans}} between now and' => 'O número de {{type|trans}} entre agora e',

--- a/tests/feature/Validators/AfterTest.php
+++ b/tests/feature/Validators/AfterTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::after('trim', v::notSpaced())->assert(' two words '),
-    fn(string $message) => expect($message)->toBe('"two words" must not contain whitespaces'),
+    fn(string $message) => expect($message)->toBe('"two words" must not contain whitespace'),
 ));
 
 test('Scenario #2', catchMessage(

--- a/tests/feature/Validators/AllOfTest.php
+++ b/tests/feature/Validators/AllOfTest.php
@@ -67,15 +67,15 @@ test('Inverted: pass, pass', catchAll(
 test('Inverted: pass, fail, fail', catchAll(
     fn() => v::allOf(v::intType(), v::alpha(), v::stringType())->assert(2),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('2 must contain only letters (a-z)')
+        ->and($message)->toBe('2 must consist only of letters (a-z)')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
             - 2 must pass the rules
-              - 2 must contain only letters (a-z)
+              - 2 must consist only of letters (a-z)
               - 2 must be a string
             FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '2 must pass the rules',
-            'alpha' => '2 must contain only letters (a-z)',
+            'alpha' => '2 must consist only of letters (a-z)',
             'stringType' => '2 must be a string',
         ]),
 ));

--- a/tests/feature/Validators/AlnumTest.php
+++ b/tests/feature/Validators/AlnumTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::alnum()->assert('abc%1'),
-    fn(string $message) => expect($message)->toBe('"abc%1" must contain only letters (a-z) and digits (0-9)'),
+    fn(string $message) => expect($message)->toBe('"abc%1" must consist only of letters (a-z) and digits (0-9)'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::alnum(' ')->assert('abc%2'),
-    fn(string $message) => expect($message)->toBe('"abc%2" must contain only letters (a-z), digits (0-9), and " "'),
+    fn(string $message) => expect($message)->toBe('"abc%2" must consist only of letters (a-z), digits (0-9), or " "'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::alnum())->assert('abcd3'),
-    fn(string $message) => expect($message)->toBe('"abcd3" must not contain letters (a-z) or digits (0-9)'),
+    fn(string $message) => expect($message)->toBe('"abcd3" must not consist only of letters (a-z) or digits (0-9)'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::alnum('% '))->assert('abc%4'),
-    fn(string $message) => expect($message)->toBe('"abc%4" must not contain letters (a-z), digits (0-9), or "% "'),
+    fn(string $message) => expect($message)->toBe('"abc%4" must not consist only of letters (a-z), digits (0-9), or "% "'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::alnum()->assert('abc^1'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc^1" must contain only letters (a-z) and digits (0-9)'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc^1" must consist only of letters (a-z) and digits (0-9)'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::not(v::alnum())->assert('abcd2'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abcd2" must not contain letters (a-z) or digits (0-9)'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abcd2" must not consist only of letters (a-z) or digits (0-9)'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::alnum('* &%')->assert('abc^3'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc^3" must contain only letters (a-z), digits (0-9), and "* &%"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc^3" must consist only of letters (a-z), digits (0-9), or "* &%"'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::alnum('^'))->assert('abc^4'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc^4" must not contain letters (a-z), digits (0-9), or "^"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc^4" must not consist only of letters (a-z), digits (0-9), or "^"'),
 ));

--- a/tests/feature/Validators/AlphaTest.php
+++ b/tests/feature/Validators/AlphaTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::alpha()->assert('aaa%a'),
-    fn(string $message) => expect($message)->toBe('"aaa%a" must contain only letters (a-z)'),
+    fn(string $message) => expect($message)->toBe('"aaa%a" must consist only of letters (a-z)'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::alpha(' ')->assert('bbb%b'),
-    fn(string $message) => expect($message)->toBe('"bbb%b" must contain only letters (a-z) and " "'),
+    fn(string $message) => expect($message)->toBe('"bbb%b" must consist only of letters (a-z) or " "'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::alpha())->assert('ccccc'),
-    fn(string $message) => expect($message)->toBe('"ccccc" must not contain letters (a-z)'),
+    fn(string $message) => expect($message)->toBe('"ccccc" must not consist only of letters (a-z)'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::alpha('% '))->assert('ddd%d'),
-    fn(string $message) => expect($message)->toBe('"ddd%d" must not contain letters (a-z) or "% "'),
+    fn(string $message) => expect($message)->toBe('"ddd%d" must not consist only of letters (a-z) or "% "'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::alpha()->assert('eee^e'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "eee^e" must contain only letters (a-z)'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "eee^e" must consist only of letters (a-z)'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::not(v::alpha())->assert('fffff'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "fffff" must not contain letters (a-z)'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "fffff" must not consist only of letters (a-z)'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::alpha('* &%')->assert('ggg^g'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ggg^g" must contain only letters (a-z) and "* &%"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ggg^g" must consist only of letters (a-z) or "* &%"'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::alpha('^'))->assert('hhh^h'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "hhh^h" must not contain letters (a-z) or "^"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "hhh^h" must not consist only of letters (a-z) or "^"'),
 ));

--- a/tests/feature/Validators/ArrayValTest.php
+++ b/tests/feature/Validators/ArrayValTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::arrayVal()->assert('Bla %123'),
-    fn(string $message) => expect($message)->toBe('"Bla %123" must be an array value'),
+    fn(string $message) => expect($message)->toBe('"Bla %123" must be an array'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::arrayVal())->assert([42]),
-    fn(string $message) => expect($message)->toBe('`[42]` must not be an array value'),
+    fn(string $message) => expect($message)->toBe('`[42]` must not be an array'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::arrayVal()->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be an array value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be an array'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::arrayVal())->assert(new ArrayObject([2, 3])),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [2, 3] }` must not be an array value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [2, 3] }` must not be an array'),
 ));

--- a/tests/feature/Validators/AttributesTest.php
+++ b/tests/feature/Validators/AttributesTest.php
@@ -22,9 +22,9 @@ test('Default', catchAll(
 test('Inverted', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '2024-06-23', 'john.doe@gmail.com', '+1234567890')),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`.phone` must be a valid telephone number or must be null')
-        ->and($fullMessage)->toBe('- `.phone` must be a valid telephone number or must be null')
-        ->and($messages)->toBe(['phone' => '`.phone` must be a valid telephone number or must be null']),
+        ->and($message)->toBe('`.phone` must be a phone number or must be null')
+        ->and($fullMessage)->toBe('- `.phone` must be a phone number or must be null')
+        ->and($messages)->toBe(['phone' => '`.phone` must be a phone number or must be null']),
 ));
 
 test('Not an object', catchAll(
@@ -38,9 +38,9 @@ test('Not an object', catchAll(
 test('Nullable', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '2024-06-23', 'john.doe@gmail.com', 'not a phone number')),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`.phone` must be a valid telephone number or must be null')
-        ->and($fullMessage)->toBe('- `.phone` must be a valid telephone number or must be null')
-        ->and($messages)->toBe(['phone' => '`.phone` must be a valid telephone number or must be null']),
+        ->and($message)->toBe('`.phone` must be a phone number or must be null')
+        ->and($fullMessage)->toBe('- `.phone` must be a phone number or must be null')
+        ->and($messages)->toBe(['phone' => '`.phone` must be a phone number or must be null']),
 ));
 
 test('Multiple attributes, all failed', catchAll(
@@ -51,21 +51,21 @@ test('Multiple attributes, all failed', catchAll(
             - `Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" #$phone="not a phone number" + ... }` must pass the rules
               - `.name` must be defined
               - `.birthdate` must pass all the rules
-                - `.birthdate` must be a valid date in the format "2005-12-30"
-                - For comparison with now, `.birthdate` must be a valid datetime
-              - `.phone` must be a valid telephone number or must be null
-              - `.email` must be a valid email address or must be null
+                - `.birthdate` must be a date in the "2005-12-30" format
+                - For comparison with now, `.birthdate` must be a datetime
+              - `.phone` must be a phone number or must be null
+              - `.email` must be an email address or must be null
             FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '`Respect\Validation\Test\Stubs\WithAttributes { +$name="" +$birthdate="not a date" #$phone="not a phone number" + ... }` must pass the rules',
             'name' => '`.name` must be defined',
             'birthdate' => [
                 '__root__' => '`.birthdate` must pass all the rules',
-                0 => '`.birthdate` must be a valid date in the format "2005-12-30"',
-                1 => 'For comparison with now, `.birthdate` must be a valid datetime',
+                0 => '`.birthdate` must be a date in the "2005-12-30" format',
+                1 => 'For comparison with now, `.birthdate` must be a datetime',
             ],
-            'phone' => '`.phone` must be a valid telephone number or must be null',
-            'email' => '`.email` must be a valid email address or must be null',
+            'phone' => '`.phone` must be a phone number or must be null',
+            'email' => '`.email` must be an email address or must be null',
         ]),
 ));
 
@@ -90,7 +90,7 @@ test('Failed attributes on the class', catchAll(
 test('Multiple attributes, one failed', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('John Doe', '22 years ago', 'john.doe@gmail.com')),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`.birthdate` must be a valid date in the format "2005-12-30"')
-        ->and($fullMessage)->toBe('- `.birthdate` must be a valid date in the format "2005-12-30"')
-        ->and($messages)->toBe(['birthdate' => '`.birthdate` must be a valid date in the format "2005-12-30"']),
+        ->and($message)->toBe('`.birthdate` must be a date in the "2005-12-30" format')
+        ->and($fullMessage)->toBe('- `.birthdate` must be a date in the "2005-12-30" format')
+        ->and($messages)->toBe(['birthdate' => '`.birthdate` must be a date in the "2005-12-30" format']),
 ));

--- a/tests/feature/Validators/Base64Test.php
+++ b/tests/feature/Validators/Base64Test.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::base64()->assert('=c3VyZS4'),
-    fn(string $message) => expect($message)->toBe('"=c3VyZS4" must be a base64 encoded string'),
+    fn(string $message) => expect($message)->toBe('"=c3VyZS4" must be a base64-encoded string'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::base64())->assert('c3VyZS4='),
-    fn(string $message) => expect($message)->toBe('"c3VyZS4=" must not be a base64 encoded string'),
+    fn(string $message) => expect($message)->toBe('"c3VyZS4=" must not be a base64-encoded string'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::base64()->assert('=c3VyZS4'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "=c3VyZS4" must be a base64 encoded string'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "=c3VyZS4" must be a base64-encoded string'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::base64())->assert('c3VyZS4='),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "c3VyZS4=" must not be a base64 encoded string'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "c3VyZS4=" must not be a base64-encoded string'),
 ));

--- a/tests/feature/Validators/BoolValTest.php
+++ b/tests/feature/Validators/BoolValTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::boolVal()->assert('ok'),
-    fn(string $message) => expect($message)->toBe('"ok" must be a boolean value'),
+    fn(string $message) => expect($message)->toBe('"ok" must be a boolean'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::boolVal())->assert('yes'),
-    fn(string $message) => expect($message)->toBe('"yes" must not be a boolean value'),
+    fn(string $message) => expect($message)->toBe('"yes" must not be a boolean'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::boolVal()->assert('yep'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "yep" must be a boolean value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "yep" must be a boolean'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::boolVal())->assert('on'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "on" must not be a boolean value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "on" must not be a boolean'),
 ));

--- a/tests/feature/Validators/BsnTest.php
+++ b/tests/feature/Validators/BsnTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::bsn()->assert('acb'),
-    fn(string $message) => expect($message)->toBe('"acb" must be a valid BSN'),
+    fn(string $message) => expect($message)->toBe('"acb" must be a BSN'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::bsn())->assert('612890053'),
-    fn(string $message) => expect($message)->toBe('"612890053" must not be a valid BSN'),
+    fn(string $message) => expect($message)->toBe('"612890053" must not be a BSN'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::bsn()->assert('abc'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc" must be a valid BSN'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc" must be a BSN'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::bsn())->assert('612890053'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "612890053" must not be a valid BSN'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "612890053" must not be a BSN'),
 ));

--- a/tests/feature/Validators/CallableTypeTest.php
+++ b/tests/feature/Validators/CallableTypeTest.php
@@ -10,22 +10,22 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::callableType()->assert([]),
-    fn(string $message) => expect($message)->toBe('`[]` must be a callable'),
+    fn(string $message) => expect($message)->toBe('`[]` must be a callable function'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::callableType())->assert('trim'),
-    fn(string $message) => expect($message)->toBe('"trim" must not be a callable'),
+    fn(string $message) => expect($message)->toBe('"trim" must not be a callable function'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::callableType()->assert(true),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be a callable'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be a callable function'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::callableType())->assert(function (): void {
         // Do nothing
     }),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `Closure { fn(): void }` must not be a callable'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `Closure { fn(): void }` must not be a callable function'),
 ));

--- a/tests/feature/Validators/CharsetTest.php
+++ b/tests/feature/Validators/CharsetTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::charset('ASCII')->assert('açaí'),
-    fn(string $message) => expect($message)->toBe('"açaí" must only contain characters from the `["ASCII"]` charset'),
+    fn(string $message) => expect($message)->toBe('"açaí" must consist only of characters from the "ASCII" character-set'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::charset('UTF-8'))->assert('açaí'),
-    fn(string $message) => expect($message)->toBe('"açaí" must not contain any characters from the `["UTF-8"]` charset'),
+    fn(string $message) => expect($message)->toBe('"açaí" must not consist only of characters from the "UTF-8" character-set'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::charset('ASCII')->assert('açaí'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "açaí" must only contain characters from the `["ASCII"]` charset'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "açaí" must consist only of characters from the "ASCII" character-set'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::charset('UTF-8'))->assert('açaí'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "açaí" must not contain any characters from the `["UTF-8"]` charset'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "açaí" must not consist only of characters from the "UTF-8" character-set'),
 ));

--- a/tests/feature/Validators/CnhTest.php
+++ b/tests/feature/Validators/CnhTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::cnh()->assert('batman'),
-    fn(string $message) => expect($message)->toBe('"batman" must be a valid CNH number'),
+    fn(string $message) => expect($message)->toBe('"batman" must be a CNH'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::cnh())->assert('02650306461'),
-    fn(string $message) => expect($message)->toBe('"02650306461" must not be a valid CNH number'),
+    fn(string $message) => expect($message)->toBe('"02650306461" must not be a CNH'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::cnh()->assert('bruce wayne'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bruce wayne" must be a valid CNH number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bruce wayne" must be a CNH'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::cnh())->assert('02650306461'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "02650306461" must not be a valid CNH number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "02650306461" must not be a CNH'),
 ));

--- a/tests/feature/Validators/CnpjTest.php
+++ b/tests/feature/Validators/CnpjTest.php
@@ -12,20 +12,20 @@ require_once 'vendor/autoload.php';
 
 test('Scenario #1', catchMessage(
     fn() => v::cnpj()->assert('não cnpj'),
-    fn(string $message) => expect($message)->toBe('"não cnpj" must be a valid CNPJ number'),
+    fn(string $message) => expect($message)->toBe('"não cnpj" must be a CNPJ'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::cnpj())->assert('65.150.175/0001-20'),
-    fn(string $message) => expect($message)->toBe('"65.150.175/0001-20" must not be a valid CNPJ number'),
+    fn(string $message) => expect($message)->toBe('"65.150.175/0001-20" must not be a CNPJ'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::cnpj()->assert('test'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "test" must be a valid CNPJ number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "test" must be a CNPJ'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::cnpj())->assert('65.150.175/0001-20'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "65.150.175/0001-20" must not be a valid CNPJ number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "65.150.175/0001-20" must not be a CNPJ'),
 ));

--- a/tests/feature/Validators/CntrlTest.php
+++ b/tests/feature/Validators/CntrlTest.php
@@ -12,40 +12,40 @@ require_once 'vendor/autoload.php';
 
 test('Scenario #1', catchMessage(
     fn() => v::control()->assert('16-50'),
-    fn(string $message) => expect($message)->toBe('"16-50" must only contain control characters'),
+    fn(string $message) => expect($message)->toBe('"16-50" must consist only of control characters'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::control('16')->assert('16-50'),
-    fn(string $message) => expect($message)->toBe('"16-50" must only contain control characters and "16"'),
+    fn(string $message) => expect($message)->toBe('"16-50" must consist only of control characters or "16"'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::control())->assert("\n"),
-    fn(string $message) => expect($message)->toBe('"\\n" must not contain control characters'),
+    fn(string $message) => expect($message)->toBe('"\\n" must not consist only of control characters'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::control('16'))->assert("16\n"),
-    fn(string $message) => expect($message)->toBe('"16\\n" must not contain control characters or "16"'),
+    fn(string $message) => expect($message)->toBe('"16\\n" must not consist only of control characters or "16"'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::control()->assert('Foo'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must only contain control characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must consist only of control characters'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::control('Bar')->assert('Foo'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must only contain control characters and "Bar"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must consist only of control characters or "Bar"'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::control())->assert("\n"),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "\\n" must not contain control characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "\\n" must not consist only of control characters'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::control('Bar'))->assert("Bar\n"),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Bar\\n" must not contain control characters or "Bar"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Bar\\n" must not consist only of control characters or "Bar"'),
 ));

--- a/tests/feature/Validators/ConsonantTest.php
+++ b/tests/feature/Validators/ConsonantTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::consonant()->assert('aeiou'),
-    fn(string $message) => expect($message)->toBe('"aeiou" must only contain consonants'),
+    fn(string $message) => expect($message)->toBe('"aeiou" must consist only of consonants'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::consonant('d')->assert('daeiou'),
-    fn(string $message) => expect($message)->toBe('"daeiou" must only contain consonants and "d"'),
+    fn(string $message) => expect($message)->toBe('"daeiou" must consist only of consonants or "d"'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::consonant())->assert('bcd'),
-    fn(string $message) => expect($message)->toBe('"bcd" must not contain consonants'),
+    fn(string $message) => expect($message)->toBe('"bcd" must not consist only of consonants'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::consonant('a'))->assert('abcd'),
-    fn(string $message) => expect($message)->toBe('"abcd" must not contain consonants or "a"'),
+    fn(string $message) => expect($message)->toBe('"abcd" must not consist only of consonants or "a"'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::consonant()->assert('aeiou'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "aeiou" must only contain consonants'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "aeiou" must consist only of consonants'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::consonant('d')->assert('daeiou'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "daeiou" must only contain consonants and "d"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "daeiou" must consist only of consonants or "d"'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::consonant())->assert('bcd'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bcd" must not contain consonants'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bcd" must not consist only of consonants'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::consonant('a'))->assert('abcd'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abcd" must not contain consonants or "a"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abcd" must not consist only of consonants or "a"'),
 ));

--- a/tests/feature/Validators/CountableTest.php
+++ b/tests/feature/Validators/CountableTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::countable()->assert(1.0),
-    fn(string $message) => expect($message)->toBe('1.0 must be a countable value'),
+    fn(string $message) => expect($message)->toBe('1.0 must be countable'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::countable())->assert([]),
-    fn(string $message) => expect($message)->toBe('`[]` must not be a countable value'),
+    fn(string $message) => expect($message)->toBe('`[]` must not be countable'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::countable()->assert('Not countable!'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Not countable!" must be a countable value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Not countable!" must be countable'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::countable())->assert(new ArrayObject()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [] }` must not be a countable value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `ArrayObject { getArrayCopy() => [] }` must not be countable'),
 ));

--- a/tests/feature/Validators/CountryCodeTest.php
+++ b/tests/feature/Validators/CountryCodeTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::countryCode()->assert('1'),
-    fn(string $message) => expect($message)->toBe('"1" must be a valid country code'),
+    fn(string $message) => expect($message)->toBe('"1" must be a country code'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::countryCode())->assert('BR'),
-    fn(string $message) => expect($message)->toBe('"BR" must not be a valid country code'),
+    fn(string $message) => expect($message)->toBe('"BR" must not be a country code'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::countryCode()->assert('1'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must be a valid country code'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must be a country code'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::countryCode())->assert('BR'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "BR" must not be a valid country code'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "BR" must not be a country code'),
 ));

--- a/tests/feature/Validators/CpfTest.php
+++ b/tests/feature/Validators/CpfTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::cpf()->assert('this thing'),
-    fn(string $message) => expect($message)->toBe('"this thing" must be a valid CPF number'),
+    fn(string $message) => expect($message)->toBe('"this thing" must be a CPF'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::cpf())->assert('276.865.775-11'),
-    fn(string $message) => expect($message)->toBe('"276.865.775-11" must not be a valid CPF number'),
+    fn(string $message) => expect($message)->toBe('"276.865.775-11" must not be a CPF'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::cpf()->assert('your mother'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "your mother" must be a valid CPF number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "your mother" must be a CPF'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::cpf())->assert('61836182848'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "61836182848" must not be a valid CPF number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "61836182848" must not be a CPF'),
 ));

--- a/tests/feature/Validators/CreditCardTest.php
+++ b/tests/feature/Validators/CreditCardTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::creditCard('Discover')->assert(3566002020360505),
-    fn(string $message) => expect($message)->toBe('3566002020360505 must be a valid Discover credit card number'),
+    fn(string $message) => expect($message)->toBe('3566002020360505 must be a Discover credit card number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::creditCard('Visa'))->assert(4024007153361885),
-    fn(string $message) => expect($message)->toBe('4024007153361885 must not be a valid Visa credit card number'),
+    fn(string $message) => expect($message)->toBe('4024007153361885 must not be a Visa credit card number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::creditCard('MasterCard')->assert(3566002020360505),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3566002020360505 must be a valid MasterCard credit card number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3566002020360505 must be a MasterCard credit card number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::creditCard())->assert(5555444433331111),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 5555444433331111 must not be a valid credit card number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 5555444433331111 must not be a credit card number'),
 ));

--- a/tests/feature/Validators/CurrencyCodeTest.php
+++ b/tests/feature/Validators/CurrencyCodeTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::currencyCode()->assert('batman'),
-    fn(string $message) => expect($message)->toBe('"batman" must be a valid currency code'),
+    fn(string $message) => expect($message)->toBe('"batman" must be a currency code'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::currencyCode())->assert('BRL'),
-    fn(string $message) => expect($message)->toBe('"BRL" must not be a valid currency code'),
+    fn(string $message) => expect($message)->toBe('"BRL" must not be a currency code'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::currencyCode()->assert('ppz'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ppz" must be a valid currency code'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ppz" must be a currency code'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::currencyCode())->assert('GBP'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "GBP" must not be a valid currency code'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "GBP" must not be a currency code'),
 ));

--- a/tests/feature/Validators/DateTest.php
+++ b/tests/feature/Validators/DateTest.php
@@ -12,20 +12,20 @@ date_default_timezone_set('UTC');
 
 test('Scenario #1', catchMessage(
     fn() => v::date()->assert('2018-01-29T08:32:54+00:00'),
-    fn(string $message) => expect($message)->toBe('"2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"'),
+    fn(string $message) => expect($message)->toBe('"2018-01-29T08:32:54+00:00" must be a date in the "2005-12-30" format'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::date())->assert('2018-01-29'),
-    fn(string $message) => expect($message)->toBe('"2018-01-29" must not be a valid date in the format "2005-12-30"'),
+    fn(string $message) => expect($message)->toBe('"2018-01-29" must not be a date in the "2005-12-30" format'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::date()->assert('2018-01-29T08:32:54+00:00'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-01-29T08:32:54+00:00" must be a valid date in the format "2005-12-30"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-01-29T08:32:54+00:00" must be a date in the "2005-12-30" format'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::date('d/m/Y'))->assert('29/01/2018'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "29/01/2018" must not be a valid date in the format "30/12/2005"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "29/01/2018" must not be a date in the "30/12/2005" format'),
 ));

--- a/tests/feature/Validators/DateTimeDiffTest.php
+++ b/tests/feature/Validators/DateTimeDiffTest.php
@@ -66,16 +66,16 @@ test('With custom $format', catchAll(
 test('With input in non-parseable date', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2))->assert('not a date'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('For comparison with now, "not a date" must be a valid datetime')
-        ->and($fullMessage)->toBe('- For comparison with now, "not a date" must be a valid datetime')
-        ->and($messages)->toBe(['dateTimeDiffEquals' => 'For comparison with now, "not a date" must be a valid datetime']),
+        ->and($message)->toBe('For comparison with now, "not a date" must be a datetime')
+        ->and($fullMessage)->toBe('- For comparison with now, "not a date" must be a datetime')
+        ->and($messages)->toBe(['dateTimeDiffEquals' => 'For comparison with now, "not a date" must be a datetime']),
 ));
 
 test('With input in incorrect $format', catchAll(
     fn() => v::dateTimeDiff('years', v::equals(2), 'Y-m-d')->assert('1 year ago'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toMatch('/For comparison with \d+-\d+-\d+, "1 year ago" must be a valid datetime in the format \d+-\d+-\d+/')
-        ->and($fullMessage)->toMatch('/- For comparison with \d+-\d+-\d+, "1 year ago" must be a valid datetime in the format \d+-\d+-\d+/'),
+        ->and($message)->toMatch('/For comparison with \d+-\d+-\d+, "1 year ago" must be a datetime in the format \d+-\d+-\d+/')
+        ->and($fullMessage)->toMatch('/- For comparison with \d+-\d+-\d+, "1 year ago" must be a datetime in the format \d+-\d+-\d+/'),
 ));
 
 test('With custom $now', catchAll(

--- a/tests/feature/Validators/DateTimeTest.php
+++ b/tests/feature/Validators/DateTimeTest.php
@@ -12,40 +12,40 @@ date_default_timezone_set('UTC');
 
 test('Scenario #1', catchMessage(
     fn() => v::dateTime()->assert('FooBarBazz'),
-    fn(string $message) => expect($message)->toBe('"FooBarBazz" must be a valid date/time'),
+    fn(string $message) => expect($message)->toBe('"FooBarBazz" must be a date/time'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::dateTime('c')->assert('06-12-1995'),
-    fn(string $message) => expect($message)->toBe('"06-12-1995" must be a valid date/time in the format "2005-12-30T01:02:03+00:00"'),
+    fn(string $message) => expect($message)->toBe('"06-12-1995" must be a date/time in the "2005-12-30T01:02:03+00:00" format'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::dateTime()->assert('QuxQuuxx'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "QuxQuuxx" must be a valid date/time'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "QuxQuuxx" must be a date/time'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::dateTime('r')->assert(2018013030),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2018013030 must be a valid date/time in the format "Fri, 30 Dec 2005 01:02:03 +0000"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2018013030 must be a date/time in the "Fri, 30 Dec 2005 01:02:03 +0000" format'),
 ));
 
 test('Scenario #5', catchMessage(
     fn() => v::not(v::dateTime())->assert('4 days ago'),
-    fn(string $message) => expect($message)->toBe('"4 days ago" must not be a valid date/time'),
+    fn(string $message) => expect($message)->toBe('"4 days ago" must not be a date/time'),
 ));
 
 test('Scenario #6', catchMessage(
     fn() => v::not(v::dateTime('Y-m-d'))->assert('1988-09-09'),
-    fn(string $message) => expect($message)->toBe('"1988-09-09" must not be a valid date/time in the format "2005-12-30"'),
+    fn(string $message) => expect($message)->toBe('"1988-09-09" must not be a date/time in the "2005-12-30" format'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::dateTime())->assert('+3 weeks'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "+3 weeks" must not be a valid date/time'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "+3 weeks" must not be a date/time'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::dateTime('d/m/y'))->assert('23/07/99'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "23/07/99" must not be a valid date/time in the format "30/12/05"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "23/07/99" must not be a date/time in the "30/12/05" format'),
 ));

--- a/tests/feature/Validators/DecimalTest.php
+++ b/tests/feature/Validators/DecimalTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::decimal(3)->assert(0.1234),
-    fn(string $message) => expect($message)->toBe('0.1234 must have 3 decimals'),
+    fn(string $message) => expect($message)->toBe('0.1234 must have 3 decimal places'),
 ));
 
 test('Scenario #2', catchFullMessage(
     fn() => v::decimal(2)->assert(0.123),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0.123 must have 2 decimals'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0.123 must have 2 decimal places'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::decimal(5))->assert(0.12345),
-    fn(string $message) => expect($message)->toBe('0.12345 must not have 5 decimals'),
+    fn(string $message) => expect($message)->toBe('0.12345 must not have 5 decimal places'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::decimal(2))->assert(0.34),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0.34 must not have 2 decimals'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 0.34 must not have 2 decimal places'),
 ));

--- a/tests/feature/Validators/DigitTest.php
+++ b/tests/feature/Validators/DigitTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::digit()->assert('abc'),
-    fn(string $message) => expect($message)->toBe('"abc" must contain only digits (0-9)'),
+    fn(string $message) => expect($message)->toBe('"abc" must consist only of digits (0-9)'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::digit('-')->assert('a-b'),
-    fn(string $message) => expect($message)->toBe('"a-b" must contain only digits (0-9) and "-"'),
+    fn(string $message) => expect($message)->toBe('"a-b" must consist only of digits (0-9) or "-"'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::digit())->assert('123'),
-    fn(string $message) => expect($message)->toBe('"123" must not contain digits (0-9)'),
+    fn(string $message) => expect($message)->toBe('"123" must not consist only of digits (0-9)'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::digit('-'))->assert('1-3'),
-    fn(string $message) => expect($message)->toBe('"1-3" must not contain digits (0-9) and "-"'),
+    fn(string $message) => expect($message)->toBe('"1-3" must not consist only of digits (0-9) or "-"'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::digit()->assert('abc'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc" must contain only digits (0-9)'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "abc" must consist only of digits (0-9)'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::digit('-')->assert('a-b'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a-b" must contain only digits (0-9) and "-"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a-b" must consist only of digits (0-9) or "-"'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::digit())->assert('123'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "123" must not contain digits (0-9)'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "123" must not consist only of digits (0-9)'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::digit('-'))->assert('1-3'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1-3" must not contain digits (0-9) and "-"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1-3" must not consist only of digits (0-9) or "-"'),
 ));

--- a/tests/feature/Validators/DirectoryTest.php
+++ b/tests/feature/Validators/DirectoryTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::directory()->assert('batman'),
-    fn(string $message) => expect($message)->toBe('"batman" must be a directory'),
+    fn(string $message) => expect($message)->toBe('"batman" must be an accessible existing directory'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::directory())->assert(dirname('/etc/')),
-    fn(string $message) => expect($message)->toBe('"/" must not be a directory'),
+    fn(string $message) => expect($message)->toBe('"/" must not be an accessible existing directory'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::directory()->assert('ppz'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ppz" must be a directory'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ppz" must be an accessible existing directory'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::directory())->assert(dirname('/etc/')),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "/" must not be a directory'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "/" must not be an accessible existing directory'),
 ));

--- a/tests/feature/Validators/DomainTest.php
+++ b/tests/feature/Validators/DomainTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::domain()->assert('batman'),
-    fn(string $message) => expect($message)->toBe('"batman" must be a valid domain'),
+    fn(string $message) => expect($message)->toBe('"batman" must be an internet domain'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::domain())->assert('r--w.com'),
-    fn(string $message) => expect($message)->toBe('"r--w.com" must not be a valid domain'),
+    fn(string $message) => expect($message)->toBe('"r--w.com" must not be an internet domain'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::domain()->assert('p-éz-.kk'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "p-éz-.kk" must be a valid domain'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "p-éz-.kk" must be an internet domain'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::domain())->assert('github.com'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "github.com" must not be a valid domain'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "github.com" must not be an internet domain'),
 ));

--- a/tests/feature/Validators/EmailTest.php
+++ b/tests/feature/Validators/EmailTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::email()->assert('batman'),
-    fn(string $message) => expect($message)->toBe('"batman" must be a valid email address'),
+    fn(string $message) => expect($message)->toBe('"batman" must be an email address'),
 ));
 
 test('Scenario #2', catchMessage(
@@ -20,7 +20,7 @@ test('Scenario #2', catchMessage(
 
 test('Scenario #3', catchFullMessage(
     fn() => v::email()->assert('bruce wayne'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bruce wayne" must be a valid email address'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bruce wayne" must be an email address'),
 ));
 
 test('Scenario #4', catchFullMessage(

--- a/tests/feature/Validators/ExecutableTest.php
+++ b/tests/feature/Validators/ExecutableTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::executable()->assert('bar'),
-    fn(string $message) => expect($message)->toBe('"bar" must be an executable file'),
+    fn(string $message) => expect($message)->toBe('"bar" must be an accessible existing executable file'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::executable())->assert('tests/fixtures/executable'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/executable" must not be an executable file'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/executable" must not be an accessible existing executable file'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::executable()->assert('bar'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bar" must be an executable file'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "bar" must be an accessible existing executable file'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::executable())->assert('tests/fixtures/executable'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/executable" must not be an executable file'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/executable" must not be an accessible existing executable file'),
 ));

--- a/tests/feature/Validators/ExtensionTest.php
+++ b/tests/feature/Validators/ExtensionTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::extension('png')->assert('filename.txt'),
-    fn(string $message) => expect($message)->toBe('"filename.txt" must have "png" extension'),
+    fn(string $message) => expect($message)->toBe('"filename.txt" must have the "png" extension'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::extension('gif'))->assert('filename.gif'),
-    fn(string $message) => expect($message)->toBe('"filename.gif" must not have "gif" extension'),
+    fn(string $message) => expect($message)->toBe('"filename.gif" must not have the "gif" extension'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::extension('mp3')->assert('filename.wav'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename.wav" must have "mp3" extension'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "filename.wav" must have the "mp3" extension'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::extension('png'))->assert('tests/fixtures/invalid-image.png'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must not have "png" extension'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must not have the "png" extension'),
 ));

--- a/tests/feature/Validators/FileTest.php
+++ b/tests/feature/Validators/FileTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::file()->assert('tests/fixtures/non-existent.sh'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/non-existent.sh" must be a valid file'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/non-existent.sh" must be an accessible existing file'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::file())->assert('tests/fixtures/valid-image.png'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must be an invalid file'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be an accessible existing file'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::file()->assert('tests/fixtures/non-existent.sh'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/non-existent.sh" must be a valid file'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/non-existent.sh" must be an accessible existing file'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::file())->assert('tests/fixtures/valid-image.png'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.png" must be an invalid file'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.png" must not be an accessible existing file'),
 ));

--- a/tests/feature/Validators/FloatTypeTest.php
+++ b/tests/feature/Validators/FloatTypeTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::floatType()->assert('42.33'),
-    fn(string $message) => expect($message)->toBe('"42.33" must be float'),
+    fn(string $message) => expect($message)->toBe('"42.33" must be a float'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::floatType())->assert(INF),
-    fn(string $message) => expect($message)->toBe('`INF` must not be float'),
+    fn(string $message) => expect($message)->toBe('`INF` must not be a float'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::floatType()->assert(true),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be float'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `true` must be a float'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::floatType())->assert(2.0),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2.0 must not be float'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 2.0 must not be a float'),
 ));

--- a/tests/feature/Validators/FloatvalTest.php
+++ b/tests/feature/Validators/FloatvalTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::floatVal()->assert('a'),
-    fn(string $message) => expect($message)->toBe('"a" must be a float value'),
+    fn(string $message) => expect($message)->toBe('"a" must be a floating-point number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::floatVal())->assert(165.0),
-    fn(string $message) => expect($message)->toBe('165.0 must not be a float value'),
+    fn(string $message) => expect($message)->toBe('165.0 must not be a floating-point number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::floatVal()->assert('a'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a float value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a floating-point number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::floatVal())->assert('165.7'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "165.7" must not be a float value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "165.7" must not be a floating-point number'),
 ));

--- a/tests/feature/Validators/GraphTest.php
+++ b/tests/feature/Validators/GraphTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::graph()->assert("foo\nbar"),
-    fn(string $message) => expect($message)->toBe('"foo\\nbar" must contain only graphical characters'),
+    fn(string $message) => expect($message)->toBe('"foo\\nbar" must consist only of printable non-spacing characters'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::graph('foo')->assert("foo\nbar"),
-    fn(string $message) => expect($message)->toBe('"foo\\nbar" must contain only graphical characters and "foo"'),
+    fn(string $message) => expect($message)->toBe('"foo\\nbar" must consist only of printable non-spacing characters or "foo"'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::graph())->assert('foobar'),
-    fn(string $message) => expect($message)->toBe('"foobar" must not contain graphical characters'),
+    fn(string $message) => expect($message)->toBe('"foobar" must not consist only of printable non-spacing characters'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::graph("\n"))->assert("foo\nbar"),
-    fn(string $message) => expect($message)->toBe('"foo\\nbar" must not contain graphical characters or "\\n"'),
+    fn(string $message) => expect($message)->toBe('"foo\\nbar" must not consist only of printable non-spacing characters or "\\n"'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::graph()->assert("foo\nbar"),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must contain only graphical characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must consist only of printable non-spacing characters'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::graph('foo')->assert("foo\nbar"),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must contain only graphical characters and "foo"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must consist only of printable non-spacing characters or "foo"'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::graph())->assert('foobar'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foobar" must not contain graphical characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foobar" must not consist only of printable non-spacing characters'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::graph("\n"))->assert("foo\nbar"),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must not contain graphical characters or "\\n"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must not consist only of printable non-spacing characters or "\\n"'),
 ));

--- a/tests/feature/Validators/HetuTest.php
+++ b/tests/feature/Validators/HetuTest.php
@@ -11,17 +11,17 @@ declare(strict_types=1);
 test('Default', catchAll(
     fn() => v::hetu()->assert('010106A901O'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"010106A901O" must be a valid Finnish personal identity code')
-        ->and($fullMessage)->toBe('- "010106A901O" must be a valid Finnish personal identity code')
-        ->and($messages)->toBe(['hetu' => '"010106A901O" must be a valid Finnish personal identity code']),
+        ->and($message)->toBe('"010106A901O" must be a Finnish personal identity code')
+        ->and($fullMessage)->toBe('- "010106A901O" must be a Finnish personal identity code')
+        ->and($messages)->toBe(['hetu' => '"010106A901O" must be a Finnish personal identity code']),
 ));
 
 test('Inverted', catchAll(
     fn() => v::not(v::hetu())->assert('010106A9012'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"010106A9012" must not be a valid Finnish personal identity code')
-        ->and($fullMessage)->toBe('- "010106A9012" must not be a valid Finnish personal identity code')
-        ->and($messages)->toBe(['notHetu' => '"010106A9012" must not be a valid Finnish personal identity code']),
+        ->and($message)->toBe('"010106A9012" must not be a Finnish personal identity code')
+        ->and($fullMessage)->toBe('- "010106A9012" must not be a Finnish personal identity code')
+        ->and($messages)->toBe(['notHetu' => '"010106A9012" must not be a Finnish personal identity code']),
 ));
 
 test('With template', catchAll(
@@ -35,7 +35,7 @@ test('With template', catchAll(
 test('With name', catchAll(
     fn() => v::named('Hetu', v::hetu())->assert('010106A901O'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Hetu must be a valid Finnish personal identity code')
-        ->and($fullMessage)->toBe('- Hetu must be a valid Finnish personal identity code')
-        ->and($messages)->toBe(['hetu' => 'Hetu must be a valid Finnish personal identity code']),
+        ->and($message)->toBe('Hetu must be a Finnish personal identity code')
+        ->and($fullMessage)->toBe('- Hetu must be a Finnish personal identity code')
+        ->and($messages)->toBe(['hetu' => 'Hetu must be a Finnish personal identity code']),
 ));

--- a/tests/feature/Validators/IbanTest.php
+++ b/tests/feature/Validators/IbanTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::iban()->assert('SE35 5000 5880 7742'),
-    fn(string $message) => expect($message)->toBe('"SE35 5000 5880 7742" must be a valid IBAN'),
+    fn(string $message) => expect($message)->toBe('"SE35 5000 5880 7742" must be an IBAN'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::iban())->assert('GB82 WEST 1234 5698 7654 32'),
-    fn(string $message) => expect($message)->toBe('"GB82 WEST 1234 5698 7654 32" must not be a valid IBAN'),
+    fn(string $message) => expect($message)->toBe('"GB82 WEST 1234 5698 7654 32" must not be an IBAN'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::iban()->assert('NOT AN IBAN'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "NOT AN IBAN" must be a valid IBAN'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "NOT AN IBAN" must be an IBAN'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::iban())->assert('HU93 1160 0006 0000 0000 1234 5676'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "HU93 1160 0006 0000 0000 1234 5676" must not be a valid IBAN'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "HU93 1160 0006 0000 0000 1234 5676" must not be an IBAN'),
 ));

--- a/tests/feature/Validators/ImageTest.php
+++ b/tests/feature/Validators/ImageTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::image()->assert('tests/fixtures/invalid-image.png'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/invalid-image.png" must be a valid image file'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/invalid-image.png" must be an accessible existing image file'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::image())->assert('tests/fixtures/valid-image.png'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be a valid image file'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be an accessible existing image file'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::image()->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a valid image file'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be an accessible existing image file'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::image())->assert('tests/fixtures/valid-image.gif'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.gif" must not be a valid image file'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/valid-image.gif" must not be an accessible existing image file'),
 ));

--- a/tests/feature/Validators/ImeiTest.php
+++ b/tests/feature/Validators/ImeiTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::imei()->assert('490154203237512'),
-    fn(string $message) => expect($message)->toBe('"490154203237512" must be a valid IMEI number'),
+    fn(string $message) => expect($message)->toBe('"490154203237512" must be an IMEI number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::imei())->assert('350077523237513'),
-    fn(string $message) => expect($message)->toBe('"350077523237513" must not be a valid IMEI number'),
+    fn(string $message) => expect($message)->toBe('"350077523237513" must not be an IMEI number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::imei()->assert(null),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `null` must be a valid IMEI number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `null` must be an IMEI number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::imei())->assert('356938035643809'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "356938035643809" must not be a valid IMEI number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "356938035643809" must not be an IMEI number'),
 ));

--- a/tests/feature/Validators/IntValTest.php
+++ b/tests/feature/Validators/IntValTest.php
@@ -10,30 +10,30 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::intVal()->assert('42.33'),
-    fn(string $message) => expect($message)->toBe('"42.33" must be an integer value'),
+    fn(string $message) => expect($message)->toBe('"42.33" must be an integer'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::intVal())->assert(2),
-    fn(string $message) => expect($message)->toBe('2 must not be an integer value'),
+    fn(string $message) => expect($message)->toBe('2 must not be an integer'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::intVal()->assert('Foo'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must be an integer value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "Foo" must be an integer'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::intVal())->assert(3),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3 must not be an integer value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 3 must not be an integer'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::not(v::intVal())->assert(-42),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- -42 must not be an integer value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- -42 must not be an integer'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::not(v::intVal())->assert('-42'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "-42" must not be an integer value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "-42" must not be an integer'),
 ));

--- a/tests/feature/Validators/IsbnTest.php
+++ b/tests/feature/Validators/IsbnTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::isbn()->assert('ISBN-12: 978-0-596-52068-7'),
-    fn(string $message) => expect($message)->toBe('"ISBN-12: 978-0-596-52068-7" must be a valid ISBN'),
+    fn(string $message) => expect($message)->toBe('"ISBN-12: 978-0-596-52068-7" must be an ISBN'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::isbn())->assert('ISBN-13: 978-0-596-52068-7'),
-    fn(string $message) => expect($message)->toBe('"ISBN-13: 978-0-596-52068-7" must not be a valid ISBN'),
+    fn(string $message) => expect($message)->toBe('"ISBN-13: 978-0-596-52068-7" must not be an ISBN'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::isbn()->assert('978 10 596 52068 7'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "978 10 596 52068 7" must be a valid ISBN'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "978 10 596 52068 7" must be an ISBN'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::isbn())->assert('978 0 596 52068 7'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "978 0 596 52068 7" must not be a valid ISBN'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "978 0 596 52068 7" must not be an ISBN'),
 ));

--- a/tests/feature/Validators/IterableValTest.php
+++ b/tests/feature/Validators/IterableValTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::iterableVal()->assert(3),
-    fn(string $message) => expect($message)->toBe('3 must be an iterable value'),
+    fn(string $message) => expect($message)->toBe('3 must be iterable'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::iterableVal())->assert([2, 3]),
-    fn(string $message) => expect($message)->toBe('`[2, 3]` must not be an iterable value'),
+    fn(string $message) => expect($message)->toBe('`[2, 3]` must not be iterable'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::iterableVal()->assert('String'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "String" must be an iterable value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "String" must be iterable'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::iterableVal())->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must not be an iterable value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must not be iterable'),
 ));

--- a/tests/feature/Validators/JsonTest.php
+++ b/tests/feature/Validators/JsonTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::json()->assert(false),
-    fn(string $message) => expect($message)->toBe('`false` must be a valid JSON string'),
+    fn(string $message) => expect($message)->toBe('`false` must be a JSON string'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::json())->assert('{"foo": "bar", "number":1}'),
-    fn(string $message) => expect($message)->toBe('"{\\"foo\\": \\"bar\\", \\"number\\":1}" must not be a valid JSON string'),
+    fn(string $message) => expect($message)->toBe('"{\\"foo\\": \\"bar\\", \\"number\\":1}" must not be a JSON string'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::json()->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a valid JSON string'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a JSON string'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::json())->assert('{}'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "{}" must not be a valid JSON string'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "{}" must not be a JSON string'),
 ));

--- a/tests/feature/Validators/LanguageCodeTest.php
+++ b/tests/feature/Validators/LanguageCodeTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::languageCode()->assert(null),
-    fn(string $message) => expect($message)->toBe('`null` must be a valid language code'),
+    fn(string $message) => expect($message)->toBe('`null` must be a language code'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::languageCode())->assert('pt'),
-    fn(string $message) => expect($message)->toBe('"pt" must not be a valid language code'),
+    fn(string $message) => expect($message)->toBe('"pt" must not be a language code'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::languageCode()->assert('por'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "por" must be a valid language code'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "por" must be a language code'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::languageCode())->assert('en'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "en" must not be a valid language code'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "en" must not be a language code'),
 ));

--- a/tests/feature/Validators/LeapDateTest.php
+++ b/tests/feature/Validators/LeapDateTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::leapDate('Y-m-d')->assert('1989-02-29'),
-    fn(string $message) => expect($message)->toBe('"1989-02-29" must be a valid leap date'),
+    fn(string $message) => expect($message)->toBe('"1989-02-29" must be a leap date'),
 ));
 
 test('Scenario #2', catchMessage(
@@ -20,7 +20,7 @@ test('Scenario #2', catchMessage(
 
 test('Scenario #3', catchFullMessage(
     fn() => v::leapDate('Y-m-d')->assert('1990-02-29'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1990-02-29" must be a valid leap date'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1990-02-29" must be a leap date'),
 ));
 
 test('Scenario #4', catchFullMessage(

--- a/tests/feature/Validators/LeapYearTest.php
+++ b/tests/feature/Validators/LeapYearTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::leapYear()->assert('2009'),
-    fn(string $message) => expect($message)->toBe('"2009" must be a valid leap year'),
+    fn(string $message) => expect($message)->toBe('"2009" must be a leap year'),
 ));
 
 test('Scenario #2', catchMessage(
@@ -20,7 +20,7 @@ test('Scenario #2', catchMessage(
 
 test('Scenario #3', catchFullMessage(
     fn() => v::leapYear()->assert('2009-02-29'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2009-02-29" must be a valid leap year'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2009-02-29" must be a leap year'),
 ));
 
 test('Scenario #4', catchFullMessage(

--- a/tests/feature/Validators/LowercaseTest.php
+++ b/tests/feature/Validators/LowercaseTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::lowercase()->assert('UPPERCASE'),
-    fn(string $message) => expect($message)->toBe('"UPPERCASE" must contain only lowercase letters'),
+    fn(string $message) => expect($message)->toBe('"UPPERCASE" must consist only of lowercase letters'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::lowercase())->assert('lowercase'),
-    fn(string $message) => expect($message)->toBe('"lowercase" must not contain only lowercase letters'),
+    fn(string $message) => expect($message)->toBe('"lowercase" must not consist only of lowercase letters'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::lowercase()->assert('UPPERCASE'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "UPPERCASE" must contain only lowercase letters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "UPPERCASE" must consist only of lowercase letters'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::lowercase())->assert('lowercase'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "lowercase" must not contain only lowercase letters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "lowercase" must not consist only of lowercase letters'),
 ));

--- a/tests/feature/Validators/LuhnTest.php
+++ b/tests/feature/Validators/LuhnTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::luhn()->assert('2222400041240021'),
-    fn(string $message) => expect($message)->toBe('"2222400041240021" must be a valid Luhn number'),
+    fn(string $message) => expect($message)->toBe('"2222400041240021" must be a Luhn number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::luhn())->assert('2223000048400011'),
-    fn(string $message) => expect($message)->toBe('"2223000048400011" must not be a valid Luhn number'),
+    fn(string $message) => expect($message)->toBe('"2223000048400011" must not be a Luhn number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::luhn()->assert('340316193809334'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "340316193809334" must be a valid Luhn number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "340316193809334" must be a Luhn number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::luhn())->assert('6011000990139424'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "6011000990139424" must not be a valid Luhn number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "6011000990139424" must not be a Luhn number'),
 ));

--- a/tests/feature/Validators/MacAddressTest.php
+++ b/tests/feature/Validators/MacAddressTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::macAddress()->assert('00-11222:33:44:55'),
-    fn(string $message) => expect($message)->toBe('"00-11222:33:44:55" must be a valid MAC address'),
+    fn(string $message) => expect($message)->toBe('"00-11222:33:44:55" must be a MAC address'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::macAddress())->assert('00:11:22:33:44:55'),
-    fn(string $message) => expect($message)->toBe('"00:11:22:33:44:55" must not be a valid MAC address'),
+    fn(string $message) => expect($message)->toBe('"00:11:22:33:44:55" must not be a MAC address'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::macAddress()->assert('90-bc-nk:1a-dd-cc'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "90-bc-nk:1a-dd-cc" must be a valid MAC address'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "90-bc-nk:1a-dd-cc" must be a MAC address'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::macAddress())->assert('AF:0F:bd:12:44:ba'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AF:0F:bd:12:44:ba" must not be a valid MAC address'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AF:0F:bd:12:44:ba" must not be a MAC address'),
 ));

--- a/tests/feature/Validators/MaskedTest.php
+++ b/tests/feature/Validators/MaskedTest.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 test('input is not a string', catchAll(
     fn() => v::masked('1-@', v::email())->assert(new stdClass()),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`stdClass {}` must be a string value')
-        ->and($fullMessage)->toBe('- `stdClass {}` must be a string value')
-        ->and($messages)->toBe(['email' => '`stdClass {}` must be a string value']),
+        ->and($message)->toBe('`stdClass {}` must be a string')
+        ->and($fullMessage)->toBe('- `stdClass {}` must be a string')
+        ->and($messages)->toBe(['email' => '`stdClass {}` must be a string']),
 ));
 
 test('failed validator', catchAll(
     fn() => v::masked('1-@', v::email())->assert('in valid@email.com'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"********@email.com" must be a valid email address')
-        ->and($fullMessage)->toBe('- "********@email.com" must be a valid email address')
-        ->and($messages)->toBe(['email' => '"********@email.com" must be a valid email address']),
+        ->and($message)->toBe('"********@email.com" must be an email address')
+        ->and($fullMessage)->toBe('- "********@email.com" must be an email address')
+        ->and($messages)->toBe(['email' => '"********@email.com" must be an email address']),
 ));

--- a/tests/feature/Validators/NfeAccessKeyTest.php
+++ b/tests/feature/Validators/NfeAccessKeyTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906'),
-    fn(string $message) => expect($message)->toBe('"31841136830118868211870485416765268625116906" must be a valid NFe access key'),
+    fn(string $message) => expect($message)->toBe('"31841136830118868211870485416765268625116906" must be a NFe access key'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::nfeAccessKey())->assert('52060433009911002506550120000007800267301615'),
-    fn(string $message) => expect($message)->toBe('"52060433009911002506550120000007800267301615" must not be a valid NFe access key'),
+    fn(string $message) => expect($message)->toBe('"52060433009911002506550120000007800267301615" must not be a NFe access key'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::nfeAccessKey()->assert('31841136830118868211870485416765268625116906'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "31841136830118868211870485416765268625116906" must be a valid NFe access key'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "31841136830118868211870485416765268625116906" must be a NFe access key'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nfeAccessKey())->assert('52060433009911002506550120000007800267301615'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "52060433009911002506550120000007800267301615" must not be a valid NFe access key'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "52060433009911002506550120000007800267301615" must not be a NFe access key'),
 ));

--- a/tests/feature/Validators/NifTest.php
+++ b/tests/feature/Validators/NifTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::nif()->assert('06357771Q'),
-    fn(string $message) => expect($message)->toBe('"06357771Q" must be a valid NIF'),
+    fn(string $message) => expect($message)->toBe('"06357771Q" must be a NIF'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::nif())->assert('71110316C'),
-    fn(string $message) => expect($message)->toBe('"71110316C" must not be a valid NIF'),
+    fn(string $message) => expect($message)->toBe('"71110316C" must not be a NIF'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::nif()->assert('06357771Q'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "06357771Q" must be a valid NIF'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "06357771Q" must be a NIF'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nif())->assert('R1332622H'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "R1332622H" must not be a valid NIF'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "R1332622H" must not be a NIF'),
 ));

--- a/tests/feature/Validators/NipTest.php
+++ b/tests/feature/Validators/NipTest.php
@@ -12,20 +12,20 @@ require_once 'vendor/autoload.php';
 
 test('Scenario #1', catchMessage(
     fn() => v::nip()->assert('1645865778'),
-    fn(string $message) => expect($message)->toBe('"1645865778" must be a valid Polish VAT identification number'),
+    fn(string $message) => expect($message)->toBe('"1645865778" must be a Polish VAT identification number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::nip())->assert('1645865777'),
-    fn(string $message) => expect($message)->toBe('"1645865777" must not be a valid Polish VAT identification number'),
+    fn(string $message) => expect($message)->toBe('"1645865777" must not be a Polish VAT identification number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::nip()->assert('1645865778'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1645865778" must be a valid Polish VAT identification number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1645865778" must be a Polish VAT identification number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::nip())->assert('1645865777'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1645865777" must not be a valid Polish VAT identification number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1645865777" must not be a Polish VAT identification number'),
 ));

--- a/tests/feature/Validators/NoneOfTest.php
+++ b/tests/feature/Validators/NoneOfTest.php
@@ -37,15 +37,15 @@ test('Default: pass, fail', catchAll(
 test('Default: pass, fail, fail', catchAll(
     fn() => v::noneOf(v::intType(), v::alpha(), v::stringType())->assert('string'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"string" must not contain letters (a-z)')
+        ->and($message)->toBe('"string" must not consist only of letters (a-z)')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - "string" must pass the rules
-          - "string" must not contain letters (a-z)
+          - "string" must not consist only of letters (a-z)
           - "string" must not be a string
         FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '"string" must pass the rules',
-            'alpha' => '"string" must not contain letters (a-z)',
+            'alpha' => '"string" must not consist only of letters (a-z)',
             'stringType' => '"string" must not be a string',
         ]),
 ));

--- a/tests/feature/Validators/NullOrTest.php
+++ b/tests/feature/Validators/NullOrTest.php
@@ -11,57 +11,57 @@ declare(strict_types=1);
 test('Default', catchAll(
     fn() => v::nullOr(v::alpha())->assert(1234),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('1234 must contain only letters (a-z) or must be null')
-        ->and($fullMessage)->toBe('- 1234 must contain only letters (a-z) or must be null')
-        ->and($messages)->toBe(['nullOrAlpha' => '1234 must contain only letters (a-z) or must be null']),
+        ->and($message)->toBe('1234 must consist only of letters (a-z) or must be null')
+        ->and($fullMessage)->toBe('- 1234 must consist only of letters (a-z) or must be null')
+        ->and($messages)->toBe(['nullOrAlpha' => '1234 must consist only of letters (a-z) or must be null']),
 ));
 
 test('Inverted wrapper', catchAll(
     fn() => v::not(v::nullOr(v::alpha()))->assert('alpha'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"alpha" must not contain letters (a-z) and must not be null')
-        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) and must not be null')
-        ->and($messages)->toBe(['notNullOrAlpha' => '"alpha" must not contain letters (a-z) and must not be null']),
+        ->and($message)->toBe('"alpha" must not consist only of letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- "alpha" must not consist only of letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => '"alpha" must not consist only of letters (a-z) and must not be null']),
 ));
 
 test('Inverted wrapped', catchAll(
     fn() => v::nullOr(v::not(v::alpha()))->assert('alpha'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"alpha" must not contain letters (a-z) or must be null')
-        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) or must be null')
-        ->and($messages)->toBe(['nullOrNotAlpha' => '"alpha" must not contain letters (a-z) or must be null']),
+        ->and($message)->toBe('"alpha" must not consist only of letters (a-z) or must be null')
+        ->and($fullMessage)->toBe('- "alpha" must not consist only of letters (a-z) or must be null')
+        ->and($messages)->toBe(['nullOrNotAlpha' => '"alpha" must not consist only of letters (a-z) or must be null']),
 ));
 
 test('Inverted nullined', catchAll(
     fn() => v::not(v::nullOr(v::alpha()))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`null` must not contain letters (a-z) and must not be null')
-        ->and($fullMessage)->toBe('- `null` must not contain letters (a-z) and must not be null')
-        ->and($messages)->toBe(['notNullOrAlpha' => '`null` must not contain letters (a-z) and must not be null']),
+        ->and($message)->toBe('`null` must not consist only of letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- `null` must not consist only of letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => '`null` must not consist only of letters (a-z) and must not be null']),
 ));
 
 test('Inverted nullined, wrapped name', catchAll(
     fn() => v::not(v::nullOr(v::named('Wrapped', v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapped must not contain letters (a-z) and must not be null')
-        ->and($fullMessage)->toBe('- Wrapped must not contain letters (a-z) and must not be null')
-        ->and($messages)->toBe(['notNullOrAlpha' => 'Wrapped must not contain letters (a-z) and must not be null']),
+        ->and($message)->toBe('Wrapped must not consist only of letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- Wrapped must not consist only of letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Wrapped must not consist only of letters (a-z) and must not be null']),
 ));
 
 test('Inverted nullined, wrapper name', catchAll(
     fn() => v::not(v::named('Wrapper', v::nullOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must not contain letters (a-z) and must not be null')
-        ->and($fullMessage)->toBe('- Wrapper must not contain letters (a-z) and must not be null')
-        ->and($messages)->toBe(['notNullOrAlpha' => 'Wrapper must not contain letters (a-z) and must not be null']),
+        ->and($message)->toBe('Wrapper must not consist only of letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- Wrapper must not consist only of letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Wrapper must not consist only of letters (a-z) and must not be null']),
 ));
 
 test('Inverted nullined, not name', catchAll(
     fn() => v::named('Not', v::not(v::nullOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Not must not contain letters (a-z) and must not be null')
-        ->and($fullMessage)->toBe('- Not must not contain letters (a-z) and must not be null')
-        ->and($messages)->toBe(['notNullOrAlpha' => 'Not must not contain letters (a-z) and must not be null']),
+        ->and($message)->toBe('Not must not consist only of letters (a-z) and must not be null')
+        ->and($fullMessage)->toBe('- Not must not consist only of letters (a-z) and must not be null')
+        ->and($messages)->toBe(['notNullOrAlpha' => 'Not must not consist only of letters (a-z) and must not be null']),
 ));
 
 test('With template', catchAll(
@@ -91,15 +91,15 @@ test('Inverted nullined with template', catchAll(
 test('Without adjacent result', catchAll(
     fn() => v::nullOr(v::alpha()->stringType())->assert(1234),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('1234 must contain only letters (a-z) or must be null')
+        ->and($message)->toBe('1234 must consist only of letters (a-z) or must be null')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - 1234 must pass all the rules
-          - 1234 must contain only letters (a-z) or must be null
+          - 1234 must consist only of letters (a-z) or must be null
           - 1234 must be a string or must be null
         FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '1234 must pass all the rules',
-            'nullOrAlpha' => '1234 must contain only letters (a-z) or must be null',
+            'nullOrAlpha' => '1234 must consist only of letters (a-z) or must be null',
             'nullOrStringType' => '1234 must be a string or must be null',
         ]),
 ));

--- a/tests/feature/Validators/NumberTest.php
+++ b/tests/feature/Validators/NumberTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::number()->assert(acos(1.01)),
-    fn(string $message) => expect($message)->toBe('`NaN` must be a valid number'),
+    fn(string $message) => expect($message)->toBe('`NaN` must be a number'),
 ));
 
 test('Scenario #2', catchMessage(
@@ -20,7 +20,7 @@ test('Scenario #2', catchMessage(
 
 test('Scenario #3', catchFullMessage(
     fn() => v::number()->assert(NAN),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `NaN` must be a valid number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `NaN` must be a number'),
 ));
 
 test('Scenario #4', catchFullMessage(

--- a/tests/feature/Validators/NumericValTest.php
+++ b/tests/feature/Validators/NumericValTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::numericVal()->assert('a'),
-    fn(string $message) => expect($message)->toBe('"a" must be a numeric value'),
+    fn(string $message) => expect($message)->toBe('"a" must be numeric'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::numericVal())->assert('1'),
-    fn(string $message) => expect($message)->toBe('"1" must not be a numeric value'),
+    fn(string $message) => expect($message)->toBe('"1" must not be numeric'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::numericVal()->assert('a'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be a numeric value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a" must be numeric'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::numericVal())->assert('1'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must not be a numeric value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1" must not be numeric'),
 ));

--- a/tests/feature/Validators/OneOfTest.php
+++ b/tests/feature/Validators/OneOfTest.php
@@ -32,13 +32,13 @@ test('Default: fail, pass, pass', catchAll(
         - "string" must pass only one of the rules
           - "string" must be an integer
           - "string" must be a string
-          - "string" must contain only letters (a-z)
+          - "string" must consist only of letters (a-z)
         FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '"string" must pass only one of the rules',
             'intType' => '"string" must be an integer',
             'stringType' => '"string" must be a string',
-            'alpha' => '"string" must contain only letters (a-z)',
+            'alpha' => '"string" must consist only of letters (a-z)',
         ]),
 ));
 
@@ -50,13 +50,13 @@ test('Default: pass, fail, pass', catchAll(
         - "string" must pass only one of the rules
           - "string" must be an integer
           - "string" must be a string
-          - "string" must contain only letters (a-z)
+          - "string" must consist only of letters (a-z)
         FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '"string" must pass only one of the rules',
             'intType' => '"string" must be an integer',
             'stringType' => '"string" must be a string',
-            'alpha' => '"string" must contain only letters (a-z)',
+            'alpha' => '"string" must consist only of letters (a-z)',
         ]),
 ));
 
@@ -68,13 +68,13 @@ test('Default: pass, pass, fail', catchAll(
         - "string" must pass only one of the rules
           - "string" must be an integer
           - "string" must be a string
-          - "string" must contain only letters (a-z)
+          - "string" must consist only of letters (a-z)
         FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '"string" must pass only one of the rules',
             'intType' => '"string" must be an integer',
             'stringType' => '"string" must be a string',
-            'alpha' => '"string" must contain only letters (a-z)',
+            'alpha' => '"string" must consist only of letters (a-z)',
         ]),
 ));
 

--- a/tests/feature/Validators/PeselTest.php
+++ b/tests/feature/Validators/PeselTest.php
@@ -12,20 +12,20 @@ require_once 'vendor/autoload.php';
 
 test('Scenario #1', catchMessage(
     fn() => v::pesel()->assert('21120209251'),
-    fn(string $message) => expect($message)->toBe('"21120209251" must be a valid PESEL'),
+    fn(string $message) => expect($message)->toBe('"21120209251" must be a PESEL'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::pesel())->assert('21120209256'),
-    fn(string $message) => expect($message)->toBe('"21120209256" must not be a valid PESEL'),
+    fn(string $message) => expect($message)->toBe('"21120209256" must not be a PESEL'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::pesel()->assert('21120209251'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "21120209251" must be a valid PESEL'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "21120209251" must be a PESEL'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::pesel())->assert('21120209256'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "21120209256" must not be a valid PESEL'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "21120209256" must not be a PESEL'),
 ));

--- a/tests/feature/Validators/PhoneTest.php
+++ b/tests/feature/Validators/PhoneTest.php
@@ -11,39 +11,39 @@ declare(strict_types=1);
 test('Default', catchAll(
     fn() => v::phone()->assert('123'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"123" must be a valid telephone number')
-        ->and($fullMessage)->toBe('- "123" must be a valid telephone number')
-        ->and($messages)->toBe(['phone' => '"123" must be a valid telephone number']),
+        ->and($message)->toBe('"123" must be a phone number')
+        ->and($fullMessage)->toBe('- "123" must be a phone number')
+        ->and($messages)->toBe(['phone' => '"123" must be a phone number']),
 ));
 
 test('Country-specific', catchAll(
     fn() => v::phone('BR')->assert('+1 650 253 00 00'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"+1 650 253 00 00" must be a valid telephone number for country Brazil')
-        ->and($fullMessage)->toBe('- "+1 650 253 00 00" must be a valid telephone number for country Brazil')
-        ->and($messages)->toBe(['phone' => '"+1 650 253 00 00" must be a valid telephone number for country Brazil']),
+        ->and($message)->toBe('"+1 650 253 00 00" must be a phone number for country Brazil')
+        ->and($fullMessage)->toBe('- "+1 650 253 00 00" must be a phone number for country Brazil')
+        ->and($messages)->toBe(['phone' => '"+1 650 253 00 00" must be a phone number for country Brazil']),
 ));
 
 test('Inverted', catchAll(
     fn() => v::not(v::phone())->assert('+55 11 91111 1111'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"+55 11 91111 1111" must not be a valid telephone number')
-        ->and($fullMessage)->toBe('- "+55 11 91111 1111" must not be a valid telephone number')
-        ->and($messages)->toBe(['notPhone' => '"+55 11 91111 1111" must not be a valid telephone number']),
+        ->and($message)->toBe('"+55 11 91111 1111" must not be a phone number')
+        ->and($fullMessage)->toBe('- "+55 11 91111 1111" must not be a phone number')
+        ->and($messages)->toBe(['notPhone' => '"+55 11 91111 1111" must not be a phone number']),
 ));
 
 test('Default with name', catchAll(
     fn() => v::named('Phone', v::phone())->assert('123'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Phone must be a valid telephone number')
-        ->and($fullMessage)->toBe('- Phone must be a valid telephone number')
-        ->and($messages)->toBe(['phone' => 'Phone must be a valid telephone number']),
+        ->and($message)->toBe('Phone must be a phone number')
+        ->and($fullMessage)->toBe('- Phone must be a phone number')
+        ->and($messages)->toBe(['phone' => 'Phone must be a phone number']),
 ));
 
 test('Country-specific with name', catchAll(
     fn() => v::named('Phone', v::phone('US'))->assert('123'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Phone must be a valid telephone number for country United States')
-        ->and($fullMessage)->toBe('- Phone must be a valid telephone number for country United States')
-        ->and($messages)->toBe(['phone' => 'Phone must be a valid telephone number for country United States']),
+        ->and($message)->toBe('Phone must be a phone number for country United States')
+        ->and($fullMessage)->toBe('- Phone must be a phone number for country United States')
+        ->and($messages)->toBe(['phone' => 'Phone must be a phone number for country United States']),
 ));

--- a/tests/feature/Validators/PisTest.php
+++ b/tests/feature/Validators/PisTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::pis()->assert('this thing'),
-    fn(string $message) => expect($message)->toBe('"this thing" must be a valid PIS number'),
+    fn(string $message) => expect($message)->toBe('"this thing" must be a PIS number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::pis())->assert('120.6671.406-4'),
-    fn(string $message) => expect($message)->toBe('"120.6671.406-4" must not be a valid PIS number'),
+    fn(string $message) => expect($message)->toBe('"120.6671.406-4" must not be a PIS number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::pis()->assert('your mother'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "your mother" must be a valid PIS number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "your mother" must be a PIS number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::pis())->assert('120.9378.174-5'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "120.9378.174-5" must not be a valid PIS number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "120.9378.174-5" must not be a PIS number'),
 ));

--- a/tests/feature/Validators/PolishIdCardTest.php
+++ b/tests/feature/Validators/PolishIdCardTest.php
@@ -12,20 +12,20 @@ require_once 'vendor/autoload.php';
 
 test('Scenario #1', catchMessage(
     fn() => v::polishIdCard()->assert('AYE205411'),
-    fn(string $message) => expect($message)->toBe('"AYE205411" must be a valid Polish Identity Card number'),
+    fn(string $message) => expect($message)->toBe('"AYE205411" must be a Polish Identity Card number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::polishIdCard())->assert('AYE205410'),
-    fn(string $message) => expect($message)->toBe('"AYE205410" must not be a valid Polish Identity Card number'),
+    fn(string $message) => expect($message)->toBe('"AYE205410" must not be a Polish Identity Card number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::polishIdCard()->assert('AYE205411'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AYE205411" must be a valid Polish Identity Card number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AYE205411" must be a Polish Identity Card number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::polishIdCard())->assert('AYE205410'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AYE205410" must not be a valid Polish Identity Card number'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "AYE205410" must not be a Polish Identity Card number'),
 ));

--- a/tests/feature/Validators/PostalCodeTest.php
+++ b/tests/feature/Validators/PostalCodeTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::postalCode('BR')->assert('1057BV'),
-    fn(string $message) => expect($message)->toBe('"1057BV" must be a valid postal code on "BR"'),
+    fn(string $message) => expect($message)->toBe('"1057BV" must be a postal code for "BR"'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::postalCode('NL'))->assert('1057BV'),
-    fn(string $message) => expect($message)->toBe('"1057BV" must not be a valid postal code on "NL"'),
+    fn(string $message) => expect($message)->toBe('"1057BV" must not be a postal code for "NL"'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::postalCode('BR')->assert('1057BV'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1057BV" must be a valid postal code on "BR"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1057BV" must be a postal code for "BR"'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::postalCode('NL'))->assert('1057BV'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1057BV" must not be a valid postal code on "NL"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1057BV" must not be a postal code for "NL"'),
 ));

--- a/tests/feature/Validators/PrintableTest.php
+++ b/tests/feature/Validators/PrintableTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::printable()->assert(''),
-    fn(string $message) => expect($message)->toBe('"" must contain only printable characters'),
+    fn(string $message) => expect($message)->toBe('"" must consist only of printable characters'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::printable())->assert('abc'),
-    fn(string $message) => expect($message)->toBe('"abc" must not contain printable characters'),
+    fn(string $message) => expect($message)->toBe('"abc" must not consist only of printable characters'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::printable()->assert('foo' . chr(10) . 'bar'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must contain only printable characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo\\nbar" must consist only of printable characters'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::printable())->assert('$%asd'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "$%asd" must not contain printable characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "$%asd" must not consist only of printable characters'),
 ));

--- a/tests/feature/Validators/PunctTest.php
+++ b/tests/feature/Validators/PunctTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::punct()->assert('a'),
-    fn(string $message) => expect($message)->toBe('"a" must contain only punctuation characters'),
+    fn(string $message) => expect($message)->toBe('"a" must consist only of punctuation characters'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::punct('c')->assert('b'),
-    fn(string $message) => expect($message)->toBe('"b" must contain only punctuation characters and "c"'),
+    fn(string $message) => expect($message)->toBe('"b" must consist only of punctuation characters or "c"'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::punct())->assert('.'),
-    fn(string $message) => expect($message)->toBe('"." must not contain punctuation characters'),
+    fn(string $message) => expect($message)->toBe('"." must not consist only of punctuation characters'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::punct('d'))->assert('?'),
-    fn(string $message) => expect($message)->toBe('"?" must not contain punctuation characters or "d"'),
+    fn(string $message) => expect($message)->toBe('"?" must not consist only of punctuation characters or "d"'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::punct()->assert('e'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e" must contain only punctuation characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e" must consist only of punctuation characters'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::punct('f')->assert('g'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g" must contain only punctuation characters and "f"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g" must consist only of punctuation characters or "f"'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::punct())->assert('!'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "!" must not contain punctuation characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "!" must not consist only of punctuation characters'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::punct('h'))->assert(';'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- ";" must not contain punctuation characters or "h"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- ";" must not consist only of punctuation characters or "h"'),
 ));

--- a/tests/feature/Validators/RegexTest.php
+++ b/tests/feature/Validators/RegexTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::regex('/^w+$/')->assert('w poiur'),
-    fn(string $message) => expect($message)->toBe('"w poiur" must match the pattern `/^w+$/`'),
+    fn(string $message) => expect($message)->toBe('"w poiur" must match the `/^w+$/` pattern'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::regex('/^[a-z]+$/'))->assert('wpoiur'),
-    fn(string $message) => expect($message)->toBe('"wpoiur" must not match the pattern `/^[a-z]+$/`'),
+    fn(string $message) => expect($message)->toBe('"wpoiur" must not match the `/^[a-z]+$/` pattern'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::regex('/^w+$/')->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must match the pattern `/^w+$/`'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must match the `/^w+$/` pattern'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::regex('/^[a-z]+$/i'))->assert('wPoiur'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "wPoiur" must not match the pattern `/^[a-z]+$/i`'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "wPoiur" must not match the `/^[a-z]+$/i` pattern'),
 ));

--- a/tests/feature/Validators/ResourceTypeTest.php
+++ b/tests/feature/Validators/ResourceTypeTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::resourceType()->assert('test'),
-    fn(string $message) => expect($message)->toBe('"test" must be a resource'),
+    fn(string $message) => expect($message)->toBe('"test" must be an internal resource'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::resourceType())->assert(tmpfile()),
-    fn(string $message) => expect($message)->toBe('`resource <stream>` must not be a resource'),
+    fn(string $message) => expect($message)->toBe('`resource <stream>` must not be an internal resource'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::resourceType()->assert([]),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be a resource'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be an internal resource'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::resourceType())->assert(tmpfile()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `resource <stream>` must not be a resource'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `resource <stream>` must not be an internal resource'),
 ));

--- a/tests/feature/Validators/RomanTest.php
+++ b/tests/feature/Validators/RomanTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::roman()->assert(1234),
-    fn(string $message) => expect($message)->toBe('1234 must be a valid Roman numeral'),
+    fn(string $message) => expect($message)->toBe('1234 must be a Roman numeral'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::roman())->assert('XL'),
-    fn(string $message) => expect($message)->toBe('"XL" must not be a valid Roman numeral'),
+    fn(string $message) => expect($message)->toBe('"XL" must not be a Roman numeral'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::roman()->assert('e2'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e2" must be a valid Roman numeral'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e2" must be a Roman numeral'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::roman())->assert('IV'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "IV" must not be a valid Roman numeral'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "IV" must not be a Roman numeral'),
 ));

--- a/tests/feature/Validators/SatisfiesTest.php
+++ b/tests/feature/Validators/SatisfiesTest.php
@@ -15,7 +15,7 @@ test('Scenario #1', catchMessage(
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::satisfies('is_string'))->assert('foo'),
-    fn(string $message) => expect($message)->toBe('"foo" must be invalid'),
+    fn(string $message) => expect($message)->toBe('"foo" must not be valid'),
 ));
 
 test('Scenario #3', catchFullMessage(
@@ -25,5 +25,5 @@ test('Scenario #3', catchFullMessage(
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::satisfies('is_string'))->assert('foo'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo" must be invalid'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "foo" must not be valid'),
 ));

--- a/tests/feature/Validators/ScalarValTest.php
+++ b/tests/feature/Validators/ScalarValTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::scalarVal()->assert([]),
-    fn(string $message) => expect($message)->toBe('`[]` must be a scalar value'),
+    fn(string $message) => expect($message)->toBe('`[]` must be a scalar'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::scalarVal())->assert(true),
-    fn(string $message) => expect($message)->toBe('`true` must not be a scalar value'),
+    fn(string $message) => expect($message)->toBe('`true` must not be a scalar'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::scalarVal()->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a scalar value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a scalar'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::scalarVal())->assert(42),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a scalar value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a scalar'),
 ));

--- a/tests/feature/Validators/SizeTest.php
+++ b/tests/feature/Validators/SizeTest.php
@@ -34,9 +34,9 @@ test('Default', catchAll(
 test('Wrong type', catchAll(
     fn() => v::size('KB', v::lessThan(2))->assert(new stdClass()),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface')
-        ->and($fullMessage)->toBe('- `stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface')
-        ->and($messages)->toBe(['sizeLessThan' => '`stdClass {}` must be a filename or an instance of SplFileInfo or a PSR-7 interface']),
+        ->and($message)->toBe('`stdClass {}` must be a filename, an instance of SplFileInfo or a PSR-7 interface')
+        ->and($fullMessage)->toBe('- `stdClass {}` must be a filename, an instance of SplFileInfo or a PSR-7 interface')
+        ->and($messages)->toBe(['sizeLessThan' => '`stdClass {}` must be a filename, an instance of SplFileInfo or a PSR-7 interface']),
 ));
 
 test('Inverted', catchAll(

--- a/tests/feature/Validators/SlugTest.php
+++ b/tests/feature/Validators/SlugTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::slug()->assert('my-Slug'),
-    fn(string $message) => expect($message)->toBe('"my-Slug" must be a valid slug'),
+    fn(string $message) => expect($message)->toBe('"my-Slug" must be a slug'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::slug())->assert('my-slug'),
-    fn(string $message) => expect($message)->toBe('"my-slug" must not be a valid slug'),
+    fn(string $message) => expect($message)->toBe('"my-slug" must not be a slug'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::slug()->assert('my-Slug'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "my-Slug" must be a valid slug'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "my-Slug" must be a slug'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::slug())->assert('my-slug'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "my-slug" must not be a valid slug'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "my-slug" must not be a slug'),
 ));

--- a/tests/feature/Validators/SpaceTest.php
+++ b/tests/feature/Validators/SpaceTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::space()->assert('ab'),
-    fn(string $message) => expect($message)->toBe('"ab" must contain only space characters'),
+    fn(string $message) => expect($message)->toBe('"ab" must consist only of space characters'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::space('c')->assert('cd'),
-    fn(string $message) => expect($message)->toBe('"cd" must contain only space characters and "c"'),
+    fn(string $message) => expect($message)->toBe('"cd" must consist only of space characters or "c"'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::space())->assert("\t"),
-    fn(string $message) => expect($message)->toBe('"\\t" must not contain space characters'),
+    fn(string $message) => expect($message)->toBe('"\\t" must not consist only of space characters'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::space('def'))->assert("\r"),
-    fn(string $message) => expect($message)->toBe('"\\r" must not contain space characters or "def"'),
+    fn(string $message) => expect($message)->toBe('"\\r" must not consist only of space characters or "def"'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::space()->assert('ef'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ef" must contain only space characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "ef" must consist only of space characters'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::space('e')->assert('gh'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "gh" must contain only space characters and "e"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "gh" must consist only of space characters or "e"'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::space())->assert("\n"),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "\\n" must not contain space characters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "\\n" must not consist only of space characters'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::space('yk'))->assert(' k'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- " k" must not contain space characters or "yk"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- " k" must not consist only of space characters or "yk"'),
 ));

--- a/tests/feature/Validators/SpacedTest.php
+++ b/tests/feature/Validators/SpacedTest.php
@@ -19,7 +19,7 @@ test('default template', catchAll(
 test('inverted template', catchAll(
     fn() => v::not(v::spaced())->assert('two words'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"two words" must not contain whitespaces')
-        ->and($fullMessage)->toBe('- "two words" must not contain whitespaces')
-        ->and($messages)->toBe(['notSpaced' => '"two words" must not contain whitespaces']),
+        ->and($message)->toBe('"two words" must not contain whitespace')
+        ->and($fullMessage)->toBe('- "two words" must not contain whitespace')
+        ->and($messages)->toBe(['notSpaced' => '"two words" must not contain whitespace']),
 ));

--- a/tests/feature/Validators/StringValTest.php
+++ b/tests/feature/Validators/StringValTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::stringVal()->assert([]),
-    fn(string $message) => expect($message)->toBe('`[]` must be a string value'),
+    fn(string $message) => expect($message)->toBe('`[]` must be a string'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::stringVal())->assert(true),
-    fn(string $message) => expect($message)->toBe('`true` must not be a string value'),
+    fn(string $message) => expect($message)->toBe('`true` must not be a string'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::stringVal()->assert(new stdClass()),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a string value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `stdClass {}` must be a string'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::stringVal())->assert(42),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a string value'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- 42 must not be a string'),
 ));

--- a/tests/feature/Validators/SymbolicLinkTest.php
+++ b/tests/feature/Validators/SymbolicLinkTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::symbolicLink()->assert('tests/fixtures/fake-filename'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/fake-filename" must be a symbolic link'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/fake-filename" must be an accessible existing symbolic link'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::symbolicLink())->assert('tests/fixtures/symbolic-link'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/symbolic-link" must not be a symbolic link'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/symbolic-link" must not be an accessible existing symbolic link'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::symbolicLink()->assert('tests/fixtures/fake-filename'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/fake-filename" must be a symbolic link'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/fake-filename" must be an accessible existing symbolic link'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::symbolicLink())->assert('tests/fixtures/symbolic-link'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/symbolic-link" must not be a symbolic link'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/symbolic-link" must not be an accessible existing symbolic link'),
 ));

--- a/tests/feature/Validators/TimeTest.php
+++ b/tests/feature/Validators/TimeTest.php
@@ -12,20 +12,20 @@ date_default_timezone_set('UTC');
 
 test('Scenario #1', catchMessage(
     fn() => v::time()->assert('2018-01-30'),
-    fn(string $message) => expect($message)->toBe('"2018-01-30" must be a valid time in the format "23:59:59"'),
+    fn(string $message) => expect($message)->toBe('"2018-01-30" must be a time in the "23:59:59" format'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::time())->assert('09:25:46'),
-    fn(string $message) => expect($message)->toBe('"09:25:46" must not be a valid time in the format "23:59:59"'),
+    fn(string $message) => expect($message)->toBe('"09:25:46" must not be a time in the "23:59:59" format'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::time()->assert('2018-01-30'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-01-30" must be a valid time in the format "23:59:59"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "2018-01-30" must be a time in the "23:59:59" format'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::time('g:i A'))->assert('8:13 AM'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "8:13 AM" must not be a valid time in the format "11:59 PM"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "8:13 AM" must not be a time in the "11:59 PM" format'),
 ));

--- a/tests/feature/Validators/TldTest.php
+++ b/tests/feature/Validators/TldTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::tld()->assert('42'),
-    fn(string $message) => expect($message)->toBe('"42" must be a valid top-level domain name'),
+    fn(string $message) => expect($message)->toBe('"42" must be a top-level domain name'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::tld())->assert('com'),
-    fn(string $message) => expect($message)->toBe('"com" must not be a valid top-level domain name'),
+    fn(string $message) => expect($message)->toBe('"com" must not be a top-level domain name'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::tld()->assert('1984'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1984" must be a valid top-level domain name'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1984" must be a top-level domain name'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::tld())->assert('com'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "com" must not be a valid top-level domain name'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "com" must not be a top-level domain name'),
 ));

--- a/tests/feature/Validators/UndefOrTest.php
+++ b/tests/feature/Validators/UndefOrTest.php
@@ -11,57 +11,57 @@ declare(strict_types=1);
 test('Default', catchAll(
     fn() => v::undefOr(v::alpha())->assert(1234),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('1234 must contain only letters (a-z) or must be undefined')
-        ->and($fullMessage)->toBe('- 1234 must contain only letters (a-z) or must be undefined')
-        ->and($messages)->toBe(['undefOrAlpha' => '1234 must contain only letters (a-z) or must be undefined']),
+        ->and($message)->toBe('1234 must consist only of letters (a-z) or must be undefined')
+        ->and($fullMessage)->toBe('- 1234 must consist only of letters (a-z) or must be undefined')
+        ->and($messages)->toBe(['undefOrAlpha' => '1234 must consist only of letters (a-z) or must be undefined']),
 ));
 
 test('Inverted wrapper', catchAll(
     fn() => v::not(v::undefOr(v::alpha()))->assert('alpha'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"alpha" must not contain letters (a-z) and must not be undefined')
-        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) and must not be undefined')
-        ->and($messages)->toBe(['notUndefOrAlpha' => '"alpha" must not contain letters (a-z) and must not be undefined']),
+        ->and($message)->toBe('"alpha" must not consist only of letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- "alpha" must not consist only of letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => '"alpha" must not consist only of letters (a-z) and must not be undefined']),
 ));
 
 test('Inverted wrapped', catchAll(
     fn() => v::undefOr(v::not(v::alpha()))->assert('alpha'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('"alpha" must not contain letters (a-z) or must be undefined')
-        ->and($fullMessage)->toBe('- "alpha" must not contain letters (a-z) or must be undefined')
-        ->and($messages)->toBe(['undefOrNotAlpha' => '"alpha" must not contain letters (a-z) or must be undefined']),
+        ->and($message)->toBe('"alpha" must not consist only of letters (a-z) or must be undefined')
+        ->and($fullMessage)->toBe('- "alpha" must not consist only of letters (a-z) or must be undefined')
+        ->and($messages)->toBe(['undefOrNotAlpha' => '"alpha" must not consist only of letters (a-z) or must be undefined']),
 ));
 
 test('Inverted undefined', catchAll(
     fn() => v::not(v::undefOr(v::alpha()))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('`null` must not contain letters (a-z) and must not be undefined')
-        ->and($fullMessage)->toBe('- `null` must not contain letters (a-z) and must not be undefined')
-        ->and($messages)->toBe(['notUndefOrAlpha' => '`null` must not contain letters (a-z) and must not be undefined']),
+        ->and($message)->toBe('`null` must not consist only of letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- `null` must not consist only of letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => '`null` must not consist only of letters (a-z) and must not be undefined']),
 ));
 
 test('Inverted undefined, wrapped name', catchAll(
     fn() => v::not(v::undefOr(v::named('Wrapped', v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapped must not contain letters (a-z) and must not be undefined')
-        ->and($fullMessage)->toBe('- Wrapped must not contain letters (a-z) and must not be undefined')
-        ->and($messages)->toBe(['notUndefOrAlpha' => 'Wrapped must not contain letters (a-z) and must not be undefined']),
+        ->and($message)->toBe('Wrapped must not consist only of letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- Wrapped must not consist only of letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Wrapped must not consist only of letters (a-z) and must not be undefined']),
 ));
 
 test('Inverted undefined, wrapper name', catchAll(
     fn() => v::not(v::named('Wrapper', v::undefOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Wrapper must not contain letters (a-z) and must not be undefined')
-        ->and($fullMessage)->toBe('- Wrapper must not contain letters (a-z) and must not be undefined')
-        ->and($messages)->toBe(['notUndefOrAlpha' => 'Wrapper must not contain letters (a-z) and must not be undefined']),
+        ->and($message)->toBe('Wrapper must not consist only of letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- Wrapper must not consist only of letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Wrapper must not consist only of letters (a-z) and must not be undefined']),
 ));
 
 test('Inverted undefined, not name', catchAll(
     fn() => v::named('Not', v::not(v::undefOr(v::alpha())))->assert(null),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('Not must not contain letters (a-z) and must not be undefined')
-        ->and($fullMessage)->toBe('- Not must not contain letters (a-z) and must not be undefined')
-        ->and($messages)->toBe(['notUndefOrAlpha' => 'Not must not contain letters (a-z) and must not be undefined']),
+        ->and($message)->toBe('Not must not consist only of letters (a-z) and must not be undefined')
+        ->and($fullMessage)->toBe('- Not must not consist only of letters (a-z) and must not be undefined')
+        ->and($messages)->toBe(['notUndefOrAlpha' => 'Not must not consist only of letters (a-z) and must not be undefined']),
 ));
 
 test('With template', catchAll(
@@ -91,15 +91,15 @@ test('Inverted undefined with template', catchAll(
 test('Without adjacent result', catchAll(
     fn() => v::undefOr(v::alpha()->stringType())->assert(1234),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('1234 must contain only letters (a-z) or must be undefined')
+        ->and($message)->toBe('1234 must consist only of letters (a-z) or must be undefined')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
         - 1234 must pass all the rules
-          - 1234 must contain only letters (a-z) or must be undefined
+          - 1234 must consist only of letters (a-z) or must be undefined
           - 1234 must be a string or must be undefined
         FULL_MESSAGE)
         ->and($messages)->toBe([
             '__root__' => '1234 must pass all the rules',
-            'undefOrAlpha' => '1234 must contain only letters (a-z) or must be undefined',
+            'undefOrAlpha' => '1234 must consist only of letters (a-z) or must be undefined',
             'undefOrStringType' => '1234 must be a string or must be undefined',
         ]),
 ));

--- a/tests/feature/Validators/UppercaseTest.php
+++ b/tests/feature/Validators/UppercaseTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::uppercase()->assert('lowercase'),
-    fn(string $message) => expect($message)->toBe('"lowercase" must contain only uppercase letters'),
+    fn(string $message) => expect($message)->toBe('"lowercase" must consist only of uppercase letters'),
 ));
 
 test('Scenario #2', catchFullMessage(
     fn() => v::uppercase()->assert('lowercase'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "lowercase" must contain only uppercase letters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "lowercase" must consist only of uppercase letters'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::uppercase())->assert('UPPERCASE'),
-    fn(string $message) => expect($message)->toBe('"UPPERCASE" must not contain only uppercase letters'),
+    fn(string $message) => expect($message)->toBe('"UPPERCASE" must not consist only of uppercase letters'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::uppercase())->assert('UPPERCASE'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "UPPERCASE" must not contain only uppercase letters'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "UPPERCASE" must not consist only of uppercase letters'),
 ));

--- a/tests/feature/Validators/UrlTest.php
+++ b/tests/feature/Validators/UrlTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::url()->assert('example.com'),
-    fn(string $message) => expect($message)->toBe('"example.com" must be a valid URL'),
+    fn(string $message) => expect($message)->toBe('"example.com" must be a URL'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::url())->assert('http://example.com'),
-    fn(string $message) => expect($message)->toBe('"http://example.com" must not be a valid URL'),
+    fn(string $message) => expect($message)->toBe('"http://example.com" must not be a URL'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::url()->assert('example.com'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a valid URL'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "example.com" must be a URL'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::url())->assert('http://example.com'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "http://example.com" must not be a valid URL'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "http://example.com" must not be a URL'),
 ));

--- a/tests/feature/Validators/UuidTest.php
+++ b/tests/feature/Validators/UuidTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::uuid()->assert('g71a18f4-3a13-11e7-a919-92ebcb67fe33'),
-    fn(string $message) => expect($message)->toBe('"g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID'),
+    fn(string $message) => expect($message)->toBe('"g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a UUID'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::uuid(1)->assert('e0b5ffb9-9caf-2a34-9673-8fc91db78be6'),
-    fn(string $message) => expect($message)->toBe('"e0b5ffb9-9caf-2a34-9673-8fc91db78be6" must be a valid UUID version 1'),
+    fn(string $message) => expect($message)->toBe('"e0b5ffb9-9caf-2a34-9673-8fc91db78be6" must be a UUID v1'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::uuid())->assert('fb3a7909-8034-59f5-8f38-21adbc168db7'),
-    fn(string $message) => expect($message)->toBe('"fb3a7909-8034-59f5-8f38-21adbc168db7" must not be a valid UUID'),
+    fn(string $message) => expect($message)->toBe('"fb3a7909-8034-59f5-8f38-21adbc168db7" must not be a UUID'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::uuid(3))->assert('11a38b9a-b3da-360f-9353-a5a725514269'),
-    fn(string $message) => expect($message)->toBe('"11a38b9a-b3da-360f-9353-a5a725514269" must not be a valid UUID version 3'),
+    fn(string $message) => expect($message)->toBe('"11a38b9a-b3da-360f-9353-a5a725514269" must not be a UUID v3'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::uuid()->assert('g71a18f4-3a13-11e7-a919-92ebcb67fe33'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "g71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a UUID'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::uuid(4)->assert('a71a18f4-3a13-11e7-a919-92ebcb67fe33'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a valid UUID version 4'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "a71a18f4-3a13-11e7-a919-92ebcb67fe33" must be a UUID v4'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::not(v::uuid())->assert('e0b5ffb9-9caf-4a34-9673-8fc91db78be6'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e0b5ffb9-9caf-4a34-9673-8fc91db78be6" must not be a valid UUID'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "e0b5ffb9-9caf-4a34-9673-8fc91db78be6" must not be a UUID'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::uuid(5))->assert('c4a760a8-dbcf-5254-a0d9-6a4474bd1b62'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "c4a760a8-dbcf-5254-a0d9-6a4474bd1b62" must not be a valid UUID version 5'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "c4a760a8-dbcf-5254-a0d9-6a4474bd1b62" must not be a UUID v5'),
 ));

--- a/tests/feature/Validators/VersionTest.php
+++ b/tests/feature/Validators/VersionTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::version()->assert('1.3.7--'),
-    fn(string $message) => expect($message)->toBe('"1.3.7--" must be a version'),
+    fn(string $message) => expect($message)->toBe('"1.3.7--" must be a version number'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::version())->assert('1.0.0-alpha'),
-    fn(string $message) => expect($message)->toBe('"1.0.0-alpha" must not be a version'),
+    fn(string $message) => expect($message)->toBe('"1.0.0-alpha" must not be a version number'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::version()->assert('1.2.3.4-beta'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1.2.3.4-beta" must be a version'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1.2.3.4-beta" must be a version number'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::version())->assert('1.3.7-rc.1'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1.3.7-rc.1" must not be a version'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "1.3.7-rc.1" must not be a version number'),
 ));

--- a/tests/feature/Validators/VowelTest.php
+++ b/tests/feature/Validators/VowelTest.php
@@ -15,7 +15,7 @@ test('Scenario #1', catchMessage(
 
 test('Scenario #2', catchMessage(
     fn() => v::vowel('c')->assert('d'),
-    fn(string $message) => expect($message)->toBe('"d" must consist of vowels and "c"'),
+    fn(string $message) => expect($message)->toBe('"d" must consist of vowels or "c"'),
 ));
 
 test('Scenario #3', catchMessage(
@@ -35,7 +35,7 @@ test('Scenario #5', catchFullMessage(
 
 test('Scenario #6', catchFullMessage(
     fn() => v::vowel('h')->assert('j'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "j" must consist of vowels and "h"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "j" must consist of vowels or "h"'),
 ));
 
 test('Scenario #7', catchFullMessage(

--- a/tests/feature/Validators/WritableTest.php
+++ b/tests/feature/Validators/WritableTest.php
@@ -10,20 +10,20 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::writable()->assert('/path/of/a/valid/writable/file.txt'),
-    fn(string $message) => expect($message)->toBe('"/path/of/a/valid/writable/file.txt" must be writable'),
+    fn(string $message) => expect($message)->toBe('"/path/of/a/valid/writable/file.txt" must be an accessible existing writable filesystem entry'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::not(v::writable())->assert('tests/fixtures/valid-image.png'),
-    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be writable'),
+    fn(string $message) => expect($message)->toBe('"tests/fixtures/valid-image.png" must not be an accessible existing writable filesystem entry'),
 ));
 
 test('Scenario #3', catchFullMessage(
     fn() => v::writable()->assert([]),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be writable'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- `[]` must be an accessible existing writable filesystem entry'),
 ));
 
 test('Scenario #4', catchFullMessage(
     fn() => v::not(v::writable())->assert('tests/fixtures/invalid-image.png'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must not be writable'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "tests/fixtures/invalid-image.png" must not be an accessible existing writable filesystem entry'),
 ));

--- a/tests/feature/Validators/XdigitTest.php
+++ b/tests/feature/Validators/XdigitTest.php
@@ -10,40 +10,40 @@ declare(strict_types=1);
 
 test('Scenario #1', catchMessage(
     fn() => v::xdigit()->assert('aaa%a'),
-    fn(string $message) => expect($message)->toBe('"aaa%a" must only contain hexadecimal digits'),
+    fn(string $message) => expect($message)->toBe('"aaa%a" must consist only of hexadecimal digits'),
 ));
 
 test('Scenario #2', catchMessage(
     fn() => v::xdigit(' ')->assert('bbb%b'),
-    fn(string $message) => expect($message)->toBe('"bbb%b" must contain hexadecimal digits and " "'),
+    fn(string $message) => expect($message)->toBe('"bbb%b" must consist only of hexadecimal digits or " "'),
 ));
 
 test('Scenario #3', catchMessage(
     fn() => v::not(v::xdigit())->assert('ccccc'),
-    fn(string $message) => expect($message)->toBe('"ccccc" must not only contain hexadecimal digits'),
+    fn(string $message) => expect($message)->toBe('"ccccc" must not consist only of hexadecimal digits'),
 ));
 
 test('Scenario #4', catchMessage(
     fn() => v::not(v::xdigit('% '))->assert('ddd%d'),
-    fn(string $message) => expect($message)->toBe('"ddd%d" must not contain hexadecimal digits or "% "'),
+    fn(string $message) => expect($message)->toBe('"ddd%d" must not consist only of hexadecimal digits or "% "'),
 ));
 
 test('Scenario #5', catchFullMessage(
     fn() => v::xdigit()->assert('eee^e'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "eee^e" must only contain hexadecimal digits'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "eee^e" must consist only of hexadecimal digits'),
 ));
 
 test('Scenario #6', catchFullMessage(
     fn() => v::not(v::xdigit())->assert('fffff'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "fffff" must not only contain hexadecimal digits'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "fffff" must not consist only of hexadecimal digits'),
 ));
 
 test('Scenario #7', catchFullMessage(
     fn() => v::xdigit('* &%')->assert('000^0'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "000^0" must contain hexadecimal digits and "* &%"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "000^0" must consist only of hexadecimal digits or "* &%"'),
 ));
 
 test('Scenario #8', catchFullMessage(
     fn() => v::not(v::xdigit('^'))->assert('111^1'),
-    fn(string $fullMessage) => expect($fullMessage)->toBe('- "111^1" must not contain hexadecimal digits or "^"'),
+    fn(string $fullMessage) => expect($fullMessage)->toBe('- "111^1" must not consist only of hexadecimal digits or "^"'),
 ));


### PR DESCRIPTION
 - Remove redundant "valid" prefix: Date, DateTime, DateTimeDiff, Domain, Email, Iban, Imei, Ip, Isbn, Json, LanguageCode, LeapDate, LeapYear, Luhn, MacAddress, NfeAccessKey, Nif, Nip, Pesel, Phone, Pis, PolishIdCard, PostalCode, Roman, Slug, Tld, Url, Uuid, Version.

 - Remove redundant "value" suffix ArrayVal, BoolVal, Countable, FloatVal, IntVal, IterableVal, NumericVal, ScalarVal, StringVal.

 - Standardize "consist only of" phrasing Alnum, Alpha, Cntrl, Consonant, Digit, Graph, Lowercase, Printable, Punct, Space, Spaced, Uppercase, Vowel, Xdigit.

 - Improve file accessibility messages Directory, Executable, File, Image, Readable, SymbolicLink, Writable.

 - Improve grammar and article usage CreditCard, Extension, Mimetype, Regex, Size.