### PR TITLE
Fix double validation and state leaks in Attributes recursion

### DIFF
--- a/docs/validators/Attributes.md
+++ b/docs/validators/Attributes.md
@@ -86,16 +86,24 @@ When a property is nullable (e.g., `?string $email`), `Attributes` wraps the pro
 When a property's type is a class (named, union, or intersection type), `Attributes` recursively validates that object's own properties, so there is no need to explicitly add `#[Attributes]` on the property.
 
 - **Named types** (`NestedAddress $address`): the nested object is validated directly.
-- **Union types** (`string|NestedAddress $address`): the nested object is only validated if it passes an `Instance` check first, so string values in the union are safely skipped.
+- **Union types** (`string|NestedAddress $address`): the nested value is only validated when it is an object, so string values in the union are safely skipped.
 - **Intersection types** (`NestedWithAttributes&Nested $address`): the nested object is validated directly, since it must satisfy all types in the intersection.
 - **Untyped properties** (no type declaration, or builtin types like `string`): are never recursively validated.
 - **Array properties**: `Attributes` **does not** recursively validate objects inside arrays. To validate each element, use the `#[Each]` attribute on the property (e.g., `#[Each(new Attributes())]`).
+
+An explicit `Attributes` rule prevents implicit recursion, so the nested value is validated once. Direct `#[Attributes]` shares the current traversal; a new instance inside another rule (e.g., `#[NullOr(new Attributes())]`) starts a separate one.
+
+Any other attribute on the property is combined with the implicit recursion instead of replacing it, so `#[Instance(Address::class)] public Address $address` still validates the nested object's own attributes.
 
 ### Circular references
 
 When a nested object graph contains a cycle (e.g., `$a->next = $b`, `$b->next = $a`), `Attributes` detects the revisit and fails with the `TEMPLATE_CIRCULAR_REFERENCE` template. This prevents infinite recursion and stack overflow.
 
-Note that circular reference detection only works for direct object references. If a cycle passes through an array (e.g., `$a->items = [$b]`, `$b->parent = $a`), `Attributes` cannot track the reference and the validation will recurse infinitely, causing a stack overflow.
+Detection is per *path*: a shared object on two sibling properties is not a cycle and is validated on each path.
+
+A separate `Attributes` instance does not know the current path, so cycles through it recurse indefinitely.
+
+Cycles through arrays are not detected and recurse indefinitely.
 
 ## Templates
 

--- a/src/Validators/Attributes.php
+++ b/src/Validators/Attributes.php
@@ -19,6 +19,8 @@ use ReflectionIntersectionType;
 use ReflectionNamedType;
 use ReflectionObject;
 use ReflectionProperty;
+use ReflectionReference;
+use ReflectionType;
 use ReflectionUnionType;
 use Respect\Fluent\Attributes\Composable;
 use Respect\Parameter\Resolver;
@@ -28,6 +30,7 @@ use Respect\Validation\Result;
 use Respect\Validation\Validator;
 use Respect\Validation\Validators\Core\Reducer;
 
+use function is_array;
 use function spl_object_id;
 
 #[Composable(without: [All::class, Key::class, Property::class, Not::class, UndefOr::class])]
@@ -37,15 +40,16 @@ use function spl_object_id;
     '{{subject}} must contain a circular reference',
     Attributes::TEMPLATE_CIRCULAR_REFERENCE,
 )]
-final class Attributes implements Validator
+final readonly class Attributes implements Validator
 {
     public const string TEMPLATE_CIRCULAR_REFERENCE = '__circular_reference__';
 
     /** @var array<int, true> */
-    private array $visited = [];
+    private array $path;
 
-    public function __construct(private readonly Resolver|null $resolver = null)
+    public function __construct(private Resolver|null $resolver = null)
     {
+        $this->path = self::rootPath();
     }
 
     public function evaluate(mixed $input): Result
@@ -57,19 +61,24 @@ final class Attributes implements Validator
         }
 
         $objectId = spl_object_id($input);
