### PR TITLE
Rename Composite to LogicalComposite

### DIFF
--- a/src/Validators/AllOf.php
+++ b/src/Validators/AllOf.php
@@ -19,7 +19,7 @@ use Respect\Validation\Helpers\CanEvaluateShortCircuit;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
-use Respect\Validation\Validators\Core\Composite;
+use Respect\Validation\Validators\Core\LogicalComposite;
 use Respect\Validation\Validators\Core\ShortCircuitable;
 
 use function array_filter;
@@ -38,7 +38,7 @@ use function count;
     '{{subject}} must pass all the rules',
     self::TEMPLATE_ALL,
 )]
-final class AllOf extends Composite implements ShortCircuitable
+final class AllOf extends LogicalComposite implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;
 

--- a/src/Validators/AnyOf.php
+++ b/src/Validators/AnyOf.php
@@ -19,7 +19,7 @@ use Respect\Validation\Helpers\CanEvaluateShortCircuit;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
-use Respect\Validation\Validators\Core\Composite;
+use Respect\Validation\Validators\Core\LogicalComposite;
 use Respect\Validation\Validators\Core\ShortCircuitable;
 
 use function array_map;
@@ -30,7 +30,7 @@ use function array_reduce;
     '{{subject}} must pass at least one of the rules',
     '{{subject}} must pass at least one of the rules',
 )]
-final class AnyOf extends Composite implements ShortCircuitable
+final class AnyOf extends LogicalComposite implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;
 

--- a/src/Validators/Core/LogicalComposite.php
+++ b/src/Validators/Core/LogicalComposite.php
@@ -15,7 +15,7 @@ use Respect\Validation\Validator;
 
 use function array_merge;
 
-abstract class Composite implements Validator
+abstract class LogicalComposite implements Validator
 {
     /** @var non-empty-array<Validator> */
     protected readonly array $validators;

--- a/src/Validators/NoneOf.php
+++ b/src/Validators/NoneOf.php
@@ -18,7 +18,7 @@ use Attribute;
 use Respect\Validation\Helpers\CanEvaluateShortCircuit;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\Composite;
+use Respect\Validation\Validators\Core\LogicalComposite;
 use Respect\Validation\Validators\Core\ShortCircuitable;
 
 use function count;
@@ -34,7 +34,7 @@ use function count;
     '{{subject}} must pass all the rules',
     self::TEMPLATE_ALL,
 )]
-final class NoneOf extends Composite implements ShortCircuitable
+final class NoneOf extends LogicalComposite implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;
 

--- a/src/Validators/OneOf.php
+++ b/src/Validators/OneOf.php
@@ -20,7 +20,7 @@ use Respect\Validation\Helpers\CanEvaluateShortCircuit;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
-use Respect\Validation\Validators\Core\Composite;
+use Respect\Validation\Validators\Core\LogicalComposite;
 use Respect\Validation\Validators\Core\ShortCircuitable;
 
 use function array_filter;
@@ -40,7 +40,7 @@ use function usort;
     '{{subject}} must pass only one of the rules',
     self::TEMPLATE_MORE_THAN_ONE,
 )]
-final class OneOf extends Composite implements ShortCircuitable
+final class OneOf extends LogicalComposite implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;
 

--- a/tests/src/Validators/Core/ConcreteLogicalComposite.php
+++ b/tests/src/Validators/Core/ConcreteLogicalComposite.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Test\Validators\Core;
 
 use Respect\Validation\Result;
-use Respect\Validation\Validators\Core\Composite;
+use Respect\Validation\Validators\Core\LogicalComposite;
 
-final class ConcreteComposite extends Composite
+final class ConcreteLogicalComposite extends LogicalComposite
 {
     public function evaluate(mixed $input): Result
     {

--- a/tests/unit/Validators/Core/CompositeTest.php
+++ b/tests/unit/Validators/Core/CompositeTest.php
@@ -15,18 +15,18 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Test\TestCase;
-use Respect\Validation\Test\Validators\Core\ConcreteComposite;
+use Respect\Validation\Test\Validators\Core\ConcreteLogicalComposite;
 use Respect\Validation\Test\Validators\Stub;
 
 #[Group('core')]
-#[CoversClass(Composite::class)]
+#[CoversClass(LogicalComposite::class)]
 final class CompositeTest extends TestCase
 {
     #[Test]
     public function itShouldReturnItsChildren(): void
     {
         $expected = [Stub::daze(), Stub::daze(), Stub::daze()];
-        $sut = new ConcreteComposite(...$expected);
+        $sut = new ConcreteLogicalComposite(...$expected);
         $actual = $sut->getValidators();
 
         self::assertCount(3, $actual);


### PR DESCRIPTION
Rename the Composite class to LogicalComposite to more accurately reflect its purpose as a validator that combines child validators using logical operations (AND, OR, NAND, XOR).

This better naming also opens the door for additional composite patterns beyond logical operations, enabling future validator compositions.