### PR TITLE
Add FormatterModifier to message rendering and expand test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.5",
         "php-di/php-di": "^7.1",
         "psr/container": "^2.0",
-        "respect/string-formatter": "^1.6",
+        "respect/string-formatter": "^1.7",
         "respect/stringifier": "^3.0",
         "symfony/polyfill-intl-idn": "^1.33",
         "symfony/polyfill-mbstring": "^1.33"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa9f29c82a049d9f491ccfc5af541b2d",
+    "content-hash": "fb8bd733c6dead511a06f445eab760ff",
     "packages": [
         {
             "name": "laravel/serializable-closure",
@@ -250,16 +250,16 @@
         },
         {
             "name": "respect/string-formatter",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Respect/StringFormatter.git",
-                "reference": "4c3bfd069c0704f38715b6208d8b22fa4fcc8376"
+                "reference": "113499ae9f211e51abab10f65eb8bc9fc7a0b99f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Respect/StringFormatter/zipball/4c3bfd069c0704f38715b6208d8b22fa4fcc8376",
-                "reference": "4c3bfd069c0704f38715b6208d8b22fa4fcc8376",
+                "url": "https://api.github.com/repos/Respect/StringFormatter/zipball/113499ae9f211e51abab10f65eb8bc9fc7a0b99f",
+                "reference": "113499ae9f211e51abab10f65eb8bc9fc7a0b99f",
                 "shasum": ""
             },
             "require": {
@@ -302,9 +302,9 @@
             "description": "A powerful and flexible way of formatting and transforming strings",
             "support": {
                 "issues": "https://github.com/Respect/StringFormatter/issues",
-                "source": "https://github.com/Respect/StringFormatter/tree/1.6.1"
+                "source": "https://github.com/Respect/StringFormatter/tree/1.7.0"
             },
-            "time": "2026-02-09T12:41:42+00:00"
+            "time": "2026-02-09T12:55:44+00:00"
         },
         {
             "name": "respect/stringifier",

--- a/src/ContainerRegistry.php
+++ b/src/ContainerRegistry.php
@@ -16,6 +16,7 @@ use libphonenumber\PhoneNumberUtil;
 use Psr\Container\ContainerInterface;
 use Respect\StringFormatter\BypassTranslator;
 use Respect\StringFormatter\Modifier;
+use Respect\StringFormatter\Modifiers\FormatterModifier;
 use Respect\StringFormatter\Modifiers\ListModifier;
 use Respect\StringFormatter\Modifiers\QuoteModifier;
 use Respect\StringFormatter\Modifiers\RawModifier;
@@ -92,7 +93,7 @@ final class ContainerRegistry
                 new ListModifier(
                     new QuoteModifier(
                         new RawModifier(
-                            new StringifyModifier($container->get(Stringifier::class)),
+                            new FormatterModifier(new StringifyModifier($container->get(Stringifier::class))),
                         ),
                     ),
                     $container->get(TranslatorInterface::class),

--- a/tests/feature/FormatterModifierTest.php
+++ b/tests/feature/FormatterModifierTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+test('uppercase modifier', catchMessage(
+    fn() => v::templated('{{input|uppercase}} is not valid', v::email())->assert('not an email'),
+    fn(string $message) => expect($message)->toBe('NOT AN EMAIL is not valid'),
+));
+
+test('lowercase modifier', catchMessage(
+    fn() => v::templated('{{input|lowercase}} is not valid', v::email())->assert('NOT AN EMAIL'),
+    fn(string $message) => expect($message)->toBe('not an email is not valid'),
+));
+
+test('mask modifier', catchMessage(
+    fn() => v::templated('{{input|mask:1-4}} is masked', v::alwaysInvalid())->assert('secret'),
+    fn(string $message) => expect($message)->toBe('****et is masked'),
+));
+
+test('mask modifier with custom replacement', catchMessage(
+    fn() => v::templated('{{input|mask:1-4:X}} is masked', v::alwaysInvalid())->assert('secret'),
+    fn(string $message) => expect($message)->toBe('XXXXet is masked'),
+));
+
+test('pattern modifier', catchMessage(
+    fn() => v::templated('Formatted: {{input|pattern:###-####}}', v::alwaysInvalid())->assert('1234567'),
+    fn(string $message) => expect($message)->toBe('Formatted: 123-4567'),
+));
+
+test('date modifier', catchMessage(
+    fn() => v::templated('Date: {{input|date:d/m/Y}}', v::alwaysInvalid())->assert('2024-01-15'),
+    fn(string $message) => expect($message)->toBe('Date: 15/01/2024'),
+));
+
+test('number modifier', catchMessage(
+    fn() => v::templated('Value: {{input|number:2}}', v::alwaysInvalid())->assert('1234567.89'),
+    fn(string $message) => expect($message)->toBe('Value: 1,234,567.89'),
+));
+
+test('creditCard modifier', catchMessage(
+    fn() => v::templated('Card: {{input|creditCard}}', v::alwaysInvalid())->assert('4532015112830366'),
+    fn(string $message) => expect($message)->toBe('Card: 4532 0151 1283 0366'),
+));
+
+test('secureCreditCard modifier', catchMessage(
+    fn() => v::templated('Card: {{input|secureCreditCard}}', v::alwaysInvalid())->assert('4532015112830366'),
+    fn(string $message) => expect($message)->toBe('Card: 4532 **** **** 0366'),
+));
+
+test('trim modifier', catchMessage(
+    fn() => v::templated('{{input|trim}} is not valid', v::email())->assert('  not-email  '),
+    fn(string $message) => expect($message)->toBe('not-email is not valid'),
+));
+
+test('metric modifier', catchMessage(
+    fn() => v::templated('Distance: {{input|metric:mm}}', v::alwaysInvalid())->assert('5000'),
+    fn(string $message) => expect($message)->toBe('Distance: 5m'),
+));
+
+test('custom parameter with modifier', catchMessage(
+    fn() => v::templated('Name: {{name|uppercase}}', v::alwaysInvalid(), ['name' => 'john'])->assert(1),
+    fn(string $message) => expect($message)->toBe('Name: JOHN'),
+));
+
+test('chained modifiers', catchMessage(
+    fn() => v::templated('{{input|mask:1-4|uppercase}}', v::alwaysInvalid())->assert('secret'),
+    fn(string $message) => expect($message)->toBe('****ET'),
+));

--- a/tests/feature/Validators/FormattedTest.php
+++ b/tests/feature/Validators/FormattedTest.php
@@ -33,3 +33,67 @@ test('failed validator with pattern formatted input', catchAll(
         ->and($fullMessage)->toBe('- "1234 1234 1234 1234" must be a credit card number')
         ->and($messages)->toBe(['creditCard' => '"1234 1234 1234 1234" must be a credit card number']),
 ));
+
+test('failed validator with uppercase formatted input', catchAll(
+    fn() => v::formatted(f::uppercase(), v::email())->assert('not an email'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"NOT AN EMAIL" must be an email address')
+        ->and($fullMessage)->toBe('- "NOT AN EMAIL" must be an email address')
+        ->and($messages)->toBe(['email' => '"NOT AN EMAIL" must be an email address']),
+));
+
+test('failed validator with lowercase formatted input', catchAll(
+    fn() => v::formatted(f::lowercase(), v::email())->assert('NOT AN EMAIL'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"not an email" must be an email address')
+        ->and($fullMessage)->toBe('- "not an email" must be an email address')
+        ->and($messages)->toBe(['email' => '"not an email" must be an email address']),
+));
+
+test('failed validator with trimmed input', catchAll(
+    fn() => v::formatted(f::trim('both', null), v::email())->assert('  not-email  '),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"not-email" must be an email address')
+        ->and($fullMessage)->toBe('- "not-email" must be an email address')
+        ->and($messages)->toBe(['email' => '"not-email" must be an email address']),
+));
+
+test('failed validator with number formatted input', catchAll(
+    fn() => v::formatted(f::number(2, '.', ','), v::email())->assert('1234567.89'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"1,234,567.89" must be an email address')
+        ->and($fullMessage)->toBe('- "1,234,567.89" must be an email address')
+        ->and($messages)->toBe(['email' => '"1,234,567.89" must be an email address']),
+));
+
+test('failed validator with date formatted input', catchAll(
+    fn() => v::formatted(f::date('d/m/Y'), v::email())->assert('2024-01-15'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"15/01/2024" must be an email address')
+        ->and($fullMessage)->toBe('- "15/01/2024" must be an email address')
+        ->and($messages)->toBe(['email' => '"15/01/2024" must be an email address']),
+));
+
+test('failed validator with credit card formatted input', catchAll(
+    fn() => v::formatted(f::creditCard(), v::creditCard())->assert('1234567890123456'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"1234 5678 9012 3456" must be a credit card number')
+        ->and($fullMessage)->toBe('- "1234 5678 9012 3456" must be a credit card number')
+        ->and($messages)->toBe(['creditCard' => '"1234 5678 9012 3456" must be a credit card number']),
+));
+
+test('failed validator with secure credit card formatted input', catchAll(
+    fn() => v::formatted(f::secureCreditCard(), v::creditCard())->assert('1234567890123456'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"1234 **** **** 3456" must be a credit card number')
+        ->and($fullMessage)->toBe('- "1234 **** **** 3456" must be a credit card number')
+        ->and($messages)->toBe(['creditCard' => '"1234 **** **** 3456" must be a credit card number']),
+));
+
+test('failed validator with chained formatters', catchAll(
+    fn() => v::formatted(f::trim('both', null)->uppercase(), v::email())->assert('  not an email  '),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('"NOT AN EMAIL" must be an email address')
+        ->and($fullMessage)->toBe('- "NOT AN EMAIL" must be an email address')
+        ->and($messages)->toBe(['email' => '"NOT AN EMAIL" must be an email address']),
+));


### PR DESCRIPTION
Integrate FormatterModifier into the validation message modifier chain, enabling StringFormatter formatters to be used as pipe modifiers in message templates (e.g., {{input|uppercase}}, {{input|mask:1-4:X}}). This requires bumping respect/string-formatter to ^1.7.

Add feature tests for both the Formatted validator (uppercase, lowercase, trim, number, date, creditCard, secureCreditCard, chained formatters) and the FormatterModifier in templates (all major formatters, custom parameters, multi-argument modifiers, and chained modifiers).

Assisted-by: Claude Code (Claude Opus 4.6)