-        if (isset($this->visited[$objectId])) {
+        if (isset($this->path[$objectId])) {
             return Result::failed($input, $this, [], self::TEMPLATE_CIRCULAR_REFERENCE)->withId($id);
         }
 
-        $this->visited[$objectId] = true;
+        $path = $this->path + [$objectId => true];
+        $child = clone ($this, ['path' => $path]);
 
         $reflection = new ReflectionObject($input);
-        $validators = [...$this->getClassValidators($reflection), ...$this->getPropertyValidators($reflection)];
-        if ($validators === []) {
-            return (new AlwaysValid())->evaluate($input)->withId($id);
-        }
+        $validators = [...$child->getClassValidators($reflection), ...$child->getPropertyValidators($reflection)];
+        $rule = $validators === [] ? new AlwaysValid() : new Reducer(...$validators);
 
-        return (new Reducer(...$validators))->evaluate($input)->withId($id);
+        return $rule->evaluate($input)->withId($id);
+    }
+
+    /** @return array<int, true> */
+    private static function rootPath(): array
+    {
+        return [];
     }
 
     /** @return array<Validator> */
@@ -110,46 +119,119 @@ final class Attributes implements Validator
     private function getPropertyInnerValidators(ReflectionProperty $property): array
     {
         $propertyValidators = [];
-        $hasExplicitAttributes = false;
         foreach ($property->getAttributes(Validator::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             if ($attribute->getName() === self::class) {
-                $propertyValidator = $this;
-            } else {
-                $propertyValidator = $this->instantiateAttribute($attribute);
+                $propertyValidators[] = $this;
+
+                continue;
             }
 
-            $hasExplicitAttributes = $hasExplicitAttributes || $propertyValidator === $this;
-            $propertyValidators[] = $propertyValidator;
+            $propertyValidators[] = $this->instantiateAttribute($attribute);
         }
 
-        if ($hasExplicitAttributes) {
+        $recursion = $this->getRecursionValidator($property->getType());
+        if ($recursion === null) {
             return $propertyValidators;
         }
 
-        $type = $property->getType();
-        if ($type instanceof ReflectionNamedType) {
-            if (!$type->isBuiltin()) {
-                $propertyValidators[] = $this;
+        foreach ($propertyValidators as $propertyValidator) {
+            if (self::containsSelf($propertyValidator)) {
+                return $propertyValidators;
             }
+        }
+
+        $propertyValidators[] = $recursion;
+
+        return $propertyValidators;
+    }
+
+    private function getRecursionValidator(ReflectionType|null $type): Validator|null
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return $type->isBuiltin() ? null : $this;
         }
 
         if ($type instanceof ReflectionIntersectionType) {
-            $propertyValidators[] = $this;
+            return $this;
         }
 
-        if ($type instanceof ReflectionUnionType) {
-            foreach ($type->getTypes() as $innerType) {
-                if (!$innerType instanceof ReflectionNamedType || $innerType->isBuiltin()) {
-                    continue;
-                }
+        if (!$type instanceof ReflectionUnionType) {
+            return null;
+        }
 
-                /** @var class-string $class */
-                $class = $innerType->getName();
-                $propertyValidators[] = new Given(new Instance($class), $this);
+        foreach ($type->getTypes() as $innerType) {
+            if ($this->getRecursionValidator($innerType) !== null) {
+                return new Given(new ObjectType(), $this);
             }
         }
 
-        return $propertyValidators;
+        return null;
+    }
+
+    /** @param array<string, true> $visited */
+    private static function containsSelf(mixed $value, array &$visited = []): bool
+    {
+        if ($value instanceof self) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                if (is_array($item) && !self::isUnvisitedReference($value, $key, $visited)) {
+                    continue;
+                }
+
+                if (self::containsSelf($item, $visited)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (!$value instanceof Validator) {
+            return false;
+        }
+
+        $objectId = 'validator:' . spl_object_id($value);
+        if (isset($visited[$objectId])) {
+            return false;
+        }
+
+        $visited[$objectId] = true;
+        $reflection = new ReflectionObject($value);
+        while ($reflection instanceof ReflectionClass) {
+            foreach ($reflection->getProperties() as $property) {
+                if ($property->isInitialized($value) && self::containsSelf($property->getValue($value), $visited)) {
+                    return true;
+                }
+            }
+
+            $reflection = $reflection->getParentClass();
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<mixed> $array
+     * @param array<string, true> $visited
+     */
+    private static function isUnvisitedReference(array $array, int|string $key, array &$visited): bool
+    {
+        $reference = ReflectionReference::fromArrayElement($array, $key);
+        if ($reference === null) {
+            return true;
+        }
+
+        $referenceId = 'reference:' . $reference->getId();
+        if (isset($visited[$referenceId])) {
+            return false;
+        }
+
+        $visited[$referenceId] = true;
+
+        return true;
     }
 
     /** @return array<ReflectionProperty> */

--- a/tests/feature/Validators/AttributesTest.php
+++ b/tests/feature/Validators/AttributesTest.php
@@ -17,6 +17,7 @@ use Respect\Validation\Test\Stubs\WithCyclicAttributes;
 use Respect\Validation\Test\Stubs\WithIntersectionTypeNested;
 use Respect\Validation\Test\Stubs\WithNestedAttributes;
 use Respect\Validation\Test\Stubs\WithUnionTypeNested;
+use Respect\Validation\Test\Stubs\WithWrappedAttributesOnNested;
 
 test('Default', catchAll(
     fn() => v::attributes()->assert(new WithAttributes('', '2024-06-23', 'john.doe@gmail.com')),
@@ -116,6 +117,14 @@ test('Recursive: union type with invalid nested object property', catchAll(
         ->and($message)->toBe('`.address.street` must be defined')
         ->and($fullMessage)->toBe('- `.address.street` must be defined')
         ->and($messages)->toBe(['address' => '`.address.street` must be defined']),
+));
+
+test('Recursive: wrapped Attributes on nested property is not duplicated', catchAll(
+    fn() => v::attributes()->assert(new WithWrappedAttributesOnNested(new NestedAddress('', 'Springfield'))),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('`.address.street` must be defined')
+        ->and($fullMessage)->toBe('- `.address.street` must be defined')
+        ->and($messages)->toBe(['street' => '`.address.street` must be defined']),
 ));
 
 test('Recursive: intersection type with invalid nested object property', catchAll(

--- a/tests/src/Stubs/ArrayValidator.php
+++ b/tests/src/Stubs/ArrayValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Attribute;
+use Respect\Validation\Result;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\AlwaysValid;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ArrayValidator implements Validator
+{
+    /** @var array{0: string, self: array<mixed>} */
+    private array $children;
+
+    public function __construct()
+    {
+        $children = ['value'];
+        $children['self'] = &$children;
+
+        $this->children = $children;
+    }
+
+    public function evaluate(mixed $input): Result
+    {
+        return (new AlwaysValid())->evaluate($input);
+    }
+}

--- a/tests/src/Stubs/CyclicValidator.php
+++ b/tests/src/Stubs/CyclicValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Attribute;
+use Respect\Validation\Result;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\AlwaysValid;
+use Respect\Validation\Validators\Attributes;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class CyclicValidator implements Validator
+{
+    /** @var array{self, Attributes, string} */
+    private array $children;
+
+    public function __construct()
+    {
+        $this->children = [$this, new Attributes(), 'cyclic'];
+    }
+
+    public function evaluate(mixed $input): Result
+    {
+        return (new AlwaysValid())->evaluate($input);
+    }
+}

--- a/tests/src/Stubs/EnvelopeAttributes.php
+++ b/tests/src/Stubs/EnvelopeAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Attribute;
+use Respect\Validation\Validators\Attributes;
+use Respect\Validation\Validators\Core\Envelope;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class EnvelopeAttributes extends Envelope
+{
+    public function __construct()
+    {
+        parent::__construct(new Attributes());
+    }
+}

--- a/tests/src/Stubs/NestedArrayValidator.php
+++ b/tests/src/Stubs/NestedArrayValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Attribute;
+use Respect\Validation\Result;
+use Respect\Validation\Validator;
+use Respect\Validation\Validators\AlwaysValid;
+use Respect\Validation\Validators\Attributes;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class NestedArrayValidator implements Validator
+{
+    /** @var array{0: array{0: string, 1: Attributes}} */
+    private array $children;
+
+    public function __construct()
+    {
+        $this->children = [['nested', new Attributes()]];
+    }
+
+    public function evaluate(mixed $input): Result
+    {
+        return (new AlwaysValid())->evaluate($input);
+    }
+}

--- a/tests/src/Stubs/ResolvedDependency.php
+++ b/tests/src/Stubs/ResolvedDependency.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class ResolvedDependency
+{
+    public function __construct(
+        public string $expected,
+    ) {
+    }
+}

--- a/tests/src/Stubs/ResolvedValidator.php
+++ b/tests/src/Stubs/ResolvedValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Attribute;
+use Respect\Validation\Result;
+use Respect\Validation\Validator;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ResolvedValidator implements Validator
+{
+    private readonly ResolvedDependency $dependency;
+
+    public function __construct(ResolvedDependency|null $dependency = null)
+    {
+        $this->dependency = $dependency ?? new ResolvedDependency('not resolved');
+    }
+
+    public function evaluate(mixed $input): Result
+    {
+        return Result::of($input === $this->dependency->expected, $input, $this);
+    }
+}

--- a/tests/src/Stubs/WithArrayValidator.php
+++ b/tests/src/Stubs/WithArrayValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithArrayValidator
+{
+    public function __construct(
+        #[ArrayValidator]
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithCyclicValidator.php
+++ b/tests/src/Stubs/WithCyclicValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithCyclicValidator
+{
+    public function __construct(
+        #[CyclicValidator]
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithDnfUnionTypeNested.php
+++ b/tests/src/Stubs/WithDnfUnionTypeNested.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithDnfUnionTypeNested
+{
+    public function __construct(
+        public NestedAddress|(NestedWithAttributes&Nested) $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithEnvelopeAttributesOnNested.php
+++ b/tests/src/Stubs/WithEnvelopeAttributesOnNested.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithEnvelopeAttributesOnNested
+{
+    public function __construct(
+        #[EnvelopeAttributes]
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithNestedArrayValidator.php
+++ b/tests/src/Stubs/WithNestedArrayValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithNestedArrayValidator
+{
+    public function __construct(
+        #[NestedArrayValidator]
+        public NestedAddress $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithOverlappingUnionTypeNested.php
+++ b/tests/src/Stubs/WithOverlappingUnionTypeNested.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithOverlappingUnionTypeNested
+{
+    public function __construct(
+        public NestedWithAttributes|Nested $address,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithResolvedValidator.php
+++ b/tests/src/Stubs/WithResolvedValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithResolvedValidator
+{
+    public function __construct(
+        #[ResolvedValidator]
+        public string $value,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithSharedNested.php
+++ b/tests/src/Stubs/WithSharedNested.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+final class WithSharedNested
+{
+    public function __construct(
+        public NestedAddress $billing,
+        public NestedAddress $shipping,
+    ) {
+    }
+}

--- a/tests/src/Stubs/WithWrappedAttributesOnNested.php
+++ b/tests/src/Stubs/WithWrappedAttributesOnNested.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ * SPDX-FileContributor: Alexandre Gomes Gaigalas <alganet@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use Respect\Validation\Validators as Rule;
+
+final class WithWrappedAttributesOnNested
+{
+    public function __construct(
+        #[Rule\NullOr(new Rule\Attributes())]
+        public NestedAddress|null $address = null,
+    ) {
+    }
+}

--- a/tests/unit/Validators/AttributesTest.php
+++ b/tests/unit/Validators/AttributesTest.php
@@ -15,23 +15,37 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Respect\Config\Container;
+use Respect\Parameter\ContainerResolver;
 use Respect\Validation\Test\Stubs\CyclicNode;
+use Respect\Validation\Test\Stubs\EnvelopeAttributes;
 use Respect\Validation\Test\Stubs\NestedAddress;
 use Respect\Validation\Test\Stubs\NestedPassThrough;
 use Respect\Validation\Test\Stubs\NestedValidated;
 use Respect\Validation\Test\Stubs\NestedWithAttributes;
 use Respect\Validation\Test\Stubs\NestedWithoutAttributes;
+use Respect\Validation\Test\Stubs\ResolvedDependency;
+use Respect\Validation\Test\Stubs\WithArrayValidator;
 use Respect\Validation\Test\Stubs\WithAttributes;
 use Respect\Validation\Test\Stubs\WithAttributesNotLastOnNested;
 use Respect\Validation\Test\Stubs\WithCyclicAttributes;
+use Respect\Validation\Test\Stubs\WithCyclicValidator;
 use Respect\Validation\Test\Stubs\WithDeeplyNestedAttributes;
+use Respect\Validation\Test\Stubs\WithDnfUnionTypeNested;
+use Respect\Validation\Test\Stubs\WithEnvelopeAttributesOnNested;
 use Respect\Validation\Test\Stubs\WithExplicitAttributesOnNested;
 use Respect\Validation\Test\Stubs\WithIntersectionTypeNested;
+use Respect\Validation\Test\Stubs\WithNestedArrayValidator;
 use Respect\Validation\Test\Stubs\WithNestedAttributes;
 use Respect\Validation\Test\Stubs\WithNestedWithoutAttributes;
 use Respect\Validation\Test\Stubs\WithNullableNestedAttributes;
+use Respect\Validation\Test\Stubs\WithOverlappingUnionTypeNested;
+use Respect\Validation\Test\Stubs\WithResolvedValidator;
+use Respect\Validation\Test\Stubs\WithSharedNested;
 use Respect\Validation\Test\Stubs\WithUnionTypeNested;
+use Respect\Validation\Test\Stubs\WithWrappedAttributesOnNested;
 use Respect\Validation\Test\TestCase;
+use stdClass;
 
 #[Group(' rule')]
 #[CoversClass(Attributes::class)]
@@ -206,6 +220,48 @@ final class AttributesTest extends TestCase
     }
 
     #[Test]
+    public function shouldRecursivelyValidateDnfUnionTypeNestedWhenValid(): void
+    {
+        $input = new WithDnfUnionTypeNested(new NestedAddress('123 Main St', 'Springfield'));
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateDnfUnionTypeNestedWhenInvalid(): void
+    {
+        $input = new WithDnfUnionTypeNested(new NestedWithAttributes('', 'Springfield'));
+
+        self::assertInvalidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldNotRecursivelyValidateBuiltinUnionTypes(): void
+    {
+        $input = new class {
+            #[StringType]
+            public string|int $value = 42;
+        };
+
+        $result = (new Attributes())->evaluate($input);
+
+        self::assertFalse($result->hasPassed);
+        self::assertInstanceOf(StringType::class, $result->validator);
+    }
+
+    #[Test]
+    public function shouldNotRecursivelyValidateUntypedProperties(): void
+    {
+        $input = new stdClass();
+        $input->value = 'anything';
+
+        $result = (new Attributes())->evaluate($input);
+
+        self::assertTrue($result->hasPassed);
+        self::assertInstanceOf(AlwaysValid::class, $result->validator);
+    }
+
+    #[Test]
     public function shouldRecursivelyValidateIntersectionTypeNestedWhenValid(): void
     {
         $validAddress = new NestedWithAttributes('123 Main St', 'Springfield');
@@ -247,6 +303,79 @@ final class AttributesTest extends TestCase
         $input = new WithAttributesNotLastOnNested(new NestedAddress('123 Main St', 'Springfield'));
 
         self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldNotDuplicateAttributesWhenWrappedOnNestedProperty(): void
+    {
+        $input = new WithWrappedAttributesOnNested(new NestedAddress('123 Main St', 'Springfield'));
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldNotDuplicateAttributesWhenWrappedByAnAncestor(): void
+    {
+        $input = new WithEnvelopeAttributesOnNested(new NestedAddress('', 'Springfield'));
+        $result = (new Attributes())->evaluate($input);
+
+        self::assertFalse($result->hasPassed);
+        self::assertInstanceOf(EnvelopeAttributes::class, $result->validator);
+    }
+
+    #[Test]
+    public function shouldNotDuplicateAttributesWrappedByCyclicValidator(): void
+    {
+        self::assertValidInput(new Attributes(), new WithCyclicValidator(new NestedAddress('', '')));
+    }
+
+    #[Test]
+    public function shouldNotDuplicateAttributesWrappedInNestedValidatorArrays(): void
+    {
+        self::assertValidInput(new Attributes(), new WithNestedArrayValidator(new NestedAddress('', '')));
+    }
+
+    #[Test]
+    public function shouldRecursivelyValidateThroughSelfReferentialValidatorArrays(): void
+    {
+        self::assertInvalidInput(new Attributes(), new WithArrayValidator(new NestedAddress('', '')));
+    }
+
+    #[Test]
+    public function shouldNotDuplicateAttributesWhenUnionTypesOverlap(): void
+    {
+        $input = new WithOverlappingUnionTypeNested(new NestedWithAttributes('123 Main St', 'Springfield'));
+
+        self::assertValidInput(new Attributes(), $input);
+    }
+
+    #[Test]
+    public function shouldNotTreatSharedReferencesAsCircular(): void
+    {
+        $address = new NestedAddress('123 Main St', 'Springfield');
+
+        self::assertValidInput(new Attributes(), new WithSharedNested($address, $address));
+    }
+
+    #[Test]
+    public function shouldBeReusableAcrossEvaluations(): void
+    {
+        $rule = new Attributes();
+        $input = new WithNestedAttributes('John Doe', new NestedAddress('123 Main St', 'Springfield'));
+
+        self::assertValidInput($rule, $input);
+        self::assertValidInput($rule, $input);
+    }
+
+    #[Test]
+    public function shouldInstantiateAttributesWithTheGivenResolver(): void
+    {
+        $resolver = new ContainerResolver(
+            new Container([ResolvedDependency::class => new ResolvedDependency('expected')]),
+        );
+
+        self::assertInvalidInput(new Attributes(), new WithResolvedValidator('expected'));
+        self::assertValidInput(new Attributes($resolver), new WithResolvedValidator('expected'));
     }
 
     #[Test]


### PR DESCRIPTION
Recursive validation for nested objects guarded against validating a nested object twice by checking whether the property already carried #[Attributes] directly on the property. That guard did not recognise the rule inside a wrapper, and the state backing the recursion was never released, producing five defects:

- #[NullOr(new Attributes())] on a class-typed property validated the nested object twice and reported every nested failure twice. This was the documented way of validating a nullable nested object before recursion existed, so upgrading silently duplicated messages.
- The same object held by two sibling properties failed as a circular reference, because visited objects accumulated for the whole traversal instead of the current path.
- An Attributes instance could only be used once: nothing ever cleared the visited objects, so every evaluation after the first failed.
- A union type whose value satisfied more than one of its class members recursed once per member, and the second one reported the object it had just visited as a circular reference.
- A custom validator attribute with cyclic internal state made wrapped-rule detection recurse indefinitely.

Detect the rule anywhere inside a property's attributes rather than only at the top level, so a wrapped Attributes suppresses implicit recursion as an explicit one does. Make the rule immutable and give each recursion level its own instance carrying the path to the object being evaluated, so visited objects represent the path from the root rather than every object ever seen. Collapse union recursion into a single Given over the disjunction of its class members. Track the validators visited while inspecting a wrapped rule, preventing a cyclic validator graph from overflowing the stack.

The detection only runs for properties whose type can hold an object, so attributes with large arguments, such as #[In], no longer pay for it.

---

This is a smaller, more focused fix for the recursion problem that does not introduce an external resolver like #1799. It is intended to focus on the behavior, leaving open the possibility of introducing such resolver in the dependency chain as a substitute non-breaking change.
