### PR TITLE
Report unknown size instead of passing false or 0 bytes to the inner validator

### DIFF
--- a/docs/validators/Size.md
+++ b/docs/validators/Size.md
@@ -50,6 +50,15 @@ Used when the input is not a valid file path, a `SplFileInfo` object, or a PSR-7
 |  `default` | {{subject}} must be a filename, an instance of SplFileInfo or a PSR-7 interface     |
 | `inverted` | {{subject}} must not be a filename, an instance of SplFileInfo or a PSR-7 interface |
 
+### `Size::TEMPLATE_UNKNOWN_SIZE`
+
+Used when it's impossible to get the size of the input.
+
+|       Mode | Template                                                |
+| ---------: | :------------------------------------------------------ |
+|  `default` | It is not possible to determine the size of {{subject}} |
+| `inverted` | It is not possible to determine the size of {{subject}} |
+
 ## Template as prefix
 
 The template serves as a prefix to the template of the inner validator.
@@ -76,12 +85,13 @@ v::size('KB', v::not(v::equals(56)))->assert('/path/to/file');
 
 ## Changelog
 
-| Version | Description             |
-| ------: | :---------------------- |
-|   3.0.0 | Templates changed       |
-|   3.0.0 | Became a transformation |
-|   2.1.0 | Add [PSR-7][] support   |
-|   1.0.0 | Created                 |
+| Version | Description                   |
+| ------: | :---------------------------- |
+|   3.2.0 | Added `TEMPLATE_UNKNOWN_SIZE` |
+|   3.0.0 | Templates changed             |
+|   3.0.0 | Became a transformation       |
+|   2.1.0 | Add [PSR-7][] support         |
+|   1.0.0 | Created                       |
 
 ## See Also
 

--- a/src/Validators/Size.php
+++ b/src/Validators/Size.php
@@ -20,9 +20,11 @@ use Respect\Validation\Exceptions\InvalidValidatorException;
 use Respect\Validation\Message\Template;
 use Respect\Validation\Result;
 use Respect\Validation\Validator;
+use RuntimeException;
 use SplFileInfo;
 
 use function filesize;
+use function is_file;
 use function is_string;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
@@ -36,9 +38,16 @@ use function is_string;
     '{{subject}} must not be a filename, an instance of SplFileInfo or a PSR-7 interface',
     self::TEMPLATE_WRONG_TYPE,
 )]
