### PR TITLE
Change isValid method to public + Change validator registration

### DIFF
--- a/docs/custom-validators.md
+++ b/docs/custom-validators.md
@@ -27,7 +27,7 @@ use Respect\Validation\Validators\Core\Simple;
 )]
 final class Something extends Simple
 {
-    protected function isValid(mixed $input): bool
+    public function isValid(mixed $input): bool
     {
         // Do something here with the $input and return a boolean value
     }
@@ -42,9 +42,15 @@ Validation to execute your validator (or validators) in the chain, you must over
 default `Factory`.
 
 ```php
-Factory::setDefaultInstance(
-    (new Factory())
-        ->withNamespace('My\\Validation\\Validators')
+use Respect\Validation\ContainerRegistry;
+
+ContainerRegistry::setContainer(
+    ContainerRegistry::createContainer([
+        'respect.validation.rule_factory.namespaces' => [
+            'My\\Validation\\Validators',
+            'Respect\\Validation\\Validators',
+        ],
+    ])
 );
 v::something(); // Try to load "My\Validation\Validators\Something" if any
 ```


### PR DESCRIPTION
The "protected" isValid() method didn't work, threw an exception sying it needs to be "public".

Also the registration didn't work that way. I was unable to fix it but found an alternate way which works. Maybe it's not the right one but I'm indicating it here.

