### PR TITLE
Add TheRespectPanda Bot workflow

### DIFF
--- a/.github/workflows/panda.yml
+++ b/.github/workflows/panda.yml
@@ -1,0 +1,43 @@
+name: TheRespectPanda Bot
+
+on:
+  issue_comment:
+    types: [created]
+    if: startsWith(github.event.comment.body, '@TheRespectPanda')
+
+jobs:
+  listen-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PANDA_GITHUB_PAT }}
+          script: |
+            const body = (context.payload.comment && context.payload.comment.body).trim() || '';
+            const usage = 'Usage: `@TheRespectPanda ping|help`';
+
+            if (!body.startsWith('@TheRespectPanda')) {
+              return;
+            }
+
+            switch (body) {
+              case '@TheRespectPanda ping':
+                answer = 'Pong! 🐼';
+                break;
+              case '@TheRespectPanda':
+              case '@TheRespectPanda help':
+                answer = 'Hello! I am TheRespectPanda Bot. ' + usage;
+                break;
+              default:
+                answer = "I'm sorry, I don't understand that command. " + usage;
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: answer
+            });


### PR DESCRIPTION
Includes a basic bot workflow that just answers "pong" to ping requests.

This is the minimum feature that exercises token access, non recursive comments (answering to its own pong) and so on.

This workflow has been tested in a private testing repo:

https://github.com/Respect/GitHubTests/issues/2 (visible to `Respect` org members)

Feel free to interact with the bot there.