### PR TITLE
Add wildcard support to ResultQuery::findByPath()

### DIFF
--- a/docs/handling-results.md
+++ b/docs/handling-results.md
@@ -174,6 +174,24 @@ if ($emailResult?->hasFailed()) {
 }
 ```
 
+Paths support wildcards using `*` to match any single path segment:
+- `items.*` matches the first result under `items`
+- `*.email` matches the first `.email` path found
+- `data.*.value` matches the first nested path ending with `.value`
+
+```php
+$result = v::init()
+    ->key('items', v::each(v::positive()))
+    ->validate(['items' => [10, -5, 20]]);
+
+// Find the first invalid item (items.1)
+$firstInvalid = $result->findByPath('items.*');
+if ($firstInvalid?->hasFailed()) {
+    echo $firstInvalid->getMessage();
+    // → `.items.1` must be a positive number
+}
+```
+
 ### findByName()
 
 Finds a result by a custom name assigned with the `Named` validator.

--- a/tests/unit/ResultQueryTest.php
+++ b/tests/unit/ResultQueryTest.php
@@ -589,6 +589,93 @@ final class ResultQueryTest extends TestCase
         self::assertSame($formatter->format($child, $renderer, []), (string) $found);
     }
 
+    #[Test]
+    public function itShouldFindByPathWithWildcard(): void
+    {
+        $renderer = new TestingMessageRenderer();
+        $formatter = new TestingStringFormatter(uniqid());
+
+        $childPath = uniqid();
+        $parentPath = uniqid();
+
+        $child = (new ResultBuilder())
+            ->path(new Path($childPath, new Path($parentPath)))
+            ->hasPassed(false)
+            ->build();
+
+        $parent = (new ResultBuilder())
+            ->hasPassed(false)
+            ->children($child)
+            ->build();
+
+        $resultQuery = $this->createResultQuery($parent, renderer: $renderer, messageFormatter: $formatter);
+
+        $found = $resultQuery->findByPath('*.' . $childPath);
+
+        self::assertNotNull($found);
+        self::assertSame($formatter->format($child, $renderer, []), (string) $found);
+    }
+
+    #[Test]
+    public function itShouldFindByPathWithWildcardAtEnd(): void
+    {
+        $renderer = new TestingMessageRenderer();
+        $formatter = new TestingStringFormatter(uniqid());
+
+        $parentPath = uniqid();
+        $child = (new ResultBuilder())
+            ->path(new Path(uniqid(), new Path($parentPath)))
+            ->hasPassed(false)
+            ->build();
+
+        $parent = (new ResultBuilder())
+            ->hasPassed(false)
+            ->children($child)
+            ->build();
+
+        $resultQuery = $this->createResultQuery($parent, renderer: $renderer, messageFormatter: $formatter);
+
+        $found = $resultQuery->findByPath($parentPath . '.*');
+
+        self::assertNotNull($found);
+        self::assertSame($formatter->format($child, $renderer, []), (string) $found);
+    }
+
+    #[Test]
+    public function itShouldReturnNullWhenPathWithWildcardDoesNotMatch(): void
+    {
+        $child = (new ResultBuilder())
+            ->path(new Path(uniqid()))
+            ->build();
+
+        $parent = (new ResultBuilder())
+            ->hasPassed(false)
+            ->children($child)
+            ->build();
+
+        $resultQuery = $this->createResultQuery($parent);
+
+        self::assertNull($resultQuery->findByPath(uniqid() . '.*'));
+    }
+
+    #[Test]
+    public function itShouldReturnNullWhenPathLengthDoesNotMatch(): void
+    {
+        $child = (new ResultBuilder())
+            ->path(new Path(uniqid()))
+            ->hasPassed(false)
+            ->build();
+
+        $parent = (new ResultBuilder())
+            ->hasPassed(false)
+            ->children($child)
+            ->build();
+
+        $resultQuery = $this->createResultQuery($parent);
+
+        self::assertNull($resultQuery->findByPath('*.*'));
+    }
+
     private function createResultQuery(
         Result $result,
         TestingMessageRenderer|null $renderer = null,


### PR DESCRIPTION
Before this change, querying validation results required knowing the exact path to a specific result node—including numeric indices for array elements (e.g., `items.1.email`). This made it impractical to locate the first failing result in dynamic collections where the failing index is not known ahead of time.

Wildcard segments (`*`) allow matching any single path component, so patterns like `items.*`, `*.email`, or `data.*.value` will traverse the result tree and return the first node whose path matches. This is particularly valuable when validating arrays of items with `each()`, because consumers can now ask "give me the first failure under items" without iterating manually.

The implementation replaces the previous flat `array_find` lookup with a recursive depth-first traversal that, when a wildcard is present, compares each node's full path against the pattern using segment-level matching. Non-wildcard lookups continue to use exact array equality, so there is no behavioral change for existing callers.

Assisted-by: Claude Code (claude-opus-4-6)