### PR TITLE
Add IDE type narrowing to generated validator mixins

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -27,6 +27,7 @@ jobs:
 
       - run: composer phpunit
       - run: composer pest
+      - run: composer inference
 
   code-coverage:
     name: Code Coverage

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "type": "library",
     "homepage": "http://respect.github.io/",
     "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Respect/Validation Contributors",
@@ -23,7 +25,7 @@
         "php": ">=8.5",
         "psr/container": "^2.0",
         "respect/config": "^3.0",
-        "respect/fluent": "^2.0",
+        "respect/fluent": "3.0.x-dev",
         "respect/parameter": "^3.0",
         "respect/string-formatter": "^1.7",
         "respect/stringifier": "^3.0",
@@ -45,7 +47,7 @@
         "psr/http-message": "^1.0 || ^2.0",
         "ramsey/uuid": "^4",
         "respect/coding-standard": "^5.0",
-        "respect/fluentgen": "^2.0",
+        "respect/fluentgen": "2.1.x-dev",
         "sebastian/diff": "^7.0",
         "sokil/php-isocodes": "^4.2.1",
         "sokil/php-isocodes-db-only": "^4.0",
@@ -87,6 +89,7 @@
         "phpcs": "vendor/bin/phpcs",
         "phpstan": "vendor/bin/phpstan analyze",
         "phpunit": "vendor/bin/phpunit --testsuite=unit",
+        "inference": "vendor/bin/phpunit --testsuite=inference",
         "smoke-complete": "bin/console smoke-tests:check-complete",
         "spdx-lint": "bin/console lint:spdx",
         "qa": [
@@ -95,6 +98,7 @@
             "@phpstan",
             "@phpunit",
             "@pest",
+            "@inference",
             "@docs",
             "@smoke-complete"
         ]

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "type": "library",
     "homepage": "http://respect.github.io/",
     "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Respect/Validation Contributors",
@@ -23,7 +25,7 @@
         "php": ">=8.5",
         "psr/container": "^2.0",
         "respect/config": "^3.0",
-        "respect/fluent": "^2.0",
+        "respect/fluent": "^3.0",
         "respect/parameter": "^3.0",
         "respect/string-formatter": "^1.7",
         "respect/stringifier": "^3.0",
@@ -45,7 +47,7 @@
         "psr/http-message": "^1.0 || ^2.0",
         "ramsey/uuid": "^4",
         "respect/coding-standard": "^5.0",
-        "respect/fluentgen": "^2.0",
+        "respect/fluentgen": "^2.1",
         "sebastian/diff": "^7.0",
         "sokil/php-isocodes": "^4.2.1",
         "sokil/php-isocodes-db-only": "^4.0",
@@ -87,6 +89,7 @@
         "phpcs": "vendor/bin/phpcs",
         "phpstan": "vendor/bin/phpstan analyze",
         "phpunit": "vendor/bin/phpunit --testsuite=unit",
+        "inference": "vendor/bin/phpunit --testsuite=inference",
         "smoke-complete": "bin/console smoke-tests:check-complete",
         "spdx-lint": "bin/console lint:spdx",
         "qa": [
@@ -95,6 +98,7 @@
             "@phpstan",
             "@phpunit",
             "@pest",
+            "@inference",
             "@docs",
             "@smoke-complete"
         ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "683a4f0e3e7054eddcef31faf9cc9b1c",
+    "content-hash": "eb09c441327241556e460c98c2728154",
     "packages": [
         {
             "name": "psr/container",
@@ -122,16 +122,16 @@
         },
         {
             "name": "respect/fluent",
-            "version": "2.0.1",
+            "version": "dev-ide-narrowing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Respect/Fluent.git",
-                "reference": "f32c76e37a82a9e63d6fe700a27201534f72da60"
+                "reference": "8469e6e8d30d28f36c0b79a381703ea9b26b0ecd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Respect/Fluent/zipball/f32c76e37a82a9e63d6fe700a27201534f72da60",
-                "reference": "f32c76e37a82a9e63d6fe700a27201534f72da60",
+                "url": "https://api.github.com/repos/Respect/Fluent/zipball/8469e6e8d30d28f36c0b79a381703ea9b26b0ecd",
+                "reference": "8469e6e8d30d28f36c0b79a381703ea9b26b0ecd",
                 "shasum": ""
             },
             "require": {
@@ -142,10 +142,15 @@
                 "phpstan/phpstan-deprecation-rules": "^2.0",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^12.5",
+                "phpunit/phpunit": "^12.5 || ^13.0",
                 "respect/coding-standard": "^5.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-ide-narrowing": "3.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Respect\\Fluent\\": "src/"
@@ -169,9 +174,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Respect/Fluent/issues",
-                "source": "https://github.com/Respect/Fluent/tree/2.0.1"
+                "source": "https://github.com/Respect/Fluent/tree/ide-narrowing"
             },
-            "time": "2026-03-26T04:24:51+00:00"
+            "time": "2026-06-26T19:36:25+00:00"
         },
         {
             "name": "respect/parameter",
@@ -2191,16 +2196,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.7.3",
+            "version": "v4.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "87882a8561bf3ddf230b9a6b764f367f687d5b2f"
+                "reference": "ee2e97e932d158faceeaa63a4dc17324b15152cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/87882a8561bf3ddf230b9a6b764f367f687d5b2f",
-                "reference": "87882a8561bf3ddf230b9a6b764f367f687d5b2f",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ee2e97e932d158faceeaa63a4dc17324b15152cb",
+                "reference": "ee2e97e932d158faceeaa63a4dc17324b15152cb",
                 "shasum": ""
             },
             "require": {
@@ -2213,12 +2218,12 @@
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.29",
+                "phpunit/phpunit": "^12.5.30",
                 "symfony/process": "^7.4.13|^8.1.0"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.29",
+                "phpunit/phpunit": ">12.5.30",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
@@ -2294,7 +2299,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.7.3"
+                "source": "https://github.com/pestphp/pest/tree/v4.7.4"
             },
             "funding": [
                 {
@@ -2306,7 +2311,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-12T05:57:27+00:00"
+            "time": "2026-06-25T19:09:05+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -3636,16 +3641,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.29",
+            "version": "12.5.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a"
+                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9aa66a47db3ea70f1a468e66dd969f67e594945a",
-                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/900400a5b616d6fb306f9549f6da33ba615d3fbb",
+                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb",
                 "shasum": ""
             },
             "require": {
@@ -3714,7 +3719,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.30"
             },
             "funding": [
                 {
@@ -3722,7 +3727,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-06-04T06:14:42+00:00"
+            "time": "2026-06-15T13:12:30+00:00"
         },
         {
             "name": "psr/cache",
@@ -4126,16 +4131,16 @@
         },
         {
             "name": "respect/fluentgen",
-            "version": "2.0.0",
+            "version": "dev-ide-narrowing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Respect/FluentGen.git",
-                "reference": "6a9065516f403c5f5abc86646290bd08e44c538e"
+                "reference": "518208d2a690ad0229c05ae6f001348dc6936da0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Respect/FluentGen/zipball/6a9065516f403c5f5abc86646290bd08e44c538e",
-                "reference": "6a9065516f403c5f5abc86646290bd08e44c538e",
+                "url": "https://api.github.com/repos/Respect/FluentGen/zipball/518208d2a690ad0229c05ae6f001348dc6936da0",
+                "reference": "518208d2a690ad0229c05ae6f001348dc6936da0",
                 "shasum": ""
             },
             "require": {
@@ -4148,12 +4153,17 @@
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^12.5",
                 "respect/coding-standard": "^5.0",
-                "respect/fluent": "^2.0"
+                "respect/fluent": "3.0.x-dev"
             },
             "suggest": {
                 "respect/fluent": "Enables #[Composable] prefix composition support"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-ide-narrowing": "2.1.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Respect\\FluentGen\\": "src/"
@@ -4178,9 +4188,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Respect/FluentGen/issues",
-                "source": "https://github.com/Respect/FluentGen/tree/2.0.0"
+                "source": "https://github.com/Respect/FluentGen/tree/ide-narrowing"
             },
-            "time": "2026-03-25T05:50:09+00:00"
+            "time": "2026-06-26T19:40:15+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6809,9 +6819,12 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {},
-    "prefer-stable": false,
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "respect/fluent": 20,
+        "respect/fluentgen": 20
+    },
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "683a4f0e3e7054eddcef31faf9cc9b1c",
+    "content-hash": "d57824f9167d942373052be175b0c72f",
     "packages": [
         {
             "name": "psr/container",
@@ -122,16 +122,16 @@
         },
         {
             "name": "respect/fluent",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Respect/Fluent.git",
-                "reference": "f32c76e37a82a9e63d6fe700a27201534f72da60"
+                "reference": "a77c71d05c59f082459c29503c0190e6e26c68f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Respect/Fluent/zipball/f32c76e37a82a9e63d6fe700a27201534f72da60",
-                "reference": "f32c76e37a82a9e63d6fe700a27201534f72da60",
+                "url": "https://api.github.com/repos/Respect/Fluent/zipball/a77c71d05c59f082459c29503c0190e6e26c68f9",
+                "reference": "a77c71d05c59f082459c29503c0190e6e26c68f9",
                 "shasum": ""
             },
             "require": {
@@ -142,7 +142,7 @@
                 "phpstan/phpstan-deprecation-rules": "^2.0",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^12.5",
+                "phpunit/phpunit": "^12.5 || ^13.0",
                 "respect/coding-standard": "^5.0"
             },
             "type": "library",
@@ -169,9 +169,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Respect/Fluent/issues",
-                "source": "https://github.com/Respect/Fluent/tree/2.0.1"
+                "source": "https://github.com/Respect/Fluent/tree/3.0.0"
             },
-            "time": "2026-03-26T04:24:51+00:00"
+            "time": "2026-09-05T17:11:56+00:00"
         },
         {
             "name": "respect/parameter",
@@ -1535,16 +1535,16 @@
         },
         {
             "name": "giggsey/libphonenumber-for-php-lite",
-            "version": "9.0.37",
+            "version": "9.0.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php-lite.git",
-                "reference": "8e2514898587995033a4425683e32674f2073e1d"
+                "reference": "a165edb4765b39abc4f4af3bde9ed3b5f9690384"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/8e2514898587995033a4425683e32674f2073e1d",
-                "reference": "8e2514898587995033a4425683e32674f2073e1d",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/a165edb4765b39abc4f4af3bde9ed3b5f9690384",
+                "reference": "a165edb4765b39abc4f4af3bde9ed3b5f9690384",
                 "shasum": ""
             },
             "require": {
@@ -1609,7 +1609,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php-lite/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php-lite"
             },
-            "time": "2026-08-15T20:02:37+00:00"
+            "time": "2026-09-01T10:41:38+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -1725,20 +1725,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -1773,15 +1773,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nette/php-generator",
@@ -1859,16 +1859,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -1888,7 +1888,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -1944,9 +1944,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2007,23 +2007,23 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.9.4",
+            "version": "v8.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "716af8f95a470e9094cfca09ed897b023be191a5"
+                "reference": "fb53eacd509a1d303858e2d20cfebf2d630254ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/716af8f95a470e9094cfca09ed897b023be191a5",
-                "reference": "716af8f95a470e9094cfca09ed897b023be191a5",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/fb53eacd509a1d303858e2d20cfebf2d630254ec",
+                "reference": "fb53eacd509a1d303858e2d20cfebf2d630254ec",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.18.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.4.8 || ^8.0.8"
+                "symfony/console": "^7.4.14 || ^8.1.1"
             },
             "conflict": {
                 "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -2031,12 +2031,12 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.5",
-                "larastan/larastan": "^3.9.6",
-                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
-                "laravel/pint": "^1.29.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
-                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
+                "larastan/larastan": "^3.10.0",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.20.0",
+                "laravel/pint": "^1.29.3",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.3.5",
+                "pestphp/pest": "^3.8.5 || ^4.7.5 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.1.2 || ^9.3.2"
             },
             "type": "library",
             "extra": {
@@ -2099,7 +2099,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-04-21T14:04:20+00:00"
+            "time": "2026-07-15T19:09:14+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -2190,39 +2190,39 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.7.5",
+            "version": "v4.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "5dc49a71d63602a9b98fed0f2017c4679ef9f8e0"
+                "reference": "5b2293f67adcf1b2320b33f521b94a692d18f360"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/5dc49a71d63602a9b98fed0f2017c4679ef9f8e0",
-                "reference": "5dc49a71d63602a9b98fed0f2017c4679ef9f8e0",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/5b2293f67adcf1b2320b33f521b94a692d18f360",
+                "reference": "5b2293f67adcf1b2320b33f521b94a692d18f360",
                 "shasum": ""
             },
             "require": {
                 "brianium/paratest": "^7.20.0",
                 "composer/xdebug-handler": "^3.0.5",
-                "nunomaduro/collision": "^8.9.4",
+                "nunomaduro/collision": "^8.9.5",
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^4.0.0",
                 "pestphp/pest-plugin-arch": "^4.0.2",
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.30",
+                "phpunit/phpunit": "^12.5.33",
                 "symfony/process": "^7.4.13|^8.1.0"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.30",
+                "phpunit/phpunit": ">12.5.33",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
-                "mrpunyapal/peststan": "^0.2.11",
+                "mrpunyapal/peststan": "^0.2.12",
                 "pestphp/pest-dev-tools": "^4.1.0",
                 "pestphp/pest-plugin-browser": "^4.3.1",
                 "pestphp/pest-plugin-type-coverage": "^4.0.4",
@@ -2253,7 +2253,6 @@
                         "Pest\\Plugins\\Verbose",
                         "Pest\\Plugins\\Version",
                         "Pest\\Plugins\\Shard",
-                        "Pest\\Plugins\\Tia",
                         "Pest\\Plugins\\Parallel"
                     ]
                 },
