### PR TITLE
Guard Cpf and NfeAccessKey against non-scalar input

### DIFF
--- a/src/Validators/Cpf.php
+++ b/src/Validators/Cpf.php
@@ -24,6 +24,7 @@ use Respect\Validation\Message\Template;
 use Respect\Validation\Validators\Core\Simple;
 
 use function intval;
+use function is_scalar;
 use function mb_strlen;
 use function preg_match;
 use function preg_replace;
@@ -37,8 +38,12 @@ final class Cpf extends Simple
 {
     public function isValid(mixed $input): bool
     {
+        if (!is_scalar($input)) {
+            return false;
+        }
+
         // Code ported from jsfromhell.com
-        $c = preg_replace('/\D/', '', $input);
+        $c = (string) preg_replace('/\D/', '', (string) $input);
 
         if (mb_strlen($c) != 11 || preg_match('/^' . $c[0] . '{11}$/', $c) || $c === '01234567890') {
             return false;

--- a/src/Validators/NfeAccessKey.php
+++ b/src/Validators/NfeAccessKey.php
@@ -20,6 +20,7 @@ use Respect\Validation\Validators\Core\Simple;
 
 use function array_map;
 use function floor;
+use function is_scalar;
 use function mb_strlen;
 use function str_split;
 
@@ -33,11 +34,15 @@ final class NfeAccessKey extends Simple
 {
     public function isValid(mixed $input): bool
     {
-        if (mb_strlen($input) !== 44) {
+        if (!is_scalar($input)) {
             return false;
         }
 
-        $digits = array_map('intval', str_split($input));
+        if (mb_strlen((string) $input) !== 44) {
+            return false;
+        }
+
+        $digits = array_map('intval', str_split((string) $input));
         $w = [];
         for ($i = 0, $z = 5, $m = 43; $i <= $m; ++$i) {
             $z = $i < $m ? $z - 1 == 1 ? 9 : $z - 1 : 0;

--- a/tests/unit/Validators/CpfTest.php
+++ b/tests/unit/Validators/CpfTest.php
@@ -18,6 +18,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use Respect\Validation\Test\RuleTestCase;
+use stdClass;
 
 #[Group('validator')]
 #[CoversClass(Cpf::class)]
@@ -35,6 +36,7 @@ final class CpfTest extends RuleTestCase
             [$validator, '693-319-118-40'],
             [$validator, '3.6.8.8.9.2.5.5.4.8.8'],
             [$validator, '11598647644'],
+            [$validator, 11598647644],
             [$validator, '86734718697'],
             [$validator, '86223423284'],
             [$validator, '24845408333'],
@@ -66,6 +68,10 @@ final class CpfTest extends RuleTestCase
             [$validator, '22'],
             [$validator, '123'],
             [$validator, '992999999999929384'],
+            [$validator, []],
+            [$validator, new stdClass()],
+            [$validator, null],
+            [$validator, true],
         ];
     }
 }

--- a/tests/unit/Validators/NfeAccessKeyTest.php
+++ b/tests/unit/Validators/NfeAccessKeyTest.php
@@ -17,6 +17,7 @@ namespace Respect\Validation\Validators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use Respect\Validation\Test\RuleTestCase;
+use stdClass;
 
 #[Group('validator')]
 #[CoversClass(NfeAccessKey::class)]
@@ -57,6 +58,10 @@ final class NfeAccessKeyTest extends RuleTestCase
             [$nfe, '5858836670181917762140106857095788313119136'],
             [$nfe, '6098412281885524361833754087461339281130'],
             [$nfe, '9025299113310221'],
+            [$nfe, []],
+            [$nfe, new stdClass()],
+            [$nfe, null],
+            [$nfe, true],
         ];
     }
 }


### PR DESCRIPTION
`Cpf` and `NfeAccessKey` call string functions on raw `mixed` input, so `v::cpf()->isValid([])` (or an object, `null`, etc.) throws a `TypeError` where every sibling in the document/checksum family (`Cnpj`, `Bsn`, `Cnh`, `Pis`, …) returns `false` — they all start with an `is_scalar` guard that these two never got (#980 tried to standardise `Cpf` but was closed unmerged).

The fix mirrors `Cnpj`: guard non-scalars, then cast scalars to string, so `v::cpf()->isValid(11598647644)` behaves like the string form instead of crashing. I checked every `Simple` subclass that hits raw `$input` with a string function and only these two were affected (`Luhn` looks similar but delegates to the guarded `Digit` first). Tests cover non-scalar input returning `false` and the int form of a valid CPF still passing.
