### PR TITLE
Extract PropertyResolver strategy

### DIFF
--- a/docs/validators/Attributes.md
+++ b/docs/validators/Attributes.md
@@ -8,7 +8,11 @@ SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
 # Attributes
 
 - `Attributes()`
+<<<<<<< HEAD
 - `Attributes(Resolver $resolver)`
+=======
+- `Attributes(PropertyResolver $propertyResolver)`
+>>>>>>> f2ab556e (Extract PropertyResolver strategy)
 
 Validates the PHP attributes defined in the properties of the input.
 

--- a/src-dev/Commands/LintMixinCommand.php
+++ b/src-dev/Commands/LintMixinCommand.php
@@ -22,6 +22,7 @@ use Respect\FluentGen\NamespaceScanner;
 use Respect\Validation\Mixins\Chain;
 use Respect\Validation\Validator;
 use Respect\Validation\ValidatorBuilder;
+use Respect\Validation\Validators\Attributes\PropertyResolver;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -75,7 +76,7 @@ final class LintMixinCommand extends Command
             scanner: $scanner,
             methodBuilder: new MethodBuilder(
                 excludedTypePrefixes: ['Sokil', 'Egulias', 'Ramsey', 'libphonenumber'],
-                excludedTypeNames: ['Respect\\Parameter\\Resolver'],
+                excludedTypeNames: ['finfo', PropertyResolver::class],
             ),
             interfaces: [
                 new InterfaceConfig(

--- a/src/Validators/Attributes.php
+++ b/src/Validators/Attributes.php
@@ -28,8 +28,7 @@ use Respect\Validation\Validators\Attributes\DeclaredTypePropertyResolver;
 use Respect\Validation\Validators\Attributes\ExplicitAttributePropertyResolver;
 use Respect\Validation\Validators\Attributes\PropertyResolver;
 use Respect\Validation\Validators\Core\Reducer;
-
-use function spl_object_id;
+use WeakMap;
 
 #[Composable(without: [All::class, Key::class, Property::class, Not::class, UndefOr::class])]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
@@ -42,8 +41,8 @@ final class Attributes implements Validator
 {
     public const string TEMPLATE_CIRCULAR_REFERENCE = '__circular_reference__';
 
-    /** @var array<int, true> */
-    private array $visited = [];
+    /** @var WeakMap<object, true> */
+    private WeakMap $visited;
 
     private readonly PropertyResolver $propertyResolver;
 
@@ -54,6 +53,7 @@ final class Attributes implements Validator
             new ExplicitAttributePropertyResolver(new BypassResolver()),
             new DeclaredTypePropertyResolver(),
         );
+        $this->visited = new WeakMap();
     }
 
     public function evaluate(mixed $input): Result
@@ -64,12 +64,11 @@ final class Attributes implements Validator
             return $objectType->withId($id);
         }
 
-        $objectId = spl_object_id($input);
-        if (isset($this->visited[$objectId])) {
+        if ($this->visited->offsetExists($input)) {
             return Result::failed($input, $this, [], self::TEMPLATE_CIRCULAR_REFERENCE)->withId($id);
         }
 
-        $this->visited[$objectId] = true;
+        $this->visited[$input] = true;
 
         $reflection = new ReflectionObject($input);
         $validators = [...$this->getClassValidators($reflection), ...$this->getPropertyValidators($reflection)];
@@ -127,5 +126,16 @@ final class Attributes implements Validator
         }
 
         return $properties;
+    }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        return ['propertyResolver'];
+    }
+
+    public function __wakeup(): void
+    {
+        $this->visited = new WeakMap();
     }
 }

--- a/src/Validators/Attributes.php
+++ b/src/Validators/Attributes.php
@@ -15,17 +15,18 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use ReflectionAttribute;
 use ReflectionClass;
-use ReflectionIntersectionType;
-use ReflectionNamedType;
 use ReflectionObject;
 use ReflectionProperty;
-use ReflectionUnionType;
 use Respect\Fluent\Attributes\Composable;
-use Respect\Parameter\Resolver;
 use Respect\Validation\Id;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
+use Respect\Validation\Validators\Attributes\BypassResolver;
+use Respect\Validation\Validators\Attributes\CompositePropertyResolver;
+use Respect\Validation\Validators\Attributes\DeclaredTypePropertyResolver;
+use Respect\Validation\Validators\Attributes\ExplicitAttributePropertyResolver;
+use Respect\Validation\Validators\Attributes\PropertyResolver;
 use Respect\Validation\Validators\Core\Reducer;
 
 use function spl_object_id;
