### PR TITLE
Add recursive validation to Attributes for nested object properties

### DIFF
--- a/docs/validators/Attributes.md
+++ b/docs/validators/Attributes.md
@@ -72,9 +72,38 @@ v::attributes()->assert(new Person('', 'not a date', 'not an email', 'not a phon
 
 ## Caveats
 
-- If the object has no attributes, the validation will always pass.
-- When the property is nullable, this validator will wrap the validator on the property into [NullOr](NullOr.md) validator.
-- This validator has no templates because it uses the templates of the validators that are applied to the properties.
+### Empty objects
+
+If the object has no validator attributes on any of its properties or class, the validation will always pass.
+
+### Nullable properties
+
+When a property is nullable (e.g., `?string $email`), `Attributes` wraps the property's validator into [NullOr](NullOr.md), so `null` values are accepted automatically.
+
+### Nested object validation
+
+When a property's type is a class (named, union, or intersection type), `Attributes` recursively validates that object's own properties, so there is no need to explicitly add `#[Attributes]` on the property.
+
+- **Named types** (`NestedAddress $address`): the nested object is validated directly.
+- **Union types** (`string|NestedAddress $address`): the nested object is only validated if it passes an `Instance` check first, so string values in the union are safely skipped.
+- **Intersection types** (`NestedWithAttributes&Nested $address`): the nested object is validated directly, since it must satisfy all types in the intersection.
+- **Untyped properties** (no type declaration, or builtin types like `string`): are never recursively validated.
+- **Array properties**: `Attributes` **does not** recursively validate objects inside arrays. To validate each element, use the `#[Each]` attribute on the property (e.g., `#[Each(new Attributes())]`).
+
+### Circular references
+
+When a nested object graph contains a cycle (e.g., `$a->next = $b`, `$b->next = $a`), `Attributes` detects the revisit and fails with the `TEMPLATE_CIRCULAR_REFERENCE` template. This prevents infinite recursion and stack overflow.
+
+Note that circular reference detection only works for direct object references. If a cycle passes through an array (e.g., `$a->items = [$b]`, `$b->parent = $a`), `Attributes` cannot track the reference and the validation will recurse infinitely, causing a stack overflow.
+
+## Templates
+
+### `Attributes::TEMPLATE_CIRCULAR_REFERENCE`
+
+|       Mode | Template                                          |
+| ---------: | :------------------------------------------------ |
+|  `default` | {{subject}} must not contain a circular reference |
+| `inverted` | {{subject}} must contain a circular reference     |
 
 ## Categorization
 

--- a/src/Validators/Attributes.php
+++ b/src/Validators/Attributes.php
@@ -15,18 +15,34 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
 use ReflectionObject;
 use ReflectionProperty;
+use ReflectionUnionType;
 use Respect\Dev\CodeGen\FluentBuilder\Mixin;
 use Respect\Validation\Id;
+use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
 use Respect\Validation\Validators\Core\Reducer;
 
+use function spl_object_id;
+
 #[Mixin(exclude: ['all', 'key', 'property', 'not', 'undefOr'])]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Template(
+    '{{subject}} must not contain a circular reference',
+    '{{subject}} must contain a circular reference',
+    Attributes::TEMPLATE_CIRCULAR_REFERENCE,
+)]
 final class Attributes implements Validator
 {
+    public const string TEMPLATE_CIRCULAR_REFERENCE = '__circular_reference__';
+
+    /** @var array<int, true> */
+    private array $visited = [];
+
     public function evaluate(mixed $input): Result
     {
         $id = new Id('attributes');
@@ -34,6 +50,13 @@ final class Attributes implements Validator
         if (!$objectType->hasPassed) {
             return $objectType->withId($id);
         }
+
+        $objectId = spl_object_id($input);
+        if (isset($this->visited[$objectId])) {
+            return Result::failed($input, $this, [], self::TEMPLATE_CIRCULAR_REFERENCE)->withId($id);
+        }
+
+        $this->visited[$objectId] = true;
 
         $reflection = new ReflectionObject($input);
         $validators = [...$this->getClassValidators($reflection), ...$this->getPropertyValidators($reflection)];
@@ -64,11 +87,7 @@ final class Attributes implements Validator
     {
         $validators = [];
         foreach ($this->getProperties($reflection) as $propertyName => $property) {
-            $propertyValidators = [];
-            foreach ($property->getAttributes(Validator::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                $propertyValidators[] = $attribute->newInstance();
-            }
-
+            $propertyValidators = $this->getPropertyInnerValidators($property);
             if ($propertyValidators === []) {
                 continue;
             }
@@ -80,6 +99,47 @@ final class Attributes implements Validator
         }
 
         return $validators;
+    }
+
+    /** @return array<Validator> */
+    private function getPropertyInnerValidators(ReflectionProperty $property): array
+    {
+        $propertyValidators = [];
+        $hasExplicitAttributes = false;
+        foreach ($property->getAttributes(Validator::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $propertyValidator = $attribute->getName() === self::class ? $this : $attribute->newInstance();
+            $hasExplicitAttributes = $propertyValidator === $this;
+            $propertyValidators[] = $propertyValidator;
+        }
+
+        if ($hasExplicitAttributes) {
+            return $propertyValidators;
+        }
+
+        $type = $property->getType();
+        if ($type instanceof ReflectionNamedType) {
+            if (!$type->isBuiltin()) {
+                $propertyValidators[] = $this;
+            }
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            $propertyValidators[] = $this;
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $innerType) {
+                if (!$innerType instanceof ReflectionNamedType || $innerType->isBuiltin()) {
+                    continue;
+                }
+
+                /** @var class-string $class */
+                $class = $innerType->getName();
+                $propertyValidators[] = new Given(new Instance($class), $this);
+            }
+        }
+
+        return $propertyValidators;
     }
 
     /** @return array<ReflectionProperty> */

--- a/tests/feature/Validators/AttributesTest.php
+++ b/tests/feature/Validators/AttributesTest.php
@@ -9,7 +9,14 @@
 
 declare(strict_types=1);
 
+use Respect\Validation\Test\Stubs\CyclicNode;
+use Respect\Validation\Test\Stubs\NestedAddress;
+use Respect\Validation\Test\Stubs\NestedWithAttributes;
 use Respect\Validation\Test\Stubs\WithAttributes;
+use Respect\Validation\Test\Stubs\WithCyclicAttributes;
+use Respect\Validation\Test\Stubs\WithIntersectionTypeNested;
+use Respect\Validation\Test\Stubs\WithNestedAttributes;
+use Respect\Validation\Test\Stubs\WithUnionTypeNested;
 
 test('Default', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('', '2024-06-23', 'john.doe@gmail.com')),
@@ -93,4 +100,40 @@ test('Multiple attributes, one failed', catchAll(
         ->and($message)->toBe('`.birthdate` must be a date in the "2005-12-30" format')
         ->and($fullMessage)->toBe('- `.birthdate` must be a date in the "2005-12-30" format')
         ->and($messages)->toBe(['birthdate' => '`.birthdate` must be a date in the "2005-12-30" format']),
+));
+
+test('Recursive: invalid nested object property', catchAll(
+    fn() => v::attributes()->assert(new WithNestedAttributes('John Doe', new NestedAddress('', 'Springfield'))),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.address.street` must be defined')
+        ->and($fullMessage)->toBe('- `.address.street` must be defined')
+        ->and($messages)->toBe(['address' => '`.address.street` must be defined']),
+));
+
+test('Recursive: union type with invalid nested object property', catchAll(
+    fn() => v::attributes()->assert(new WithUnionTypeNested('John Doe', new NestedAddress('', 'Springfield'))),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.address.street` must be defined')
+        ->and($fullMessage)->toBe('- `.address.street` must be defined')
+        ->and($messages)->toBe(['address' => '`.address.street` must be defined']),
+));
+
+test('Recursive: intersection type with invalid nested object property', catchAll(
+    fn() => v::attributes()->assert(new WithIntersectionTypeNested('John Doe', new NestedWithAttributes('', 'Springfield'))),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.address.street` must be defined')
+        ->and($fullMessage)->toBe('- `.address.street` must be defined')
+        ->and($messages)->toBe(['address' => '`.address.street` must be defined']),
+));
+
+test('Circular reference: self-referencing', catchAll(
+    fn() => (function (): void {
+        $node = new CyclicNode('hello');
+        $node->next = $node;
+        v::attributes()->assert(new WithCyclicAttributes('John Doe', $node));
+    })(),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.next.next` must not contain a circular reference or must be null')
+        ->and($fullMessage)->toBe('- `.next.next` must not contain a circular reference or must be null')
+        ->and($messages)->toBe(['next' => '`.next.next` must not contain a circular reference or must be null']),
 ));

--- a/tests/src/Stubs/CyclicNode.php
+++ b/tests/src/Stubs/CyclicNode.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class CyclicNode
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $value,
+        public self|null $next = null,
+    ) {
+    }
+}

--- a/tests/src/Stubs/Nested.php
+++ b/tests/src/Stubs/Nested.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+interface Nested
+{
+}

--- a/tests/src/Stubs/NestedAddress.php
+++ b/tests/src/Stubs/NestedAddress.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class NestedAddress implements Nested
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $street,
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $city,
+        #[Rule\StringType]
+        public string|null $country = null,
+    ) {
+    }
+}

