### PR TITLE
Fix: anchor MasterCard credit-card pattern (missing `^` regressed in 94a79c033)

### DIFF
--- a/src/Validators/CreditCard.php
+++ b/src/Validators/CreditCard.php
@@ -59,7 +59,7 @@ final readonly class CreditCard implements Validator
         self::DINERS_CLUB => '/^3(?:0[0-5]|[68]\d)\d{11}$/',
         self::DISCOVER => '/^6(?:011|5\d{2})\d{12}$/',
         self::JCB => '/^(?:2131|1800|35\d{3})\d{11}$/',
-        self::MASTERCARD => '/(5[1-5]|2[2-7])\d{14}$/',
+        self::MASTERCARD => '/^(5[1-5]|2[2-7])\d{14}$/',
         self::VISA => '/^4\d{12}(?:\d{3})?$/',
         self::RUPAY => '/^6(?!011)(?:0[0-9]{14}|52[12][0-9]{12})$/',
     ];

--- a/tests/unit/Validators/CreditCardTest.php
+++ b/tests/unit/Validators/CreditCardTest.php
@@ -94,6 +94,7 @@ final class CreditCardTest extends RuleTestCase
             [$diners, '4012888888881881'], // Visa
             [$discover, '371449635398431'], // American Express
             [$jcb, '38520000023237'], // Diners Club
+            [$master, '05105105105105100'], // Over-long (17-digit) Luhn-valid number; regression for missing ^ anchor
         ];
     }
 }


### PR DESCRIPTION
The `MasterCard` entry in `CreditCard`'s `BRAND_REGEX_LIST` is the only one of the eight brand patterns missing a leading `^` anchor. Because of this, `v::creditCard('MasterCard')` accepts inputs that are **not** valid MasterCard numbers specifically, Luhn-valid digit strings **longer than 16 digits** whose trailing 16 digits match the MasterCard pattern.

```php
use Respect\Validation\Validator as v;

// 16-digit MasterCard from the docs — correctly accepted
var_dump(v::creditCard('MasterCard')->isValid('5376747397208720')); // true (OK)

// 17-digit, Luhn-valid, NOT a MasterCard — wrongly accepted today
var_dump(v::creditCard('MasterCard')->isValid('05105105105105100')); // true (BUG; should be false and rejected? No?)
```

Self-contained demonstration (no Composer needed), mirroring `evaluate()` +
`Luhn::isValid()` and using the verbatim shipped regex:

```
input                | luhn  | shipped  | fixed   | expectation
--------------------------------------------------------------------------------
5376747397208720     | pass  | ACCEPT   | ACCEPT  | valid 16-digit MasterCard -> must ACCEPT
05105105105105100    | pass  | ACCEPT   | reject  | INVALID 17-digit number   -> must REJECT
```

## Fix

```diff
- self::MASTERCARD => '/(5[1-5]|2[2-7])\d{14}$/',
+ self::MASTERCARD => '/^(5[1-5]|2[2-7])\d{14}$/',
```

## Regression test

Add to `providerForInvalidInput()` in `tests/unit/Validators/CreditCardTest.php` (alongside the other `$master`negatives):

```php
[$master, '05105105105105100'], // 17-digit (over-long): regression for missing ^ anchor
```