+#[Template(
+    'It is not possible to determine the size of {{subject}}',
+    'It is not possible to determine the size of {{subject}}',
+    self::TEMPLATE_UNKNOWN_SIZE,
+)]
 final readonly class Size implements Validator
 {
     public const string TEMPLATE_WRONG_TYPE = '__wrong_type__';
+
+    public const string TEMPLATE_UNKNOWN_SIZE = '__unknown_size__';
 
     private const array DATA_STORAGE_UNITS = [
         'B' => ['name' => 'bytes', 'bytes' => 1],
@@ -64,14 +73,19 @@ final readonly class Size implements Validator
 
     public function evaluate(mixed $input): Result
     {
-        $size = $this->getSize($input);
-        if ($size === null) {
-            return Result::failed($input, $this, [], self::TEMPLATE_WRONG_TYPE)
+        $parameters = ['unit' => self::DATA_STORAGE_UNITS[$this->unit]['name']];
+        if (!$this->isSupported($input)) {
+            return Result::failed($input, $this, $parameters, self::TEMPLATE_WRONG_TYPE)
                 ->withId($this->validator->evaluate($input)->id->withPrefix('size'));
         }
 
-        $result = $this->validator->evaluate($this->getSize($input) / self::DATA_STORAGE_UNITS[$this->unit]['bytes']);
-        $parameters = ['unit' => self::DATA_STORAGE_UNITS[$this->unit]['name']];
+        $size = $this->getSize($input);
+        if ($size === null) {
+            return Result::failed($input, $this, $parameters, self::TEMPLATE_UNKNOWN_SIZE)
+                ->withId($this->validator->evaluate($input)->id->withPrefix('size'));
+        }
+
+        $result = $this->validator->evaluate($size / self::DATA_STORAGE_UNITS[$this->unit]['bytes']);
 
         return $result->asAdjacentOf(
             Result::of($result->hasPassed, $input, $this, $parameters),
@@ -79,21 +93,37 @@ final readonly class Size implements Validator
         );
     }
 
+    private function isSupported(mixed $input): bool
+    {
+        return is_string($input)
+            || $input instanceof SplFileInfo
+            || $input instanceof UploadedFileInterface
+            || $input instanceof StreamInterface;
+    }
+
     private function getSize(mixed $input): int|null
     {
         if (is_string($input)) {
-            return (int) filesize($input);
+            if (!is_file($input)) {
+                return null;
+            }
+
+            $size = @filesize($input);
+
+            return $size === false ? null : $size;
         }
 
         if ($input instanceof SplFileInfo) {
-            return $input->getSize();
+            try {
+                $size = $input->getSize();
+            } catch (RuntimeException) {
+                return null;
+            }
+
+            return $size === false ? null : $size;
         }
 
-        if ($input instanceof UploadedFileInterface) {
-            return $input->getSize();
-        }
-
-        if ($input instanceof StreamInterface) {
+        if ($input instanceof UploadedFileInterface || $input instanceof StreamInterface) {
             return $input->getSize();
         }
 

--- a/tests/feature/Validators/SizeTest.php
+++ b/tests/feature/Validators/SizeTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
+use Respect\Validation\Test\Stubs\StreamStub;
 
 beforeEach(function (): void {
     $this->root = vfsStream::setup();
@@ -38,6 +39,26 @@ test('Wrong type', catchAll(
         ->and($message)->toBe('`stdClass {}` must be a filename, an instance of SplFileInfo or a PSR-7 interface')
         ->and($fullMessage)->toBe('- `stdClass {}` must be a filename, an instance of SplFileInfo or a PSR-7 interface')
         ->and($messages)->toBe(['sizeLessThan' => '`stdClass {}` must be a filename, an instance of SplFileInfo or a PSR-7 interface']),
+));
+
+test('Unknown size of a filename that does not exist', catchAll(
+    fn() => v::size('KB', v::lessThan(2))->assert('vfs://root/does-not-exist.txt'),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('It is not possible to determine the size of "vfs://root/does-not-exist.txt"')
+        ->and($fullMessage)->toBe('- It is not possible to determine the size of "vfs://root/does-not-exist.txt"')
+        ->and($messages)->toBe(['sizeLessThan' => 'It is not possible to determine the size of "vfs://root/does-not-exist.txt"']),
+));
+
+test('Unknown size of a stream', catchAll(
+    fn() => v::size('KB', v::lessThan(2))->assert(StreamStub::create()),
+    fn(string $message, string $fullMessage, array $messages) => expect()
+        ->and($message)->toBe('It is not possible to determine the size of `Respect\\Validation\\Test\\Stubs\\StreamStub { __toString() => "" }`')
+        ->and($fullMessage)->toBe('- It is not possible to determine the size of '
+            . '`Respect\\Validation\\Test\\Stubs\\StreamStub { __toString() => "" }`')
+        ->and($messages)->toBe([
+            'sizeLessThan' => 'It is not possible to determine the size of '
+                . '`Respect\\Validation\\Test\\Stubs\\StreamStub { __toString() => "" }`',
+        ]),
 ));
 
 test('Inverted', catchAll(

--- a/tests/src/Stubs/SplFileInfoStub.php
+++ b/tests/src/Stubs/SplFileInfoStub.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: (c) Respect Project Contributors
+ */
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Test\Stubs;
+
+use SplFileInfo;
+
+final class SplFileInfoStub extends SplFileInfo
+{
+    private int|false $size = false;
+
+    public static function createWithoutSize(string $filename): self
+    {
+        return new self($filename);
+    }
+
+    public static function createWithSize(string $filename, int $size): self
+    {
+        $stub = new self($filename);
+        $stub->size = $size;
+
+        return $stub;
+    }
+
+    public function getSize(): int|false
+    {
+        return $this->size;
+    }
+}

--- a/tests/unit/Validators/SizeTest.php
+++ b/tests/unit/Validators/SizeTest.php
@@ -17,9 +17,11 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Respect\Validation\Exceptions\InvalidValidatorException;
+use Respect\Validation\Test\Stubs\SplFileInfoStub;
 use Respect\Validation\Test\Stubs\StreamStub;
 use Respect\Validation\Test\Stubs\UploadedFileStub;
 use Respect\Validation\Test\TestCase;
@@ -100,5 +102,54 @@ final class SizeTest extends TestCase
         $validator->evaluate($file);
 
         self::assertSame([2], $wrapped->inputs);
+    }
+
+    #[Test]
+    public function shouldGetTheSizeOfFilePassedAsSplFileInfoOverridingGetSize(): void
+    {
+        $wrapped = Stub::pass(1);
+        $validator = new Size('KB', $wrapped);
+        $validator->evaluate(SplFileInfoStub::createWithSize(uniqid(), 3 * 1024));
+
+        self::assertSame([3], $wrapped->inputs);
+    }
+
+    #[Test]
+    public function shouldReportWrongTypeWhenTheInputTypeIsNotSupported(): void
+    {
+        $input = 1;
+
+        $wrapped = Stub::pass(1);
+        $result = (new Size('KB', $wrapped))->evaluate($input);
+
+        self::assertFalse($result->hasPassed);
+        self::assertSame(Size::TEMPLATE_WRONG_TYPE, $result->template);
+        self::assertSame([$input], $wrapped->inputs);
+    }
+
+    #[Test]
+    #[DataProvider('providerForInputWithUndeterminableSize')]
+    public function shouldReportUnknownSizeWhenTheSizeCannotBeDetermined(mixed $input): void
+    {
+        $wrapped = Stub::pass(1);
+        $result = (new Size('KB', $wrapped))->evaluate($input);
+
+        self::assertFalse($result->hasPassed);
+        self::assertSame(Size::TEMPLATE_UNKNOWN_SIZE, $result->template);
+        self::assertSame([$input], $wrapped->inputs, 'The inner validator must not be given a size');
+    }
+
+    /** @return array<string, array{mixed}> */
+    public static function providerForInputWithUndeterminableSize(): array
+    {
+        $missingFilename = 'vfs://root/' . uniqid();
+
+        return [
+            'filename that does not exist' => [$missingFilename],
+            'SplFileInfo whose "stat" fails' => [new SplFileInfo($missingFilename)],
+            'SplFileInfo whose "getSize()" returns FALSE' => [SplFileInfoStub::createWithoutSize($missingFilename)],
+            'UploadedFileInterface with an unknown size' => [UploadedFileStub::create()],
+            'StreamInterface with an unknown size' => [StreamStub::create()],
+        ];
     }
 }


### PR DESCRIPTION
`Size` casted the return of `filesize()` to an integer, and `(int) false === 0`, so a
filename that does not exist or is not readable validated as 0 bytes. Every upper-bound
check passed on a file that was never there:

    v::size('KB', v::lessThan(2))->assert('/path/that/does/not/exist');
    // Validation passes successfully

`SplFileInfo::getSize()` throws when `stat` fails, so the same missing file escaped as an
uncaught `RuntimeException` instead of a validation failure; its documented return type is
`int|false`, so overrides may return `false` rather than throw ([Symfony's `Stream`](https://github.com/symfony/symfony/blob/5e9597f80aa6570bfea5fb3852362d8b41b48240/src/Symfony/Component/HttpFoundation/File/Stream.php#L21)
does exactly that). PSR-7 streams and uploaded files may legitimately report `null` for an
unknown size, and that was reported as `TEMPLATE_WRONG_TYPE`, which is misleading: the type
is fine, only the size is not knowable.

Check the input type up front, so unsupported types keep reporting `TEMPLATE_WRONG_TYPE`,
and report a supported input whose size cannot be determined under the new
`TEMPLATE_UNKNOWN_SIZE`. Guard `filesize()`, catch the `RuntimeException` from `SplFileInfo`
and narrow every `getSize()` result with `is_int()`. `getSize()` was also being called twice
per evaluation; it is now called once.

Inputs that previously validated against a bogus 0 now fail, which is a behaviour change. The existing
template constant and message are untouched.

---

There is no open issue for this. I found it in a Symfony API validating user-supplied
files, which arrive as `HttpFoundation\File\File` an `SplFileInfo` subclass.