@@ -2293,7 +2292,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.7.5"
+                "source": "https://github.com/pestphp/pest/tree/v4.7.8"
             },
             "funding": [
                 {
@@ -2305,7 +2304,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-06T17:06:29+00:00"
+            "time": "2026-08-03T20:49:44+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -3073,16 +3072,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.3",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+                "reference": "148cefffaf0233e4c08cc13db8a195a56dd6dfe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/148cefffaf0233e4c08cc13db8a195a56dd6dfe9",
+                "reference": "148cefffaf0233e4c08cc13db8a195a56dd6dfe9",
                 "shasum": ""
             },
             "require": {
@@ -3114,17 +3113,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.5"
             },
-            "time": "2026-07-08T07:01:06+00:00"
+            "time": "2026-08-31T16:05:28+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.10",
+            "version": "2.2.13",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36d1509c998b0602811824143526b4a9ee2774e7",
-                "reference": "36d1509c998b0602811824143526b4a9ee2774e7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
+                "reference": "9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
                 "shasum": ""
             },
             "require": {
@@ -3180,7 +3179,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-30T12:46:16+00:00"
+            "time": "2026-09-03T20:38:19+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -3381,23 +3380,23 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
+                "reference": "a248d1640ab059b075f53a2ef0f9856e864e06b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a248d1640ab059b075f53a2ef0f9856e864e06b5",
+                "reference": "a248d1640ab059b075f53a2ef0f9856e864e06b5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.5.33"
             },
             "type": "library",
             "extra": {
@@ -3430,7 +3429,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.2"
             },
             "funding": [
                 {
@@ -3450,7 +3449,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T14:04:18+00:00"
+            "time": "2026-08-25T14:40:53+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -3638,24 +3637,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.30",
+            "version": "12.5.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb"
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/900400a5b616d6fb306f9549f6da33ba615d3fbb",
-                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -3716,7 +3715,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.30"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.33"
             },
             "funding": [
                 {
@@ -3724,7 +3723,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-06-15T13:12:30+00:00"
+            "time": "2026-07-28T13:58:09+00:00"
         },
         {
             "name": "psr/cache",
@@ -4128,16 +4127,16 @@
         },
         {
             "name": "respect/fluentgen",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Respect/FluentGen.git",
-                "reference": "6a9065516f403c5f5abc86646290bd08e44c538e"
+                "reference": "4bed557a2ca6266e42e8953624bcb8f337843542"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Respect/FluentGen/zipball/6a9065516f403c5f5abc86646290bd08e44c538e",
-                "reference": "6a9065516f403c5f5abc86646290bd08e44c538e",
+                "url": "https://api.github.com/repos/Respect/FluentGen/zipball/4bed557a2ca6266e42e8953624bcb8f337843542",
+                "reference": "4bed557a2ca6266e42e8953624bcb8f337843542",
                 "shasum": ""
             },
             "require": {
@@ -4148,9 +4147,9 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-deprecation-rules": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^12.5",
+                "phpunit/phpunit": "^12.5 || ^13.0",
                 "respect/coding-standard": "^5.0",
-                "respect/fluent": "^2.0"
+                "respect/fluent": "^3.0"
             },
             "suggest": {
                 "respect/fluent": "Enables #[Composable] prefix composition support"
@@ -4180,9 +4179,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Respect/FluentGen/issues",
-                "source": "https://github.com/Respect/FluentGen/tree/2.0.0"
+                "source": "https://github.com/Respect/FluentGen/tree/2.1.0"
             },
-            "time": "2026-03-25T05:50:09+00:00"
+            "time": "2026-09-05T17:14:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4405,24 +4404,24 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+                "reference": "cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6",
+                "reference": "cd4cabe39f8a4e8ee6818ba99f10a05561ea4ad6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
+                "phpunit/phpunit": "^12.5.33",
+                "symfony/process": "^7.4.17"
             },
             "type": "library",
             "extra": {
@@ -4460,15 +4459,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:46+00:00"
+            "time": "2026-08-25T15:35:54+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5159,32 +5170,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.29.0",
+            "version": "8.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
+                "reference": "0a40807a48873948bfa7ffce2a4e69ba40cf5e76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
-                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/0a40807a48873948bfa7ffce2a4e69ba40cf5e76",
+                "reference": "0a40807a48873948bfa7ffce2a4e69ba40cf5e76",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpdoc-parser": "^2.3.2",
+                "phpstan/phpdoc-parser": "^2.3.3",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.54",
-                "phpstan/phpstan-deprecation-rules": "2.0.4",
-                "phpstan/phpstan-phpunit": "2.0.16",
-                "phpstan/phpstan-strict-rules": "2.0.11",
-                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
+                "phpstan/phpstan": "2.2.7",
+                "phpstan/phpstan-deprecation-rules": "2.0.5",
+                "phpstan/phpstan-phpunit": "2.0.18",
+                "phpstan/phpstan-strict-rules": "2.0.12",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.56|12.5.33"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5208,7 +5219,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.31.1"
             },
             "funding": [
                 {
@@ -5220,7 +5231,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-07T05:48:08+00:00"
+            "time": "2026-07-31T10:42:43+00:00"
         },
         {
             "name": "sokil/php-isocodes",
@@ -5632,16 +5643,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.1.0",
+            "version": "v8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
+                "reference": "7599ebb855fede59413ddb7f15198d67bfcae7ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7599ebb855fede59413ddb7f15198d67bfcae7ba",
+                "reference": "7599ebb855fede59413ddb7f15198d67bfcae7ba",
                 "shasum": ""
             },
             "require": {
@@ -5679,7 +5690,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.6"
             },
             "funding": [
                 {
@@ -5699,20 +5710,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-08-23T10:06:25+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v8.1.1",
+            "version": "v8.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
+                "reference": "8d7acede2b2ae07605783d1c43e49b5767036474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
-                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8d7acede2b2ae07605783d1c43e49b5767036474",
+                "reference": "8d7acede2b2ae07605783d1c43e49b5767036474",
                 "shasum": ""
             },
             "require": {
@@ -5747,7 +5758,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.1.1"
+                "source": "https://github.com/symfony/finder/tree/v8.1.5"
             },
             "funding": [
                 {
@@ -5767,7 +5778,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-27T09:05:56+00:00"
+            "time": "2026-08-21T12:16:08+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -6174,16 +6185,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.1.0",
+            "version": "v8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5"
+                "reference": "d863f5e70d7c87abb906ac11b61f83036093000b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
-                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d863f5e70d7c87abb906ac11b61f83036093000b",
+                "reference": "d863f5e70d7c87abb906ac11b61f83036093000b",
                 "shasum": ""
             },
             "require": {
@@ -6215,7 +6226,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.1.0"
+                "source": "https://github.com/symfony/process/tree/v8.1.6"
             },
             "funding": [
                 {
@@ -6235,7 +6246,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6816,9 +6827,9 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {},
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.5"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,9 @@
     <file>src-dev/</file>
     <file>tests/</file>
 
+    <!-- PHPStan type-inference fixtures: intentional global functions + assertType() calls. -->
+    <exclude-pattern>tests/inference/assertions/*</exclude-pattern>
+
     <rule ref="Respect" />
 
     <!-- Exclusions -->
@@ -27,6 +30,21 @@
     <rule ref="Generic.Files.LineLength.TooLong">
         <exclude-pattern>src/Mixins/</exclude-pattern>
         <exclude-pattern>tests/feature/</exclude-pattern>
+    </rule>
+    <!-- Generated mixin docblocks carry @template/@param/@return narrowing types whose
+         formatting (annotation groups, fully-qualified class names, bare iterable item
+         types, null ordering) is the generator's concern, not hand-maintained style. -->
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
+        <exclude-pattern>src/Mixins/</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
+        <exclude-pattern>src/Mixins/</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
+        <exclude-pattern>src/Mixins/</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition">
+        <exclude-pattern>src/Mixins/</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic">
         <exclude-pattern>tests/Pest.php</exclude-pattern>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,16 @@ parameters:
       path: tests/src/Message/TestingHandler.php
     - message: '/Property Respect\\Validation\\Test\\Stubs\\.+::\$[a-zA-Z]+ is never read, only written./'
       path: tests/src/Stubs
+    -
+      # Why: src/Mixins/* are generated typing aids. Their @return Chain<...> carry the
+      # narrowing types derived from #[Assurance] (the same ones FluentAnalysis computes
+      # at analysis time), e.g. bare `array` or `ArrayAccess`. Fully parameterising those
+      # generics would only clutter the IDE-facing types without adding narrowing value.
+      identifier: missingType.iterableValue
+      path: src/Mixins/*
+    -
+      identifier: missingType.generics
+      path: src/Mixins/*
   level: 8
   treatPhpDocTypesAsCertain: false
   paths:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,9 @@
     <testsuite name="feature">
       <directory suffix="Test.php">./tests/feature</directory>
     </testsuite>
+    <testsuite name="inference">
+      <directory suffix="Test.php">tests/inference/</directory>
+    </testsuite>
   </testsuites>
   <source>
     <include>

--- a/src-dev/Commands/LintMixinCommand.php
+++ b/src-dev/Commands/LintMixinCommand.php
@@ -18,6 +18,7 @@ use Respect\FluentGen\Fluent\InterfaceConfig;
 use Respect\FluentGen\Fluent\MethodBuilder;
 use Respect\FluentGen\Fluent\MixinGenerator;
 use Respect\FluentGen\Fluent\PrefixConstantsGenerator;
+use Respect\FluentGen\Fluent\TerminalMethod;
 use Respect\FluentGen\NamespaceScanner;
 use Respect\Validation\Mixins\Chain;
 use Respect\Validation\Validator;
@@ -82,6 +83,7 @@ final class LintMixinCommand extends Command
                     suffix: 'Builder',
                     returnType: Chain::class,
                     static: true,
+                    emitNarrowing: true,
                 ),
                 new InterfaceConfig(
                     suffix: 'Chain',
@@ -89,6 +91,29 @@ final class LintMixinCommand extends Command
                     rootExtends: [Validator::class],
                     rootComment: '@mixin ValidatorBuilder',
                     rootUses: [ValidatorBuilder::class],
+                    emitNarrowing: true,
+                    templateParam: 'TSure',
+                    terminalMethods: [
+                        new TerminalMethod(
+                            name: 'assert',
+                            returnType: 'void',
+                            parameters: ['input' => 'mixed'],
+                            comments: ['@phpstan-assert TSure $input', '@psalm-assert TSure $input'],
+                            optionalParameters: ['template' => 'mixed'],
+                        ),
+                        new TerminalMethod(
+                            name: 'check',
+                            returnType: 'void',
+                            parameters: ['input' => 'mixed'],
+                            comments: ['@phpstan-assert TSure $input', '@psalm-assert TSure $input'],
+                            optionalParameters: ['template' => 'mixed'],
+                        ),
+                        new TerminalMethod(
+                            name: 'isValid',
+                            returnType: 'bool',
+                            parameters: ['input' => 'mixed'],
+                        ),
+                    ],
                 ),
             ],
         );

--- a/src/Mixins/AllBuilder.php
+++ b/src/Mixins/AllBuilder.php
@@ -17,300 +17,462 @@ use Respect\Validation\Validator;
 
 interface AllBuilder
 {
+    /** @return Chain<iterable> */
     public static function allAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAlwaysInvalid(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAlwaysValid(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable<array>> */
     public static function allArrayType(): Chain;
 
+    /** @return Chain<iterable<array|\ArrayAccess|\SimpleXMLElement>> */
     public static function allArrayVal(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allBase64(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBlank(): Chain;
 
+    /** @return Chain<iterable<bool>> */
     public static function allBoolType(): Chain;
 
+    /** @return Chain<iterable<scalar|null>> */
     public static function allBoolVal(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allBsn(): Chain;
 
+    /** @return Chain<iterable<callable>> */
     public static function allCallableType(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allCnh(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allCnpj(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<scalar|array>> */
     public static function allContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<iterable<scalar|array>>
+     */
     public static function allContainsAny(array $needles): Chain;
 
+    /** @return Chain<iterable<scalar|array>> */
     public static function allContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<array|\Countable>> */
     public static function allCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<iterable<string>>
+     */
     public static function allCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allCpf(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<iterable<string>>
+     */
     public static function allCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<iterable<scalar|\DateTimeInterface>> */
     public static function allDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<iterable<string|\DateTimeInterface>>
+     */
     public static function allDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allDecimal(int $decimals): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allDirectory(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEach(Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEachKey(Validator $validator): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allEmail(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allEmoji(): Chain;
 
+    /** @return Chain<iterable<array|string>> */
     public static function allEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allEven(): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allExecutable(): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allExtension(string $extension): Chain;
 
+    /** @return Chain<iterable> */
     public static function allFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<iterable>
+     */
     public static function allFactory(callable $factory): Chain;
 
+    /** @return Chain<iterable<scalar|null>> */
     public static function allFalseVal(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allFalsy(): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allFile(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allFinite(): Chain;
 
+    /** @return Chain<iterable<float>> */
     public static function allFloatType(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string|true>> */
     public static function allFloatVal(): Chain;
 
+    /** @return Chain<iterable<scalar|\Stringable>> */
     public static function allFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<iterable> */
     public static function allGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable> */
     public static function allGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function allGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allHetu(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allHexRgbColor(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allIban(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allImage(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allImei(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allIn(mixed $haystack): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<iterable>
+     */
     public static function allInstance(string $class): Chain;
 
+    /** @return Chain<iterable<int>> */
     public static function allIntType(): Chain;
 
+    /** @return Chain<iterable<int|numeric-string>> */
     public static function allIntVal(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allIsbn(): Chain;
 
+    /** @return Chain<iterable<iterable>> */
     public static function allIterableType(): Chain;
 
+    /** @return Chain<iterable<array|\stdClass|\Traversable>> */
     public static function allIterableVal(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allJson(): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<iterable<string>>
+     */
     public static function allLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<iterable<scalar|\DateTimeInterface>> */
     public static function allLeapDate(string $format): Chain;
 
+    /** @return Chain<iterable<scalar|\DateTimeInterface>> */
     public static function allLeapYear(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allLength(Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function allLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allLowercase(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allLuhn(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allMacAddress(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allMax(Validator $validator): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allMimetype(string $mimetype): Chain;
 
+    /** @return Chain<iterable> */
     public static function allMin(Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allNegative(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allNfeAccessKey(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allNif(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allNip(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable> */
     public static function allNot(Validator $validator): Chain;
 
+    /** @return Chain<iterable<null>> */
     public static function allNullType(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allNumber(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allNumericVal(): Chain;
 
+    /** @return Chain<iterable<object>> */
     public static function allObjectType(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allOdd(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPesel(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPis(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPolishIdCard(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allPortugueseNif(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allPositive(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPublicDomainSuffix(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo|\Psr\Http\Message\StreamInterface>> */
     public static function allReadable(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allRegex(string $regex): Chain;
 
+    /** @return Chain<iterable<resource>> */
     public static function allResourceType(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allRoman(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<iterable<int|float|bool|string>> */
     public static function allScalarVal(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<iterable<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface>>
+     */
     public static function allSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allSlug(): Chain;
 
+    /** @return Chain<iterable<array|string>> */
     public static function allSorted(string $direction): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allSpaced(): Chain;
 
+    /** @return Chain<iterable<array|string>> */
     public static function allStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allStringType(): Chain;
 
+    /** @return Chain<iterable<scalar|\Stringable>> */
     public static function allStringVal(): Chain;
 
+    /** @return Chain<iterable<scalar|null>> */
     public static function allSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<iterable<array>>
+     */
     public static function allSubset(array $superset): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allSymbolicLink(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allTld(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allTrueVal(): Chain;
 
+    /** @return Chain<iterable<null|''>> */
     public static function allUndef(): Chain;
 
+    /** @return Chain<iterable<array>> */
     public static function allUnique(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allUppercase(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allUrl(): Chain;
 
+    /** @return Chain<iterable<string|\Ramsey\Uuid\UuidInterface>> */
     public static function allUuid(int|null $version = null): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allVersion(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable> */
     public static function allWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo|\Psr\Http\Message\StreamInterface>> */
     public static function allWritable(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/AllBuilder.php
+++ b/src/Mixins/AllBuilder.php
@@ -17,300 +17,462 @@ use Respect\Validation\Validator;
 
 interface AllBuilder
 {
+    /** @return Chain<iterable> */
     public static function allAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAlwaysInvalid(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAlwaysValid(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable<array>> */
     public static function allArrayType(): Chain;
 
+    /** @return Chain<iterable<array|\ArrayAccess|\SimpleXMLElement>> */
     public static function allArrayVal(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allBase64(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<iterable> */
     public static function allBlank(): Chain;
 
+    /** @return Chain<iterable<bool>> */
     public static function allBoolType(): Chain;
 
+    /** @return Chain<iterable<scalar|null>> */
     public static function allBoolVal(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allBsn(): Chain;
 
+    /** @return Chain<iterable<callable>> */
     public static function allCallableType(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allCnh(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allCnpj(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<scalar|array>> */
     public static function allContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<iterable<scalar|array>>
+     */
     public static function allContainsAny(array $needles): Chain;
 
+    /** @return Chain<iterable<scalar|array>> */
     public static function allContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<array|\Countable>> */
     public static function allCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<iterable<string>>
+     */
     public static function allCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allCpf(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<iterable<string>>
+     */
     public static function allCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<iterable<scalar|\DateTimeInterface>> */
     public static function allDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<iterable<string|int|\DateTimeInterface>>
+     */
     public static function allDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allDecimal(int $decimals): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allDirectory(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEach(Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEachKey(Validator $validator): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allEmail(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allEmoji(): Chain;
 
+    /** @return Chain<iterable<array|string>> */
     public static function allEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function allEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allEven(): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allExecutable(): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allExtension(string $extension): Chain;
 
+    /** @return Chain<iterable> */
     public static function allFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<iterable>
+     */
     public static function allFactory(callable $factory): Chain;
 
+    /** @return Chain<iterable<scalar|null>> */
     public static function allFalseVal(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allFalsy(): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allFile(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allFinite(): Chain;
 
+    /** @return Chain<iterable<float>> */
     public static function allFloatType(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string|true>> */
     public static function allFloatVal(): Chain;
 
+    /** @return Chain<iterable<scalar|\Stringable>> */
     public static function allFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<iterable> */
     public static function allGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable> */
     public static function allGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function allGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allHetu(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allHexRgbColor(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allIban(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allImage(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allImei(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allIn(mixed $haystack): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<iterable>
+     */
     public static function allInstance(string $class): Chain;
 
+    /** @return Chain<iterable<int>> */
     public static function allIntType(): Chain;
 
+    /** @return Chain<iterable<int|numeric-string>> */
     public static function allIntVal(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allIsbn(): Chain;
 
+    /** @return Chain<iterable<iterable>> */
     public static function allIterableType(): Chain;
 
+    /** @return Chain<iterable<array|\stdClass|\Traversable>> */
     public static function allIterableVal(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allJson(): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<iterable<string>>
+     */
     public static function allLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<iterable<scalar|\DateTimeInterface>> */
     public static function allLeapDate(string $format): Chain;
 
+    /** @return Chain<iterable<scalar|\DateTimeInterface>> */
     public static function allLeapYear(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allLength(Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function allLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allLowercase(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allLuhn(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allMacAddress(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allMax(Validator $validator): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allMimetype(string $mimetype): Chain;
 
+    /** @return Chain<iterable> */
     public static function allMin(Validator $validator): Chain;
 
+    /** @return Chain<iterable> */
     public static function allMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allNegative(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allNfeAccessKey(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allNif(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allNip(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable> */
     public static function allNot(Validator $validator): Chain;
 
+    /** @return Chain<iterable<null>> */
     public static function allNullType(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allNumber(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allNumericVal(): Chain;
 
+    /** @return Chain<iterable<object>> */
     public static function allObjectType(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allOdd(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPesel(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPis(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPolishIdCard(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allPortugueseNif(): Chain;
 
+    /** @return Chain<iterable<int|float|numeric-string>> */
     public static function allPositive(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPublicDomainSuffix(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo|\Psr\Http\Message\StreamInterface>> */
     public static function allReadable(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allRegex(string $regex): Chain;
 
+    /** @return Chain<iterable<resource>> */
     public static function allResourceType(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allRoman(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<iterable<int|float|bool|string>> */
     public static function allScalarVal(): Chain;
 
+    /** @return Chain<iterable> */
     public static function allShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<iterable<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface>>
+     */
     public static function allSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allSlug(): Chain;
 
+    /** @return Chain<iterable<array|string>> */
     public static function allSorted(string $direction): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allSpaced(): Chain;
 
+    /** @return Chain<iterable<array|string>> */
     public static function allStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allStringType(): Chain;
 
+    /** @return Chain<iterable<scalar|\Stringable>> */
     public static function allStringVal(): Chain;
 
+    /** @return Chain<iterable<scalar|null>> */
     public static function allSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<iterable<array>>
+     */
     public static function allSubset(array $superset): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo>> */
     public static function allSymbolicLink(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allTld(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allTrueVal(): Chain;
 
+    /** @return Chain<iterable<null|''>> */
     public static function allUndef(): Chain;
 
+    /** @return Chain<iterable<array>> */
     public static function allUnique(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allUppercase(): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allUrl(): Chain;
 
+    /** @return Chain<iterable<string|\Ramsey\Uuid\UuidInterface>> */
     public static function allUuid(int|null $version = null): Chain;
 
+    /** @return Chain<iterable<string>> */
     public static function allVersion(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<iterable> */
     public static function allWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<iterable<string|\SplFileInfo|\Psr\Http\Message\StreamInterface>> */
     public static function allWritable(): Chain;
 
+    /** @return Chain<iterable<scalar>> */
     public static function allXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/AllChain.php
+++ b/src/Mixins/AllChain.php
@@ -17,300 +17,462 @@ use Respect\Validation\Validator;
 
 interface AllChain
 {
+    /** @return Chain<mixed> */
     public function allAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function allAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public function allAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public function allAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function allArrayType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public function allBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public function allBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function allBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function allBlank(): Chain;
 
+    /** @return Chain<mixed> */
     public function allBoolType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allBoolVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allBsn(): Chain;
 
+    /** @return Chain<mixed> */
     public function allCallableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public function allCnh(): Chain;
 
+    /** @return Chain<mixed> */
     public function allCnpj(): Chain;
 
+    /** @return Chain<mixed> */
     public function allConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public function allContainsAny(array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public function allContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public function allControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function allCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function allCpf(): Chain;
 
+    /** @return Chain<mixed> */
     public function allCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function allCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public function allDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public function allDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public function allDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public function allDecimal(int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public function allDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allDirectory(): Chain;
 
+    /** @return Chain<mixed> */
     public function allDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public function allEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allEachKey(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allEmail(): Chain;
 
+    /** @return Chain<mixed> */
     public function allEmoji(): Chain;
 
+    /** @return Chain<mixed> */
     public function allEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public function allEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function allExecutable(): Chain;
 
+    /** @return Chain<mixed> */
     public function allExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public function allFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public function allFactory(callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public function allFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allFalsy(): Chain;
 
+    /** @return Chain<mixed> */
     public function allFile(): Chain;
 
+    /** @return Chain<mixed> */
     public function allFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function allFloatType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allFloatVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public function allGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public function allGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allHetu(): Chain;
 
+    /** @return Chain<mixed> */
     public function allHexRgbColor(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIban(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allImage(): Chain;
 
+    /** @return Chain<mixed> */
     public function allImei(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function allInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public function allInstance(string $class): Chain;
 
+    /** @return Chain<mixed> */
     public function allIntType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIntVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public function allIsbn(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIterableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allIterableVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allJson(): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public function allLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function allLeapDate(string $format): Chain;
 
+    /** @return Chain<mixed> */
     public function allLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public function allLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function allLowercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function allLuhn(): Chain;
 
+    /** @return Chain<mixed> */
     public function allMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public function allMax(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public function allMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function allNegative(): Chain;
 
+    /** @return Chain<mixed> */
     public function allNfeAccessKey(): Chain;
 
+    /** @return Chain<mixed> */
     public function allNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function allNip(): Chain;
 
+    /** @return Chain<mixed> */
     public function allNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function allNot(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allNullType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allNumber(): Chain;
 
+    /** @return Chain<mixed> */
     public function allNumericVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allObjectType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function allOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function allPesel(): Chain;
 
+    /** @return Chain<mixed> */
     public function allPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public function allPis(): Chain;
 
+    /** @return Chain<mixed> */
     public function allPolishIdCard(): Chain;
 
+    /** @return Chain<mixed> */
     public function allPortugueseNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function allPositive(): Chain;
 
+    /** @return Chain<mixed> */
     public function allPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public function allPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allPublicDomainSuffix(): Chain;
 
+    /** @return Chain<mixed> */
     public function allPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allReadable(): Chain;
 
+    /** @return Chain<mixed> */
     public function allRegex(string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public function allResourceType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public function allSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public function allScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public function allSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function allSlug(): Chain;
 
+    /** @return Chain<mixed> */
     public function allSorted(string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public function allSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allSpaced(): Chain;
 
+    /** @return Chain<mixed> */
     public function allStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public function allStringType(): Chain;
 
+    /** @return Chain<mixed> */
     public function allStringVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public function allSubset(array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public function allSymbolicLink(): Chain;
 
+    /** @return Chain<mixed> */
     public function allTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public function allTld(): Chain;
 
+    /** @return Chain<mixed> */
     public function allTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public function allTrueVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function allUndef(): Chain;
 
+    /** @return Chain<mixed> */
     public function allUnique(): Chain;
 
+    /** @return Chain<mixed> */
     public function allUppercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function allUrl(): Chain;
 
+    /** @return Chain<mixed> */
     public function allUuid(int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public function allVersion(): Chain;
 
+    /** @return Chain<mixed> */
     public function allVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function allWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public function allWritable(): Chain;
 
+    /** @return Chain<mixed> */
     public function allXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/Builder.php
+++ b/src/Mixins/Builder.php
@@ -18,331 +18,523 @@ use Respect\Validation\Validator;
 
 interface Builder extends AllBuilder, KeyBuilder, LengthBuilder, MaxBuilder, MinBuilder, NotBuilder, NullOrBuilder, PropertyBuilder, UndefOrBuilder
 {
+    /** @return Chain<mixed> */
     public static function after(callable $callable, Validator $validator): Chain;
 
+    /**
+     * @template T
+     * @param Chain<T> $validator
+     * @return Chain<iterable<T>>
+     */
     public static function all(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function allOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar> */
     public static function alnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar> */
     public static function alpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function alwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function alwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function anyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array> */
     public static function arrayType(): Chain;
 
+    /** @return Chain<array|\ArrayAccess|\SimpleXMLElement> */
     public static function arrayVal(): Chain;
 
+    /** @return Chain<object> */
     public static function attributes(): Chain;
 
+    /** @return Chain<mixed> */
     public static function base(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<string> */
     public static function base64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function between(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function betweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public static function blank(): Chain;
 
+    /** @return Chain<bool> */
     public static function boolType(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function boolVal(): Chain;
 
+    /** @return Chain<scalar> */
     public static function bsn(): Chain;
 
+    /** @return Chain<callable> */
     public static function callableType(): Chain;
 
+    /** @return Chain<string> */
     public static function charset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<scalar> */
     public static function cnh(): Chain;
 
+    /** @return Chain<scalar> */
     public static function cnpj(): Chain;
 
+    /** @return Chain<scalar> */
     public static function consonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|array> */
     public static function contains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<scalar|array>
+     */
     public static function containsAny(array $needles): Chain;
 
+    /** @return Chain<scalar|array> */
     public static function containsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<scalar> */
     public static function control(string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\Countable> */
     public static function countable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<string>
+     */
     public static function countryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<string> */
     public static function cpf(): Chain;
 
+    /** @return Chain<scalar> */
     public static function creditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<string>
+     */
     public static function currencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<scalar> */
     public static function date(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface> */
     public static function dateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<string|\DateTimeInterface>
+     */
     public static function dateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function decimal(int $decimals): Chain;
 
+    /** @return Chain<scalar> */
     public static function digit(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function directory(): Chain;
 
+    /** @return Chain<string> */
     public static function domain(bool $tldCheck = true): Chain;
 
+    /**
+     * @template T
+     * @param Chain<T> $validator
+     * @return Chain<iterable<T>>
+     */
     public static function each(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function eachKey(Validator $validator): Chain;
 
+    /** @return Chain<string> */
     public static function email(): Chain;
 
+    /** @return Chain<string> */
     public static function emoji(): Chain;
 
+    /** @return Chain<array|string> */
     public static function endsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function equals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function equivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function even(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function executable(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function exists(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function extension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function factor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function factory(callable $factory): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function falseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function falsy(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function file(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function finite(): Chain;
 
+    /** @return Chain<float> */
     public static function floatType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|true> */
     public static function floatVal(): Chain;
 
+    /** @return Chain<scalar|\Stringable> */
     public static function format(Formatter $formatter): Chain;
 
+    /** @return Chain<scalar|\Stringable> */
     public static function formatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function given(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<scalar> */
     public static function graph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function greaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function greaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string> */
     public static function hetu(): Chain;
 
+    /** @return Chain<scalar> */
     public static function hexRgbColor(): Chain;
 
+    /** @return Chain<string> */
     public static function iban(): Chain;
 
+    /**
+     * @template T
+     * @param T $compareTo
+     * @return Chain<T>
+     */
     public static function identical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function image(): Chain;
 
+    /** @return Chain<scalar> */
     public static function imei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function in(mixed $haystack): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function infinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @template T of object
+     * @param class-string<T> $class
+     * @return Chain<T>
+     */
     public static function instance(string $class): Chain;
 
+    /** @return Chain<int> */
     public static function intType(): Chain;
 
+    /** @return Chain<int|numeric-string> */
     public static function intVal(): Chain;
 
+    /** @return Chain<string> */
     public static function ip(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<scalar> */
     public static function isbn(): Chain;
 
+    /** @return Chain<iterable> */
     public static function iterableType(): Chain;
 
+    /** @return Chain<array|\stdClass|\Traversable> */
     public static function iterableVal(): Chain;
 
+    /** @return Chain<string> */
     public static function json(): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function key(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function keyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array> */
     public static function keySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<string>
+     */
     public static function languageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface> */
     public static function leapDate(string $format): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface> */
     public static function leapYear(): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function length(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function lessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function lessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string> */
     public static function lowercase(): Chain;
 
+    /** @return Chain<scalar> */
     public static function luhn(): Chain;
 
+    /** @return Chain<string> */
     public static function macAddress(): Chain;
 
+    /** @return Chain<iterable> */
     public static function max(Validator $validator): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function mimetype(string $mimetype): Chain;
 
+    /** @return Chain<iterable> */
     public static function min(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function multiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public static function named(Name|string $name, Validator $validator): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function negative(): Chain;
 
+    /** @return Chain<string> */
     public static function nfeAccessKey(): Chain;
 
+    /** @return Chain<string> */
     public static function nif(): Chain;
 
+    /** @return Chain<scalar> */
     public static function nip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function noneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function not(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOr(Validator $validator): Chain;
 
+    /** @return Chain<null> */
     public static function nullType(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function number(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function numericVal(): Chain;
 
+    /** @return Chain<object> */
     public static function objectType(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function odd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function oneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar> */
     public static function pesel(): Chain;
 
+    /** @return Chain<scalar> */
     public static function phone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<scalar> */
     public static function pis(): Chain;
 
+    /** @return Chain<scalar> */
     public static function polishIdCard(): Chain;
 
+    /** @return Chain<string> */
     public static function portugueseNif(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function positive(): Chain;
 
+    /** @return Chain<scalar> */
     public static function postalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<scalar> */
     public static function printable(string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function property(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function propertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<scalar> */
     public static function publicDomainSuffix(): Chain;
 
+    /** @return Chain<scalar> */
     public static function punct(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface> */
     public static function readable(): Chain;
 
+    /** @return Chain<scalar> */
     public static function regex(string $regex): Chain;
 
+    /** @return Chain<resource> */
     public static function resourceType(): Chain;
 
+    /** @return Chain<string> */
     public static function roman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function satisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<int|float|bool|string> */
     public static function scalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function shortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface>
+     */
     public static function size(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<string> */
     public static function slug(): Chain;
 
+    /** @return Chain<array|string> */
     public static function sorted(string $direction): Chain;
 
+    /** @return Chain<scalar> */
     public static function space(string ...$additionalChars): Chain;
 
+    /** @return Chain<string> */
     public static function spaced(): Chain;
 
+    /** @return Chain<array|string> */
     public static function startsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<string> */
     public static function stringType(): Chain;
 
+    /** @return Chain<scalar|\Stringable> */
     public static function stringVal(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function subdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array>
+     */
     public static function subset(array $superset): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function symbolicLink(): Chain;
 
-    /** @param array<string, mixed> $parameters */
+    /**
+     * @param array<string, mixed> $parameters
+     * @return Chain<mixed>
+     */
     public static function templated(string $template, Validator $validator, array $parameters = []): Chain;
 
+    /** @return Chain<scalar> */
     public static function time(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<string> */
     public static function tld(): Chain;
 
+    /** @return Chain<string> */
     public static function trimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<scalar> */
     public static function trueVal(): Chain;
 
+    /** @return Chain<null|''> */
     public static function undef(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOr(Validator $validator): Chain;
 
+    /** @return Chain<array> */
     public static function unique(): Chain;
 
+    /** @return Chain<string> */
     public static function uppercase(): Chain;
 
+    /** @return Chain<string> */
     public static function url(): Chain;
 
+    /** @return Chain<string|\Ramsey\Uuid\UuidInterface> */
     public static function uuid(int|null $version = null): Chain;
 
+    /** @return Chain<string> */
     public static function version(): Chain;
 
+    /** @return Chain<scalar> */
     public static function vowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function when(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface> */
     public static function writable(): Chain;
 
+    /** @return Chain<scalar> */
     public static function xdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/Builder.php
+++ b/src/Mixins/Builder.php
@@ -18,331 +18,523 @@ use Respect\Validation\Validator;
 
 interface Builder extends AllBuilder, KeyBuilder, LengthBuilder, MaxBuilder, MinBuilder, NotBuilder, NullOrBuilder, PropertyBuilder, UndefOrBuilder
 {
+    /** @return Chain<mixed> */
     public static function after(callable $callable, Validator $validator): Chain;
 
+    /**
+     * @template T
+     * @param Chain<T> $validator
+     * @return Chain<iterable<T>>
+     */
     public static function all(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function allOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar> */
     public static function alnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar> */
     public static function alpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function alwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function alwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function anyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array> */
     public static function arrayType(): Chain;
 
+    /** @return Chain<array|\ArrayAccess|\SimpleXMLElement> */
     public static function arrayVal(): Chain;
 
+    /** @return Chain<object> */
     public static function attributes(): Chain;
 
+    /** @return Chain<mixed> */
     public static function base(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<string> */
     public static function base64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function between(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function betweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public static function blank(): Chain;
 
+    /** @return Chain<bool> */
     public static function boolType(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function boolVal(): Chain;
 
+    /** @return Chain<scalar> */
     public static function bsn(): Chain;
 
+    /** @return Chain<callable> */
     public static function callableType(): Chain;
 
+    /** @return Chain<string> */
     public static function charset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<scalar> */
     public static function cnh(): Chain;
 
+    /** @return Chain<scalar> */
     public static function cnpj(): Chain;
 
+    /** @return Chain<scalar> */
     public static function consonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|array> */
     public static function contains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<scalar|array>
+     */
     public static function containsAny(array $needles): Chain;
 
+    /** @return Chain<scalar|array> */
     public static function containsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<scalar> */
     public static function control(string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\Countable> */
     public static function countable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<string>
+     */
     public static function countryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<string> */
     public static function cpf(): Chain;
 
+    /** @return Chain<scalar> */
     public static function creditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<string>
+     */
     public static function currencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<scalar> */
     public static function date(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface> */
     public static function dateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<string|int|\DateTimeInterface>
+     */
     public static function dateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function decimal(int $decimals): Chain;
 
+    /** @return Chain<scalar> */
     public static function digit(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function directory(): Chain;
 
+    /** @return Chain<string> */
     public static function domain(bool $tldCheck = true): Chain;
 
+    /**
+     * @template T
+     * @param Chain<T> $validator
+     * @return Chain<iterable<T>>
+     */
     public static function each(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function eachKey(Validator $validator): Chain;
 
+    /** @return Chain<string> */
     public static function email(): Chain;
 
+    /** @return Chain<string> */
     public static function emoji(): Chain;
 
+    /** @return Chain<array|string> */
     public static function endsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function equals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function equivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function even(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function executable(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function exists(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function extension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function factor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function factory(callable $factory): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function falseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function falsy(): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function file(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function finite(): Chain;
 
+    /** @return Chain<float> */
     public static function floatType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|true> */
     public static function floatVal(): Chain;
 
+    /** @return Chain<scalar|\Stringable> */
     public static function format(Formatter $formatter): Chain;
 
+    /** @return Chain<scalar|\Stringable> */
     public static function formatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function given(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<scalar> */
     public static function graph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function greaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function greaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string> */
     public static function hetu(): Chain;
 
+    /** @return Chain<scalar> */
     public static function hexRgbColor(): Chain;
 
+    /** @return Chain<string> */
     public static function iban(): Chain;
 
+    /**
+     * @template T
+     * @param T $compareTo
+     * @return Chain<T>
+     */
     public static function identical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function image(): Chain;
 
+    /** @return Chain<scalar> */
     public static function imei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function in(mixed $haystack): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function infinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @template T of object
+     * @param class-string<T> $class
+     * @return Chain<T>
+     */
     public static function instance(string $class): Chain;
 
+    /** @return Chain<int> */
     public static function intType(): Chain;
 
+    /** @return Chain<int|numeric-string> */
     public static function intVal(): Chain;
 
+    /** @return Chain<string> */
     public static function ip(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<scalar> */
     public static function isbn(): Chain;
 
+    /** @return Chain<iterable> */
     public static function iterableType(): Chain;
 
+    /** @return Chain<array|\stdClass|\Traversable> */
     public static function iterableVal(): Chain;
 
+    /** @return Chain<string> */
     public static function json(): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function key(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function keyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array> */
     public static function keySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<string>
+     */
     public static function languageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface> */
     public static function leapDate(string $format): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface> */
     public static function leapYear(): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function length(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function lessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function lessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string> */
     public static function lowercase(): Chain;
 
+    /** @return Chain<scalar> */
     public static function luhn(): Chain;
 
+    /** @return Chain<string> */
     public static function macAddress(): Chain;
 
+    /** @return Chain<iterable> */
     public static function max(Validator $validator): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function mimetype(string $mimetype): Chain;
 
+    /** @return Chain<iterable> */
     public static function min(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function multiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public static function named(Name|string $name, Validator $validator): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function negative(): Chain;
 
+    /** @return Chain<string> */
     public static function nfeAccessKey(): Chain;
 
+    /** @return Chain<string> */
     public static function nif(): Chain;
 
+    /** @return Chain<scalar> */
     public static function nip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function noneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function not(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOr(Validator $validator): Chain;
 
+    /** @return Chain<null> */
     public static function nullType(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function number(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function numericVal(): Chain;
 
+    /** @return Chain<object> */
     public static function objectType(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function odd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function oneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar> */
     public static function pesel(): Chain;
 
+    /** @return Chain<scalar> */
     public static function phone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<scalar> */
     public static function pis(): Chain;
 
+    /** @return Chain<scalar> */
     public static function polishIdCard(): Chain;
 
+    /** @return Chain<string> */
     public static function portugueseNif(): Chain;
 
+    /** @return Chain<int|float|numeric-string> */
     public static function positive(): Chain;
 
+    /** @return Chain<scalar> */
     public static function postalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<scalar> */
     public static function printable(string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function property(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function propertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<scalar> */
     public static function publicDomainSuffix(): Chain;
 
+    /** @return Chain<scalar> */
     public static function punct(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface> */
     public static function readable(): Chain;
 
+    /** @return Chain<scalar> */
     public static function regex(string $regex): Chain;
 
+    /** @return Chain<resource> */
     public static function resourceType(): Chain;
 
+    /** @return Chain<string> */
     public static function roman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function satisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<int|float|bool|string> */
     public static function scalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function shortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface>
+     */
     public static function size(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<string> */
     public static function slug(): Chain;
 
+    /** @return Chain<array|string> */
     public static function sorted(string $direction): Chain;
 
+    /** @return Chain<scalar> */
     public static function space(string ...$additionalChars): Chain;
 
+    /** @return Chain<string> */
     public static function spaced(): Chain;
 
+    /** @return Chain<array|string> */
     public static function startsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<string> */
     public static function stringType(): Chain;
 
+    /** @return Chain<scalar|\Stringable> */
     public static function stringVal(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function subdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array>
+     */
     public static function subset(array $superset): Chain;
 
+    /** @return Chain<string|\SplFileInfo> */
     public static function symbolicLink(): Chain;
 
-    /** @param array<string, mixed> $parameters */
+    /**
+     * @param array<string, mixed> $parameters
+     * @return Chain<mixed>
+     */
     public static function templated(string $template, Validator $validator, array $parameters = []): Chain;
 
+    /** @return Chain<scalar> */
     public static function time(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<string> */
     public static function tld(): Chain;
 
+    /** @return Chain<string> */
     public static function trimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<scalar> */
     public static function trueVal(): Chain;
 
+    /** @return Chain<null|''> */
     public static function undef(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOr(Validator $validator): Chain;
 
+    /** @return Chain<array> */
     public static function unique(): Chain;
 
+    /** @return Chain<string> */
     public static function uppercase(): Chain;
 
+    /** @return Chain<string> */
     public static function url(): Chain;
 
+    /** @return Chain<string|\Ramsey\Uuid\UuidInterface> */
     public static function uuid(int|null $version = null): Chain;
 
+    /** @return Chain<string> */
     public static function version(): Chain;
 
+    /** @return Chain<scalar> */
     public static function vowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function when(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface> */
     public static function writable(): Chain;
 
+    /** @return Chain<scalar> */
     public static function xdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/Chain.php
+++ b/src/Mixins/Chain.php
@@ -17,334 +17,538 @@ use Respect\Validation\Name;
 use Respect\Validation\Validator;
 use Respect\Validation\ValidatorBuilder;
 
-/** @mixin ValidatorBuilder */
+/**
+ * @template-covariant TSure
+ * @mixin ValidatorBuilder
+ */
 interface Chain extends Validator, AllChain, KeyChain, LengthChain, MaxChain, MinChain, NotChain, NullOrChain, PropertyChain, UndefOrChain
 {
+    /** @return Chain<TSure> */
     public function after(callable $callable, Validator $validator): Chain;
 
+    /**
+     * @template T
+     * @param Chain<T> $validator
+     * @return Chain<iterable<T>>
+     */
     public function all(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function allOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<TSure> */
     public function alnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function alpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function alwaysInvalid(): Chain;
 
+    /** @return Chain<TSure> */
     public function alwaysValid(): Chain;
 
+    /** @return Chain<TSure> */
     public function anyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<TSure> */
     public function arrayType(): Chain;
 
+    /** @return Chain<TSure> */
     public function arrayVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function attributes(): Chain;
 
+    /** @return Chain<TSure> */
     public function base(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<TSure> */
     public function base64(): Chain;
 
+    /** @return Chain<TSure> */
     public function between(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<TSure> */
     public function betweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<TSure> */
     public function blank(): Chain;
 
+    /** @return Chain<TSure> */
     public function boolType(): Chain;
 
+    /** @return Chain<TSure> */
     public function boolVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function bsn(): Chain;
 
+    /** @return Chain<TSure> */
     public function callableType(): Chain;
 
+    /** @return Chain<TSure> */
     public function charset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<TSure> */
     public function cnh(): Chain;
 
+    /** @return Chain<TSure> */
     public function cnpj(): Chain;
 
+    /** @return Chain<TSure> */
     public function consonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function contains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<TSure>
+     */
     public function containsAny(array $needles): Chain;
 
+    /** @return Chain<TSure> */
     public function containsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<TSure> */
     public function control(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function countable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<TSure>
+     */
     public function countryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<TSure> */
     public function cpf(): Chain;
 
+    /** @return Chain<TSure> */
     public function creditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<TSure>
+     */
     public function currencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<TSure> */
     public function date(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<TSure> */
     public function dateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<TSure>
+     */
     public function dateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<TSure> */
     public function decimal(int $decimals): Chain;
 
+    /** @return Chain<TSure> */
     public function digit(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function directory(): Chain;
 
+    /** @return Chain<TSure> */
     public function domain(bool $tldCheck = true): Chain;
 
+    /**
+     * @template T
+     * @param Chain<T> $validator
+     * @return Chain<iterable<T>>
+     */
     public function each(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function eachKey(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function email(): Chain;
 
+    /** @return Chain<TSure> */
     public function emoji(): Chain;
 
+    /** @return Chain<TSure> */
     public function endsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<TSure> */
     public function equals(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function equivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function even(): Chain;
 
+    /** @return Chain<TSure> */
     public function executable(): Chain;
 
+    /** @return Chain<TSure> */
     public function exists(): Chain;
 
+    /** @return Chain<TSure> */
     public function extension(string $extension): Chain;
 
+    /** @return Chain<TSure> */
     public function factor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<TSure>
+     */
     public function factory(callable $factory): Chain;
 
+    /** @return Chain<TSure> */
     public function falseVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function falsy(): Chain;
 
+    /** @return Chain<TSure> */
     public function file(): Chain;
 
+    /** @return Chain<TSure> */
     public function finite(): Chain;
 
+    /** @return Chain<TSure> */
     public function floatType(): Chain;
 
+    /** @return Chain<TSure> */
     public function floatVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function format(Formatter $formatter): Chain;
 
+    /** @return Chain<TSure> */
     public function formatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function given(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<TSure> */
     public function graph(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function greaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function greaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function hetu(): Chain;
 
+    /** @return Chain<TSure> */
     public function hexRgbColor(): Chain;
 
+    /** @return Chain<TSure> */
     public function iban(): Chain;
 
+    /** @return Chain<TSure> */
     public function identical(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function image(): Chain;
 
+    /** @return Chain<TSure> */
     public function imei(): Chain;
 
+    /** @return Chain<TSure> */
     public function in(mixed $haystack): Chain;
 
+    /** @return Chain<TSure> */
     public function infinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<TSure>
+     */
     public function instance(string $class): Chain;
 
+    /** @return Chain<TSure> */
     public function intType(): Chain;
 
+    /** @return Chain<TSure> */
     public function intVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function ip(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<TSure> */
     public function isbn(): Chain;
 
+    /** @return Chain<TSure> */
     public function iterableType(): Chain;
 
+    /** @return Chain<TSure> */
     public function iterableVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function json(): Chain;
 
+    /** @return Chain<TSure> */
     public function key(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function keyExists(int|string $key): Chain;
 
+    /** @return Chain<TSure> */
     public function keyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function keySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<TSure>
+     */
     public function languageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<TSure> */
     public function leapDate(string $format): Chain;
 
+    /** @return Chain<TSure> */
     public function leapYear(): Chain;
 
+    /** @return Chain<TSure> */
     public function length(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function lessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function lessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<TSure> */
     public function lowercase(): Chain;
 
+    /** @return Chain<TSure> */
     public function luhn(): Chain;
 
+    /** @return Chain<TSure> */
     public function macAddress(): Chain;
 
+    /** @return Chain<TSure> */
     public function max(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function mimetype(string $mimetype): Chain;
 
+    /** @return Chain<TSure> */
     public function min(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function multiple(int $multipleOf): Chain;
 
+    /** @return Chain<TSure> */
     public function named(Name|string $name, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function negative(): Chain;
 
+    /** @return Chain<TSure> */
     public function nfeAccessKey(): Chain;
 
+    /** @return Chain<TSure> */
     public function nif(): Chain;
 
+    /** @return Chain<TSure> */
     public function nip(): Chain;
 
+    /** @return Chain<TSure> */
     public function noneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<TSure> */
     public function not(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function nullOr(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function nullType(): Chain;
 
+    /** @return Chain<TSure> */
     public function number(): Chain;
 
+    /** @return Chain<TSure> */
     public function numericVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function objectType(): Chain;
 
+    /** @return Chain<TSure> */
     public function odd(): Chain;
 
+    /** @return Chain<TSure> */
     public function oneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<TSure> */
     public function pesel(): Chain;
 
+    /** @return Chain<TSure> */
     public function phone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<TSure> */
     public function pis(): Chain;
 
+    /** @return Chain<TSure> */
     public function polishIdCard(): Chain;
 
+    /** @return Chain<TSure> */
     public function portugueseNif(): Chain;
 
+    /** @return Chain<TSure> */
     public function positive(): Chain;
 
+    /** @return Chain<TSure> */
     public function postalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<TSure> */
     public function printable(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function property(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function propertyExists(string $propertyName): Chain;
 
+    /** @return Chain<TSure> */
     public function propertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function publicDomainSuffix(): Chain;
 
+    /** @return Chain<TSure> */
     public function punct(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function readable(): Chain;
 
+    /** @return Chain<TSure> */
     public function regex(string $regex): Chain;
 
+    /** @return Chain<TSure> */
     public function resourceType(): Chain;
 
+    /** @return Chain<TSure> */
     public function roman(): Chain;
 
+    /** @return Chain<TSure> */
     public function satisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<TSure> */
     public function scalarVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function shortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<TSure>
+     */
     public function size(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function slug(): Chain;
 
+    /** @return Chain<TSure> */
     public function sorted(string $direction): Chain;
 
+    /** @return Chain<TSure> */
     public function space(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function spaced(): Chain;
 
+    /** @return Chain<TSure> */
     public function startsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<TSure> */
     public function stringType(): Chain;
 
+    /** @return Chain<TSure> */
     public function stringVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function subdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<TSure>
+     */
     public function subset(array $superset): Chain;
 
+    /** @return Chain<TSure> */
     public function symbolicLink(): Chain;
 
-    /** @param array<string, mixed> $parameters */
+    /**
+     * @param array<string, mixed> $parameters
+     * @return Chain<TSure>
+     */
     public function templated(string $template, Validator $validator, array $parameters = []): Chain;
 
+    /** @return Chain<TSure> */
     public function time(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<TSure> */
     public function tld(): Chain;
 
+    /** @return Chain<TSure> */
     public function trimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<TSure> */
     public function trueVal(): Chain;
 
+    /** @return Chain<TSure> */
     public function undef(): Chain;
 
+    /** @return Chain<TSure> */
     public function undefOr(Validator $validator): Chain;
 
+    /** @return Chain<TSure> */
     public function unique(): Chain;
 
+    /** @return Chain<TSure> */
     public function uppercase(): Chain;
 
+    /** @return Chain<TSure> */
     public function url(): Chain;
 
+    /** @return Chain<TSure> */
     public function uuid(int|null $version = null): Chain;
 
+    /** @return Chain<TSure> */
     public function version(): Chain;
 
+    /** @return Chain<TSure> */
     public function vowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<TSure> */
     public function when(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<TSure> */
     public function writable(): Chain;
 
+    /** @return Chain<TSure> */
     public function xdigit(string ...$additionalChars): Chain;
+
+    /**
+     * @phpstan-assert TSure $input
+     * @psalm-assert TSure $input
+     */
+    public function assert(mixed $input, mixed $template = null): void;
+
+    /**
+     * @phpstan-assert TSure $input
+     * @psalm-assert TSure $input
+     */
+    public function check(mixed $input, mixed $template = null): void;
+
+    public function isValid(mixed $input): bool;
 }

--- a/src/Mixins/KeyBuilder.php
+++ b/src/Mixins/KeyBuilder.php
@@ -17,302 +17,465 @@ use Respect\Validation\Validator;
 
 interface KeyBuilder
 {
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAfter(int|string $key, callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAll(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAllOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAlnum(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAlpha(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAlwaysInvalid(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAlwaysValid(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyAnyOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyArrayType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyArrayVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBase(int|string $key, int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBase64(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBetween(int|string $key, mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBetweenExclusive(int|string $key, mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBlank(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBoolType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBoolVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyBsn(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCallableType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCharset(int|string $key, string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCnh(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCnpj(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyConsonant(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyContains(int|string $key, mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyContainsAny(int|string $key, array $needles): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyContainsCount(int|string $key, mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyControl(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCountable(int|string $key): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyCountryCode(int|string $key, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCpf(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyCreditCard(int|string $key, string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyCurrencyCode(int|string $key, string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyDate(int|string $key, string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyDateTime(int|string $key, string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyDateTimeDiff(int|string $key, string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyDecimal(int|string $key, int $decimals): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyDigit(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyDirectory(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyDomain(int|string $key, bool $tldCheck = true): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEach(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEachKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEmail(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEmoji(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEndsWith(int|string $key, mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEquals(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEquivalent(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyEven(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyExecutable(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyExtension(int|string $key, string $extension): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFactor(int|string $key, int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyFactory(int|string $key, callable $factory): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFalseVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFalsy(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFile(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFinite(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFloatType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFloatVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyFormat(int|string $key, Formatter $formatter): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyGiven(int|string $key, Validator $when, Validator $then): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyGraph(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyGreaterThan(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyGreaterThanOrEqual(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyHetu(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyHexRgbColor(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIban(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIdentical(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyImage(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyImei(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIn(int|string $key, mixed $haystack): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyInfinite(int|string $key): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyInstance(int|string $key, string $class): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIntType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIntVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIp(int|string $key, string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIsbn(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIterableType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyIterableVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyJson(int|string $key): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keyLanguageCode(int|string $key, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLeapDate(int|string $key, string $format): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLeapYear(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLength(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLessThan(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLessThanOrEqual(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLowercase(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyLuhn(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyMacAddress(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyMax(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyMimetype(int|string $key, string $mimetype): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyMin(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyMultiple(int|string $key, int $multipleOf): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNegative(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNfeAccessKey(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNif(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNip(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNoneOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNot(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNullType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNumber(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyNumericVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyObjectType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyOdd(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyOneOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPesel(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPhone(int|string $key, string|null $countryCode = null): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPis(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPolishIdCard(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPortugueseNif(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPositive(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPostalCode(int|string $key, string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPrintable(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPublicDomainSuffix(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyPunct(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyReadable(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyRegex(int|string $key, string $regex): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyResourceType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyRoman(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySatisfies(int|string $key, callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyScalarVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyShortCircuit(int|string $key, Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keySize(int|string $key, string $unit, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySlug(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySorted(int|string $key, string $direction): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySpace(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySpaced(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyStartsWith(int|string $key, mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyStringType(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyStringVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySubdivisionCode(int|string $key, string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array|\ArrayAccess>
+     */
     public static function keySubset(int|string $key, array $superset): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keySymbolicLink(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyTime(int|string $key, string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyTld(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyTrimmed(int|string $key, string ...$trimValues): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyTrueVal(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyUndef(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyUnique(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyUppercase(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyUrl(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyUuid(int|string $key, int|null $version = null): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyVersion(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyVowel(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyWhen(int|string $key, Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyWritable(int|string $key): Chain;
 
+    /** @return Chain<array|\ArrayAccess> */
     public static function keyXdigit(int|string $key, string ...$additionalChars): Chain;
 }

--- a/src/Mixins/KeyChain.php
+++ b/src/Mixins/KeyChain.php
@@ -17,302 +17,465 @@ use Respect\Validation\Validator;
 
 interface KeyChain
 {
+    /** @return Chain<mixed> */
     public function keyAfter(int|string $key, callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAll(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAllOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAlnum(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAlpha(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAlwaysInvalid(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAlwaysValid(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyAnyOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function keyArrayType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyArrayVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBase(int|string $key, int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBase64(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBetween(int|string $key, mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBetweenExclusive(int|string $key, mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBlank(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBoolType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBoolVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyBsn(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCallableType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCharset(int|string $key, string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCnh(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCnpj(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyConsonant(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyContains(int|string $key, mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public function keyContainsAny(int|string $key, array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public function keyContainsCount(int|string $key, mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public function keyControl(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCountable(int|string $key): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function keyCountryCode(int|string $key, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCpf(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyCreditCard(int|string $key, string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function keyCurrencyCode(int|string $key, string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public function keyDate(int|string $key, string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public function keyDateTime(int|string $key, string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public function keyDateTimeDiff(int|string $key, string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public function keyDecimal(int|string $key, int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public function keyDigit(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyDirectory(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyDomain(int|string $key, bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEach(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEachKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEmail(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEmoji(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEndsWith(int|string $key, mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEquals(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEquivalent(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyEven(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyExecutable(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyExtension(int|string $key, string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFactor(int|string $key, int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public function keyFactory(int|string $key, callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFalseVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFalsy(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFile(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFinite(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFloatType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFloatVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyFormat(int|string $key, Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public function keyGiven(int|string $key, Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public function keyGraph(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyGreaterThan(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyGreaterThanOrEqual(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyHetu(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyHexRgbColor(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIban(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIdentical(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyImage(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyImei(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIn(int|string $key, mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function keyInfinite(int|string $key): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public function keyInstance(int|string $key, string $class): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIntType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIntVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIp(int|string $key, string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIsbn(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIterableType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyIterableVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyJson(int|string $key): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public function keyLanguageCode(int|string $key, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLeapDate(int|string $key, string $format): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLeapYear(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLength(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLessThan(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLessThanOrEqual(int|string $key, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLowercase(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyLuhn(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyMacAddress(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyMax(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyMimetype(int|string $key, string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public function keyMin(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyMultiple(int|string $key, int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNegative(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNfeAccessKey(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNif(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNip(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNoneOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNot(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNullType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNumber(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyNumericVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyObjectType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyOdd(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyOneOf(int|string $key, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPesel(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPhone(int|string $key, string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPis(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPolishIdCard(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPortugueseNif(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPositive(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPostalCode(int|string $key, string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPrintable(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPublicDomainSuffix(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyPunct(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyReadable(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyRegex(int|string $key, string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public function keyResourceType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyRoman(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keySatisfies(int|string $key, callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public function keyScalarVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyShortCircuit(int|string $key, Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public function keySize(int|string $key, string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function keySlug(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keySorted(int|string $key, string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public function keySpace(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keySpaced(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyStartsWith(int|string $key, mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public function keyStringType(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyStringVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keySubdivisionCode(int|string $key, string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public function keySubset(int|string $key, array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public function keySymbolicLink(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyTime(int|string $key, string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public function keyTld(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyTrimmed(int|string $key, string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public function keyTrueVal(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyUndef(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyUnique(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyUppercase(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyUrl(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyUuid(int|string $key, int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public function keyVersion(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyVowel(int|string $key, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function keyWhen(int|string $key, Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public function keyWritable(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function keyXdigit(int|string $key, string ...$additionalChars): Chain;
 }

--- a/src/Mixins/LengthBuilder.php
+++ b/src/Mixins/LengthBuilder.php
@@ -13,37 +13,54 @@ namespace Respect\Validation\Mixins;
 
 interface LengthBuilder
 {
+    /** @return Chain<string|array|\Countable> */
     public static function lengthBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthEven(): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthFactor(int $dividend): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthFinite(): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthIn(mixed $haystack): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthInfinite(): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthOdd(): Chain;
 
+    /** @return Chain<string|array|\Countable> */
     public static function lengthPositive(): Chain;
 }

--- a/src/Mixins/LengthChain.php
+++ b/src/Mixins/LengthChain.php
@@ -13,37 +13,54 @@ namespace Respect\Validation\Mixins;
 
 interface LengthChain
 {
+    /** @return Chain<mixed> */
     public function lengthBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthFactor(int $dividend): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthInfinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function lengthPositive(): Chain;
 }

--- a/src/Mixins/MaxBuilder.php
+++ b/src/Mixins/MaxBuilder.php
@@ -13,37 +13,54 @@ namespace Respect\Validation\Mixins;
 
 interface MaxBuilder
 {
+    /** @return Chain<iterable> */
     public static function maxBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxEven(): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxFactor(int $dividend): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxFinite(): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxIn(mixed $haystack): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxInfinite(): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxOdd(): Chain;
 
+    /** @return Chain<iterable> */
     public static function maxPositive(): Chain;
 }

--- a/src/Mixins/MaxChain.php
+++ b/src/Mixins/MaxChain.php
@@ -13,37 +13,54 @@ namespace Respect\Validation\Mixins;
 
 interface MaxChain
 {
+    /** @return Chain<mixed> */
     public function maxBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function maxBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function maxEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function maxFactor(int $dividend): Chain;
 
+    /** @return Chain<mixed> */
     public function maxFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function maxGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function maxInfinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function maxLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function maxMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function maxOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function maxPositive(): Chain;
 }

--- a/src/Mixins/MinBuilder.php
+++ b/src/Mixins/MinBuilder.php
@@ -13,37 +13,54 @@ namespace Respect\Validation\Mixins;
 
 interface MinBuilder
 {
+    /** @return Chain<iterable> */
     public static function minBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<iterable> */
     public static function minBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<iterable> */
     public static function minEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minEven(): Chain;
 
+    /** @return Chain<iterable> */
     public static function minFactor(int $dividend): Chain;
 
+    /** @return Chain<iterable> */
     public static function minFinite(): Chain;
 
+    /** @return Chain<iterable> */
     public static function minGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minIn(mixed $haystack): Chain;
 
+    /** @return Chain<iterable> */
     public static function minInfinite(): Chain;
 
+    /** @return Chain<iterable> */
     public static function minLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<iterable> */
     public static function minMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<iterable> */
     public static function minOdd(): Chain;
 
+    /** @return Chain<iterable> */
     public static function minPositive(): Chain;
 }

--- a/src/Mixins/MinChain.php
+++ b/src/Mixins/MinChain.php
@@ -13,37 +13,54 @@ namespace Respect\Validation\Mixins;
 
 interface MinChain
 {
+    /** @return Chain<mixed> */
     public function minBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function minBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function minEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function minFactor(int $dividend): Chain;
 
+    /** @return Chain<mixed> */
     public function minFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function minGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function minInfinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function minLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function minMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function minOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function minPositive(): Chain;
 }

--- a/src/Mixins/NotBuilder.php
+++ b/src/Mixins/NotBuilder.php
@@ -17,318 +17,489 @@ use Respect\Validation\Validator;
 
 interface NotBuilder
 {
+    /** @return Chain<mixed> */
     public static function notAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function notArrayType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBlank(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBoolType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBoolVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notBsn(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCallableType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCnh(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCnpj(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public static function notContainsAny(array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public static function notContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public static function notControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public static function notCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCpf(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public static function notCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public static function notDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public static function notDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public static function notDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public static function notDecimal(int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public static function notDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notDirectory(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEachKey(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEmail(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEmoji(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notEven(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notExecutable(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notExists(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function notFactory(callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFalsy(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFile(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFloatType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFloatVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public static function notFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public static function notGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notHetu(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notHexRgbColor(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIban(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notImage(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notImei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public static function notInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public static function notInstance(string $class): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIntType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIntVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIsbn(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIterableType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notIterableVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notJson(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function notKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public static function notLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLeapDate(string $format): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLowercase(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notLuhn(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notMax(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public static function notMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNegative(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNfeAccessKey(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNif(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNullType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNumber(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notNumericVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notObjectType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPesel(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPis(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPolishIdCard(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPortugueseNif(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPositive(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPublicDomainSuffix(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notReadable(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notRegex(string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public static function notResourceType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public static function notScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public static function notSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSlug(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSorted(string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSpaced(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function notStringType(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notStringVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public static function notSubset(array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public static function notSymbolicLink(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public static function notTld(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function notTrueVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notUndef(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notUnique(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notUppercase(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notUrl(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notUuid(int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public static function notVersion(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function notWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public static function notWritable(): Chain;
 
+    /** @return Chain<mixed> */
     public static function notXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/NotChain.php
+++ b/src/Mixins/NotChain.php
@@ -17,318 +17,489 @@ use Respect\Validation\Validator;
 
 interface NotChain
 {
+    /** @return Chain<mixed> */
     public function notAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function notAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public function notAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public function notAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function notArrayType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public function notBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public function notBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function notBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function notBlank(): Chain;
 
+    /** @return Chain<mixed> */
     public function notBoolType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notBoolVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notBsn(): Chain;
 
+    /** @return Chain<mixed> */
     public function notCallableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public function notCnh(): Chain;
 
+    /** @return Chain<mixed> */
     public function notCnpj(): Chain;
 
+    /** @return Chain<mixed> */
     public function notConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public function notContainsAny(array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public function notContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public function notControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function notCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function notCpf(): Chain;
 
+    /** @return Chain<mixed> */
     public function notCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function notCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public function notDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public function notDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public function notDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public function notDecimal(int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public function notDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notDirectory(): Chain;
 
+    /** @return Chain<mixed> */
     public function notDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public function notEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notEachKey(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notEmail(): Chain;
 
+    /** @return Chain<mixed> */
     public function notEmoji(): Chain;
 
+    /** @return Chain<mixed> */
     public function notEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public function notEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function notExecutable(): Chain;
 
+    /** @return Chain<mixed> */
     public function notExists(): Chain;
 
+    /** @return Chain<mixed> */
     public function notExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public function notFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public function notFactory(callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public function notFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notFalsy(): Chain;
 
+    /** @return Chain<mixed> */
     public function notFile(): Chain;
 
+    /** @return Chain<mixed> */
     public function notFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function notFloatType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notFloatVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public function notFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public function notGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notHetu(): Chain;
 
+    /** @return Chain<mixed> */
     public function notHexRgbColor(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIban(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notImage(): Chain;
 
+    /** @return Chain<mixed> */
     public function notImei(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function notInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public function notInstance(string $class): Chain;
 
+    /** @return Chain<mixed> */
     public function notIntType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIntVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public function notIsbn(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIterableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notIterableVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notJson(): Chain;
 
+    /** @return Chain<mixed> */
     public function notKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function notKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public function notLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function notLeapDate(string $format): Chain;
 
+    /** @return Chain<mixed> */
     public function notLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public function notLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function notLowercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function notLuhn(): Chain;
 
+    /** @return Chain<mixed> */
     public function notMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public function notMax(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public function notMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function notNegative(): Chain;
 
+    /** @return Chain<mixed> */
     public function notNfeAccessKey(): Chain;
 
+    /** @return Chain<mixed> */
     public function notNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function notNip(): Chain;
 
+    /** @return Chain<mixed> */
     public function notNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function notNullType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notNumber(): Chain;
 
+    /** @return Chain<mixed> */
     public function notNumericVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notObjectType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function notOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function notPesel(): Chain;
 
+    /** @return Chain<mixed> */
     public function notPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public function notPis(): Chain;
 
+    /** @return Chain<mixed> */
     public function notPolishIdCard(): Chain;
 
+    /** @return Chain<mixed> */
     public function notPortugueseNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function notPositive(): Chain;
 
+    /** @return Chain<mixed> */
     public function notPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public function notPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function notPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notPublicDomainSuffix(): Chain;
 
+    /** @return Chain<mixed> */
     public function notPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notReadable(): Chain;
 
+    /** @return Chain<mixed> */
     public function notRegex(string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public function notResourceType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public function notSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public function notScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public function notSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function notSlug(): Chain;
 
+    /** @return Chain<mixed> */
     public function notSorted(string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public function notSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notSpaced(): Chain;
 
+    /** @return Chain<mixed> */
     public function notStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public function notStringType(): Chain;
 
+    /** @return Chain<mixed> */
     public function notStringVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public function notSubset(array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public function notSymbolicLink(): Chain;
 
+    /** @return Chain<mixed> */
     public function notTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public function notTld(): Chain;
 
+    /** @return Chain<mixed> */
     public function notTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public function notTrueVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function notUndef(): Chain;
 
+    /** @return Chain<mixed> */
     public function notUnique(): Chain;
 
+    /** @return Chain<mixed> */
     public function notUppercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function notUrl(): Chain;
 
+    /** @return Chain<mixed> */
     public function notUuid(int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public function notVersion(): Chain;
 
+    /** @return Chain<mixed> */
     public function notVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function notWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public function notWritable(): Chain;
 
+    /** @return Chain<mixed> */
     public function notXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/NullOrBuilder.php
+++ b/src/Mixins/NullOrBuilder.php
@@ -17,318 +17,489 @@ use Respect\Validation\Validator;
 
 interface NullOrBuilder
 {
+    /** @return Chain<mixed> */
     public static function nullOrAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|null> */
     public static function nullOrArrayType(): Chain;
 
+    /** @return Chain<array|\ArrayAccess|\SimpleXMLElement|null> */
     public static function nullOrArrayVal(): Chain;
 
+    /** @return Chain<object|null> */
     public static function nullOrAttributes(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<bool|null> */
     public static function nullOrBoolType(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrBoolVal(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrBsn(): Chain;
 
+    /** @return Chain<callable|null> */
     public static function nullOrCallableType(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrCnh(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrCnpj(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|array|null> */
     public static function nullOrContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<scalar|array|null>
+     */
     public static function nullOrContainsAny(array $needles): Chain;
 
+    /** @return Chain<scalar|array|null> */
     public static function nullOrContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\Countable|null> */
     public static function nullOrCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<string|null>
+     */
     public static function nullOrCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrCpf(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<string|null>
+     */
     public static function nullOrCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null> */
     public static function nullOrDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<string|\DateTimeInterface|null>
+     */
     public static function nullOrDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrDecimal(int $decimals): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrDirectory(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEachKey(Validator $validator): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrEmail(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrEmoji(): Chain;
 
+    /** @return Chain<array|string|null> */
     public static function nullOrEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrEven(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrExecutable(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrExists(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function nullOrFactory(callable $factory): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrFalsy(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrFile(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrFinite(): Chain;
 
+    /** @return Chain<float|null> */
     public static function nullOrFloatType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|true|null> */
     public static function nullOrFloatVal(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null> */
     public static function nullOrFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<scalar|\Stringable|null> */
     public static function nullOrFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrHetu(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrHexRgbColor(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrIban(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrImage(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrImei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrIn(mixed $haystack): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public static function nullOrInstance(string $class): Chain;
 
+    /** @return Chain<int|null> */
     public static function nullOrIntType(): Chain;
 
+    /** @return Chain<int|numeric-string|null> */
     public static function nullOrIntVal(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrIsbn(): Chain;
 
+    /** @return Chain<iterable|null> */
     public static function nullOrIterableType(): Chain;
 
+    /** @return Chain<array|\stdClass|\Traversable|null> */
     public static function nullOrIterableVal(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrJson(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess|null> */
     public static function nullOrKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|null> */
     public static function nullOrKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<string|null>
+     */
     public static function nullOrLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null> */
     public static function nullOrLeapDate(string $format): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null> */
     public static function nullOrLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrLowercase(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrLuhn(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrMax(Validator $validator): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrNegative(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrNfeAccessKey(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrNif(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrNip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrNot(Validator $validator): Chain;
 
+    /** @return Chain<null> */
     public static function nullOrNullType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrNumber(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrNumericVal(): Chain;
 
+    /** @return Chain<object|null> */
     public static function nullOrObjectType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPesel(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPis(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPolishIdCard(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrPortugueseNif(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrPositive(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object|null> */
     public static function nullOrPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPublicDomainSuffix(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null> */
     public static function nullOrReadable(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrRegex(string $regex): Chain;
 
+    /** @return Chain<resource|null> */
     public static function nullOrResourceType(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<int|float|bool|string|null> */
     public static function nullOrScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface|null>
+     */
     public static function nullOrSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrSlug(): Chain;
 
+    /** @return Chain<array|string|null> */
     public static function nullOrSorted(string $direction): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrSpaced(): Chain;
 
+    /** @return Chain<array|string|null> */
     public static function nullOrStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrStringType(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null> */
     public static function nullOrStringVal(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array|null>
+     */
     public static function nullOrSubset(array $superset): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrSymbolicLink(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrTld(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrTrueVal(): Chain;
 
+    /** @return Chain<array|null> */
     public static function nullOrUnique(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrUppercase(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrUrl(): Chain;
 
+    /** @return Chain<string|\Ramsey\Uuid\UuidInterface|null> */
     public static function nullOrUuid(int|null $version = null): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrVersion(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null> */
     public static function nullOrWritable(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/NullOrBuilder.php
+++ b/src/Mixins/NullOrBuilder.php
@@ -17,318 +17,489 @@ use Respect\Validation\Validator;
 
 interface NullOrBuilder
 {
+    /** @return Chain<mixed> */
     public static function nullOrAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|null> */
     public static function nullOrArrayType(): Chain;
 
+    /** @return Chain<array|\ArrayAccess|\SimpleXMLElement|null> */
     public static function nullOrArrayVal(): Chain;
 
+    /** @return Chain<object|null> */
     public static function nullOrAttributes(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<bool|null> */
     public static function nullOrBoolType(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrBoolVal(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrBsn(): Chain;
 
+    /** @return Chain<callable|null> */
     public static function nullOrCallableType(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrCnh(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrCnpj(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|array|null> */
     public static function nullOrContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<scalar|array|null>
+     */
     public static function nullOrContainsAny(array $needles): Chain;
 
+    /** @return Chain<scalar|array|null> */
     public static function nullOrContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\Countable|null> */
     public static function nullOrCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<string|null>
+     */
     public static function nullOrCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrCpf(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<string|null>
+     */
     public static function nullOrCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null> */
     public static function nullOrDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<string|int|\DateTimeInterface|null>
+     */
     public static function nullOrDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrDecimal(int $decimals): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrDirectory(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEachKey(Validator $validator): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrEmail(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrEmoji(): Chain;
 
+    /** @return Chain<array|string|null> */
     public static function nullOrEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrEven(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrExecutable(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrExists(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function nullOrFactory(callable $factory): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrFalsy(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrFile(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrFinite(): Chain;
 
+    /** @return Chain<float|null> */
     public static function nullOrFloatType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|true|null> */
     public static function nullOrFloatVal(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null> */
     public static function nullOrFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<scalar|\Stringable|null> */
     public static function nullOrFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrHetu(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrHexRgbColor(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrIban(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrImage(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrImei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrIn(mixed $haystack): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public static function nullOrInstance(string $class): Chain;
 
+    /** @return Chain<int|null> */
     public static function nullOrIntType(): Chain;
 
+    /** @return Chain<int|numeric-string|null> */
     public static function nullOrIntVal(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrIsbn(): Chain;
 
+    /** @return Chain<iterable|null> */
     public static function nullOrIterableType(): Chain;
 
+    /** @return Chain<array|\stdClass|\Traversable|null> */
     public static function nullOrIterableVal(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrJson(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess|null> */
     public static function nullOrKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|null> */
     public static function nullOrKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<string|null>
+     */
     public static function nullOrLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null> */
     public static function nullOrLeapDate(string $format): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null> */
     public static function nullOrLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrLowercase(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrLuhn(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrMax(Validator $validator): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrNegative(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrNfeAccessKey(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrNif(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrNip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrNot(Validator $validator): Chain;
 
+    /** @return Chain<null> */
     public static function nullOrNullType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrNumber(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrNumericVal(): Chain;
 
+    /** @return Chain<object|null> */
     public static function nullOrObjectType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPesel(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPis(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPolishIdCard(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrPortugueseNif(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null> */
     public static function nullOrPositive(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object|null> */
     public static function nullOrPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPublicDomainSuffix(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null> */
     public static function nullOrReadable(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrRegex(string $regex): Chain;
 
+    /** @return Chain<resource|null> */
     public static function nullOrResourceType(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<int|float|bool|string|null> */
     public static function nullOrScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface|null>
+     */
     public static function nullOrSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrSlug(): Chain;
 
+    /** @return Chain<array|string|null> */
     public static function nullOrSorted(string $direction): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrSpaced(): Chain;
 
+    /** @return Chain<array|string|null> */
     public static function nullOrStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrStringType(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null> */
     public static function nullOrStringVal(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array|null>
+     */
     public static function nullOrSubset(array $superset): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null> */
     public static function nullOrSymbolicLink(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrTld(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrTrueVal(): Chain;
 
+    /** @return Chain<array|null> */
     public static function nullOrUnique(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrUppercase(): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrUrl(): Chain;
 
+    /** @return Chain<string|\Ramsey\Uuid\UuidInterface|null> */
     public static function nullOrUuid(int|null $version = null): Chain;
 
+    /** @return Chain<string|null> */
     public static function nullOrVersion(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function nullOrWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null> */
     public static function nullOrWritable(): Chain;
 
+    /** @return Chain<scalar|null> */
     public static function nullOrXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/NullOrChain.php
+++ b/src/Mixins/NullOrChain.php
@@ -17,318 +17,489 @@ use Respect\Validation\Validator;
 
 interface NullOrChain
 {
+    /** @return Chain<mixed> */
     public function nullOrAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrArrayType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrAttributes(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBoolType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBoolVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrBsn(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCallableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCnh(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCnpj(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public function nullOrContainsAny(array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function nullOrCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCpf(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function nullOrCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public function nullOrDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrDecimal(int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrDirectory(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEachKey(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEmail(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEmoji(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrExecutable(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrExists(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public function nullOrFactory(callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFalsy(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFile(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFloatType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFloatVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrHetu(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrHexRgbColor(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIban(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrImage(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrImei(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public function nullOrInstance(string $class): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIntType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIntVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIsbn(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIterableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrIterableVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrJson(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public function nullOrLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLeapDate(string $format): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLowercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrLuhn(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrMax(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNegative(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNfeAccessKey(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNip(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNot(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNullType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNumber(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrNumericVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrObjectType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPesel(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPis(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPolishIdCard(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPortugueseNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPositive(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPublicDomainSuffix(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrReadable(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrRegex(string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrResourceType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public function nullOrSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSlug(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSorted(string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSpaced(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrStringType(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrStringVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public function nullOrSubset(array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrSymbolicLink(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrTld(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrTrueVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrUnique(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrUppercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrUrl(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrUuid(int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrVersion(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrWritable(): Chain;
 
+    /** @return Chain<mixed> */
     public function nullOrXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/PropertyBuilder.php
+++ b/src/Mixins/PropertyBuilder.php
@@ -17,302 +17,465 @@ use Respect\Validation\Validator;
 
 interface PropertyBuilder
 {
+    /** @return Chain<object> */
     public static function propertyAfter(string $propertyName, callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAll(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAllOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAlnum(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAlpha(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAlwaysInvalid(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAlwaysValid(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyAnyOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<object> */
     public static function propertyArrayType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyArrayVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBase(string $propertyName, int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBase64(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBetween(string $propertyName, mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBetweenExclusive(string $propertyName, mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBlank(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBoolType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBoolVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyBsn(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCallableType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCharset(string $propertyName, string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCnh(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCnpj(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyConsonant(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyContains(string $propertyName, mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<object>
+     */
     public static function propertyContainsAny(string $propertyName, array $needles): Chain;
 
+    /** @return Chain<object> */
     public static function propertyContainsCount(string $propertyName, mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<object> */
     public static function propertyControl(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCountable(string $propertyName): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<object>
+     */
     public static function propertyCountryCode(string $propertyName, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCpf(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyCreditCard(string $propertyName, string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<object>
+     */
     public static function propertyCurrencyCode(string $propertyName, string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<object> */
     public static function propertyDate(string $propertyName, string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<object> */
     public static function propertyDateTime(string $propertyName, string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<object>
+     */
     public static function propertyDateTimeDiff(string $propertyName, string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<object> */
     public static function propertyDecimal(string $propertyName, int $decimals): Chain;
 
+    /** @return Chain<object> */
     public static function propertyDigit(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyDirectory(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyDomain(string $propertyName, bool $tldCheck = true): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEach(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEachKey(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEmail(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEmoji(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEndsWith(string $propertyName, mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEquals(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEquivalent(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyEven(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyExecutable(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyExtension(string $propertyName, string $extension): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFactor(string $propertyName, int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<object>
+     */
     public static function propertyFactory(string $propertyName, callable $factory): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFalseVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFalsy(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFile(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFinite(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFloatType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFloatVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyFormat(string $propertyName, Formatter $formatter): Chain;
 
+    /** @return Chain<object> */
     public static function propertyGiven(string $propertyName, Validator $when, Validator $then): Chain;
 
+    /** @return Chain<object> */
     public static function propertyGraph(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyGreaterThan(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyGreaterThanOrEqual(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyHetu(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyHexRgbColor(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIban(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIdentical(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyImage(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyImei(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIn(string $propertyName, mixed $haystack): Chain;
 
+    /** @return Chain<object> */
     public static function propertyInfinite(string $propertyName): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<object>
+     */
     public static function propertyInstance(string $propertyName, string $class): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIntType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIntVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIp(string $propertyName, string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIsbn(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIterableType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyIterableVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyJson(string $propertyName): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<object>
+     */
     public static function propertyLanguageCode(string $propertyName, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLeapDate(string $propertyName, string $format): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLeapYear(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLength(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLessThan(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLessThanOrEqual(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLowercase(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyLuhn(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyMacAddress(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyMax(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyMimetype(string $propertyName, string $mimetype): Chain;
 
+    /** @return Chain<object> */
     public static function propertyMin(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyMultiple(string $propertyName, int $multipleOf): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNegative(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNfeAccessKey(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNif(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNip(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNoneOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNot(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNullType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNumber(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyNumericVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyObjectType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyOdd(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyOneOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPesel(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPhone(string $propertyName, string|null $countryCode = null): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPis(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPolishIdCard(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPortugueseNif(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPositive(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPostalCode(string $propertyName, string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPrintable(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPublicDomainSuffix(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyPunct(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyReadable(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyRegex(string $propertyName, string $regex): Chain;
 
+    /** @return Chain<object> */
     public static function propertyResourceType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyRoman(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertySatisfies(string $propertyName, callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<object> */
     public static function propertyScalarVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyShortCircuit(string $propertyName, Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<object>
+     */
     public static function propertySize(string $propertyName, string $unit, Validator $validator): Chain;
 
+    /** @return Chain<object> */
     public static function propertySlug(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertySorted(string $propertyName, string $direction): Chain;
 
+    /** @return Chain<object> */
     public static function propertySpace(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertySpaced(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyStartsWith(string $propertyName, mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<object> */
     public static function propertyStringType(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyStringVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertySubdivisionCode(string $propertyName, string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<object>
+     */
     public static function propertySubset(string $propertyName, array $superset): Chain;
 
+    /** @return Chain<object> */
     public static function propertySymbolicLink(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyTime(string $propertyName, string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<object> */
     public static function propertyTld(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyTrimmed(string $propertyName, string ...$trimValues): Chain;
 
+    /** @return Chain<object> */
     public static function propertyTrueVal(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyUndef(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyUnique(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyUppercase(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyUrl(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyUuid(string $propertyName, int|null $version = null): Chain;
 
+    /** @return Chain<object> */
     public static function propertyVersion(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyVowel(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<object> */
     public static function propertyWhen(string $propertyName, Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<object> */
     public static function propertyWritable(string $propertyName): Chain;
 
+    /** @return Chain<object> */
     public static function propertyXdigit(string $propertyName, string ...$additionalChars): Chain;
 }

--- a/src/Mixins/PropertyChain.php
+++ b/src/Mixins/PropertyChain.php
@@ -17,302 +17,465 @@ use Respect\Validation\Validator;
 
 interface PropertyChain
 {
+    /** @return Chain<mixed> */
     public function propertyAfter(string $propertyName, callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAll(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAllOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAlnum(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAlpha(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAlwaysInvalid(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAlwaysValid(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyAnyOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyArrayType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyArrayVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBase(string $propertyName, int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBase64(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBetween(string $propertyName, mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBetweenExclusive(string $propertyName, mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBlank(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBoolType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBoolVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyBsn(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCallableType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCharset(string $propertyName, string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCnh(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCnpj(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyConsonant(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyContains(string $propertyName, mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public function propertyContainsAny(string $propertyName, array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyContainsCount(string $propertyName, mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyControl(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCountable(string $propertyName): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function propertyCountryCode(string $propertyName, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCpf(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyCreditCard(string $propertyName, string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function propertyCurrencyCode(string $propertyName, string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyDate(string $propertyName, string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyDateTime(string $propertyName, string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public function propertyDateTimeDiff(string $propertyName, string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyDecimal(string $propertyName, int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyDigit(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyDirectory(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyDomain(string $propertyName, bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEach(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEachKey(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEmail(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEmoji(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEndsWith(string $propertyName, mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEquals(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEquivalent(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyEven(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyExecutable(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyExtension(string $propertyName, string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFactor(string $propertyName, int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public function propertyFactory(string $propertyName, callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFalseVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFalsy(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFile(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFinite(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFloatType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFloatVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyFormat(string $propertyName, Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyGiven(string $propertyName, Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyGraph(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyGreaterThan(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyGreaterThanOrEqual(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyHetu(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyHexRgbColor(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIban(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIdentical(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyImage(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyImei(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIn(string $propertyName, mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyInfinite(string $propertyName): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public function propertyInstance(string $propertyName, string $class): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIntType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIntVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIp(string $propertyName, string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIsbn(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIterableType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyIterableVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyJson(string $propertyName): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public function propertyLanguageCode(string $propertyName, string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLeapDate(string $propertyName, string $format): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLeapYear(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLength(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLessThan(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLessThanOrEqual(string $propertyName, mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLowercase(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyLuhn(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyMacAddress(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyMax(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyMimetype(string $propertyName, string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyMin(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyMultiple(string $propertyName, int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNegative(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNfeAccessKey(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNif(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNip(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNoneOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNot(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNullType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNumber(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyNumericVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyObjectType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyOdd(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyOneOf(string $propertyName, Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPesel(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPhone(string $propertyName, string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPis(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPolishIdCard(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPortugueseNif(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPositive(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPostalCode(string $propertyName, string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPrintable(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPublicDomainSuffix(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyPunct(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyReadable(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyRegex(string $propertyName, string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyResourceType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyRoman(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySatisfies(string $propertyName, callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyScalarVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyShortCircuit(string $propertyName, Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public function propertySize(string $propertyName, string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySlug(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySorted(string $propertyName, string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySpace(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySpaced(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyStartsWith(string $propertyName, mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyStringType(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyStringVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySubdivisionCode(string $propertyName, string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public function propertySubset(string $propertyName, array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public function propertySymbolicLink(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyTime(string $propertyName, string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyTld(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyTrimmed(string $propertyName, string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyTrueVal(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyUndef(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyUnique(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyUppercase(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyUrl(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyUuid(string $propertyName, int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyVersion(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyVowel(string $propertyName, string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyWhen(string $propertyName, Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyWritable(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function propertyXdigit(string $propertyName, string ...$additionalChars): Chain;
 }

--- a/src/Mixins/UndefOrBuilder.php
+++ b/src/Mixins/UndefOrBuilder.php
@@ -17,316 +17,486 @@ use Respect\Validation\Validator;
 
 interface UndefOrBuilder
 {
+    /** @return Chain<mixed> */
     public static function undefOrAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|null|''> */
     public static function undefOrArrayType(): Chain;
 
+    /** @return Chain<array|\ArrayAccess|\SimpleXMLElement|null|''> */
     public static function undefOrArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<bool|null|''> */
     public static function undefOrBoolType(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrBoolVal(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrBsn(): Chain;
 
+    /** @return Chain<callable|null|''> */
     public static function undefOrCallableType(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrCnh(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrCnpj(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|array|null|''> */
     public static function undefOrContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<scalar|array|null|''>
+     */
     public static function undefOrContainsAny(array $needles): Chain;
 
+    /** @return Chain<scalar|array|null|''> */
     public static function undefOrContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\Countable|null|''> */
     public static function undefOrCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<string|null|''>
+     */
     public static function undefOrCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrCpf(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<string|null|''>
+     */
     public static function undefOrCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null|''> */
     public static function undefOrDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<string|\DateTimeInterface|null|''>
+     */
     public static function undefOrDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrDecimal(int $decimals): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrDirectory(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEachKey(Validator $validator): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrEmail(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrEmoji(): Chain;
 
+    /** @return Chain<array|string|null|''> */
     public static function undefOrEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrEven(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrExecutable(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrExists(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function undefOrFactory(callable $factory): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrFalsy(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrFile(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrFinite(): Chain;
 
+    /** @return Chain<float|null|''> */
     public static function undefOrFloatType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|true|null|''> */
     public static function undefOrFloatVal(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null|''> */
     public static function undefOrFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<scalar|\Stringable|null|''> */
     public static function undefOrFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrHetu(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrHexRgbColor(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrIban(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrImage(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrImei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrIn(mixed $haystack): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public static function undefOrInstance(string $class): Chain;
 
+    /** @return Chain<int|null|''> */
     public static function undefOrIntType(): Chain;
 
+    /** @return Chain<int|numeric-string|null|''> */
     public static function undefOrIntVal(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrIsbn(): Chain;
 
+    /** @return Chain<iterable|null|''> */
     public static function undefOrIterableType(): Chain;
 
+    /** @return Chain<array|\stdClass|\Traversable|null|''> */
     public static function undefOrIterableVal(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrJson(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess|null|''> */
     public static function undefOrKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|null|''> */
     public static function undefOrKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<string|null|''>
+     */
     public static function undefOrLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null|''> */
     public static function undefOrLeapDate(string $format): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null|''> */
     public static function undefOrLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrLowercase(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrLuhn(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrMax(Validator $validator): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrNegative(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrNfeAccessKey(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrNif(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrNip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrNot(Validator $validator): Chain;
 
+    /** @return Chain<null|''> */
     public static function undefOrNullType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrNumber(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrNumericVal(): Chain;
 
+    /** @return Chain<object|null|''> */
     public static function undefOrObjectType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPesel(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPis(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPolishIdCard(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrPortugueseNif(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrPositive(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object|null|''> */
     public static function undefOrPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPublicDomainSuffix(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null|''> */
     public static function undefOrReadable(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrRegex(string $regex): Chain;
 
+    /** @return Chain<resource|null|''> */
     public static function undefOrResourceType(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<int|float|bool|string|null|''> */
     public static function undefOrScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface|null|''>
+     */
     public static function undefOrSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrSlug(): Chain;
 
+    /** @return Chain<array|string|null|''> */
     public static function undefOrSorted(string $direction): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrSpaced(): Chain;
 
+    /** @return Chain<array|string|null|''> */
     public static function undefOrStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrStringType(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null|''> */
     public static function undefOrStringVal(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array|null|''>
+     */
     public static function undefOrSubset(array $superset): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrSymbolicLink(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrTld(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrTrueVal(): Chain;
 
+    /** @return Chain<array|null|''> */
     public static function undefOrUnique(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrUppercase(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrUrl(): Chain;
 
+    /** @return Chain<string|\Ramsey\Uuid\UuidInterface|null|''> */
     public static function undefOrUuid(int|null $version = null): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrVersion(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null|''> */
     public static function undefOrWritable(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/UndefOrBuilder.php
+++ b/src/Mixins/UndefOrBuilder.php
@@ -17,316 +17,486 @@ use Respect\Validation\Validator;
 
 interface UndefOrBuilder
 {
+    /** @return Chain<mixed> */
     public static function undefOrAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<array|null|''> */
     public static function undefOrArrayType(): Chain;
 
+    /** @return Chain<array|\ArrayAccess|\SimpleXMLElement|null|''> */
     public static function undefOrArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<bool|null|''> */
     public static function undefOrBoolType(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrBoolVal(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrBsn(): Chain;
 
+    /** @return Chain<callable|null|''> */
     public static function undefOrCallableType(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrCnh(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrCnpj(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<scalar|array|null|''> */
     public static function undefOrContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<scalar|array|null|''>
+     */
     public static function undefOrContainsAny(array $needles): Chain;
 
+    /** @return Chain<scalar|array|null|''> */
     public static function undefOrContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<array|\Countable|null|''> */
     public static function undefOrCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<string|null|''>
+     */
     public static function undefOrCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrCpf(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<string|null|''>
+     */
     public static function undefOrCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null|''> */
     public static function undefOrDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<string|int|\DateTimeInterface|null|''>
+     */
     public static function undefOrDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrDecimal(int $decimals): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrDirectory(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEachKey(Validator $validator): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrEmail(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrEmoji(): Chain;
 
+    /** @return Chain<array|string|null|''> */
     public static function undefOrEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrEven(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrExecutable(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrExists(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public static function undefOrFactory(callable $factory): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrFalsy(): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrFile(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrFinite(): Chain;
 
+    /** @return Chain<float|null|''> */
     public static function undefOrFloatType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|true|null|''> */
     public static function undefOrFloatVal(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null|''> */
     public static function undefOrFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<scalar|\Stringable|null|''> */
     public static function undefOrFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrHetu(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrHexRgbColor(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrIban(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrImage(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrImei(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrIn(mixed $haystack): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public static function undefOrInstance(string $class): Chain;
 
+    /** @return Chain<int|null|''> */
     public static function undefOrIntType(): Chain;
 
+    /** @return Chain<int|numeric-string|null|''> */
     public static function undefOrIntVal(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrIsbn(): Chain;
 
+    /** @return Chain<iterable|null|''> */
     public static function undefOrIterableType(): Chain;
 
+    /** @return Chain<array|\stdClass|\Traversable|null|''> */
     public static function undefOrIterableVal(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrJson(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|\ArrayAccess|null|''> */
     public static function undefOrKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<array|null|''> */
     public static function undefOrKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<string|null|''>
+     */
     public static function undefOrLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null|''> */
     public static function undefOrLeapDate(string $format): Chain;
 
+    /** @return Chain<scalar|\DateTimeInterface|null|''> */
     public static function undefOrLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrLowercase(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrLuhn(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrMax(Validator $validator): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrNegative(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrNfeAccessKey(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrNif(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrNip(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrNot(Validator $validator): Chain;
 
+    /** @return Chain<null|''> */
     public static function undefOrNullType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrNumber(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrNumericVal(): Chain;
 
+    /** @return Chain<object|null|''> */
     public static function undefOrObjectType(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPesel(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPis(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPolishIdCard(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrPortugueseNif(): Chain;
 
+    /** @return Chain<int|float|numeric-string|null|''> */
     public static function undefOrPositive(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<object|null|''> */
     public static function undefOrPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPublicDomainSuffix(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null|''> */
     public static function undefOrReadable(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrRegex(string $regex): Chain;
 
+    /** @return Chain<resource|null|''> */
     public static function undefOrResourceType(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<int|float|bool|string|null|''> */
     public static function undefOrScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<string|\SplFileInfo|\Psr\Http\Message\UploadedFileInterface|\Psr\Http\Message\StreamInterface|null|''>
+     */
     public static function undefOrSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrSlug(): Chain;
 
+    /** @return Chain<array|string|null|''> */
     public static function undefOrSorted(string $direction): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrSpaced(): Chain;
 
+    /** @return Chain<array|string|null|''> */
     public static function undefOrStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrStringType(): Chain;
 
+    /** @return Chain<scalar|\Stringable|null|''> */
     public static function undefOrStringVal(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<array|null|''>
+     */
     public static function undefOrSubset(array $superset): Chain;
 
+    /** @return Chain<string|\SplFileInfo|null|''> */
     public static function undefOrSymbolicLink(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrTld(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrTrueVal(): Chain;
 
+    /** @return Chain<array|null|''> */
     public static function undefOrUnique(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrUppercase(): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrUrl(): Chain;
 
+    /** @return Chain<string|\Ramsey\Uuid\UuidInterface|null|''> */
     public static function undefOrUuid(int|null $version = null): Chain;
 
+    /** @return Chain<string|null|''> */
     public static function undefOrVersion(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public static function undefOrWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<string|\SplFileInfo|\Psr\Http\Message\StreamInterface|null|''> */
     public static function undefOrWritable(): Chain;
 
+    /** @return Chain<scalar|null|''> */
     public static function undefOrXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Mixins/UndefOrChain.php
+++ b/src/Mixins/UndefOrChain.php
@@ -17,316 +17,486 @@ use Respect\Validation\Validator;
 
 interface UndefOrChain
 {
+    /** @return Chain<mixed> */
     public function undefOrAfter(callable $callable, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAll(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAllOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAlnum(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAlpha(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAlwaysInvalid(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAlwaysValid(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrAnyOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrArrayType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrArrayVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBase(int $base, string $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBase64(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBetween(mixed $minValue, mixed $maxValue): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBetweenExclusive(mixed $minimum, mixed $maximum): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBoolType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBoolVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrBsn(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCallableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCharset(string $charset, string ...$charsets): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCnh(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCnpj(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrConsonant(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrContains(mixed $containsValue): Chain;
 
-    /** @param non-empty-array<mixed> $needles */
+    /**
+     * @param non-empty-array<mixed> $needles
+     * @return Chain<mixed>
+     */
     public function undefOrContainsAny(array $needles): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrContainsCount(mixed $containsValue, int $count): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrControl(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCountable(): Chain;
 
-    /** @param "alpha-2"|"alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-2"|"alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function undefOrCountryCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCpf(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrCreditCard(string $brand = 'Any'): Chain;
 
-    /** @param "alpha-3"|"numeric" $set */
+    /**
+     * @param "alpha-3"|"numeric" $set
+     * @return Chain<mixed>
+     */
     public function undefOrCurrencyCode(string $set = 'alpha-3'): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrDate(string $format = 'Y-m-d'): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrDateTime(string|null $format = null): Chain;
 
-    /** @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type */
+    /**
+     * @param "years"|"months"|"days"|"hours"|"minutes"|"seconds"|"microseconds" $type
+     * @return Chain<mixed>
+     */
     public function undefOrDateTimeDiff(string $type, Validator $validator, string|null $format = null, DateTimeImmutable|null $now = null): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrDecimal(int $decimals): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrDigit(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrDirectory(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrDomain(bool $tldCheck = true): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEach(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEachKey(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEmail(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEmoji(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEndsWith(mixed $endValue, mixed ...$endValues): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEquals(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEquivalent(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrEven(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrExecutable(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrExists(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrExtension(string $extension): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFactor(int $dividend): Chain;
 
-    /** @param callable(mixed): Validator $factory */
+    /**
+     * @param callable(mixed): Validator $factory
+     * @return Chain<mixed>
+     */
     public function undefOrFactory(callable $factory): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFalseVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFalsy(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFile(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFinite(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFloatType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFloatVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFormat(Formatter $formatter): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrFormatted(Formatter $formatter, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrGiven(Validator $when, Validator $then): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrGraph(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrGreaterThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrGreaterThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrHetu(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrHexRgbColor(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIban(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIdentical(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrImage(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrImei(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIn(mixed $haystack): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrInfinite(): Chain;
 
-    /** @param class-string $class */
+    /**
+     * @param class-string $class
+     * @return Chain<mixed>
+     */
     public function undefOrInstance(string $class): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIntType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIntVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIp(string $range = '*', int|null $options = null): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIsbn(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIterableType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrIterableVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrJson(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrKey(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrKeyExists(int|string $key): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrKeyOptional(int|string $key, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrKeySet(Validator $validator, Validator ...$validators): Chain;
 
-    /** @param "alpha-2"|"alpha-3" $set */
+    /**
+     * @param "alpha-2"|"alpha-3" $set
+     * @return Chain<mixed>
+     */
     public function undefOrLanguageCode(string $set = 'alpha-2'): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLeapDate(string $format): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLeapYear(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLength(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLessThan(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLessThanOrEqual(mixed $compareTo): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLowercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrLuhn(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrMacAddress(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrMax(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrMimetype(string $mimetype): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrMin(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrMultiple(int $multipleOf): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNegative(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNfeAccessKey(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNip(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNoneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNot(Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNullType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNumber(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrNumericVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrObjectType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrOdd(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrOneOf(Validator $validator1, Validator $validator2, Validator ...$validators): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPesel(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPhone(string|null $countryCode = null): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPis(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPolishIdCard(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPortugueseNif(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPositive(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPostalCode(string $countryCode, bool $formatted = false): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPrintable(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrProperty(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPropertyExists(string $propertyName): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPropertyOptional(string $propertyName, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPublicDomainSuffix(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrPunct(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrReadable(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrRegex(string $regex): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrResourceType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrRoman(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSatisfies(callable $callback, mixed ...$arguments): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrScalarVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrShortCircuit(Validator ...$validators): Chain;
 
-    /** @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit */
+    /**
+     * @param "B"|"KB"|"MB"|"GB"|"TB"|"PB"|"EB"|"ZB"|"YB" $unit
+     * @return Chain<mixed>
+     */
     public function undefOrSize(string $unit, Validator $validator): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSlug(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSorted(string $direction): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSpace(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSpaced(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrStartsWith(mixed $startValue, mixed ...$startValues): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrStringType(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrStringVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSubdivisionCode(string $countryCode): Chain;
 
-    /** @param mixed[] $superset */
+    /**
+     * @param mixed[] $superset
+     * @return Chain<mixed>
+     */
     public function undefOrSubset(array $superset): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrSymbolicLink(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrTime(string $format = 'H:i:s'): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrTld(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrTrimmed(string ...$trimValues): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrTrueVal(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrUnique(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrUppercase(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrUrl(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrUuid(int|null $version = null): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrVersion(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrVowel(string ...$additionalChars): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrWhen(Validator $when, Validator $then, Validator|null $else = null): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrWritable(): Chain;
 
+    /** @return Chain<mixed> */
     public function undefOrXdigit(string ...$additionalChars): Chain;
 }

--- a/src/Validators/All.php
+++ b/src/Validators/All.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceFrom;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Helpers\CanEvaluateShortCircuit;
 use Respect\Validation\Message\Template;
@@ -26,6 +30,8 @@ use Respect\Validation\Validators\Core\ShortCircuitable;
 #[Composable(prefix: self::class, without: [self::class])]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template('Every item in', 'Every item in')]
+#[Assurance(from: AssuranceFrom::Elements)]
+#[AssuranceSubject(AssuranceSubjectMode::Elements)]
 final class All extends FilteredArray implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;

--- a/src/Validators/Alnum.php
+++ b/src/Validators/Alnum.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -31,6 +32,7 @@ use function ctype_alnum;
     '{{subject}} must not consist only of letters (a-z), digits (0-9), or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Alnum extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Alpha.php
+++ b/src/Validators/Alpha.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -31,6 +32,7 @@ use function ctype_alpha;
     '{{subject}} must not consist only of letters (a-z) or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Alpha extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/ArrayType.php
+++ b/src/Validators/ArrayType.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function is_array;
     '{{subject}} must be an array',
     '{{subject}} must not be an array',
 )]
+#[Assurance(type: 'array')]
 final class ArrayType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/ArrayVal.php
+++ b/src/Validators/ArrayVal.php
@@ -18,6 +18,7 @@ namespace Respect\Validation\Validators;
 
 use ArrayAccess;
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SimpleXMLElement;
@@ -29,6 +30,7 @@ use function is_array;
     '{{subject}} must be an array',
     '{{subject}} must not be an array',
 )]
+#[Assurance(type: ['array', ArrayAccess::class, SimpleXMLElement::class])]
 final class ArrayVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Attributes.php
+++ b/src/Validators/Attributes.php
@@ -20,6 +20,7 @@ use ReflectionNamedType;
 use ReflectionObject;
 use ReflectionProperty;
 use ReflectionUnionType;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Parameter\Resolver;
 use Respect\Validation\Id;
@@ -37,6 +38,7 @@ use function spl_object_id;
     '{{subject}} must contain a circular reference',
     Attributes::TEMPLATE_CIRCULAR_REFERENCE,
 )]
+#[Assurance(type: 'object')]
 final class Attributes implements Validator
 {
     public const string TEMPLATE_CIRCULAR_REFERENCE = '__circular_reference__';

--- a/src/Validators/Attributes.php
+++ b/src/Validators/Attributes.php
@@ -22,6 +22,7 @@ use ReflectionProperty;
 use ReflectionReference;
 use ReflectionType;
 use ReflectionUnionType;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Parameter\Resolver;
 use Respect\Validation\Id;
@@ -40,6 +41,7 @@ use function spl_object_id;
     '{{subject}} must contain a circular reference',
     Attributes::TEMPLATE_CIRCULAR_REFERENCE,
 )]
+#[Assurance(type: 'object')]
 final readonly class Attributes implements Validator
 {
     public const string TEMPLATE_CIRCULAR_REFERENCE = '__circular_reference__';

--- a/src/Validators/Base64.php
+++ b/src/Validators/Base64.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -29,6 +30,7 @@ use function preg_match;
     '{{subject}} must be a base64-encoded string',
     '{{subject}} must not be a base64-encoded string',
 )]
+#[Assurance(type: 'string')]
 final class Base64 extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/BoolType.php
+++ b/src/Validators/BoolType.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function is_bool;
     '{{subject}} must be a boolean',
     '{{subject}} must not be a boolean',
 )]
+#[Assurance(type: 'bool')]
 final class BoolType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/BoolVal.php
+++ b/src/Validators/BoolVal.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -32,6 +33,7 @@ use const FILTER_VALIDATE_BOOLEAN;
     '{{subject}} must be a boolean',
     '{{subject}} must not be a boolean',
 )]
+#[Assurance(type: 'scalar|null')]
 final class BoolVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Bsn.php
+++ b/src/Validators/Bsn.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -29,6 +30,7 @@ use function strval;
     '{{subject}} must be a BSN',
     '{{subject}} must not be a BSN',
 )]
+#[Assurance(type: 'scalar')]
 final class Bsn extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/CallableType.php
+++ b/src/Validators/CallableType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -24,6 +25,7 @@ use function is_callable;
     '{{subject}} must be a callable function',
     '{{subject}} must not be a callable function',
 )]
+#[Assurance(type: 'callable')]
 final class CallableType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Charset.php
+++ b/src/Validators/Charset.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -33,6 +34,7 @@ use function mb_list_encodings;
     '{{subject}} must consist only of characters from the {{charset|list:or}} character-set',
     '{{subject}} must not consist only of characters from the {{charset|list:or}} character-set',
 )]
+#[Assurance(type: 'string')]
 final readonly class Charset implements Validator
 {
     /** @var non-empty-array<string> */

--- a/src/Validators/Cnh.php
+++ b/src/Validators/Cnh.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -30,6 +31,7 @@ use function preg_replace;
     '{{subject}} must be a CNH',
     '{{subject}} must not be a CNH',
 )]
+#[Assurance(type: 'scalar')]
 final class Cnh extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Cnpj.php
+++ b/src/Validators/Cnpj.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -34,6 +35,7 @@ use function strtoupper;
     '{{subject}} must be a CNPJ',
     '{{subject}} must not be a CNPJ',
 )]
+#[Assurance(type: 'scalar')]
 final class Cnpj extends Simple
 {
     private const int BASE_ASCII = 48;

--- a/src/Validators/Consonant.php
+++ b/src/Validators/Consonant.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -33,6 +34,7 @@ use function preg_match;
     '{{subject}} must not consist only of consonants or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Consonant extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Contains.php
+++ b/src/Validators/Contains.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -30,6 +31,7 @@ use function mb_strpos;
     '{{subject}} must contain {{containsValue}}',
     '{{subject}} must not contain {{containsValue}}',
 )]
+#[Assurance(type: 'scalar|array')]
 final readonly class Contains implements Validator
 {
     public function __construct(private mixed $containsValue)

--- a/src/Validators/ContainsAny.php
+++ b/src/Validators/ContainsAny.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
@@ -25,6 +26,7 @@ use function count;
     '{{subject}} must contain at least one value from {{needles}}',
     '{{subject}} must not contain any value from {{needles}}',
 )]
+#[Assurance(type: 'scalar|array')]
 final class ContainsAny extends Envelope
 {
     /** @param non-empty-array<mixed> $needles */

--- a/src/Validators/ContainsCount.php
+++ b/src/Validators/ContainsCount.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -32,6 +33,7 @@ use function mb_substr_count;
     '{{subject}} must not contain {{containsValue}} only once',
     self::TEMPLATE_ONCE,
 )]
+#[Assurance(type: 'scalar|array')]
 final readonly class ContainsCount implements Validator
 {
     public const string TEMPLATE_TIMES = '__times__';

--- a/src/Validators/Control.php
+++ b/src/Validators/Control.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -32,6 +33,7 @@ use function ctype_cntrl;
     '{{subject}} must not consist only of control characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Control extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Countable.php
+++ b/src/Validators/Countable.php
@@ -20,6 +20,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use Countable as CountableInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -30,6 +31,7 @@ use function is_array;
     '{{subject}} must be countable',
     '{{subject}} must not be countable',
 )]
+#[Assurance(type: ['array', CountableInterface::class])]
 final class Countable extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/CountryCode.php
+++ b/src/Validators/CountryCode.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
@@ -34,6 +35,7 @@ use function is_string;
     '{{subject}} must be a country code',
     '{{subject}} must not be a country code',
 )]
+#[Assurance(type: 'string')]
 final readonly class CountryCode implements Validator
 {
     private Countries $countries;

--- a/src/Validators/Cpf.php
+++ b/src/Validators/Cpf.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -33,6 +34,7 @@ use function preg_replace;
     '{{subject}} must be a CPF',
     '{{subject}} must not be a CPF',
 )]
+#[Assurance(type: 'string')]
 final class Cpf extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Cpf.php
+++ b/src/Validators/Cpf.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -34,6 +35,7 @@ use function preg_replace;
     '{{subject}} must be a CPF',
     '{{subject}} must not be a CPF',
 )]
+#[Assurance(type: 'string')]
 final class Cpf extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/CreditCard.php
+++ b/src/Validators/CreditCard.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -41,6 +42,7 @@ use function preg_replace;
     '{{subject}} must not be a {{brand|raw}} credit card number',
     self::TEMPLATE_BRANDED,
 )]
+#[Assurance(type: 'scalar')]
 final readonly class CreditCard implements Validator
 {
     public const string TEMPLATE_BRANDED = '__branded__';

--- a/src/Validators/CurrencyCode.php
+++ b/src/Validators/CurrencyCode.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
@@ -30,6 +31,7 @@ use function in_array;
     '{{subject}} must be a currency code',
     '{{subject}} must not be a currency code',
 )]
+#[Assurance(type: 'string')]
 final readonly class CurrencyCode implements Validator
 {
     private Currencies $currencies;

--- a/src/Validators/Date.php
+++ b/src/Validators/Date.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
@@ -33,6 +34,7 @@ use function strtotime;
     '{{subject}} must be a date in the {{sample}} format',
     '{{subject}} must not be a date in the {{sample}} format',
 )]
+#[Assurance(type: 'scalar')]
 final readonly class Date implements Validator
 {
     use CanValidateDateTime;

--- a/src/Validators/DateTime.php
+++ b/src/Validators/DateTime.php
@@ -18,6 +18,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use DateTimeInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -38,6 +39,7 @@ use function strtotime;
     '{{subject}} must not be a date/time in the {{sample}} format',
     self::TEMPLATE_FORMAT,
 )]
+#[Assurance(type: ['scalar', DateTimeInterface::class])]
 final class DateTime implements Validator
 {
     use CanValidateDateTime;

--- a/src/Validators/DateTimeDiff.php
+++ b/src/Validators/DateTimeDiff.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
@@ -44,6 +45,7 @@ use function in_array;
     'For comparison with {{now|raw}}, {{subject}} must not be a datetime in the format {{sample|raw}}',
     self::TEMPLATE_WRONG_FORMAT,
 )]
+#[Assurance(type: ['string', DateTimeInterface::class])]
 final readonly class DateTimeDiff implements Validator
 {
     use CanValidateDateTime;

--- a/src/Validators/DateTimeDiff.php
+++ b/src/Validators/DateTimeDiff.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
@@ -44,6 +45,7 @@ use function in_array;
     'For comparison with {{now|raw}}, {{subject}} must not be a datetime in the format {{sample|raw}}',
     self::TEMPLATE_WRONG_FORMAT,
 )]
+#[Assurance(type: ['string', 'int', DateTimeInterface::class])]
 final readonly class DateTimeDiff implements Validator
 {
     use CanValidateDateTime;

--- a/src/Validators/Decimal.php
+++ b/src/Validators/Decimal.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -28,6 +29,7 @@ use function var_export;
     '{{subject}} must have {{decimals}} decimal places',
     '{{subject}} must not have {{decimals}} decimal places',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final readonly class Decimal implements Validator
 {
     public function __construct(

--- a/src/Validators/Digit.php
+++ b/src/Validators/Digit.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -31,6 +32,7 @@ use function ctype_digit;
     '{{subject}} must not consist only of digits (0-9) or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Digit extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Directory.php
+++ b/src/Validators/Directory.php
@@ -16,6 +16,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use Directory as NativeDirectory;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SplFileInfo;
@@ -28,6 +29,7 @@ use function is_scalar;
     '{{subject}} must be an accessible existing directory',
     '{{subject}} must not be an accessible existing directory',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final class Directory extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Domain.php
+++ b/src/Validators/Domain.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -30,6 +31,7 @@ use function explode;
     '{{subject}} must be an internet domain',
     '{{subject}} must not be an internet domain',
 )]
+#[Assurance(type: 'string')]
 final class Domain implements Validator
 {
     private readonly Validator $genericRule;

--- a/src/Validators/Each.php
+++ b/src/Validators/Each.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceFrom;
 use Respect\Validation\Helpers\CanEvaluateShortCircuit;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Path;
@@ -32,6 +34,7 @@ use function array_reduce;
     'Each item in {{subject}} must be valid',
     'Each item in {{subject}} must be invalid',
 )]
+#[Assurance(from: AssuranceFrom::Elements)]
 final class Each extends FilteredArray implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;

--- a/src/Validators/Email.php
+++ b/src/Validators/Email.php
@@ -21,6 +21,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -35,6 +36,7 @@ use const FILTER_VALIDATE_EMAIL;
     '{{subject}} must be an email address',
     '{{subject}} must not be an email address',
 )]
+#[Assurance(type: 'string')]
 final class Email extends Simple
 {
     private readonly EmailValidator|null $validator;

--- a/src/Validators/Emoji.php
+++ b/src/Validators/Emoji.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -23,6 +24,7 @@ use function preg_match;
     '{{subject}} must be an emoji',
     '{{subject}} must not be an emoji',
 )]
+#[Assurance(type: 'string')]
 final class Emoji extends Simple
 {
     private const string REGEX = <<<'REGEX'

--- a/src/Validators/EndsWith.php
+++ b/src/Validators/EndsWith.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -37,6 +38,7 @@ use function mb_strrpos;
     '{{subject}} must not end with {{endValues|list:or}}',
     self::TEMPLATE_MULTIPLE_VALUES,
 )]
+#[Assurance(type: 'array|string')]
 final readonly class EndsWith implements Validator
 {
     public const string TEMPLATE_MULTIPLE_VALUES = '__multiple_values__';

--- a/src/Validators/Even.php
+++ b/src/Validators/Even.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -32,6 +33,7 @@ use const FILTER_VALIDATE_INT;
     '{{subject}} must be an even number',
     '{{subject}} must be an odd number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Even extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Executable.php
+++ b/src/Validators/Executable.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SplFileInfo;
@@ -27,6 +28,7 @@ use function is_scalar;
     '{{subject}} must be an accessible existing executable file',
     '{{subject}} must not be an accessible existing executable file',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final class Executable extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Exists.php
+++ b/src/Validators/Exists.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -29,6 +30,7 @@ use function is_string;
     '{{subject}} must be an existing file',
     '{{subject}} must not be an existing file',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final class Exists extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Extension.php
+++ b/src/Validators/Extension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -28,6 +29,7 @@ use const PATHINFO_EXTENSION;
     '{{subject}} must have the {{extension}} extension',
     '{{subject}} must not have the {{extension}} extension',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final readonly class Extension implements Validator
 {
     public function __construct(

--- a/src/Validators/FalseVal.php
+++ b/src/Validators/FalseVal.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -26,6 +27,7 @@ use const FILTER_VALIDATE_BOOLEAN;
     '{{subject}} must evaluate to `false`',
     '{{subject}} must not evaluate to `false`',
 )]
+#[Assurance(type: 'scalar|null')]
 final class FalseVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/File.php
+++ b/src/Validators/File.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SplFileInfo;
@@ -27,6 +28,7 @@ use function is_string;
     '{{subject}} must be an accessible existing file',
     '{{subject}} must not be an accessible existing file',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final class File extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Finite.php
+++ b/src/Validators/Finite.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -28,6 +29,7 @@ use function is_numeric;
     '{{subject}} must be a finite number',
     '{{subject}} must not be a finite number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Finite extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/FloatType.php
+++ b/src/Validators/FloatType.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function is_float;
     '{{subject}} must be a float',
     '{{subject}} must not be a float',
 )]
+#[Assurance(type: 'float')]
 final class FloatType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/FloatVal.php
+++ b/src/Validators/FloatVal.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -29,6 +30,7 @@ use const FILTER_VALIDATE_FLOAT;
     '{{subject}} must be a floating-point number',
     '{{subject}} must not be a floating-point number',
 )]
+#[Assurance(type: 'int|float|numeric-string|true')]
 final class FloatVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Format.php
+++ b/src/Validators/Format.php
@@ -12,16 +12,19 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\StringFormatter\Formatter;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
+use Stringable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
     '{{subject}} must be formatted as {{formatted}}',
     '{{subject}} must not be formatted as {{formatted}}',
 )]
+#[Assurance(type: ['scalar', Stringable::class])]
 final readonly class Format implements Validator
 {
     public function __construct(

--- a/src/Validators/Formatted.php
+++ b/src/Validators/Formatted.php
@@ -11,13 +11,16 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\StringFormatter\Formatter;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
+use Stringable;
 
 #[Composable(without: [All::class, Key::class, Property::class])]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Assurance(type: ['scalar', Stringable::class])]
 final readonly class Formatted implements Validator
 {
     public function __construct(

--- a/src/Validators/Graph.php
+++ b/src/Validators/Graph.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -32,6 +33,7 @@ use function ctype_graph;
     '{{subject}} must not consist only of printable non-spacing characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Graph extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Hetu.php
+++ b/src/Validators/Hetu.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -27,6 +28,7 @@ use function str_split;
     '{{subject}} must be a Finnish personal identity code',
     '{{subject}} must not be a Finnish personal identity code',
 )]
+#[Assurance(type: 'string')]
 final class Hetu extends Simple
 {
     use CanValidateDateTime;

--- a/src/Validators/HexRgbColor.php
+++ b/src/Validators/HexRgbColor.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
 
@@ -21,6 +22,7 @@ use Respect\Validation\Validators\Core\Envelope;
     '{{subject}} must be a hex RGB color',
     '{{subject}} must not be a hex RGB color',
 )]
+#[Assurance(type: 'scalar')]
 final class HexRgbColor extends Envelope
 {
     public function __construct()

--- a/src/Validators/Iban.php
+++ b/src/Validators/Iban.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -31,6 +32,7 @@ use function substr;
     '{{subject}} must be an IBAN',
     '{{subject}} must not be an IBAN',
 )]
+#[Assurance(type: 'string')]
 final class Iban extends Simple
 {
     private const array COUNTRIES_LENGTHS = [

--- a/src/Validators/Identical.php
+++ b/src/Validators/Identical.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceFrom;
+use Respect\Fluent\Attributes\AssuranceParameter;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -26,9 +29,11 @@ use Respect\Validation\Validator;
     '{{subject}} must be identical to {{compareTo}}',
     '{{subject}} must not be identical to {{compareTo}}',
 )]
+#[Assurance(from: AssuranceFrom::Value)]
 final readonly class Identical implements Validator
 {
     public function __construct(
+        #[AssuranceParameter]
         private mixed $compareTo,
     ) {
     }

--- a/src/Validators/Image.php
+++ b/src/Validators/Image.php
@@ -15,6 +15,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use finfo;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -31,6 +32,7 @@ use const FILEINFO_MIME_TYPE;
     '{{subject}} must be an accessible existing image file',
     '{{subject}} must not be an accessible existing image file',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final readonly class Image implements Validator
 {
     public function evaluate(mixed $input): Result

--- a/src/Validators/Imei.php
+++ b/src/Validators/Imei.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function preg_replace;
     '{{subject}} must be an IMEI number',
     '{{subject}} must not be an IMEI number',
 )]
+#[Assurance(type: 'scalar')]
 final class Imei extends Simple
 {
     private const int IMEI_SIZE = 15;

--- a/src/Validators/Infinite.php
+++ b/src/Validators/Infinite.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -28,6 +29,7 @@ use function is_numeric;
     '{{subject}} must be an infinite number',
     '{{subject}} must not be an infinite number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Infinite extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Instance.php
+++ b/src/Validators/Instance.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceFrom;
+use Respect\Fluent\Attributes\AssuranceParameter;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -24,10 +27,12 @@ use Respect\Validation\Validator;
     '{{subject}} must be an instance of {{class|quote}}',
     '{{subject}} must not be an instance of {{class|quote}}',
 )]
+#[Assurance(from: AssuranceFrom::TypeString)]
 final readonly class Instance implements Validator
 {
     /** @param class-string $class */
     public function __construct(
+        #[AssuranceParameter]
         private string $class,
     ) {
     }

--- a/src/Validators/IntType.php
+++ b/src/Validators/IntType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -24,6 +25,7 @@ use function is_int;
     '{{subject}} must be an integer',
     '{{subject}} must not be an integer',
 )]
+#[Assurance(type: 'int')]
 final class IntType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/IntVal.php
+++ b/src/Validators/IntVal.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -32,6 +33,7 @@ use function preg_match;
     '{{subject}} must be an integer',
     '{{subject}} must not be an integer',
 )]
+#[Assurance(type: 'int|numeric-string')]
 final class IntVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Ip.php
+++ b/src/Validators/Ip.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -49,6 +50,7 @@ use const PHP_INT_MAX;
     '{{subject}} must not be an IP address in the {{range|raw}} range',
     self::TEMPLATE_NETWORK_RANGE,
 )]
+#[Assurance(type: 'string')]
 final class Ip implements Validator
 {
     public const string TEMPLATE_NETWORK_RANGE = '__network_range__';

--- a/src/Validators/Isbn.php
+++ b/src/Validators/Isbn.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -26,6 +27,7 @@ use function sprintf;
     '{{subject}} must be an ISBN',
     '{{subject}} must not be an ISBN',
 )]
+#[Assurance(type: 'scalar')]
 final class Isbn extends Simple
 {
     /** @see https://howtodoinjava.com/regex/java-regex-validate-international-standard-book-number-isbns */

--- a/src/Validators/IterableType.php
+++ b/src/Validators/IterableType.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function is_iterable;
     '{{subject}} must be iterable',
     '{{subject}} must not iterable',
 )]
+#[Assurance(type: 'iterable')]
 final class IterableType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/IterableVal.php
+++ b/src/Validators/IterableVal.php
@@ -16,15 +16,19 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Helpers\CanValidateIterable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
+use stdClass;
+use Traversable;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template(
     '{{subject}} must be iterable',
     '{{subject}} must not be iterable',
 )]
+#[Assurance(type: ['array', stdClass::class, Traversable::class])]
 final class IterableVal extends Simple
 {
     use CanValidateIterable;

--- a/src/Validators/Json.php
+++ b/src/Validators/Json.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -31,6 +32,7 @@ use function json_validate;
     '{{subject}} must be a JSON string',
     '{{subject}} must not be a JSON string',
 )]
+#[Assurance(type: 'string')]
 final class Json extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Key.php
+++ b/src/Validators/Key.php
@@ -15,7 +15,11 @@ declare(strict_types=1);
 
 namespace Respect\Validation\Validators;
 
+use ArrayAccess;
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Fluent\Attributes\ComposableParameter;
 use Respect\Validation\Path;
@@ -25,6 +29,8 @@ use Respect\Validation\Validators\Core\KeyRelated;
 
 #[Composable(prefix: self::class, without: [All::class, self::class, Property::class])]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Assurance(type: ['array', ArrayAccess::class])]
+#[AssuranceSubject(AssuranceSubjectMode::Container)]
 final readonly class Key implements KeyRelated
 {
     public function __construct(

--- a/src/Validators/KeyExists.php
+++ b/src/Validators/KeyExists.php
@@ -13,6 +13,7 @@ namespace Respect\Validation\Validators;
 
 use ArrayAccess;
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Path;
@@ -29,6 +30,7 @@ use function is_array;
     '{{subject}} must be present',
     '{{subject}} must not be present',
 )]
+#[Assurance(type: ['array', ArrayAccess::class])]
 final class KeyExists implements Validator, KeyRelated
 {
     public function __construct(

--- a/src/Validators/KeySet.php
+++ b/src/Validators/KeySet.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanEvaluateShortCircuit;
@@ -54,6 +55,7 @@ use function array_slice;
     '{{subject}} contains no missing keys',
     self::TEMPLATE_MISSING_KEYS,
 )]
+#[Assurance(type: 'array')]
 final readonly class KeySet implements ShortCircuitable
 {
     use CanEvaluateShortCircuit;

--- a/src/Validators/LanguageCode.php
+++ b/src/Validators/LanguageCode.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
@@ -30,6 +31,7 @@ use function is_string;
     '{{subject}} must be a language code',
     '{{subject}} must not be a language code',
 )]
+#[Assurance(type: 'string')]
 final readonly class LanguageCode implements Validator
 {
     private Languages $languages;

--- a/src/Validators/LeapDate.php
+++ b/src/Validators/LeapDate.php
@@ -18,6 +18,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -28,6 +29,7 @@ use function is_scalar;
     '{{subject}} must be a leap date',
     '{{subject}} must not be a leap date',
 )]
+#[Assurance(type: ['scalar', DateTimeInterface::class])]
 final class LeapDate extends Simple
 {
     public function __construct(

--- a/src/Validators/LeapYear.php
+++ b/src/Validators/LeapYear.php
@@ -17,6 +17,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use DateTimeInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -31,6 +32,7 @@ use function strtotime;
     '{{subject}} must be a leap year',
     '{{subject}} must not be a leap year',
 )]
+#[Assurance(type: ['scalar', DateTimeInterface::class])]
 final class LeapYear extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Length.php
+++ b/src/Validators/Length.php
@@ -20,6 +20,9 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use Countable as PhpCountable;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -42,6 +45,8 @@ use function mb_strlen;
     '{{subject}} must not be countable or a string',
     self::TEMPLATE_WRONG_TYPE,
 )]
+#[Assurance(type: ['string', 'array', PhpCountable::class])]
+#[AssuranceSubject(AssuranceSubjectMode::Container)]
 final readonly class Length implements Validator
 {
     public const string TEMPLATE_WRONG_TYPE = '__wrong_type__';

--- a/src/Validators/Lowercase.php
+++ b/src/Validators/Lowercase.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function mb_strtolower;
     '{{subject}} must consist only of lowercase letters',
     '{{subject}} must not consist only of lowercase letters',
 )]
+#[Assurance(type: 'string')]
 final class Lowercase extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Luhn.php
+++ b/src/Validators/Luhn.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -28,6 +29,7 @@ use function str_split;
     '{{subject}} must be a Luhn number',
     '{{subject}} must not be a Luhn number',
 )]
+#[Assurance(type: 'scalar')]
 final class Luhn extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/MacAddress.php
+++ b/src/Validators/MacAddress.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -29,6 +30,7 @@ use function preg_match;
     '{{subject}} must be a MAC address',
     '{{subject}} must not be a MAC address',
 )]
+#[Assurance(type: 'string')]
 final class MacAddress extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Max.php
+++ b/src/Validators/Max.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -25,6 +28,8 @@ use function max;
 #[Composable(prefix: self::class, optIn: true)]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template('The maximum of', 'The maximum of')]
+#[Assurance(type: 'iterable')]
+#[AssuranceSubject(AssuranceSubjectMode::Container)]
 final class Max extends FilteredArray
 {
     /** @param non-empty-array<mixed> $input */

--- a/src/Validators/Mimetype.php
+++ b/src/Validators/Mimetype.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use finfo;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -29,6 +30,7 @@ use const FILEINFO_MIME_TYPE;
     '{{subject}} must have the {{mimetype}} MIME type',
     '{{subject}} must not have the {{mimetype}} MIME type',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final readonly class Mimetype implements Validator
 {
     public function __construct(

--- a/src/Validators/Min.php
+++ b/src/Validators/Min.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -25,6 +28,8 @@ use function min;
 #[Composable(prefix: self::class, optIn: true)]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 #[Template('The minimum of', 'The minimum of')]
+#[Assurance(type: 'iterable')]
+#[AssuranceSubject(AssuranceSubjectMode::Container)]
 final class Min extends FilteredArray
 {
     /** @param non-empty-array<mixed> $input */

--- a/src/Validators/Negative.php
+++ b/src/Validators/Negative.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function is_numeric;
     '{{subject}} must be a negative number',
     '{{subject}} must not be a negative number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Negative extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/NfeAccessKey.php
+++ b/src/Validators/NfeAccessKey.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -29,6 +30,7 @@ use function str_split;
     '{{subject}} must be a NFe access key',
     '{{subject}} must not be a NFe access key',
 )]
+#[Assurance(type: 'string')]
 final class NfeAccessKey extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/NfeAccessKey.php
+++ b/src/Validators/NfeAccessKey.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -30,6 +31,7 @@ use function str_split;
     '{{subject}} must be a NFe access key',
     '{{subject}} must not be a NFe access key',
 )]
+#[Assurance(type: 'string')]
 final class NfeAccessKey extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Nif.php
+++ b/src/Validators/Nif.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -31,6 +32,7 @@ use function str_split;
     '{{subject}} must be a NIF',
     '{{subject}} must not be a NIF',
 )]
+#[Assurance(type: 'string')]
 final class Nif extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Nip.php
+++ b/src/Validators/Nip.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function str_split;
     '{{subject}} must be a Polish VAT identification number',
     '{{subject}} must not be a Polish VAT identification number',
 )]
+#[Assurance(type: 'scalar')]
 final class Nip extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/NullOr.php
+++ b/src/Validators/NullOr.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -30,6 +33,8 @@ use function array_map;
     'or must be null',
     'and must not be null',
 )]
+#[Assurance(type: 'null')]
+#[AssuranceSubject(AssuranceSubjectMode::Wrap)]
 final readonly class NullOr implements Validator
 {
     public function __construct(

--- a/src/Validators/NullType.php
+++ b/src/Validators/NullType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -22,6 +23,7 @@ use Respect\Validation\Validators\Core\Simple;
     '{{subject}} must be null',
     '{{subject}} must not be null',
 )]
+#[Assurance(type: 'null')]
 final class NullType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Number.php
+++ b/src/Validators/Number.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -28,6 +29,7 @@ use function is_numeric;
     '{{subject}} must be a number',
     '{{subject}} must not be a number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Number extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/NumericVal.php
+++ b/src/Validators/NumericVal.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function is_numeric;
     '{{subject}} must be numeric',
     '{{subject}} must not be numeric',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class NumericVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/ObjectType.php
+++ b/src/Validators/ObjectType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -24,6 +25,7 @@ use function is_object;
     '{{subject}} must be an object',
     '{{subject}} must not be an object',
 )]
+#[Assurance(type: 'object')]
 final class ObjectType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Odd.php
+++ b/src/Validators/Odd.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -32,6 +33,7 @@ use const FILTER_VALIDATE_INT;
     '{{subject}} must be an odd number',
     '{{subject}} must be an even number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Odd extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Pesel.php
+++ b/src/Validators/Pesel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function preg_match;
     '{{subject}} must be a PESEL',
     '{{subject}} must not be a PESEL',
 )]
+#[Assurance(type: 'scalar')]
 final class Pesel extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Phone.php
+++ b/src/Validators/Phone.php
@@ -21,6 +21,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
@@ -42,6 +43,7 @@ use function is_scalar;
     '{{subject}} must not be a phone number for country {{countryName|trans}}',
     self::TEMPLATE_FOR_COUNTRY,
 )]
+#[Assurance(type: 'scalar')]
 final class Phone implements Validator
 {
     public const string TEMPLATE_FOR_COUNTRY = '__for_country__';

--- a/src/Validators/Pis.php
+++ b/src/Validators/Pis.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function preg_replace;
     '{{subject}} must be a PIS number',
     '{{subject}} must not be a PIS number',
 )]
+#[Assurance(type: 'scalar')]
 final class Pis extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/PolishIdCard.php
+++ b/src/Validators/PolishIdCard.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -25,6 +26,7 @@ use function preg_match;
     '{{subject}} must be a Polish Identity Card number',
     '{{subject}} must not be a Polish Identity Card number',
 )]
+#[Assurance(type: 'scalar')]
 final class PolishIdCard extends Simple
 {
     private const int ASCII_CODE_0 = 48;

--- a/src/Validators/PortugueseNif.php
+++ b/src/Validators/PortugueseNif.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -32,6 +33,7 @@ use function strlen;
     '{{subject}} must be a Portuguese NIF',
     '{{subject}} must not be a Portuguese NIF',
 )]
+#[Assurance(type: 'string')]
 final class PortugueseNif extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Positive.php
+++ b/src/Validators/Positive.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -27,6 +28,7 @@ use function is_numeric;
     '{{subject}} must be a positive number',
     '{{subject}} must not be a positive number',
 )]
+#[Assurance(type: 'int|float|numeric-string')]
 final class Positive extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/PostalCode.php
+++ b/src/Validators/PostalCode.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\DataLoader;
 use Respect\Validation\Message\Template;
@@ -37,6 +38,7 @@ use Respect\Validation\Validators\Core\Envelope;
     '{{subject}} must be a postal code for {{countryCode}}',
     '{{subject}} must not be a postal code for {{countryCode}}',
 )]
+#[Assurance(type: 'scalar')]
 final class PostalCode extends Envelope
 {
     private const array POSTAL_CODES_EXTRA = [

--- a/src/Validators/Printable.php
+++ b/src/Validators/Printable.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -32,6 +33,7 @@ use function ctype_print;
     '{{subject}} must not consist only of printable characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Printable extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Property.php
+++ b/src/Validators/Property.php
@@ -19,6 +19,9 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use ReflectionClass;
 use ReflectionObject;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Fluent\Attributes\ComposableParameter;
 use Respect\Validation\Path;
@@ -27,6 +30,8 @@ use Respect\Validation\Validator;
 
 #[Composable(prefix: self::class, without: [All::class, Key::class, self::class])]
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Assurance(type: 'object')]
+#[AssuranceSubject(AssuranceSubjectMode::Container)]
 final readonly class Property implements Validator
 {
     public function __construct(

--- a/src/Validators/PropertyExists.php
+++ b/src/Validators/PropertyExists.php
@@ -14,6 +14,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use ReflectionClass;
 use ReflectionObject;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Path;
@@ -28,6 +29,7 @@ use function is_object;
     '{{subject}} must be present',
     '{{subject}} must not be present',
 )]
+#[Assurance(type: 'object')]
 final readonly class PropertyExists implements Validator
 {
     public function __construct(

--- a/src/Validators/PublicDomainSuffix.php
+++ b/src/Validators/PublicDomainSuffix.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Helpers\DataLoader;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
@@ -36,6 +37,7 @@ use const INTL_IDNA_VARIANT_UTS46;
     '{{subject}} must be a public domain suffix',
     '{{subject}} must not be a public domain suffix',
 )]
+#[Assurance(type: 'scalar')]
 final class PublicDomainSuffix extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Punct.php
+++ b/src/Validators/Punct.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -32,6 +33,7 @@ use function ctype_punct;
     '{{subject}} must not consist only of punctuation characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Punct extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Readable.php
+++ b/src/Validators/Readable.php
@@ -17,6 +17,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use Psr\Http\Message\StreamInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SplFileInfo;
@@ -29,6 +30,7 @@ use function is_string;
     '{{subject}} must be readable',
     '{{subject}} must not be readable',
 )]
+#[Assurance(type: ['string', SplFileInfo::class, StreamInterface::class])]
 final class Readable extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Regex.php
+++ b/src/Validators/Regex.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -28,6 +29,7 @@ use function preg_match;
     '{{subject}} must match the {{regex|quote}} pattern',
     '{{subject}} must not match the {{regex|quote}} pattern',
 )]
+#[Assurance(type: 'scalar')]
 final readonly class Regex implements Validator
 {
     public function __construct(

--- a/src/Validators/ResourceType.php
+++ b/src/Validators/ResourceType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -24,6 +25,7 @@ use function is_resource;
     '{{subject}} must be an internal resource',
     '{{subject}} must not be an internal resource',
 )]
+#[Assurance(type: 'resource')]
 final class ResourceType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Roman.php
+++ b/src/Validators/Roman.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
 
@@ -26,6 +27,7 @@ use Respect\Validation\Validators\Core\Envelope;
     '{{subject}} must be a Roman numeral',
     '{{subject}} must not be a Roman numeral',
 )]
+#[Assurance(type: 'string')]
 final class Roman extends Envelope
 {
     public function __construct()

--- a/src/Validators/ScalarVal.php
+++ b/src/Validators/ScalarVal.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -24,6 +25,7 @@ use function is_scalar;
     '{{subject}} must be a scalar',
     '{{subject}} must not be a scalar',
 )]
+#[Assurance(type: 'int|float|bool|string')]
 final class ScalarVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Size.php
+++ b/src/Validators/Size.php
@@ -16,6 +16,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -36,6 +37,7 @@ use function is_string;
     '{{subject}} must not be a filename, an instance of SplFileInfo or a PSR-7 interface',
     self::TEMPLATE_WRONG_TYPE,
 )]
+#[Assurance(type: ['string', SplFileInfo::class, UploadedFileInterface::class, StreamInterface::class])]
 final readonly class Size implements Validator
 {
     public const string TEMPLATE_WRONG_TYPE = '__wrong_type__';

--- a/src/Validators/Size.php
+++ b/src/Validators/Size.php
@@ -16,6 +16,7 @@ namespace Respect\Validation\Validators;
 use Attribute;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -38,6 +39,7 @@ use function is_string;
     '{{subject}} must not be a filename, an instance of SplFileInfo or a PSR-7 interface',
     self::TEMPLATE_WRONG_TYPE,
 )]
+#[Assurance(type: ['string', SplFileInfo::class, UploadedFileInterface::class, StreamInterface::class])]
 #[Template(
     'It is not possible to determine the size of {{subject}}',
     'It is not possible to determine the size of {{subject}}',

--- a/src/Validators/Slug.php
+++ b/src/Validators/Slug.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -31,6 +32,7 @@ use function preg_match;
     '{{subject}} must be a slug',
     '{{subject}} must not be a slug',
 )]
+#[Assurance(type: 'string')]
 final class Slug extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Sorted.php
+++ b/src/Validators/Sorted.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
@@ -35,6 +36,7 @@ use function str_split;
     '{{subject}} must not be sorted in descending order',
     self::TEMPLATE_DESCENDING,
 )]
+#[Assurance(type: 'array|string')]
 final readonly class Sorted implements Validator
 {
     public const string TEMPLATE_ASCENDING = '__ascending__';

--- a/src/Validators/Space.php
+++ b/src/Validators/Space.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -32,6 +33,7 @@ use function ctype_space;
     '{{subject}} must not consist only of space characters or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Space extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Spaced.php
+++ b/src/Validators/Spaced.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function preg_match;
     '{{subject}} must contain at least one whitespace',
     '{{subject}} must not contain whitespace',
 )]
+#[Assurance(type: 'string')]
 final class Spaced extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/StartsWith.php
+++ b/src/Validators/StartsWith.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -36,6 +37,7 @@ use function reset;
     '{{subject}} must not start with {{startValues|list:or}}',
     self::TEMPLATE_MULTIPLE_VALUES,
 )]
+#[Assurance(type: 'array|string')]
 final readonly class StartsWith implements Validator
 {
     public const string TEMPLATE_MULTIPLE_VALUES = '__multiple_values__';

--- a/src/Validators/StringType.php
+++ b/src/Validators/StringType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -24,6 +25,7 @@ use function is_string;
     '{{subject}} must be a string',
     '{{subject}} must not be a string',
 )]
+#[Assurance(type: 'string')]
 final class StringType extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/StringVal.php
+++ b/src/Validators/StringVal.php
@@ -17,8 +17,10 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
+use Stringable;
 
 use function is_object;
 use function is_scalar;
@@ -29,6 +31,7 @@ use function method_exists;
     '{{subject}} must be a string',
     '{{subject}} must not be a string',
 )]
+#[Assurance(type: ['scalar', Stringable::class])]
 final class StringVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/SubdivisionCode.php
+++ b/src/Validators/SubdivisionCode.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Helpers\CanValidateUndefined;
@@ -28,6 +29,7 @@ use function class_exists;
     '{{subject}} must be a subdivision code of {{countryName|trans}}',
     '{{subject}} must not be a subdivision code of {{countryName|trans}}',
 )]
+#[Assurance(type: 'scalar|null')]
 final readonly class SubdivisionCode implements Validator
 {
     use CanValidateUndefined;

--- a/src/Validators/Subset.php
+++ b/src/Validators/Subset.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -29,6 +30,7 @@ use function is_array;
     '{{subject}} must be subset of {{superset}}',
     '{{subject}} must not be subset of {{superset}}',
 )]
+#[Assurance(type: 'array')]
 final readonly class Subset implements Validator
 {
     /** @param mixed[] $superset */

--- a/src/Validators/SymbolicLink.php
+++ b/src/Validators/SymbolicLink.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SplFileInfo;
@@ -27,6 +28,7 @@ use function is_string;
     '{{subject}} must be an accessible existing symbolic link',
     '{{subject}} must not be an accessible existing symbolic link',
 )]
+#[Assurance(type: ['string', SplFileInfo::class])]
 final class SymbolicLink extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Time.php
+++ b/src/Validators/Time.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Helpers\CanValidateDateTime;
 use Respect\Validation\Message\Template;
@@ -33,6 +34,7 @@ use function strtotime;
     '{{subject}} must be a time in the {{sample}} format',
     '{{subject}} must not be a time in the {{sample}} format',
 )]
+#[Assurance(type: 'scalar')]
 final readonly class Time implements Validator
 {
     use CanValidateDateTime;

--- a/src/Validators/Tld.php
+++ b/src/Validators/Tld.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Helpers\DataLoader;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Envelope;
@@ -29,6 +30,7 @@ use Respect\Validation\Validators\Core\Envelope;
     '{{subject}} must be a top-level domain name',
     '{{subject}} must not be a top-level domain name',
 )]
+#[Assurance(type: 'string')]
 final class Tld extends Envelope
 {
     public function __construct()

--- a/src/Validators/Trimmed.php
+++ b/src/Validators/Trimmed.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validator;
 use Respect\Validation\Validators\Core\Envelope;
@@ -26,6 +27,7 @@ use Respect\Validation\Validators\Core\Envelope;
     '{{subject}} must contain leading or trailing {{trimValues|list:or}}',
     self::TEMPLATE_CUSTOM,
 )]
+#[Assurance(type: 'string')]
 final class Trimmed extends Envelope
 {
     public const string TEMPLATE_CUSTOM = '__custom__';

--- a/src/Validators/TrueVal.php
+++ b/src/Validators/TrueVal.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -26,6 +27,7 @@ use const FILTER_VALIDATE_BOOLEAN;
     '{{subject}} must evaluate to `true`',
     '{{subject}} must not evaluate to `true`',
 )]
+#[Assurance(type: 'scalar')]
 final class TrueVal extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Undef.php
+++ b/src/Validators/Undef.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Helpers\CanValidateUndefined;
 use Respect\Validation\Message\Template;
@@ -28,6 +29,7 @@ use Respect\Validation\Validator;
     '{{subject}} must be undefined',
     '{{subject}} must be defined',
 )]
+#[Assurance(type: "null|''")]
 final class Undef implements Validator
 {
     use CanValidateUndefined;

--- a/src/Validators/UndefOr.php
+++ b/src/Validators/UndefOr.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
+use Respect\Fluent\Attributes\AssuranceSubject;
+use Respect\Fluent\Attributes\AssuranceSubjectMode;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Validation\Helpers\CanValidateUndefined;
 use Respect\Validation\Message\Template;
@@ -30,6 +33,8 @@ use function array_map;
     'or must be undefined',
     'and must not be undefined',
 )]
+#[Assurance(type: "null|''")]
+#[AssuranceSubject(AssuranceSubjectMode::Wrap)]
 final readonly class UndefOr implements Validator
 {
     use CanValidateUndefined;

--- a/src/Validators/Unique.php
+++ b/src/Validators/Unique.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -29,6 +30,7 @@ use const SORT_REGULAR;
     '{{subject}} must not contain duplicates',
     '{{subject}} must contain duplicates',
 )]
+#[Assurance(type: 'array')]
 final class Unique extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Uppercase.php
+++ b/src/Validators/Uppercase.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function mb_strtoupper;
     '{{subject}} must consist only of uppercase letters',
     '{{subject}} must not consist only of uppercase letters',
 )]
+#[Assurance(type: 'string')]
 final class Uppercase extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Url.php
+++ b/src/Validators/Url.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
@@ -26,6 +27,7 @@ use const FILTER_VALIDATE_URL;
     '{{subject}} must be a URL',
     '{{subject}} must not be a URL',
 )]
+#[Assurance(type: 'string')]
 final class Url implements Validator
 {
     private readonly Validator $validator;

--- a/src/Validators/Uuid.php
+++ b/src/Validators/Uuid.php
@@ -22,6 +22,7 @@ use Attribute;
 use Ramsey\Uuid\Rfc4122\FieldsInterface;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Exceptions\MissingComposerDependencyException;
 use Respect\Validation\Message\Template;
@@ -43,6 +44,7 @@ use function is_string;
     '{{subject}} must not be a UUID v{{version|raw}}',
     self::TEMPLATE_VERSION,
 )]
+#[Assurance(type: ['string', UuidInterface::class])]
 final class Uuid implements Validator
 {
     public const string TEMPLATE_VERSION = '__version__';

--- a/src/Validators/Version.php
+++ b/src/Validators/Version.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
@@ -27,6 +28,7 @@ use function preg_match;
     '{{subject}} must be a version number',
     '{{subject}} must not be a version number',
 )]
+#[Assurance(type: 'string')]
 final class Version extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Vowel.php
+++ b/src/Validators/Vowel.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -33,6 +34,7 @@ use function preg_match;
     '{{subject}} must not consist of vowels or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Vowel extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/src/Validators/Writable.php
+++ b/src/Validators/Writable.php
@@ -17,6 +17,7 @@ namespace Respect\Validation\Validators;
 
 use Attribute;
 use Psr\Http\Message\StreamInterface;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 use SplFileInfo;
@@ -29,6 +30,7 @@ use function is_writable;
     '{{subject}} must be an accessible existing writable filesystem entry',
     '{{subject}} must not be an accessible existing writable filesystem entry',
 )]
+#[Assurance(type: ['string', SplFileInfo::class, StreamInterface::class])]
 final class Writable extends Simple
 {
     public function isValid(mixed $input): bool

--- a/src/Validators/Xdigit.php
+++ b/src/Validators/Xdigit.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Respect\Validation\Validators;
 
 use Attribute;
+use Respect\Fluent\Attributes\Assurance;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\FilteredString;
 
@@ -31,6 +32,7 @@ use function ctype_xdigit;
     '{{subject}} must not consist only of hexadecimal digits or {{additionalChars}}',
     self::TEMPLATE_EXTRA,
 )]
+#[Assurance(type: 'scalar')]
 final class Xdigit extends FilteredString
 {
     protected function isValid(string $input): bool

--- a/tests/inference/StaticNarrowingTest.php
+++ b/tests/inference/StaticNarrowingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Inference;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class StaticNarrowingTest extends TypeInferenceTestCase
+{
+    /** @return list<string> */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [];
+    }
+
+    /** @return iterable<mixed> */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/assertions/static-narrowing.php');
+    }
+
+    #[Test]
+    #[DataProvider('dataFileAsserts')]
+    public function fileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/inference/assertions/static-narrowing.php
+++ b/tests/inference/assertions/static-narrowing.php
@@ -1,0 +1,908 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Inference\StaticAssertions;
+
+use DateTimeInterface;
+use Respect\Validation\ValidatorBuilder as v;
+
+use function PHPStan\Testing\assertType;
+
+// Proves the generated src/Mixins
+//
+// PHPDoc narrows on its own (what IDEs such as DevSense read). One static-entry assertion
+// per assured validator that narrows, followed by combinations and boundary cases.
+//
+// Not covered here: format(), formatted() (take a Formatter object).
+
+// ============================================================================
+// Per-validator: static entry narrowing
+// ============================================================================
+
+function allAssert(mixed $x): void
+{
+    v::all(v::intType())->assert($x);
+    assertType('iterable<int>', $x);
+}
+
+function alnumAssert(mixed $x): void
+{
+    v::alnum()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function alphaAssert(mixed $x): void
+{
+    v::alpha()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function arrayTypeAssert(mixed $x): void
+{
+    v::arrayType()->assert($x);
+    assertType('array', $x);
+}
+
+function arrayValAssert(mixed $x): void
+{
+    v::arrayVal()->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+function attributesAssert(mixed $x): void
+{
+    v::attributes()->assert($x);
+    assertType('object', $x);
+}
+
+function base64Assert(mixed $x): void
+{
+    v::base64()->assert($x);
+    assertType('string', $x);
+}
+
+function boolTypeAssert(mixed $x): void
+{
+    v::boolType()->assert($x);
+    assertType('bool', $x);
+}
+
+function boolValAssert(mixed $x): void
+{
+    v::boolVal()->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function bsnAssert(mixed $x): void
+{
+    v::bsn()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function callableTypeAssert(mixed $x): void
+{
+    v::callableType()->assert($x);
+    assertType('callable(): mixed', $x);
+}
+
+function charsetAssert(mixed $x): void
+{
+    v::charset('x')->assert($x);
+    assertType('string', $x);
+}
+
+function cnhAssert(mixed $x): void
+{
+    v::cnh()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function cnpjAssert(mixed $x): void
+{
+    v::cnpj()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function consonantAssert(mixed $x): void
+{
+    v::consonant()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function containsAssert(mixed $x): void
+{
+    v::contains(1)->assert($x);
+    assertType('array|bool|float|int|string', $x);
+}
+
+function containsAnyAssert(mixed $x): void
+{
+    v::containsAny([1, 2, 3])->assert($x);
+    assertType('array|bool|float|int|string', $x);
+}
+
+function containsCountAssert(mixed $x): void
+{
+    v::containsCount(1, 1)->assert($x);
+    assertType('array|bool|float|int|string', $x);
+}
+
+function controlAssert(mixed $x): void
+{
+    v::control()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function countableAssert(mixed $x): void
+{
+    v::countable()->assert($x);
+    assertType('array|Countable', $x);
+}
+
+function countryCodeAssert(mixed $x): void
+{
+    v::countryCode()->assert($x);
+    assertType('string', $x);
+}
+
+function cpfAssert(mixed $x): void
+{
+    v::cpf()->assert($x);
+    assertType('string', $x);
+}
+
+function creditCardAssert(mixed $x): void
+{
+    v::creditCard()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function currencyCodeAssert(mixed $x): void
+{
+    v::currencyCode()->assert($x);
+    assertType('string', $x);
+}
+
+function dateAssert(mixed $x): void
+{
+    v::date()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function dateTimeAssert(mixed $x): void
+{
+    v::dateTime()->assert($x);
+    assertType('bool|DateTimeInterface|float|int|string', $x);
+}
+
+function dateTimeDiffAssert(mixed $x): void
+{
+    v::dateTimeDiff('years', v::intType())->assert($x);
+    assertType('DateTimeInterface|string', $x);
+}
+
+function decimalAssert(mixed $x): void
+{
+    v::decimal(1)->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function digitAssert(mixed $x): void
+{
+    v::digit()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function directoryAssert(mixed $x): void
+{
+    v::directory()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function domainAssert(mixed $x): void
+{
+    v::domain()->assert($x);
+    assertType('string', $x);
+}
+
+function eachAssert(mixed $x): void
+{
+    v::each(v::intType())->assert($x);
+    assertType('iterable<int>', $x);
+}
+
+function emailAssert(mixed $x): void
+{
+    v::email()->assert($x);
+    assertType('string', $x);
+}
+
+function emojiAssert(mixed $x): void
+{
+    v::emoji()->assert($x);
+    assertType('string', $x);
+}
+
+function endsWithAssert(mixed $x): void
+{
+    v::endsWith(1)->assert($x);
+    assertType('array|string', $x);
+}
+
+function evenAssert(mixed $x): void
+{
+    v::even()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function executableAssert(mixed $x): void
+{
+    v::executable()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function existsAssert(mixed $x): void
+{
+    v::exists()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function extensionAssert(mixed $x): void
+{
+    v::extension('x')->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function falseValAssert(mixed $x): void
+{
+    v::falseVal()->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function fileAssert(mixed $x): void
+{
+    v::file()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function finiteAssert(mixed $x): void
+{
+    v::finite()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function floatTypeAssert(mixed $x): void
+{
+    v::floatType()->assert($x);
+    assertType('float', $x);
+}
+
+function floatValAssert(mixed $x): void
+{
+    v::floatVal()->assert($x);
+    assertType('float|int|numeric-string|true', $x);
+}
+
+function graphAssert(mixed $x): void
+{
+    v::graph()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function hetuAssert(mixed $x): void
+{
+    v::hetu()->assert($x);
+    assertType('string', $x);
+}
+
+function hexRgbColorAssert(mixed $x): void
+{
+    v::hexRgbColor()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function ibanAssert(mixed $x): void
+{
+    v::iban()->assert($x);
+    assertType('string', $x);
+}
+
+function identicalAssert(mixed $x): void
+{
+    v::identical(42)->assert($x);
+    assertType('int', $x);
+}
+
+function imageAssert(mixed $x): void
+{
+    v::image()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function imeiAssert(mixed $x): void
+{
+    v::imei()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function infiniteAssert(mixed $x): void
+{
+    v::infinite()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function instanceAssert(mixed $x): void
+{
+    v::instance(\DateTimeInterface::class)->assert($x);
+    assertType('DateTimeInterface', $x);
+}
+
+function intTypeAssert(mixed $x): void
+{
+    v::intType()->assert($x);
+    assertType('int', $x);
+}
+
+function intValAssert(mixed $x): void
+{
+    v::intVal()->assert($x);
+    assertType('int|numeric-string', $x);
+}
+
+function ipAssert(mixed $x): void
+{
+    v::ip()->assert($x);
+    assertType('string', $x);
+}
+
+function isbnAssert(mixed $x): void
+{
+    v::isbn()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function iterableTypeAssert(mixed $x): void
+{
+    v::iterableType()->assert($x);
+    assertType('iterable', $x);
+}
+
+function iterableValAssert(mixed $x): void
+{
+    v::iterableVal()->assert($x);
+    assertType('array|stdClass|Traversable', $x);
+}
+
+function jsonAssert(mixed $x): void
+{
+    v::json()->assert($x);
+    assertType('string', $x);
+}
+
+function keyExistsAssert(mixed $x): void
+{
+    v::keyExists(1)->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+function keySetAssert(mixed $x): void
+{
+    v::keySet(v::intType())->assert($x);
+    assertType('array', $x);
+}
+
+function languageCodeAssert(mixed $x): void
+{
+    v::languageCode()->assert($x);
+    assertType('string', $x);
+}
+
+function leapDateAssert(mixed $x): void
+{
+    v::leapDate('x')->assert($x);
+    assertType('bool|DateTimeInterface|float|int|string', $x);
+}
+
+function leapYearAssert(mixed $x): void
+{
+    v::leapYear()->assert($x);
+    assertType('bool|DateTimeInterface|float|int|string', $x);
+}
+
+function lowercaseAssert(mixed $x): void
+{
+    v::lowercase()->assert($x);
+    assertType('string', $x);
+}
+
+function luhnAssert(mixed $x): void
+{
+    v::luhn()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function macAddressAssert(mixed $x): void
+{
+    v::macAddress()->assert($x);
+    assertType('string', $x);
+}
+
+function mimetypeAssert(mixed $x): void
+{
+    v::mimetype('x')->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function negativeAssert(mixed $x): void
+{
+    v::negative()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function nfeAccessKeyAssert(mixed $x): void
+{
+    v::nfeAccessKey()->assert($x);
+    assertType('string', $x);
+}
+
+function nifAssert(mixed $x): void
+{
+    v::nif()->assert($x);
+    assertType('string', $x);
+}
+
+function nipAssert(mixed $x): void
+{
+    v::nip()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function nullTypeAssert(mixed $x): void
+{
+    v::nullType()->assert($x);
+    assertType('null', $x);
+}
+
+function numberAssert(mixed $x): void
+{
+    v::number()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function numericValAssert(mixed $x): void
+{
+    v::numericVal()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function objectTypeAssert(mixed $x): void
+{
+    v::objectType()->assert($x);
+    assertType('object', $x);
+}
+
+function oddAssert(mixed $x): void
+{
+    v::odd()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function peselAssert(mixed $x): void
+{
+    v::pesel()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function phoneAssert(mixed $x): void
+{
+    v::phone()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function pisAssert(mixed $x): void
+{
+    v::pis()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function polishIdCardAssert(mixed $x): void
+{
+    v::polishIdCard()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function portugueseNifAssert(mixed $x): void
+{
+    v::portugueseNif()->assert($x);
+    assertType('string', $x);
+}
+
+function positiveAssert(mixed $x): void
+{
+    v::positive()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function postalCodeAssert(mixed $x): void
+{
+    v::postalCode('x')->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function printableAssert(mixed $x): void
+{
+    v::printable()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function propertyExistsAssert(mixed $x): void
+{
+    v::propertyExists('x')->assert($x);
+    assertType('object', $x);
+}
+
+function publicDomainSuffixAssert(mixed $x): void
+{
+    v::publicDomainSuffix()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function punctAssert(mixed $x): void
+{
+    v::punct()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function readableAssert(mixed $x): void
+{
+    v::readable()->assert($x);
+    assertType('Psr\Http\Message\StreamInterface|SplFileInfo|string', $x);
+}
+
+function regexAssert(mixed $x): void
+{
+    v::regex('x')->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function resourceTypeAssert(mixed $x): void
+{
+    v::resourceType()->assert($x);
+    assertType('resource', $x);
+}
+
+function romanAssert(mixed $x): void
+{
+    v::roman()->assert($x);
+    assertType('string', $x);
+}
+
+function scalarValAssert(mixed $x): void
+{
+    v::scalarVal()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function sizeAssert(mixed $x): void
+{
+    v::size('B', v::intType())->assert($x);
+    assertType('Psr\Http\Message\StreamInterface|Psr\Http\Message\UploadedFileInterface|SplFileInfo|string', $x);
+}
+
+function slugAssert(mixed $x): void
+{
+    v::slug()->assert($x);
+    assertType('string', $x);
+}
+
+function sortedAssert(mixed $x): void
+{
+    v::sorted('ASC')->assert($x);
+    assertType('array|string', $x);
+}
+
+function spaceAssert(mixed $x): void
+{
+    v::space()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function spacedAssert(mixed $x): void
+{
+    v::spaced()->assert($x);
+    assertType('string', $x);
+}
+
+function startsWithAssert(mixed $x): void
+{
+    v::startsWith(1)->assert($x);
+    assertType('array|string', $x);
+}
+
+function stringTypeAssert(mixed $x): void
+{
+    v::stringType()->assert($x);
+    assertType('string', $x);
+}
+
+function stringValAssert(mixed $x): void
+{
+    v::stringVal()->assert($x);
+    assertType('bool|float|int|string|Stringable', $x);
+}
+
+function subdivisionCodeAssert(mixed $x): void
+{
+    v::subdivisionCode('US')->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function subsetAssert(mixed $x): void
+{
+    v::subset([1, 2, 3])->assert($x);
+    assertType('array', $x);
+}
+
+function symbolicLinkAssert(mixed $x): void
+{
+    v::symbolicLink()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function timeAssert(mixed $x): void
+{
+    v::time()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function tldAssert(mixed $x): void
+{
+    v::tld()->assert($x);
+    assertType('string', $x);
+}
+
+function trimmedAssert(mixed $x): void
+{
+    v::trimmed()->assert($x);
+    assertType('string', $x);
+}
+
+function trueValAssert(mixed $x): void
+{
+    v::trueVal()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function undefAssert(mixed $x): void
+{
+    v::undef()->assert($x);
+    assertType("''|null", $x);
+}
+
+function uniqueAssert(mixed $x): void
+{
+    v::unique()->assert($x);
+    assertType('array', $x);
+}
+
+function uppercaseAssert(mixed $x): void
+{
+    v::uppercase()->assert($x);
+    assertType('string', $x);
+}
+
+function urlAssert(mixed $x): void
+{
+    v::url()->assert($x);
+    assertType('string', $x);
+}
+
+function uuidAssert(mixed $x): void
+{
+    v::uuid()->assert($x);
+    assertType('Ramsey\Uuid\UuidInterface|string', $x);
+}
+
+function versionAssert(mixed $x): void
+{
+    v::version()->assert($x);
+    assertType('string', $x);
+}
+
+function vowelAssert(mixed $x): void
+{
+    v::vowel()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function writableAssert(mixed $x): void
+{
+    v::writable()->assert($x);
+    assertType('Psr\Http\Message\StreamInterface|SplFileInfo|string', $x);
+}
+
+function xdigitAssert(mixed $x): void
+{
+    v::xdigit()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+// ============================================================================
+// Combinations: the first rule (the type) wins; later rules only constrain it
+// ============================================================================
+
+function chainTypeThenConstraints(mixed $x): void
+{
+    v::intType()->positive()->between(1, 10)->assert($x);
+    assertType('int', $x);
+}
+
+function chainTypeThenFormat(mixed $x): void
+{
+    v::stringType()->email()->assert($x);
+    assertType('string', $x);
+}
+
+function chainResetRuleMidChain(mixed $x): void
+{
+    // a non-expressible rule (in()) mid-chain preserves the entry type, not mixed
+    v::intType()->in([1, 2, 3])->assert($x);
+    assertType('int', $x);
+}
+
+function chainElementOnType(mixed $x): void
+{
+    // each() refines the element type even after a container type rule
+    v::arrayType()->each(v::intType())->assert($x);
+    assertType('iterable<int>', $x);
+}
+
+// ============================================================================
+// Container subject: the input is narrowed to the container type (key/property/
+// length/max/min), and the prefixed form narrows identically.
+// ============================================================================
+
+function keyNarrowsToContainer(mixed $x): void
+{
+    v::key('a', v::intType())->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+function propertyNarrowsToContainer(mixed $x): void
+{
+    v::property('id', v::intType())->assert($x);
+    assertType('object', $x);
+}
+
+function lengthNarrowsToContainer(mixed $x): void
+{
+    v::length(v::between(1, 5))->assert($x);
+    assertType('array|Countable|string', $x);
+}
+
+function maxNarrowsToIterable(mixed $x): void
+{
+    v::max(v::intType())->assert($x);
+    assertType('iterable', $x);
+}
+
+function keyPrefixNarrowsToContainer(mixed $x): void
+{
+    v::keyIntType('a')->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+// ============================================================================
+// Wrap PREFIX composition: the concrete inner type unioned with the bypass set.
+// (The nullOr()/undefOr() ARG-forms stay mixed -- see the boundary section.)
+// ============================================================================
+
+function nullOrPrefixNarrows(mixed $x): void
+{
+    v::nullOrIntType()->assert($x);
+    assertType('int|null', $x);
+}
+
+function undefOrPrefixNarrows(mixed $x): void
+{
+    v::undefOrIntType()->assert($x);
+    assertType("''|int|null", $x);
+}
+
+function nullOrPrefixDedupesBypass(mixed $x): void
+{
+    // nullOrNullType(): the inner type already admits null, so the union must not be null|null.
+    v::nullOrNullType()->assert($x);
+    assertType('null', $x);
+}
+
+function nullOrPrefixDedupesWithinUnion(mixed $x): void
+{
+    // nullOrBoolVal(): inner 'scalar|null' + 'null' bypass collapses to scalar|null.
+    v::nullOrBoolVal()->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function chainTypeThenNullOr(mixed $x): void
+{
+    // first-wins: a leading type rule survives a later nullOr() (instance preserves TSure,
+    // and the instance method carries no Chain<T> parameter, so a raw validator is fine too).
+    v::stringType()->nullOr(v::intType())->assert($x);
+    assertType('string', $x);
+}
+
+// ============================================================================
+// Boundary: rules whose assurance is not statically expressible stay mixed
+// (extension-only); they must not narrow unsoundly. The argument-wrapping forms
+// (nullOr/undefOr arg-form, anyOf/oneOf/allOf/named/templated) are here on purpose:
+// narrowing them would retype their Validator parameter to Chain<T> and reject raw
+// (non-fluent) Validator arguments.
+// ============================================================================
+
+function notDoesNotNarrow(mixed $x): void
+{
+    v::not(v::intType())->assert($x);
+    assertType('mixed', $x);
+}
+
+function inDoesNotNarrow(mixed $x): void
+{
+    v::in([1, 2, 3])->assert($x);
+    assertType('mixed', $x);
+}
+
+function whenDoesNotNarrow(mixed $x): void
+{
+    v::when(v::intType(), v::positive(), v::negative())->assert($x);
+    assertType('mixed', $x);
+}
+
+function nullOrArgFormDoesNotNarrow(mixed $x): void
+{
+    v::nullOr(v::intType())->assert($x);
+    assertType('mixed', $x);
+}
+
+function anyOfDoesNotNarrow(mixed $x): void
+{
+    v::anyOf(v::intType(), v::stringType())->assert($x);
+    assertType('mixed', $x);
+}
+
+function allOfDoesNotNarrow(mixed $x): void
+{
+    v::allOf(v::intType(), v::positive())->assert($x);
+    assertType('mixed', $x);
+}
+
+function namedDoesNotNarrow(mixed $x): void
+{
+    v::named('n', v::intType())->assert($x);
+    assertType('mixed', $x);
+}
+
+// ============================================================================
+// Soundness: isValid() must not narrow the false branch of an inexact rule;
+// check() narrows like assert()
+// ============================================================================
+
+function isValidFalseBranchStaysSound(string $x): void
+{
+    if (v::email()->isValid($x)) {
+        return;
+    }
+
+    assertType('string', $x);
+}
+
+function checkNarrowsLikeAssert(mixed $x): void
+{
+    v::stringType()->check($x);
+    assertType('string', $x);
+}

--- a/tests/inference/assertions/static-narrowing.php
+++ b/tests/inference/assertions/static-narrowing.php
@@ -1,0 +1,908 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Inference\StaticAssertions;
+
+use DateTimeInterface;
+use Respect\Validation\ValidatorBuilder as v;
+
+use function PHPStan\Testing\assertType;
+
+// Proves the generated src/Mixins
+//
+// PHPDoc narrows on its own (what IDEs such as DevSense read). One static-entry assertion
+// per assured validator that narrows, followed by combinations and boundary cases.
+//
+// Not covered here: format(), formatted() (take a Formatter object).
+
+// ============================================================================
+// Per-validator: static entry narrowing
+// ============================================================================
+
+function allAssert(mixed $x): void
+{
+    v::all(v::intType())->assert($x);
+    assertType('iterable<int>', $x);
+}
+
+function alnumAssert(mixed $x): void
+{
+    v::alnum()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function alphaAssert(mixed $x): void
+{
+    v::alpha()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function arrayTypeAssert(mixed $x): void
+{
+    v::arrayType()->assert($x);
+    assertType('array', $x);
+}
+
+function arrayValAssert(mixed $x): void
+{
+    v::arrayVal()->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+function attributesAssert(mixed $x): void
+{
+    v::attributes()->assert($x);
+    assertType('object', $x);
+}
+
+function base64Assert(mixed $x): void
+{
+    v::base64()->assert($x);
+    assertType('string', $x);
+}
+
+function boolTypeAssert(mixed $x): void
+{
+    v::boolType()->assert($x);
+    assertType('bool', $x);
+}
+
+function boolValAssert(mixed $x): void
+{
+    v::boolVal()->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function bsnAssert(mixed $x): void
+{
+    v::bsn()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function callableTypeAssert(mixed $x): void
+{
+    v::callableType()->assert($x);
+    assertType('callable(): mixed', $x);
+}
+
+function charsetAssert(mixed $x): void
+{
+    v::charset('x')->assert($x);
+    assertType('string', $x);
+}
+
+function cnhAssert(mixed $x): void
+{
+    v::cnh()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function cnpjAssert(mixed $x): void
+{
+    v::cnpj()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function consonantAssert(mixed $x): void
+{
+    v::consonant()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function containsAssert(mixed $x): void
+{
+    v::contains(1)->assert($x);
+    assertType('array|bool|float|int|string', $x);
+}
+
+function containsAnyAssert(mixed $x): void
+{
+    v::containsAny([1, 2, 3])->assert($x);
+    assertType('array|bool|float|int|string', $x);
+}
+
+function containsCountAssert(mixed $x): void
+{
+    v::containsCount(1, 1)->assert($x);
+    assertType('array|bool|float|int|string', $x);
+}
+
+function controlAssert(mixed $x): void
+{
+    v::control()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function countableAssert(mixed $x): void
+{
+    v::countable()->assert($x);
+    assertType('array|Countable', $x);
+}
+
+function countryCodeAssert(mixed $x): void
+{
+    v::countryCode()->assert($x);
+    assertType('string', $x);
+}
+
+function cpfAssert(mixed $x): void
+{
+    v::cpf()->assert($x);
+    assertType('string', $x);
+}
+
+function creditCardAssert(mixed $x): void
+{
+    v::creditCard()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function currencyCodeAssert(mixed $x): void
+{
+    v::currencyCode()->assert($x);
+    assertType('string', $x);
+}
+
+function dateAssert(mixed $x): void
+{
+    v::date()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function dateTimeAssert(mixed $x): void
+{
+    v::dateTime()->assert($x);
+    assertType('bool|DateTimeInterface|float|int|string', $x);
+}
+
+function dateTimeDiffAssert(mixed $x): void
+{
+    v::dateTimeDiff('years', v::intType())->assert($x);
+    assertType('DateTimeInterface|int|string', $x);
+}
+
+function decimalAssert(mixed $x): void
+{
+    v::decimal(1)->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function digitAssert(mixed $x): void
+{
+    v::digit()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function directoryAssert(mixed $x): void
+{
+    v::directory()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function domainAssert(mixed $x): void
+{
+    v::domain()->assert($x);
+    assertType('string', $x);
+}
+
+function eachAssert(mixed $x): void
+{
+    v::each(v::intType())->assert($x);
+    assertType('iterable<int>', $x);
+}
+
+function emailAssert(mixed $x): void
+{
+    v::email()->assert($x);
+    assertType('string', $x);
+}
+
+function emojiAssert(mixed $x): void
+{
+    v::emoji()->assert($x);
+    assertType('string', $x);
+}
+
+function endsWithAssert(mixed $x): void
+{
+    v::endsWith(1)->assert($x);
+    assertType('array|string', $x);
+}
+
+function evenAssert(mixed $x): void
+{
+    v::even()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function executableAssert(mixed $x): void
+{
+    v::executable()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function existsAssert(mixed $x): void
+{
+    v::exists()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function extensionAssert(mixed $x): void
+{
+    v::extension('x')->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function falseValAssert(mixed $x): void
+{
+    v::falseVal()->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function fileAssert(mixed $x): void
+{
+    v::file()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function finiteAssert(mixed $x): void
+{
+    v::finite()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function floatTypeAssert(mixed $x): void
+{
+    v::floatType()->assert($x);
+    assertType('float', $x);
+}
+
+function floatValAssert(mixed $x): void
+{
+    v::floatVal()->assert($x);
+    assertType('float|int|numeric-string|true', $x);
+}
+
+function graphAssert(mixed $x): void
+{
+    v::graph()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function hetuAssert(mixed $x): void
+{
+    v::hetu()->assert($x);
+    assertType('string', $x);
+}
+
+function hexRgbColorAssert(mixed $x): void
+{
+    v::hexRgbColor()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function ibanAssert(mixed $x): void
+{
+    v::iban()->assert($x);
+    assertType('string', $x);
+}
+
+function identicalAssert(mixed $x): void
+{
+    v::identical(42)->assert($x);
+    assertType('int', $x);
+}
+
+function imageAssert(mixed $x): void
+{
+    v::image()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function imeiAssert(mixed $x): void
+{
+    v::imei()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function infiniteAssert(mixed $x): void
+{
+    v::infinite()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function instanceAssert(mixed $x): void
+{
+    v::instance(\DateTimeInterface::class)->assert($x);
+    assertType('DateTimeInterface', $x);
+}
+
+function intTypeAssert(mixed $x): void
+{
+    v::intType()->assert($x);
+    assertType('int', $x);
+}
+
+function intValAssert(mixed $x): void
+{
+    v::intVal()->assert($x);
+    assertType('int|numeric-string', $x);
+}
+
+function ipAssert(mixed $x): void
+{
+    v::ip()->assert($x);
+    assertType('string', $x);
+}
+
+function isbnAssert(mixed $x): void
+{
+    v::isbn()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function iterableTypeAssert(mixed $x): void
+{
+    v::iterableType()->assert($x);
+    assertType('iterable', $x);
+}
+
+function iterableValAssert(mixed $x): void
+{
+    v::iterableVal()->assert($x);
+    assertType('array|stdClass|Traversable', $x);
+}
+
+function jsonAssert(mixed $x): void
+{
+    v::json()->assert($x);
+    assertType('string', $x);
+}
+
+function keyExistsAssert(mixed $x): void
+{
+    v::keyExists(1)->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+function keySetAssert(mixed $x): void
+{
+    v::keySet(v::intType())->assert($x);
+    assertType('array', $x);
+}
+
+function languageCodeAssert(mixed $x): void
+{
+    v::languageCode()->assert($x);
+    assertType('string', $x);
+}
+
+function leapDateAssert(mixed $x): void
+{
+    v::leapDate('x')->assert($x);
+    assertType('bool|DateTimeInterface|float|int|string', $x);
+}
+
+function leapYearAssert(mixed $x): void
+{
+    v::leapYear()->assert($x);
+    assertType('bool|DateTimeInterface|float|int|string', $x);
+}
+
+function lowercaseAssert(mixed $x): void
+{
+    v::lowercase()->assert($x);
+    assertType('string', $x);
+}
+
+function luhnAssert(mixed $x): void
+{
+    v::luhn()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function macAddressAssert(mixed $x): void
+{
+    v::macAddress()->assert($x);
+    assertType('string', $x);
+}
+
+function mimetypeAssert(mixed $x): void
+{
+    v::mimetype('x')->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function negativeAssert(mixed $x): void
+{
+    v::negative()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function nfeAccessKeyAssert(mixed $x): void
+{
+    v::nfeAccessKey()->assert($x);
+    assertType('string', $x);
+}
+
+function nifAssert(mixed $x): void
+{
+    v::nif()->assert($x);
+    assertType('string', $x);
+}
+
+function nipAssert(mixed $x): void
+{
+    v::nip()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function nullTypeAssert(mixed $x): void
+{
+    v::nullType()->assert($x);
+    assertType('null', $x);
+}
+
+function numberAssert(mixed $x): void
+{
+    v::number()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function numericValAssert(mixed $x): void
+{
+    v::numericVal()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function objectTypeAssert(mixed $x): void
+{
+    v::objectType()->assert($x);
+    assertType('object', $x);
+}
+
+function oddAssert(mixed $x): void
+{
+    v::odd()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function peselAssert(mixed $x): void
+{
+    v::pesel()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function phoneAssert(mixed $x): void
+{
+    v::phone()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function pisAssert(mixed $x): void
+{
+    v::pis()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function polishIdCardAssert(mixed $x): void
+{
+    v::polishIdCard()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function portugueseNifAssert(mixed $x): void
+{
+    v::portugueseNif()->assert($x);
+    assertType('string', $x);
+}
+
+function positiveAssert(mixed $x): void
+{
+    v::positive()->assert($x);
+    assertType('float|int|numeric-string', $x);
+}
+
+function postalCodeAssert(mixed $x): void
+{
+    v::postalCode('x')->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function printableAssert(mixed $x): void
+{
+    v::printable()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function propertyExistsAssert(mixed $x): void
+{
+    v::propertyExists('x')->assert($x);
+    assertType('object', $x);
+}
+
+function publicDomainSuffixAssert(mixed $x): void
+{
+    v::publicDomainSuffix()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function punctAssert(mixed $x): void
+{
+    v::punct()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function readableAssert(mixed $x): void
+{
+    v::readable()->assert($x);
+    assertType('Psr\Http\Message\StreamInterface|SplFileInfo|string', $x);
+}
+
+function regexAssert(mixed $x): void
+{
+    v::regex('x')->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function resourceTypeAssert(mixed $x): void
+{
+    v::resourceType()->assert($x);
+    assertType('resource', $x);
+}
+
+function romanAssert(mixed $x): void
+{
+    v::roman()->assert($x);
+    assertType('string', $x);
+}
+
+function scalarValAssert(mixed $x): void
+{
+    v::scalarVal()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function sizeAssert(mixed $x): void
+{
+    v::size('B', v::intType())->assert($x);
+    assertType('Psr\Http\Message\StreamInterface|Psr\Http\Message\UploadedFileInterface|SplFileInfo|string', $x);
+}
+
+function slugAssert(mixed $x): void
+{
+    v::slug()->assert($x);
+    assertType('string', $x);
+}
+
+function sortedAssert(mixed $x): void
+{
+    v::sorted('ASC')->assert($x);
+    assertType('array|string', $x);
+}
+
+function spaceAssert(mixed $x): void
+{
+    v::space()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function spacedAssert(mixed $x): void
+{
+    v::spaced()->assert($x);
+    assertType('string', $x);
+}
+
+function startsWithAssert(mixed $x): void
+{
+    v::startsWith(1)->assert($x);
+    assertType('array|string', $x);
+}
+
+function stringTypeAssert(mixed $x): void
+{
+    v::stringType()->assert($x);
+    assertType('string', $x);
+}
+
+function stringValAssert(mixed $x): void
+{
+    v::stringVal()->assert($x);
+    assertType('bool|float|int|string|Stringable', $x);
+}
+
+function subdivisionCodeAssert(mixed $x): void
+{
+    v::subdivisionCode('US')->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function subsetAssert(mixed $x): void
+{
+    v::subset([1, 2, 3])->assert($x);
+    assertType('array', $x);
+}
+
+function symbolicLinkAssert(mixed $x): void
+{
+    v::symbolicLink()->assert($x);
+    assertType('SplFileInfo|string', $x);
+}
+
+function timeAssert(mixed $x): void
+{
+    v::time()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function tldAssert(mixed $x): void
+{
+    v::tld()->assert($x);
+    assertType('string', $x);
+}
+
+function trimmedAssert(mixed $x): void
+{
+    v::trimmed()->assert($x);
+    assertType('string', $x);
+}
+
+function trueValAssert(mixed $x): void
+{
+    v::trueVal()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function undefAssert(mixed $x): void
+{
+    v::undef()->assert($x);
+    assertType("''|null", $x);
+}
+
+function uniqueAssert(mixed $x): void
+{
+    v::unique()->assert($x);
+    assertType('array', $x);
+}
+
+function uppercaseAssert(mixed $x): void
+{
+    v::uppercase()->assert($x);
+    assertType('string', $x);
+}
+
+function urlAssert(mixed $x): void
+{
+    v::url()->assert($x);
+    assertType('string', $x);
+}
+
+function uuidAssert(mixed $x): void
+{
+    v::uuid()->assert($x);
+    assertType('Ramsey\Uuid\UuidInterface|string', $x);
+}
+
+function versionAssert(mixed $x): void
+{
+    v::version()->assert($x);
+    assertType('string', $x);
+}
+
+function vowelAssert(mixed $x): void
+{
+    v::vowel()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+function writableAssert(mixed $x): void
+{
+    v::writable()->assert($x);
+    assertType('Psr\Http\Message\StreamInterface|SplFileInfo|string', $x);
+}
+
+function xdigitAssert(mixed $x): void
+{
+    v::xdigit()->assert($x);
+    assertType('bool|float|int|string', $x);
+}
+
+// ============================================================================
+// Combinations: the first rule (the type) wins; later rules only constrain it
+// ============================================================================
+
+function chainTypeThenConstraints(mixed $x): void
+{
+    v::intType()->positive()->between(1, 10)->assert($x);
+    assertType('int', $x);
+}
+
+function chainTypeThenFormat(mixed $x): void
+{
+    v::stringType()->email()->assert($x);
+    assertType('string', $x);
+}
+
+function chainResetRuleMidChain(mixed $x): void
+{
+    // a non-expressible rule (in()) mid-chain preserves the entry type, not mixed
+    v::intType()->in([1, 2, 3])->assert($x);
+    assertType('int', $x);
+}
+
+function chainElementOnType(mixed $x): void
+{
+    // each() refines the element type even after a container type rule
+    v::arrayType()->each(v::intType())->assert($x);
+    assertType('iterable<int>', $x);
+}
+
+// ============================================================================
+// Container subject: the input is narrowed to the container type (key/property/
+// length/max/min), and the prefixed form narrows identically.
+// ============================================================================
+
+function keyNarrowsToContainer(mixed $x): void
+{
+    v::key('a', v::intType())->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+function propertyNarrowsToContainer(mixed $x): void
+{
+    v::property('id', v::intType())->assert($x);
+    assertType('object', $x);
+}
+
+function lengthNarrowsToContainer(mixed $x): void
+{
+    v::length(v::between(1, 5))->assert($x);
+    assertType('array|Countable|string', $x);
+}
+
+function maxNarrowsToIterable(mixed $x): void
+{
+    v::max(v::intType())->assert($x);
+    assertType('iterable', $x);
+}
+
+function keyPrefixNarrowsToContainer(mixed $x): void
+{
+    v::keyIntType('a')->assert($x);
+    assertType('array|ArrayAccess', $x);
+}
+
+// ============================================================================
+// Wrap PREFIX composition: the concrete inner type unioned with the bypass set.
+// (The nullOr()/undefOr() ARG-forms stay mixed -- see the boundary section.)
+// ============================================================================
+
+function nullOrPrefixNarrows(mixed $x): void
+{
+    v::nullOrIntType()->assert($x);
+    assertType('int|null', $x);
+}
+
+function undefOrPrefixNarrows(mixed $x): void
+{
+    v::undefOrIntType()->assert($x);
+    assertType("''|int|null", $x);
+}
+
+function nullOrPrefixDedupesBypass(mixed $x): void
+{
+    // nullOrNullType(): the inner type already admits null, so the union must not be null|null.
+    v::nullOrNullType()->assert($x);
+    assertType('null', $x);
+}
+
+function nullOrPrefixDedupesWithinUnion(mixed $x): void
+{
+    // nullOrBoolVal(): inner 'scalar|null' + 'null' bypass collapses to scalar|null.
+    v::nullOrBoolVal()->assert($x);
+    assertType('bool|float|int|string|null', $x);
+}
+
+function chainTypeThenNullOr(mixed $x): void
+{
+    // first-wins: a leading type rule survives a later nullOr() (instance preserves TSure,
+    // and the instance method carries no Chain<T> parameter, so a raw validator is fine too).
+    v::stringType()->nullOr(v::intType())->assert($x);
+    assertType('string', $x);
+}
+
+// ============================================================================
+// Boundary: rules whose assurance is not statically expressible stay mixed
+// (extension-only); they must not narrow unsoundly. The argument-wrapping forms
+// (nullOr/undefOr arg-form, anyOf/oneOf/allOf/named/templated) are here on purpose:
+// narrowing them would retype their Validator parameter to Chain<T> and reject raw
+// (non-fluent) Validator arguments.
+// ============================================================================
+
+function notDoesNotNarrow(mixed $x): void
+{
+    v::not(v::intType())->assert($x);
+    assertType('mixed', $x);
+}
+
+function inDoesNotNarrow(mixed $x): void
+{
+    v::in([1, 2, 3])->assert($x);
+    assertType('mixed', $x);
+}
+
+function whenDoesNotNarrow(mixed $x): void
+{
+    v::when(v::intType(), v::positive(), v::negative())->assert($x);
+    assertType('mixed', $x);
+}
+
+function nullOrArgFormDoesNotNarrow(mixed $x): void
+{
+    v::nullOr(v::intType())->assert($x);
+    assertType('mixed', $x);
+}
+
+function anyOfDoesNotNarrow(mixed $x): void
+{
+    v::anyOf(v::intType(), v::stringType())->assert($x);
+    assertType('mixed', $x);
+}
+
+function allOfDoesNotNarrow(mixed $x): void
+{
+    v::allOf(v::intType(), v::positive())->assert($x);
+    assertType('mixed', $x);
+}
+
+function namedDoesNotNarrow(mixed $x): void
+{
+    v::named('n', v::intType())->assert($x);
+    assertType('mixed', $x);
+}
+
+// ============================================================================
+// Soundness: isValid() must not narrow the false branch of an inexact rule;
+// check() narrows like assert()
+// ============================================================================
+
+function isValidFalseBranchStaysSound(string $x): void
+{
+    if (v::email()->isValid($x)) {
+        return;
+    }
+
+    assertType('string', $x);
+}
+
+function checkNarrowsLikeAssert(mixed $x): void
+{
+    v::stringType()->check($x);
+    assertType('string', $x);
+}


### PR DESCRIPTION
Part of a PR group: [Fluent](https://github.com/Respect/Fluent/pull/28) - [FluentGen](https://github.com/Respect/FluentGen/pull/2) - [Validation](https://github.com/Respect/Validation/pull/1802)

---

Make validator chains narrow types for IDEs and PHPStan without the FluentAnalysis extension, driven entirely by the generated src/Mixins PHPDoc.

- Annotate src/Validators with #[Assurance] / #[AssuranceSubject] declaring each rule's assured type.
- Regenerate src/Mixins: Chain becomes generic (@template-covariant TSure); static entry methods narrow to Chain<concrete>; assert()/check() carry an unconditional @phpstan-assert TSure. Container rules (key/property/length/ max/min) and the concrete prefix forms (nullOrIntType, keyIntType, allIntType) narrow; argument-wrapping and compose forms stay Chain<mixed> so a raw (non-fluent) Validator argument is still accepted.
- isValid() intentionally does not narrow: its only conditional form is a two-way guard, unsound for inexact rules on the false branch.
- Add the tests/inference static-narrowing suite (no extension config) and run it in CI; scope the phpstan/phpcs accommodations for generated mixins.

---

This PR group adds advanced static (no PHPStan extension needed) type support and narrowing for fluent chains, pioneering it for Validation (StringFormatter should also be compatible with this approach)

<img width="855" height="135" alt="image" src="https://github.com/user-attachments/assets/a90edecb-ece4-4dc8-b850-7a9248f59b85" />

In the example above, the devsense extension for VSCode is correctly infering an `int[]` (iterable int) from a `each(int())` fluent validation chain.

More examples in `tests/inference/assertions/static-narrowing.php`.

---

Notes:

 - Most of the big diff is generated mixins, the PR is actually small.
 - This work is related, but distinct from #1730. FluentAnalysis offers dynamic type narrowing with much richer narrowings (but IDEs can't run the extension). This one offers basic, static narrowing for IDEs such as devsense (tested) and IntelliJ (untested).

