### PR TITLE
Stop DateTimeDiff message tests from racing the clock

### DIFF
--- a/tests/feature/Validators/DateTimeDiffTest.php
+++ b/tests/feature/Validators/DateTimeDiffTest.php
@@ -127,38 +127,44 @@ test('Wrapper with custom template', catchAll(
 ));
 
 test('Without adjacent result', catchAll(
-    fn() => v::dateTimeDiff('years', v::positive()->between(2, 5))->assert('1 year ago'),
+    fn() => v::dateTimeDiff('years', v::positive()->between(2, 5))->assert('1 year ago + 1 minute'),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('The number of years between now and "1 year ago" must be a positive number')
+        ->and($message)
+        ->toBe('The number of years between now and "1 year ago + 1 minute" must be a positive number')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
-        - "1 year ago" must pass all the rules
-          - The number of years between now and "1 year ago" must be a positive number
-          - The number of years between now and "1 year ago" must be between 2 and 5
+        - "1 year ago + 1 minute" must pass all the rules
+          - The number of years between now and "1 year ago + 1 minute" must be a positive number
+          - The number of years between now and "1 year ago + 1 minute" must be between 2 and 5
         FULL_MESSAGE)
         ->and($messages)->toBe([
-            '__root__' => '"1 year ago" must pass all the rules',
-            'dateTimeDiffPositive' => 'The number of years between now and "1 year ago" must be a positive number',
-            'dateTimeDiffBetween' => 'The number of years between now and "1 year ago" must be between 2 and 5',
+            '__root__' => '"1 year ago + 1 minute" must pass all the rules',
+            'dateTimeDiffPositive'
+                => 'The number of years between now and "1 year ago + 1 minute" must be a positive number',
+            'dateTimeDiffBetween'
+                => 'The number of years between now and "1 year ago + 1 minute" must be between 2 and 5',
         ]),
 ));
 
 test('Without adjacent result with templates', catchAll(
-    fn() => v::dateTimeDiff('years', v::positive()->between(2, 5))->assert('1 year ago', [
+    fn() => v::dateTimeDiff('years', v::positive()->between(2, 5))->assert('1 year ago + 1 minute', [
         'dateTimeDiff' => [
             'positive' => 'Interval must be a positive number',
             'between' => 'Interval must be between 2 and 5',
         ],
     ]),
     fn(string $message, string $fullMessage, array $messages) => expect()
-        ->and($message)->toBe('The number of years between now and "1 year ago" must be a positive number')
+        ->and($message)
+        ->toBe('The number of years between now and "1 year ago + 1 minute" must be a positive number')
         ->and($fullMessage)->toBe(<<<'FULL_MESSAGE'
-        - "1 year ago" must pass all the rules
-          - The number of years between now and "1 year ago" must be a positive number
-          - The number of years between now and "1 year ago" must be between 2 and 5
+        - "1 year ago + 1 minute" must pass all the rules
+          - The number of years between now and "1 year ago + 1 minute" must be a positive number
+          - The number of years between now and "1 year ago + 1 minute" must be between 2 and 5
         FULL_MESSAGE)
         ->and($messages)->toBe([
-            '__root__' => '"1 year ago" must pass all the rules',
-            'dateTimeDiffPositive' => 'The number of years between now and "1 year ago" must be a positive number',
-            'dateTimeDiffBetween' => 'The number of years between now and "1 year ago" must be between 2 and 5',
+            '__root__' => '"1 year ago + 1 minute" must pass all the rules',
+            'dateTimeDiffPositive'
+                => 'The number of years between now and "1 year ago + 1 minute" must be a positive number',
+            'dateTimeDiffBetween'
+                => 'The number of years between now and "1 year ago + 1 minute" must be between 2 and 5',
         ]),
 ));


### PR DESCRIPTION
The "Without adjacent result" tests validated "1 year ago" against positive() and between(2, 5), expecting both rules to fail so that AllOf reports "must pass all the rules".

DateTimeDiff reads the clock for $now and only then parses the input, so a relative input reads the clock a second time. When both reads land in the same microsecond the difference is exactly one year and the comparison value is 1 instead of 0, positive() passes, and AllOf reports "must pass the rules" instead. Running the file alone hides it; in the full suite, with caches warm, roughly half the runs failed.

Move the input a minute off the boundary so the number of years is always 0, the same idiom the documentation already uses. The underlying validator remains sensitive to inputs that fall exactly on a boundary.