--- a/tests/src/Stubs/NestedPassThrough.php
+++ b/tests/src/Stubs/NestedPassThrough.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class NestedPassThrough implements Nested
+{
+    public function __construct(
+        public Nested $next,
+    ) {
+    }
+}

--- a/tests/src/Stubs/NestedValidated.php
+++ b/tests/src/Stubs/NestedValidated.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class NestedValidated implements Nested
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $value,
+    ) {
+    }
+}

--- a/tests/src/Stubs/NestedWithAttributes.php
+++ b/tests/src/Stubs/NestedWithAttributes.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class NestedWithAttributes implements Nested
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $street,
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $city,
+    ) {
+    }
+}

--- a/tests/src/Stubs/NestedWithoutAttributes.php
+++ b/tests/src/Stubs/NestedWithoutAttributes.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class NestedWithoutAttributes
+{
+    public function __construct(
+        public string $value,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithCyclicAttributes.php
+++ b/tests/src/Stubs/WithCyclicAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithCyclicAttributes
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $name,
+        public CyclicNode|null $next = null,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithDeeplyNestedAttributes.php
+++ b/tests/src/Stubs/WithDeeplyNestedAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithDeeplyNestedAttributes
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $name,
+        public Nested $nested,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithExplicitAttributesOnNested.php
+++ b/tests/src/Stubs/WithExplicitAttributesOnNested.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithExplicitAttributesOnNested
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $name,
+        #[Rule\Attributes]
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithIntersectionTypeNested.php
+++ b/tests/src/Stubs/WithIntersectionTypeNested.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithIntersectionTypeNested
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $name,
+        public NestedWithAttributes&Nested $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithNestedAttributes.php
+++ b/tests/src/Stubs/WithNestedAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithNestedAttributes
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $name,
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithNestedWithoutAttributes.php
+++ b/tests/src/Stubs/WithNestedWithoutAttributes.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithNestedWithoutAttributes
+{
+    public function __construct(
+        #[Rule\StringType]
+        public string $name,
+        public NestedWithoutAttributes $nested,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithNullableNestedAttributes.php
+++ b/tests/src/Stubs/WithNullableNestedAttributes.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithNullableNestedAttributes
+{
+    public function __construct(
+        #[Rule\StringType]
+        public string $name,
+        public NestedAddress|null $address = null,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithUnionTypeNested.php
+++ b/tests/src/Stubs/WithUnionTypeNested.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithUnionTypeNested
+{
+    public function __construct(
+        #[Rule\StringType]
+        #[Rule\Not(new Rule\Undef())]
+        public string $name,
+        public string|NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/unit/Validators/AttributesTest.php
+++ b/tests/unit/Validators/AttributesTest.php
@@ -15,7 +15,21 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Validation\Test\Stubs\CyclicNode;
+use Respect\Validation\Test\Stubs\NestedAddress;
+use Respect\Validation\Test\Stubs\NestedPassThrough;
+use Respect\Validation\Test\Stubs\NestedValidated;
+use Respect\Validation\Test\Stubs\NestedWithAttributes;
+use Respect\Validation\Test\Stubs\NestedWithoutAttributes;
 use Respect\Validation\Test\Stubs\WithAttributes;
+use Respect\Validation\Test\Stubs\WithCyclicAttributes;
+use Respect\Validation\Test\Stubs\WithDeeplyNestedAttributes;
+use Respect\Validation\Test\Stubs\WithExplicitAttributesOnNested;
+use Respect\Validation\Test\Stubs\WithIntersectionTypeNested;
+use Respect\Validation\Test\Stubs\WithNestedAttributes;
+use Respect\Validation\Test\Stubs\WithNestedWithoutAttributes;
+use Respect\Validation\Test\Stubs\WithNullableNestedAttributes;
+use Respect\Validation\Test\Stubs\WithUnionTypeNested;
 use Respect\Validation\Test\TestCase;
 
 #[Group(' rule')]
@@ -78,5 +92,175 @@ final class AttributesTest extends TestCase
             [new WithAttributes('John Doe', 'not a date', 'john.doe@gmail.com', '+1234567890')],
             [new WithAttributes('John Doe', '1912-06-23', 'john.doe@gmail.com', 'not a phone number')],
         ];
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateNestedObjectsWithAttributes(): void
+    {
+        $validAddress = new NestedAddress('123 Main St', 'Springfield');
+        $input = new WithNestedAttributes('John Doe', $validAddress);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateNestedObjectsWithInvalidValues(): void
+    {
+        $invalidAddress = new NestedAddress('', 'not a city');
+        $input = new WithNestedAttributes('John Doe', $invalidAddress);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateNestedObjectPropertyFails(): void
+    {
+        $invalidAddress = new NestedAddress('123 Main St', '');
+        $input = new WithNestedAttributes('John Doe', $invalidAddress);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldNotRecursivelyValidateNestedObjectsWithoutAttributes(): void
+    {
+        $nested = new NestedWithoutAttributes('anything');
+        $input = new WithNestedWithoutAttributes('John Doe', $nested);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldHandleNullableNestedObjectsWhenNull(): void
+    {
+        $input = new WithNullableNestedAttributes('John Doe', null);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldHandleNullableNestedObjectsWhenValid(): void
+    {
+        $validAddress = new NestedAddress('123 Main St', 'Springfield');
+        $input = new WithNullableNestedAttributes('John Doe', $validAddress);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldHandleNullableNestedObjectsWhenInvalid(): void
+    {
+        $invalidAddress = new NestedAddress('', '');
+        $input = new WithNullableNestedAttributes('John Doe', $invalidAddress);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldValidateDeeplyNestedSkippingEmptyLevels(): void
+    {
+        $leaf = new NestedValidated('hello');
+        $middle = new NestedPassThrough($leaf);
+        $top = new NestedPassThrough($middle);
+        $input = new WithDeeplyNestedAttributes('John Doe', $top);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldInvalidateDeeplyNestedSkippingEmptyLevels(): void
+    {
+        $leaf = new NestedValidated('');
+        $middle = new NestedPassThrough($leaf);
+        $top = new NestedPassThrough($middle);
+        $input = new WithDeeplyNestedAttributes('John Doe', $top);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateUnionTypeNestedWhenValid(): void
+    {
+        $input = new WithUnionTypeNested('John Doe', '123 Main St');
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateUnionTypeNestedWhenValidNestedAttributes(): void
+    {
+        $validAddress = new NestedAddress('123 Main St', 'Springfield');
+        $input = new WithUnionTypeNested('John Doe', $validAddress);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateUnionTypeNestedWhenInvalid(): void
+    {
+        $invalidAddress = new NestedAddress('', '');
+        $input = new WithUnionTypeNested('John Doe', $invalidAddress);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateIntersectionTypeNestedWhenValid(): void
+    {
+        $validAddress = new NestedWithAttributes('123 Main St', 'Springfield');
+        $input = new WithIntersectionTypeNested('John Doe', $validAddress);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateIntersectionTypeNestedWhenInvalid(): void
+    {
+        $invalidAddress = new NestedWithAttributes('', '');
+        $input = new WithIntersectionTypeNested('John Doe', $invalidAddress);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldValidateNestedObjectWithExplicitAttributesWhenValid(): void
+    {
+        $validAddress = new NestedAddress('123 Main St', 'Springfield');
+        $input = new WithExplicitAttributesOnNested('John Doe', $validAddress);
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldValidateNestedObjectWithExplicitAttributesWhenInvalid(): void
+    {
+        $invalidAddress = new NestedAddress('', '');
+        $input = new WithExplicitAttributesOnNested('John Doe', $invalidAddress);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRejectSelfReferencingCyclicObjectGraph(): void
+    {
+        $node = new CyclicNode('hello');
+        $node->next = $node;
+
+        $input = new WithCyclicAttributes('John Doe', $node);
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRejectMutualCyclicObjectGraph(): void
+    {
+        $nodeA = new CyclicNode('hello');
+        $nodeB = new CyclicNode('world');
+        $nodeA->next = $nodeB;
+        $nodeB->next = $nodeA;
+
+        $input = new WithCyclicAttributes('John Doe', $nodeA);
+
+        self::assertInvalidInput(new Attributes(), $input);
     }
 }


### PR DESCRIPTION
Previously, Attributes only validated PHP attributes directly on the object's own properties and class. If a property held another object with its own validation attributes, you had to explicitly annotate that property with #[Attributes] — otherwise the nested object's constraints were silently ignored.

This was unintuitive: defining #[Email] on Address::$email and then using Address as a property type did nothing unless you also remembered to add #[Attributes] on the property declaration.

Now, when a property's type is a non-builtin class, Attributes automatically creates a recursive validator for it. This mirrors the expectation that validation should follow the object graph. The recursive check only applies when no explicit #[Attributes] is already present on the property, avoiding double-validation. Nullable types (?Address) are handled by the existing NullOr wrapper.