@@ -44,8 +45,15 @@ final class Attributes implements Validator
     /** @var array<int, true> */
     private array $visited = [];
 
-    public function __construct(private readonly Resolver|null $resolver = null)
-    {
+    private readonly PropertyResolver $propertyResolver;
+
+    public function __construct(
+        PropertyResolver|null $propertyResolver = null,
+    ) {
+        $this->propertyResolver = $propertyResolver ?? new CompositePropertyResolver(
+            new ExplicitAttributePropertyResolver(new BypassResolver()),
+            new DeclaredTypePropertyResolver(),
+        );
     }
 
     public function evaluate(mixed $input): Result
@@ -78,7 +86,7 @@ final class Attributes implements Validator
         $validators = [];
         while ($reflection instanceof ReflectionClass) {
             foreach ($reflection->getAttributes(Validator::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-                $validators[] = $this->instantiateAttribute($attribute);
+                $validators[] = $attribute->newInstance();
             }
 
             $reflection = $reflection->getParentClass();
@@ -92,7 +100,7 @@ final class Attributes implements Validator
     {
         $validators = [];
         foreach ($this->getProperties($reflection) as $propertyName => $property) {
-            $propertyValidators = $this->getPropertyInnerValidators($property);
+            $propertyValidators = $this->propertyResolver->resolve($property, $this);
             if ($propertyValidators === []) {
                 continue;
             }
@@ -104,52 +112,6 @@ final class Attributes implements Validator
         }
 
         return $validators;
-    }
-
-    /** @return array<Validator> */
-    private function getPropertyInnerValidators(ReflectionProperty $property): array
-    {
-        $propertyValidators = [];
-        $hasExplicitAttributes = false;
-        foreach ($property->getAttributes(Validator::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-            if ($attribute->getName() === self::class) {
-                $propertyValidator = $this;
-            } else {
-                $propertyValidator = $this->instantiateAttribute($attribute);
-            }
-
-            $hasExplicitAttributes = $hasExplicitAttributes || $propertyValidator === $this;
-            $propertyValidators[] = $propertyValidator;
-        }
-
-        if ($hasExplicitAttributes) {
-            return $propertyValidators;
-        }
-
-        $type = $property->getType();
-        if ($type instanceof ReflectionNamedType) {
-            if (!$type->isBuiltin()) {
-                $propertyValidators[] = $this;
-            }
-        }
-
-        if ($type instanceof ReflectionIntersectionType) {
-            $propertyValidators[] = $this;
-        }
-
-        if ($type instanceof ReflectionUnionType) {
-            foreach ($type->getTypes() as $innerType) {
-                if (!$innerType instanceof ReflectionNamedType || $innerType->isBuiltin()) {
-                    continue;
-                }
-
-                /** @var class-string $class */
-                $class = $innerType->getName();
-                $propertyValidators[] = new Given(new Instance($class), $this);
-            }
-        }
-
-        return $propertyValidators;
     }
 
     /** @return array<ReflectionProperty> */
@@ -165,21 +127,5 @@ final class Attributes implements Validator
         }
 
         return $properties;
-    }
-
-    /** @param ReflectionAttribute<Validator> $attribute */
-    private function instantiateAttribute(ReflectionAttribute $attribute): Validator
-    {
-        if ($this->resolver === null) {
-            return $attribute->newInstance();
-        }
-
-        $reflection = new ReflectionClass($attribute->getName());
-        $constructor = $reflection->getConstructor();
-        if ($constructor === null) {
-            return $attribute->newInstance();
-        }
-
-        return $reflection->newInstanceArgs($this->resolver->resolve($constructor, $attribute->getArguments()));
     }
 }

--- a/src/Validators/Attributes/BypassResolver.php
+++ b/src/Validators/Attributes/BypassResolver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Respect\Validation\Validators\Attributes;
+
+use ReflectionFunctionAbstract;
+use Respect\Parameter\Resolver;
+
+final class BypassResolver implements Resolver
+{
+    public function resolve(ReflectionFunctionAbstract $reflection, array $arguments): array
+    {
+        return $arguments;
+    }
+}

--- a/src/Validators/Attributes/CompositePropertyResolver.php
+++ b/src/Validators/Attributes/CompositePropertyResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use ReflectionProperty;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\Attributes;
+
+use function array_values;
+use function in_array;
+
+final class CompositePropertyResolver implements PropertyResolver
+{
+    /** @var list<PropertyResolver> */
+    private readonly array $resolvers;
+
+    public function __construct(PropertyResolver ...$resolvers)
+    {
+        $this->resolvers = array_values($resolvers);
+    }
+
+    /** @return array<Validator> */
+    public function resolve(ReflectionProperty $property, Attributes $attributes): array
+    {
+        $accumulated = [];
+
+        foreach ($this->resolvers as $resolver) {
+            $validators = $resolver->resolve($property, $attributes);
+            if ($validators === []) {
+                continue;
+            }
+
+            // When more than one resolver recognizes the same property (e.g. a
+            // class-typed property annotated with #[Attributes], which both
+            // DeclaredTypePropertyResolver and ExplicitAttributePropertyResolver
+            // emit `$attributes` for), collapse duplicate `$attributes` entries
+            // so the nested Attributes validator runs once instead of tripping
+            // its circular-reference guard on the second pass.
+            foreach ($validators as $validator) {
+                if ($validator === $attributes && in_array($validator, $accumulated, true)) {
+                    continue;
+                }
+
+                $accumulated[] = $validator;
+            }
+        }
+
+        return $accumulated;
+    }
+}

--- a/src/Validators/Attributes/DeclaredTypePropertyResolver.php
+++ b/src/Validators/Attributes/DeclaredTypePropertyResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionProperty;
+use ReflectionUnionType;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\Attributes;
+use Respect\Validation\Validators\Given;
+use Respect\Validation\Validators\Instance;
+
+final class DeclaredTypePropertyResolver implements PropertyResolver
+{
+    /** @return array<Validator> */
+    public function resolve(ReflectionProperty $property, Attributes $attributes): array
+    {
+        $type = $property->getType();
+
+        if ($type instanceof ReflectionNamedType) {
+            if ($type->isBuiltin()) {
+                return [];
+            }
+
+            return [$attributes];
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            return [$attributes];
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            $validators = [];
+            foreach ($type->getTypes() as $innerType) {
+                if (!$innerType instanceof ReflectionNamedType || $innerType->isBuiltin()) {
+                    continue;
+                }
+
+                /** @var class-string $class */
+                $class = $innerType->getName();
+                $validators[] = new Given(new Instance($class), $attributes);
+            }
+
+            return $validators;
+        }
+
+        return [];
+    }
+}

--- a/src/Validators/Attributes/ExplicitAttributePropertyResolver.php
+++ b/src/Validators/Attributes/ExplicitAttributePropertyResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionProperty;
+use Respect\Parameter\Resolver;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\Attributes;
+
+final class ExplicitAttributePropertyResolver implements PropertyResolver
+{
+    public function __construct(
+        private readonly Resolver $resolver,
+    ) {
+    }
+
+    /** @return array<Validator> */
+    public function resolve(ReflectionProperty $property, Attributes $attributes): array
+    {
+        $validators = [];
+        foreach ($property->getAttributes(Validator::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $propertyValidator = $this->toValidator($attribute, $attributes);
+            $validators[] = $propertyValidator;
+        }
+
+        return $validators;
+    }
+
+    private function toValidator(ReflectionAttribute $attribute, Attributes $attributes): Validator
+    {
+        /** @var class-string<Validator> $name */
+        $name = $attribute->getName();
+        if ($name === Attributes::class) {
+            return $attributes;
+        }
+
+        $reflection = new ReflectionClass($name);
+        $constructor = $reflection->getConstructor();
+        if ($constructor === null) {
+            return $attribute->newInstance();
+        }
+
+        return $reflection->newInstanceArgs($this->resolver->resolve($constructor, $attribute->getArguments()));
+    }
+}

--- a/src/Validators/Attributes/PropertyResolver.php
+++ b/src/Validators/Attributes/PropertyResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use ReflectionProperty;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\Attributes;
+
+/**
+ * Resolves validators from properties.
+ */
+interface PropertyResolver
+{
+    /** @return array<Validator> */
+    public function resolve(ReflectionProperty $property, Attributes $attributes): array;
+}

--- a/tests/src/Stubs/StubPropertyResolver.php
+++ b/tests/src/Stubs/StubPropertyResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use ReflectionProperty;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\Attributes;
+use Respect\Validation\Validators\Attributes\PropertyResolver;
+
+use function array_values;
+
+final class StubPropertyResolver implements PropertyResolver
+{
+    /** @var list<Validator> */
+    private readonly array $validators;
+
+    public function __construct(Validator ...$validators)
+    {
+        $this->validators = array_values($validators);
+    }
+
+    /** @return list<Validator> */
+    public function resolve(ReflectionProperty $property, Attributes $attributes): array
+    {
+        return $this->validators;
+    }
+}

--- a/tests/src/Stubs/WithClassTypedProperty.php
+++ b/tests/src/Stubs/WithClassTypedProperty.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithClassTypedProperty
+{
+    public function __construct(
+        public NestedAddress $value,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithExplicitAttributesAttributeProperty.php
+++ b/tests/src/Stubs/WithExplicitAttributesAttributeProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithExplicitAttributesAttributeProperty
+{
+    public function __construct(
+        #[Rule\Attributes]
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithExplicitStringTypeProperty.php
+++ b/tests/src/Stubs/WithExplicitStringTypeProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithExplicitStringTypeProperty
+{
+    public function __construct(
+        #[Rule\StringType]
+        public string $name,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithMixedProperty.php
+++ b/tests/src/Stubs/WithMixedProperty.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithMixedProperty
+{
+    public mixed $value;
+}

--- a/tests/src/Stubs/WithNoValidatorAttributes.php
+++ b/tests/src/Stubs/WithNoValidatorAttributes.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithNoValidatorAttributes
+{
+    public function __construct(
+        public mixed $value,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithUntypedProperty.php
+++ b/tests/src/Stubs/WithUntypedProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithUntypedProperty
+{
+    /** @phpstan-var array<mixed> */
+    public $value;
+}

--- a/tests/unit/Validators/Attributes/CompositePropertyResolverTest.php
+++ b/tests/unit/Validators/Attributes/CompositePropertyResolverTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Respect\Validation\Test\Stubs\StubPropertyResolver;
+use Respect\Validation\Test\Stubs\WithMixedProperty;
+use Respect\Validation\Test\TestCase;
+use Respect\Validation\Validators\Attributes;
+use Respect\Validation\Validators\IntType;
+use Respect\Validation\Validators\StringType;
+
+#[Group('rule')]
+#[CoversClass(CompositePropertyResolver::class)]
+final class CompositePropertyResolverTest extends TestCase
+{
+    private ReflectionProperty $property;
+
+    private Attributes $attributes;
+
+    protected function setUp(): void
+    {
+        $object = new WithMixedProperty();
+        $this->property = new ReflectionProperty($object::class, 'value');
+        $this->attributes = new Attributes();
+    }
+
+    #[Test]
+    public function shouldReturnEmptyWhenNoResolversProvided(): void
+    {
+        $resolver = new CompositePropertyResolver();
+
+        $result = $resolver->resolve($this->property, $this->attributes);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function shouldReturnEmptyWhenAllResolversReturnEmpty(): void
+    {
+        $empty = new StubPropertyResolver();
+
+        $resolver = new CompositePropertyResolver($empty, $empty);
+
+        $result = $resolver->resolve($this->property, $this->attributes);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function shouldConcatenateResultsFromAllResolvers(): void
+    {
+        $first = new StubPropertyResolver(new StringType());
+        $second = new StubPropertyResolver(new IntType());
+
+        $resolver = new CompositePropertyResolver($first, $second);
+
+        $result = $resolver->resolve($this->property, $this->attributes);
+
+        self::assertCount(2, $result);
+        self::assertInstanceOf(StringType::class, $result[0]);
+        self::assertInstanceOf(IntType::class, $result[1]);
+    }
+
+    #[Test]
+    public function shouldConcatenateAttributesAlongsideOtherValidators(): void
+    {
+        $attributes = $this->attributes;
+
+        $terminal = new StubPropertyResolver($attributes);
+        $other = new StubPropertyResolver(new StringType());
+
+        $resolver = new CompositePropertyResolver($terminal, $other);
+
+        $result = $resolver->resolve($this->property, $attributes);
+
+        self::assertCount(2, $result);
+        self::assertSame($attributes, $result[0]);
+        self::assertInstanceOf(StringType::class, $result[1]);
+    }
+
+    #[Test]
+    public function shouldCollapseDuplicateAttributesAcrossResolvers(): void
+    {
+        $attributes = $this->attributes;
+
+        // Both resolvers emit the same Attributes instance, as happens for a
+        // class-typed property annotated with #[Attributes] (DeclaredType and
+        // ExplicitAttribute each return [$attributes]). The composite must
+        // collapse them so the nested Attributes validator runs only once.
+        $first = new StubPropertyResolver($attributes);
+        $second = new StubPropertyResolver($attributes);
+
+        $resolver = new CompositePropertyResolver($first, $second);
+
+        $result = $resolver->resolve($this->property, $attributes);
+
+        self::assertSame([$attributes], $result);
+    }
+}

--- a/tests/unit/Validators/Attributes/DeclaredTypePropertyResolverTest.php
+++ b/tests/unit/Validators/Attributes/DeclaredTypePropertyResolverTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Respect\Validation\Test\Stubs\NestedAddress;
+use Respect\Validation\Test\Stubs\WithClassTypedProperty;
+use Respect\Validation\Test\Stubs\WithIntersectionTypeNested;
+use Respect\Validation\Test\Stubs\WithUnionTypeNested;
+use Respect\Validation\Test\Stubs\WithUntypedProperty;
+use Respect\Validation\Test\TestCase;
+use Respect\Validation\Validators\Attributes;
+use Respect\Validation\Validators\Given;
+
+use function in_array;
+
+#[Group('rule')]
+#[CoversClass(DeclaredTypePropertyResolver::class)]
+final class DeclaredTypePropertyResolverTest extends TestCase
+{
+    private DeclaredTypePropertyResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new DeclaredTypePropertyResolver();
+    }
+
+    #[Test]
+    public function shouldReturnAttributesForNonBuiltinNamedType(): void
+    {
+        $property = new ReflectionProperty(WithClassTypedProperty::class, 'value');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertCount(1, $result);
+        self::assertSame($attributes, $result[0]);
+    }
+
+    #[Test]
+    public function shouldReturnAttributesForIntersectionType(): void
+    {
+        $property = new ReflectionProperty(WithIntersectionTypeNested::class, 'address');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertCount(1, $result);
+        self::assertSame($attributes, $result[0]);
+    }
+
+    #[Test]
+    public function shouldReturnGivenValidatorsForUnionType(): void
+    {
+        $property = new ReflectionProperty(WithUnionTypeNested::class, 'address');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(Given::class, $result[0]);
+        self::assertFalse(in_array($attributes, $result, true));
+    }
+
+    #[Test]
+    public function shouldReturnEmptyForBuiltinNamedType(): void
+    {
+        $property = new ReflectionProperty(NestedAddress::class, 'street');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function shouldReturnEmptyWhenPropertyHasNoDeclaredType(): void
+    {
+        $property = new ReflectionProperty(WithUntypedProperty::class, 'value');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertSame([], $result);
+    }
+}

--- a/tests/unit/Validators/Attributes/ExplicitAttributePropertyResolverTest.php
+++ b/tests/unit/Validators/Attributes/ExplicitAttributePropertyResolverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Henrique Moody <henriquemoody@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Validators\Attributes;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Respect\Validation\Test\Stubs\WithExplicitAttributesAttributeProperty;
+use Respect\Validation\Test\Stubs\WithExplicitStringTypeProperty;
+use Respect\Validation\Test\Stubs\WithNoValidatorAttributes;
+use Respect\Validation\Test\TestCase;
+use Respect\Validation\Validators\Attributes;
+use Respect\Validation\Validators\StringType;
+
+use function in_array;
+
+#[Group('rule')]
+#[CoversClass(ExplicitAttributePropertyResolver::class)]
+final class ExplicitAttributePropertyResolverTest extends TestCase
+{
+    private ExplicitAttributePropertyResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ExplicitAttributePropertyResolver();
+    }
+
+    #[Test]
+    public function shouldReturnEmptyWhenPropertyHasNoValidatorAttributes(): void
+    {
+        $property = new ReflectionProperty(WithNoValidatorAttributes::class, 'value');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function shouldReturnValidatorWhenPropertyHasSingleValidatorAttribute(): void
+    {
+        $property = new ReflectionProperty(WithExplicitStringTypeProperty::class, 'name');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(StringType::class, $result[0]);
+        self::assertFalse(in_array($attributes, $result, true));
+    }
+
+    #[Test]
+    public function shouldReturnAttributesWhenPropertyHasAttributesAttribute(): void
+    {
+        $property = new ReflectionProperty(WithExplicitAttributesAttributeProperty::class, 'address');
+        $attributes = new Attributes();
+
+        $result = $this->resolver->resolve($property, $attributes);
+
+        self::assertCount(1, $result);
+        self::assertSame($attributes, $result[0]);
+        self::assertTrue(in_array($attributes, $result, true));
+    }
+}


### PR DESCRIPTION
Previously, the resolution of validators from property types and explicit new resolution strategies required editing the class, and a class-typed property annotated with #[Attributes] was validated twice — once by the explicit-attribute branch and again by the declared-type branch — which tripped the circular-reference guard on the second pass.

This commit moves that responsibility to a dedicated PropertyResolver interface with composable implementations, so each strategy can be developed and composed independently. The composite collapses duplicate Attributes entries, ensuring each property is validated exactly once even when multiple resolution paths produce the same instance. The Attributes class is reduced to its single responsibility, and resolver chains become pluggable through the constructor.